### PR TITLE
fix: Update qs to ^6.14.1 for security vulnerability

### DIFF
--- a/frontend-example/package.json
+++ b/frontend-example/package.json
@@ -27,7 +27,7 @@
     "linkify-it": "catalog:",
     "lodash": "catalog:",
     "luxon": "catalog:",
-    "qs": "^6.14.0",
+    "qs": "^6.14.1",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-native": "catalog:",

--- a/rtk/package.json
+++ b/rtk/package.json
@@ -10,7 +10,7 @@
     "expo-secure-store": "^15.0.8",
     "jwt-decode": "^4.0.0",
     "luxon": "catalog:",
-    "qs": "^6.14.0",
+    "qs": "^6.14.1",
     "react-native": "catalog:",
     "react-redux": "catalog:",
     "socket.io-client": "^4.8.1"


### PR DESCRIPTION
## Summary
- Updated `qs` dependency from `^6.14.0` to `^6.14.1` in `rtk/package.json` and `frontend-example/package.json`
- Addresses security vulnerability in the qs package

## Test plan
- [ ] Verify `bun install` completes successfully
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)