### PR TITLE
Improve test coverage and add 80% coverage threshold

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(PATH=\"$HOME/.bun/bin:$PATH\" bun lint:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(bun:*)",
+      "Bash(gh pr create:*)",
+      "Bash(ls:*)",
+      "Bash(cd:*)",
+    ]
+  }
+}

--- a/api/bunfig.toml
+++ b/api/bunfig.toml
@@ -3,5 +3,5 @@ preload = ["./src/tests/bunSetup.ts"]
 root = "./src"
 coverage = true
 coverageExclude = ["dist/**", "**/*.test.ts", "**/tests/**"]
-# Note: No coverageThreshold set - tests will not fail on low coverage
+coverageThreshold = { line = 80, function = 80 }
 

--- a/api/src/api.test.ts
+++ b/api/src/api.test.ts
@@ -2852,3 +2852,404 @@ describe("@terreno/api", () => {
     });
   });
 });
+
+describe("errors module", () => {
+  describe("APIError", () => {
+    it("sets default status to 500 when not provided", () => {
+      const error = new APIError({title: "Test error"});
+      expect(error.status).toBe(500);
+    });
+
+    it("sets status to 500 for invalid status codes below 400", () => {
+      const error = new APIError({status: 200, title: "Test error"});
+      expect(error.status).toBe(500);
+    });
+
+    it("sets status to 500 for invalid status codes above 599", () => {
+      const error = new APIError({status: 600, title: "Test error"});
+      expect(error.status).toBe(500);
+    });
+
+    it("includes error stack in message when error is provided", () => {
+      const originalError = new Error("Original error");
+      const apiError = new APIError({
+        error: originalError,
+        title: "Wrapped error",
+      });
+      expect(apiError.message).toContain("Wrapped error");
+      expect(originalError.stack).toBeDefined();
+      expect(apiError.message).toContain(originalError.stack as string);
+    });
+
+    it("includes detail in message when provided", () => {
+      const error = new APIError({
+        detail: "More details here",
+        title: "Test error",
+      });
+      expect(error.message).toContain("Test error");
+      expect(error.message).toContain("More details here");
+    });
+
+    it("sets fields in meta when provided", () => {
+      const error = new APIError({
+        fields: {email: "Invalid email format"},
+        title: "Validation error",
+      });
+      expect(error.meta?.fields).toEqual({email: "Invalid email format"});
+    });
+  });
+
+  describe("errorsPlugin", () => {
+    it("adds apiErrors field to schema", async () => {
+      const mongoose = await import("mongoose");
+      const {errorsPlugin} = await import("./errors");
+
+      const testSchema = new mongoose.Schema({name: String});
+      errorsPlugin(testSchema);
+
+      expect(testSchema.path("apiErrors")).toBeDefined();
+    });
+  });
+
+  describe("isAPIError", () => {
+    it("returns true for APIError instances", () => {
+      const {isAPIError} = require("./errors");
+      const error = new APIError({title: "Test"});
+      expect(isAPIError(error)).toBe(true);
+    });
+
+    it("returns false for regular Error instances", () => {
+      const {isAPIError} = require("./errors");
+      const error = new Error("Test");
+      expect(isAPIError(error)).toBe(false);
+    });
+  });
+
+  describe("getDisableExternalErrorTracking", () => {
+    it("returns undefined for non-objects", () => {
+      const {getDisableExternalErrorTracking} = require("./errors");
+      expect(getDisableExternalErrorTracking(null)).toBeUndefined();
+      expect(getDisableExternalErrorTracking("string")).toBeUndefined();
+    });
+
+    it("returns value from APIError", () => {
+      const {getDisableExternalErrorTracking} = require("./errors");
+      const error = new APIError({disableExternalErrorTracking: true, title: "Test"});
+      expect(getDisableExternalErrorTracking(error)).toBe(true);
+    });
+
+    it("returns value from plain object with property", () => {
+      const {getDisableExternalErrorTracking} = require("./errors");
+      const obj = {disableExternalErrorTracking: true};
+      expect(getDisableExternalErrorTracking(obj)).toBe(true);
+    });
+  });
+
+  describe("getAPIErrorBody", () => {
+    it("includes all non-undefined fields", () => {
+      const {getAPIErrorBody} = require("./errors");
+      const error = new APIError({
+        code: "TEST_CODE",
+        detail: "Test detail",
+        id: "error-123",
+        links: {about: "http://example.com"},
+        meta: {extra: "data"},
+        source: {parameter: "id"},
+        status: 400,
+        title: "Test error",
+      });
+      const body = getAPIErrorBody(error);
+
+      expect(body.title).toBe("Test error");
+      expect(body.status).toBe(400);
+      expect(body.code).toBe("TEST_CODE");
+      expect(body.detail).toBe("Test detail");
+      expect(body.id).toBe("error-123");
+      expect(body.links).toEqual({about: "http://example.com"});
+      expect(body.source).toEqual({parameter: "id"});
+      expect(body.meta).toEqual({extra: "data"});
+    });
+  });
+
+  describe("apiUnauthorizedMiddleware", () => {
+    it("returns 401 for Unauthorized errors", () => {
+      const {apiUnauthorizedMiddleware} = require("./errors");
+      const err = new Error("Unauthorized");
+      const res = {
+        json: function (data: any) {
+          (this as any).body = data;
+          return this;
+        },
+        send: function () {
+          return this;
+        },
+        status: function (code: number) {
+          (this as any).statusCode = code;
+          return this;
+        },
+      };
+      const next = () => {};
+
+      apiUnauthorizedMiddleware(err, {}, res, next);
+      expect((res as any).statusCode).toBe(401);
+      expect((res as any).body.title).toBe("Unauthorized");
+    });
+
+    it("calls next for non-Unauthorized errors", () => {
+      const {apiUnauthorizedMiddleware} = require("./errors");
+      const err = new Error("Some other error");
+      let nextCalled = false;
+      const next = () => {
+        nextCalled = true;
+      };
+
+      apiUnauthorizedMiddleware(err, {}, {}, next);
+      expect(nextCalled).toBe(true);
+    });
+  });
+});
+
+describe("permissions module", () => {
+  describe("OwnerQueryFilter", () => {
+    it("returns ownerId filter when user is provided", () => {
+      const {OwnerQueryFilter} = require("./permissions");
+      const user = {id: "user-123"};
+      const filter = OwnerQueryFilter(user);
+      expect(filter).toEqual({ownerId: "user-123"});
+    });
+
+    it("returns null when user is undefined", () => {
+      const {OwnerQueryFilter} = require("./permissions");
+      const filter = OwnerQueryFilter(undefined);
+      expect(filter).toBeNull();
+    });
+  });
+
+  describe("Permissions.IsAuthenticatedOrReadOnly", () => {
+    it("returns true for authenticated non-anonymous users", () => {
+      const {Permissions} = require("./permissions");
+      const user = {id: "user-123", isAnonymous: false};
+      expect(Permissions.IsAuthenticatedOrReadOnly("create", user)).toBe(true);
+    });
+
+    it("returns true for read methods when user is anonymous", () => {
+      const {Permissions} = require("./permissions");
+      const user = {id: "user-123", isAnonymous: true};
+      expect(Permissions.IsAuthenticatedOrReadOnly("list", user)).toBe(true);
+      expect(Permissions.IsAuthenticatedOrReadOnly("read", user)).toBe(true);
+    });
+
+    it("returns false for write methods when user is anonymous", () => {
+      const {Permissions} = require("./permissions");
+      const user = {id: "user-123", isAnonymous: true};
+      expect(Permissions.IsAuthenticatedOrReadOnly("create", user)).toBe(false);
+      expect(Permissions.IsAuthenticatedOrReadOnly("update", user)).toBe(false);
+      expect(Permissions.IsAuthenticatedOrReadOnly("delete", user)).toBe(false);
+    });
+  });
+
+  describe("Permissions.IsOwnerOrReadOnly", () => {
+    it("returns true when no object is provided", () => {
+      const {Permissions} = require("./permissions");
+      expect(Permissions.IsOwnerOrReadOnly("update", {id: "user-123"}, undefined)).toBe(true);
+    });
+
+    it("returns true for admin users", () => {
+      const {Permissions} = require("./permissions");
+      const user = {admin: true, id: "admin-123"};
+      const obj = {ownerId: "other-user"};
+      expect(Permissions.IsOwnerOrReadOnly("update", user, obj)).toBe(true);
+    });
+
+    it("returns true when user is owner", () => {
+      const {Permissions} = require("./permissions");
+      const user = {id: "user-123"};
+      const obj = {ownerId: "user-123"};
+      expect(Permissions.IsOwnerOrReadOnly("update", user, obj)).toBe(true);
+    });
+
+    it("returns true for read methods when not owner", () => {
+      const {Permissions} = require("./permissions");
+      const user = {id: "user-123"};
+      const obj = {ownerId: "other-user"};
+      expect(Permissions.IsOwnerOrReadOnly("list", user, obj)).toBe(true);
+      expect(Permissions.IsOwnerOrReadOnly("read", user, obj)).toBe(true);
+    });
+
+    it("returns false for write methods when not owner", () => {
+      const {Permissions} = require("./permissions");
+      const user = {id: "user-123"};
+      const obj = {ownerId: "other-user"};
+      expect(Permissions.IsOwnerOrReadOnly("update", user, obj)).toBe(false);
+      expect(Permissions.IsOwnerOrReadOnly("delete", user, obj)).toBe(false);
+    });
+  });
+});
+
+describe("utils module", () => {
+  describe("isValidObjectId", () => {
+    it("returns true for valid ObjectId strings", () => {
+      const {isValidObjectId} = require("./utils");
+      expect(isValidObjectId("507f1f77bcf86cd799439011")).toBe(true);
+    });
+
+    it("returns false for invalid ObjectId strings", () => {
+      const {isValidObjectId} = require("./utils");
+      expect(isValidObjectId("invalid-id")).toBe(false);
+      expect(isValidObjectId("12345")).toBe(false);
+      expect(isValidObjectId("")).toBe(false);
+    });
+
+    it("returns false for 12-character strings that are not valid ObjectIds", () => {
+      const {isValidObjectId} = require("./utils");
+      // mongoose's native isValid returns true for any 12-char string
+      // but our implementation should return false since toString won't match
+      expect(isValidObjectId("123456789012")).toBe(false);
+    });
+  });
+
+  describe("timeout", () => {
+    it("resolves after specified time", async () => {
+      const {timeout} = require("./utils");
+      const start = Date.now();
+      await timeout(50);
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeGreaterThanOrEqual(40);
+    });
+  });
+
+  // Note: Comprehensive checkModelsStrict tests are in utils.test.ts with mocked mongoose
+});
+
+describe("populate module", () => {
+  describe("unpopulate", () => {
+    it("throws error when path is empty", async () => {
+      const {unpopulate} = await import("./populate");
+      const doc = {name: "test"};
+      expect(() => unpopulate(doc as any, "")).toThrow("path is required");
+    });
+
+    it("unpopulates single populated field", async () => {
+      const {unpopulate} = await import("./populate");
+      const doc = {
+        name: "test",
+        ownerId: {_id: "owner-123", email: "owner@test.com"},
+      };
+      const result = unpopulate(doc as any, "ownerId") as any;
+      expect(result.ownerId).toBe("owner-123");
+    });
+
+    it("unpopulates array of populated fields", async () => {
+      const {unpopulate} = await import("./populate");
+      const doc = {
+        items: [{_id: "item-1", name: "Item 1"}, {_id: "item-2", name: "Item 2"}, "item-3"],
+        name: "test",
+      };
+      const result = unpopulate(doc as any, "items") as any;
+      expect(result.items).toEqual(["item-1", "item-2", "item-3"]);
+    });
+
+    it("handles nested paths", async () => {
+      const {unpopulate} = await import("./populate");
+      const doc = {
+        name: "test",
+        nested: {
+          items: [
+            {_id: "item-1", name: "Item 1"},
+            {_id: "item-2", name: "Item 2"},
+          ],
+        },
+      };
+      const result = unpopulate(doc as any, "nested.items") as any;
+      expect(result.nested.items).toEqual(["item-1", "item-2"]);
+    });
+
+    it("returns original doc when path does not exist", async () => {
+      const {unpopulate} = await import("./populate");
+      const doc = {name: "test"};
+      const result = unpopulate(doc as any, "nonexistent") as any;
+      expect(result).toEqual(doc);
+    });
+
+    it("handles nested array paths", async () => {
+      const {unpopulate} = await import("./populate");
+      const doc = {
+        containers: [
+          {items: [{_id: "item-1"}, {_id: "item-2"}]},
+          {items: [{_id: "item-3"}, {_id: "item-4"}]},
+        ],
+        name: "test",
+      };
+      const result = unpopulate(doc as any, "containers.items") as any;
+      expect(result.containers[0].items).toEqual(["item-1", "item-2"]);
+      expect(result.containers[1].items).toEqual(["item-3", "item-4"]);
+    });
+  });
+});
+
+describe("auth module edge cases", () => {
+  describe("generateTokens", () => {
+    it("returns null tokens when user is missing", async () => {
+      const {generateTokens} = await import("./auth");
+      const result = await generateTokens(null);
+      expect(result.token).toBeNull();
+      expect(result.refreshToken).toBeNull();
+    });
+
+    it("returns null tokens when user has no _id", async () => {
+      const {generateTokens} = await import("./auth");
+      const result = await generateTokens({email: "test@test.com"});
+      expect(result.token).toBeNull();
+      expect(result.refreshToken).toBeNull();
+    });
+
+    it("includes custom payload from generateJWTPayload option", async () => {
+      const {generateTokens} = await import("./auth");
+      const jwt = await import("jsonwebtoken");
+
+      const user = {_id: "user-123"};
+      const result = await generateTokens(user, {
+        generateJWTPayload: (u) => ({customField: "customValue", userId: u._id}),
+      });
+
+      expect(result.token).toBeDefined();
+      const decoded = jwt.decode(result.token as string) as any;
+      expect(decoded.customField).toBe("customValue");
+      expect(decoded.id).toBe("user-123");
+    });
+
+    it("uses custom token expiration from generateTokenExpiration option", async () => {
+      const {generateTokens} = await import("./auth");
+      const jwt = await import("jsonwebtoken");
+
+      const user = {_id: "user-123"};
+      const result = await generateTokens(user, {
+        generateTokenExpiration: () => "1h",
+      });
+
+      expect(result.token).toBeDefined();
+      const decoded = jwt.decode(result.token as string) as any;
+      // Check that exp is roughly 1 hour from now (within 5 seconds tolerance)
+      const expectedExp = Math.floor(Date.now() / 1000) + 3600;
+      expect(decoded.exp).toBeGreaterThan(expectedExp - 5);
+      expect(decoded.exp).toBeLessThan(expectedExp + 5);
+    });
+
+    it("uses custom refresh token expiration from generateRefreshTokenExpiration option", async () => {
+      const {generateTokens} = await import("./auth");
+      const jwt = await import("jsonwebtoken");
+
+      const user = {_id: "user-123"};
+      const result = await generateTokens(user, {
+        generateRefreshTokenExpiration: () => "7d",
+      });
+
+      expect(result.refreshToken).toBeDefined();
+      const decoded = jwt.decode(result.refreshToken as string) as any;
+      // Check that exp is roughly 7 days from now
+      const expectedExp = Math.floor(Date.now() / 1000) + 7 * 24 * 3600;
+      expect(decoded.exp).toBeGreaterThan(expectedExp - 10);
+      expect(decoded.exp).toBeLessThan(expectedExp + 10);
+    });
+  });
+});

--- a/api/src/utils.test.ts
+++ b/api/src/utils.test.ts
@@ -1,14 +1,194 @@
-import {describe, expect, it} from "bun:test";
+import {describe, expect, it, spyOn} from "bun:test";
+import mongoose from "mongoose";
 
-import {isValidObjectId} from "./utils";
+import {checkModelsStrict, isValidObjectId} from "./utils";
 
 describe("utils", () => {
-  it("checks valid ObjectIds", () => {
-    expect(isValidObjectId("62c44da0003d9f8ee8cc925c")).toBe(true);
-    expect(isValidObjectId("620000000000000000000000")).toBe(true);
-    // Mongoose's builtin "ObjectId.isValid" will falsely say this is an ObjectId.
-    expect(isValidObjectId("1234567890ab")).toBe(false);
-    expect(isValidObjectId("microsoft123")).toBe(false);
-    expect(isValidObjectId("62c44da0003d9f8ee8cc925x")).toBe(false);
+  describe("isValidObjectId", () => {
+    it("checks valid ObjectIds", () => {
+      expect(isValidObjectId("62c44da0003d9f8ee8cc925c")).toBe(true);
+      expect(isValidObjectId("620000000000000000000000")).toBe(true);
+      // Mongoose's builtin "ObjectId.isValid" will falsely say this is an ObjectId.
+      expect(isValidObjectId("1234567890ab")).toBe(false);
+      expect(isValidObjectId("microsoft123")).toBe(false);
+      expect(isValidObjectId("62c44da0003d9f8ee8cc925x")).toBe(false);
+    });
+  });
+
+  describe("checkModelsStrict", () => {
+    it("throws error when toObject.virtuals is not true", () => {
+      // Create a schema without toObject.virtuals
+      const testSchema = new mongoose.Schema({name: String});
+      testSchema.set("strict", "throw");
+      // Not setting toObject.virtuals
+
+      if (mongoose.models.ToObjectTestModel) {
+        delete mongoose.models.ToObjectTestModel;
+      }
+      mongoose.model("ToObjectTestModel", testSchema);
+
+      try {
+        // This should throw because ToObjectTestModel doesn't have toObject.virtuals
+        expect(() => checkModelsStrict()).toThrow("toObject.virtuals not set to true");
+      } finally {
+        delete mongoose.models.ToObjectTestModel;
+      }
+    });
+
+    it("throws error when toJSON.virtuals is not true", () => {
+      // Create a schema with toObject.virtuals but without toJSON.virtuals
+      const testSchema = new mongoose.Schema({name: String});
+      testSchema.set("toObject", {virtuals: true});
+      testSchema.set("strict", "throw");
+      // Not setting toJSON.virtuals
+
+      if (mongoose.models.ToJsonTestModel) {
+        delete mongoose.models.ToJsonTestModel;
+      }
+      mongoose.model("ToJsonTestModel", testSchema);
+
+      // Use spyOn to intercept modelNames and return only our test model
+      const spy = spyOn(mongoose, "modelNames").mockReturnValue(["ToJsonTestModel"]);
+
+      try {
+        expect(() => checkModelsStrict()).toThrow("toJSON.virtuals not set to true");
+      } finally {
+        spy.mockRestore();
+        delete mongoose.models.ToJsonTestModel;
+      }
+    });
+
+    it("throws error when strict mode is not set to throw", () => {
+      // Create a schema with virtuals but without strict mode
+      const testSchema = new mongoose.Schema({name: String});
+      testSchema.set("toObject", {virtuals: true});
+      testSchema.set("toJSON", {virtuals: true});
+      // Not setting strict to "throw"
+
+      if (mongoose.models.StrictTestModel) {
+        delete mongoose.models.StrictTestModel;
+      }
+      mongoose.model("StrictTestModel", testSchema);
+
+      const spy = spyOn(mongoose, "modelNames").mockReturnValue(["StrictTestModel"]);
+
+      try {
+        expect(() => checkModelsStrict()).toThrow("is not set to strict mode");
+      } finally {
+        spy.mockRestore();
+        delete mongoose.models.StrictTestModel;
+      }
+    });
+
+    it("passes when all checks pass", () => {
+      // Create a properly configured schema
+      const testSchema = new mongoose.Schema({name: String});
+      testSchema.set("toObject", {virtuals: true});
+      testSchema.set("toJSON", {virtuals: true});
+      testSchema.set("strict", "throw");
+
+      if (mongoose.models.GoodTestModel) {
+        delete mongoose.models.GoodTestModel;
+      }
+      mongoose.model("GoodTestModel", testSchema);
+
+      const spy = spyOn(mongoose, "modelNames").mockReturnValue(["GoodTestModel"]);
+
+      try {
+        expect(() => checkModelsStrict()).not.toThrow();
+      } finally {
+        spy.mockRestore();
+        delete mongoose.models.GoodTestModel;
+      }
+    });
+
+    it("skips strict mode check for ignored models", () => {
+      // Create a properly configured model
+      const goodSchema = new mongoose.Schema({name: String});
+      goodSchema.set("toObject", {virtuals: true});
+      goodSchema.set("toJSON", {virtuals: true});
+      goodSchema.set("strict", "throw");
+
+      if (mongoose.models.GoodModel) {
+        delete mongoose.models.GoodModel;
+      }
+      mongoose.model("GoodModel", goodSchema);
+
+      // Create a model without strict mode that we'll ignore
+      const badSchema = new mongoose.Schema({name: String});
+      badSchema.set("toObject", {virtuals: true});
+      badSchema.set("toJSON", {virtuals: true});
+      // Not setting strict - should fail unless ignored
+
+      if (mongoose.models.IgnoredModel) {
+        delete mongoose.models.IgnoredModel;
+      }
+      mongoose.model("IgnoredModel", badSchema);
+
+      const spy = spyOn(mongoose, "modelNames").mockReturnValue(["GoodModel", "IgnoredModel"]);
+
+      try {
+        // Without ignoring, should throw for IgnoredModel
+        expect(() => checkModelsStrict()).toThrow("is not set to strict mode");
+
+        // With ignoring IgnoredModel, should pass
+        expect(() => checkModelsStrict(["IgnoredModel"])).not.toThrow();
+      } finally {
+        spy.mockRestore();
+        delete mongoose.models.GoodModel;
+        delete mongoose.models.IgnoredModel;
+      }
+    });
+
+    it("handles multiple models and validates all", () => {
+      // Create three properly configured models
+      const schema1 = new mongoose.Schema({name: String});
+      schema1.set("toObject", {virtuals: true});
+      schema1.set("toJSON", {virtuals: true});
+      schema1.set("strict", "throw");
+
+      const schema2 = new mongoose.Schema({value: Number});
+      schema2.set("toObject", {virtuals: true});
+      schema2.set("toJSON", {virtuals: true});
+      schema2.set("strict", "throw");
+
+      const schema3 = new mongoose.Schema({active: Boolean});
+      schema3.set("toObject", {virtuals: true});
+      schema3.set("toJSON", {virtuals: true});
+      schema3.set("strict", "throw");
+
+      if (mongoose.models.MultiModel1) delete mongoose.models.MultiModel1;
+      if (mongoose.models.MultiModel2) delete mongoose.models.MultiModel2;
+      if (mongoose.models.MultiModel3) delete mongoose.models.MultiModel3;
+
+      mongoose.model("MultiModel1", schema1);
+      mongoose.model("MultiModel2", schema2);
+      mongoose.model("MultiModel3", schema3);
+
+      const spy = spyOn(mongoose, "modelNames").mockReturnValue([
+        "MultiModel1",
+        "MultiModel2",
+        "MultiModel3",
+      ]);
+
+      try {
+        expect(() => checkModelsStrict()).not.toThrow();
+      } finally {
+        spy.mockRestore();
+        delete mongoose.models.MultiModel1;
+        delete mongoose.models.MultiModel2;
+        delete mongoose.models.MultiModel3;
+      }
+    });
+
+    it("handles empty model list", () => {
+      const spy = spyOn(mongoose, "modelNames").mockReturnValue([]);
+
+      try {
+        expect(() => checkModelsStrict()).not.toThrow();
+      } finally {
+        spy.mockRestore();
+      }
+    });
   });
 });


### PR DESCRIPTION
### **User description**
- Add comprehensive tests for errors, permissions, utils, populate, and auth modules
- Improve utils.ts coverage from 35% to 100% using spyOn mocks
- Add coverage threshold (80% line/function) to bunfig.toml
- Overall line coverage improved from 86% to 91.7%


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Add comprehensive test coverage for errors, permissions, utils, populate, and auth modules

- Improve utils.ts coverage from 35% to 100% using spyOn mocks for mongoose

- Add 80% line and function coverage threshold to bunfig.toml

- Overall line coverage improved from 86% to 91.7%


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Suite Expansion"] --> B["Error Module Tests"]
  A --> C["Permissions Module Tests"]
  A --> D["Utils Module Tests"]
  A --> E["Populate Module Tests"]
  A --> F["Auth Module Tests"]
  D --> G["100% Coverage Achievement"]
  G --> H["80% Coverage Threshold"]
  H --> I["Coverage Enforcement"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.test.ts</strong><dd><code>Add comprehensive module test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/src/api.test.ts

<ul><li>Added comprehensive test suite for errors module covering APIError <br>class, errorsPlugin, isAPIError, getDisableExternalErrorTracking, <br>getAPIErrorBody, and apiUnauthorizedMiddleware<br> <li> Added tests for permissions module covering OwnerQueryFilter, <br>IsAuthenticatedOrReadOnly, and IsOwnerOrReadOnly permission checks<br> <li> Added tests for utils module covering isValidObjectId and timeout <br>functions<br> <li> Added tests for populate module covering unpopulate function with <br>various scenarios including nested paths and arrays<br> <li> Added tests for auth module edge cases covering generateTokens with <br>custom payload and expiration options</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/100/files#diff-47bf1a85b2adb3d3534b3ba150a0c7c5c9251d33ed912d8d26fe25bacfe51deb">+401/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils.test.ts</strong><dd><code>Expand utils test coverage to 100%</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/src/utils.test.ts

<ul><li>Restructured isValidObjectId tests under nested describe block<br> <li> Added comprehensive checkModelsStrict test suite with spyOn mocks for <br>mongoose.modelNames<br> <li> Tests cover toObject.virtuals, toJSON.virtuals, and strict mode <br>validation<br> <li> Tests include model ignoring functionality and multiple model <br>validation scenarios<br> <li> Added edge case tests for empty model lists</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/100/files#diff-7a2cb2773fcc8466b754d1691a84b1b2e17cecab1306bebf034d3f90f02d4ece">+189/-9</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bunfig.toml</strong><dd><code>Add 80% coverage threshold enforcement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/bunfig.toml

<ul><li>Replaced comment about no coverage threshold with actual coverage <br>threshold configuration<br> <li> Set coverageThreshold to enforce 80% line coverage and 80% function <br>coverage<br> <li> Enables test failure on coverage below threshold</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/100/files#diff-80865dd0bd38fdff392f90f54d0e5c4d7af09ac3738b536f291b5ae4c21c207d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>settings.json</strong><dd><code>Add Claude environment permissions configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.claude/settings.json

<ul><li>Created new Claude settings configuration file<br> <li> Defined permissions allowing bash commands for linting, git <br>operations, bun commands, and gh pr creation<br> <li> Enables automated workflow operations within Claude environment</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/100/files#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

