### PR TITLE
Fix publishing on tag

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -470,7 +470,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: main
+          ref: master
 
       - name: Setup Git
         run: |


### PR DESCRIPTION
### **User description**
It was reference main instead of master


___

### **PR Type**
Bug fix


___

### **Description**
- Fix GitHub Actions workflow to checkout correct branch

- Changed ref from `main` to `master` in publish-on-tag workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  workflow["publish-on-tag.yml"] -- "checkout ref" --> before["main (incorrect)"]
  workflow -- "checkout ref" --> after["master (correct)"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publish-on-tag.yml</strong><dd><code>Fix checkout branch reference in workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/publish-on-tag.yml

<ul><li>Updated checkout action ref from <code>main</code> to <code>master</code><br> <li> Fixes branch reference in publish completion job<br> <li> Ensures workflow checks out correct default branch</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/103/files#diff-3a2a0ef5b398d8921949de046ae90293fafd7418f7b0de036363e92f78aa5d1a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

