### PR TITLE
feat: add url parameter to sendToSlack function

### DIFF
--- a/api/src/notifiers/slackNotifier.ts
+++ b/api/src/notifiers/slackNotifier.ts
@@ -5,7 +5,8 @@ import {APIError} from "../errors";
 import {logger} from "../logger";
 // Convenience method to send data to a Slack webhook.
 // If `url` is provided, it will be used directly instead of looking up from environment.
-// Otherwise, the webhook URL is looked up from SLACK_WEBHOOKS environment variable by channel name.
+// DEPRECATED: Looking up webhook URLs from the SLACK_WEBHOOKS environment variable by channel name
+// is deprecated and will be removed in a future version. Please pass the `url` parameter directly.
 export async function sendToSlack(
   text: string,
   {
@@ -18,6 +19,9 @@ export async function sendToSlack(
   let slackWebhookUrl = url;
 
   if (!slackWebhookUrl) {
+    logger.debug(
+      "DEPRECATED: Looking up webhook URLs from SLACK_WEBHOOKS environment variable is deprecated and will be removed in a future version. Please pass the url parameter directly."
+    );
     // since Slack now requires a webhook for each channel, we need to store them in the environment
     // as an object, so we can look them up by channel name.
     const slackWebhooksString = process.env.SLACK_WEBHOOKS;


### PR DESCRIPTION
## Summary

Adds an optional `url` parameter to the `sendToSlack` function that allows passing a webhook URL directly instead of requiring it to be looked up from the `SLACK_WEBHOOKS` environment variable.

When `url` is provided, it's used directly. When not provided, the existing behavior of looking up the webhook URL from environment variables by channel name is preserved.

This enables sending to Slack channels that are configured per-entity (like CarePod urgent alert channels) rather than requiring all webhooks to be globally configured in environment variables.

**The environment variable lookup path is now marked as deprecated** and will be removed in a future version. A deprecation warning is logged when this path is used.

## Review & Testing Checklist for Human

- [ ] Verify the new `url` parameter path works correctly when a URL is passed directly
- [ ] Confirm existing behavior (using `SLACK_WEBHOOKS` env var lookup) still works unchanged
- [ ] Verify the deprecation warning appears in logs when using the env lookup path
- [ ] Consider whether URL validation should be added (currently accepts any string)

### Notes

This is part of a larger change to add `urgentAlertsChannel` to the CarePod model in flourish, which will store webhook URLs directly on the model. A corresponding PR in flourish is available at https://github.com/FlourishHealth/flourish/pull/4797.

Link to Devin run: https://app.devin.ai/sessions/1dbda618f0564a57978f27093900a09b
Requested by: Josh Gachnang (@joshgachnang)

## Updates since last revision

- Added deprecation notice in code comments for the `SLACK_WEBHOOKS` environment variable lookup
- Added `logger.debug` message that logs a deprecation warning when the env lookup path is used