### PR TITLE
fix: resolve require cycle between Modal and Button

### DIFF
--- a/ui/src/Button.tsx
+++ b/ui/src/Button.tsx
@@ -137,7 +137,7 @@ const ButtonComponent: FC<ButtonProps> = ({
           </Box>
         )}
       </View>
-      {withConfirmation && (
+      {withConfirmation && showConfirmation && (
         <Suspense fallback={null}>
           <LazyModal
             onDismiss={() => setShowConfirmation(false)}


### PR DESCRIPTION
## Summary

Fixes the require cycle warning: `Modal.js -> Button.js -> Modal.js`

The circular dependency existed because Modal imports Button (for its action buttons) and Button imported Modal (for the confirmation dialog feature when `withConfirmation` prop is used).

This PR uses `React.lazy()` to dynamically import the Modal component in Button.tsx, breaking the static import cycle at runtime. The Modal is wrapped in `Suspense` with a null fallback, so it loads on-demand only when a confirmation dialog is needed.

## Updates since last revision

**Approach changed based on feedback**: Instead of creating a duplicate `ConfirmationDialog` component with inline button styles, this revision uses lazy loading to break the cycle without code duplication. The original Modal component is reused directly via dynamic import.

Key changes:
- Removed the standalone `ConfirmationDialog.tsx` component
- Button.tsx now uses `React.lazy()` to import Modal dynamically
- Modal is wrapped in `<Suspense fallback={null}>` for async loading

## Review & Testing Checklist for Human

- [ ] **Require cycle warning gone**: Verify the console no longer shows `Require cycle: Modal.js -> Button.js -> Modal.js` warning
- [ ] **Confirmation dialog works**: Test a Button with `withConfirmation={true}` - the dialog should appear and both Cancel/Confirm buttons should function correctly
- [ ] **No loading delay**: Check if there's any noticeable delay or flash when opening a confirmation dialog for the first time (due to lazy loading)
- [ ] **Mobile behavior**: Verify lazy loading works correctly on mobile/native platforms

**Recommended test plan:**
1. Run the demo app and find a Button with confirmation enabled
2. Trigger the confirmation dialog on both web and mobile
3. Verify the dialog appears correctly and both Cancel/Confirm buttons work
4. Confirm the require cycle warning no longer appears in console

### Notes

Link to Devin run: https://app.devin.ai/sessions/2426b382dfeb4a619a3455aa8d92939f
Requested by: Josh Gachnang (@joshgachnang)