### PR TITLE
Fix pointerEvents deprecation warning in react-native-toast-notifications

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
     },
     "api": {
       "name": "@terreno/api",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "dependencies": {
         "@sentry/node": "^10.25.0",
         "@sentry/profiling-node": "^10.25.0",
@@ -235,7 +235,7 @@
     },
     "rtk": {
       "name": "@terreno/rtk",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "dependencies": {
         "@react-native-async-storage/async-storage": "catalog:",
         "@reduxjs/toolkit": "^2.11.1",
@@ -267,7 +267,7 @@
     },
     "ui": {
       "name": "@terreno/ui",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "dependencies": {
         "@expo-google-fonts/nunito": "^0.4.2",
         "@expo-google-fonts/titillium-web": "^0.4.1",
@@ -345,6 +345,9 @@
         "react-router-dom": "catalog:",
       },
     },
+  },
+  "patchedDependencies": {
+    "react-native-toast-notifications@3.4.0": "patches/react-native-toast-notifications@3.4.0.patch",
   },
   "catalog": {
     "@biomejs/biome": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -97,5 +97,8 @@
     "example-frontend",
     "rtk",
     "ui"
-  ]
+  ],
+  "patchedDependencies": {
+    "react-native-toast-notifications@3.4.0": "patches/react-native-toast-notifications@3.4.0.patch"
+  }
 }

--- a/patches/react-native-toast-notifications@3.4.0.patch
+++ b/patches/react-native-toast-notifications@3.4.0.patch
@@ -1,0 +1,34 @@
+diff --git a/src/toast-container.tsx b/src/toast-container.tsx
+index 5d2a8b4e9a767c8bb5e1c8c8be6c9e94d2a5ead7..b22b2a735a28bf45d0c110af37ab3a49a9fd16ae 100644
+--- a/src/toast-container.tsx
++++ b/src/toast-container.tsx
+@@ -121,8 +121,7 @@ class ToastContainer extends Component<Props, State> {
+     return (
+       <KeyboardAvoidingView
+         behavior={Platform.OS === "ios" ? "position" : undefined}
+-        style={[styles.container, style]}
+-        pointerEvents="box-none"
++        style={[styles.container, style, { pointerEvents: "box-none" }]}
+       >
+         <SafeAreaView>
+           {toasts
+@@ -147,8 +146,7 @@ class ToastContainer extends Component<Props, State> {
+     return (
+       <KeyboardAvoidingView
+         behavior={Platform.OS === "ios" ? "position" : undefined}
+-        style={[styles.container, style]}
+-        pointerEvents="box-none"
++        style={[styles.container, style, { pointerEvents: "box-none" }]}
+       >
+         <SafeAreaView>
+           {toasts
+@@ -180,8 +178,7 @@ class ToastContainer extends Component<Props, State> {
+     return (
+       <KeyboardAvoidingView
+         behavior={Platform.OS === "ios" ? "position" : undefined}
+-        style={[styles.container, style]}
+-        pointerEvents="box-none"
++        style={[styles.container, style, { pointerEvents: "box-none" }]}
+       >
+         {toasts
+           .filter((t) => t.placement === "center")


### PR DESCRIPTION
### **User description**
## Summary

Fixes the deprecation warning: `props.pointerEvents is deprecated. Use style.pointerEvents`

The warning was caused by `react-native-toast-notifications@3.4.0` using `pointerEvents="box-none"` as a direct prop on `KeyboardAvoidingView` components. This PR adds a bun patch that moves `pointerEvents` into the style object in all three toast render methods (bottom, top, center).

## Review & Testing Checklist for Human

- [ ] **Run the app and verify the deprecation warning is gone** - The warning should no longer appear in the console
- [ ] **Test toast functionality** - Verify toasts still appear correctly and that `pointerEvents: "box-none"` still works (elements behind the toast container should still be interactive)
- [ ] **Verify patch applies on fresh install** - Run `rm -rf node_modules && bun install` and confirm the patch applies without errors

### Notes

The bun.lock shows version bumps (0.0.12 → 0.0.13) for api, rtk, and ui packages - this appears to be a side effect of running `bun install` and is unrelated to the actual fix.

Link to Devin run: https://app.devin.ai/sessions/f1a55704be7d40de971d2f4721e37309
Requested by: Josh Gachnang (@joshgachnang)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes deprecation warning by moving `pointerEvents` from prop to style

- Applies patch to `react-native-toast-notifications@3.4.0` package

- Updates all three toast render methods (bottom, top, center)

- Maintains existing functionality while resolving React Native warning


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["react-native-toast-notifications<br/>pointerEvents as prop"] -->|"patch applied"| B["pointerEvents moved<br/>to style object"]
  B -->|"result"| C["Deprecation warning<br/>resolved"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add patched dependencies configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<ul><li>Added <code>patchedDependencies</code> configuration for <br><code>react-native-toast-notifications@3.4.0</code><br> <li> References new patch file to be applied during installation</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/117/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>react-native-toast-notifications@3.4.0.patch</strong><dd><code>Move pointerEvents from prop to style object</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

patches/react-native-toast-notifications@3.4.0.patch

<ul><li>Moves <code>pointerEvents="box-none"</code> from component prop to style object<br> <li> Updates three toast render methods: bottom, top, and center placements<br> <li> Changes from <code>style={[...]}</code> with separate <code>pointerEvents</code> prop to <br><code>style={[..., { pointerEvents: "box-none" }]}</code><br> <li> Maintains identical functionality while resolving deprecation warning</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/117/files#diff-305a1897ac6a8b642416bcf420b38170dd7276d5207f421736e2adec2352b354">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

