### PR TITLE
Export RTK functions

### DIFF
--- a/rtk/src/emptyApi.ts
+++ b/rtk/src/emptyApi.ts
@@ -155,7 +155,7 @@ export const refreshAuthToken = async (): Promise<void> => {
   }
 };
 
-const getBaseQuery = (
+export const getBaseQuery = (
   args: string | FetchArgs,
   api: BaseQueryApi,
   extraOptions: unknown,
@@ -199,7 +199,7 @@ const getBaseQuery = (
   })(args, api, extraOptions as any);
 };
 
-const staggeredBaseQuery = retry(
+export const staggeredBaseQuery = retry(
   async (args: string | FetchArgs, api, extraOptions) => {
     // wait until the mutex is available without locking it
     await mutex.waitForUnlock();


### PR DESCRIPTION
### **User description**
Allow apps consuming RTK to create emptySplitApi using their own parameters.


___

### **PR Type**
Enhancement


___

### **Description**
- Export `getBaseQuery` and `staggeredBaseQuery` functions for external use

- Remove unnecessary biome-ignore lint comments

- Enable consuming apps to create custom `emptySplitApi` instances


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Internal Functions"] -->|"Export"| B["getBaseQuery"]
  A -->|"Export"| C["staggeredBaseQuery"]
  B -->|"Used by"| D["emptySplitApi"]
  C -->|"Used by"| D
  D -->|"Available to"| E["Consuming Apps"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>emptyApi.ts</strong><dd><code>Export internal RTK query builder functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rtk/src/emptyApi.ts

<ul><li>Changed <code>getBaseQuery</code> from private to exported function<br> <li> Changed <code>staggeredBaseQuery</code> from private to exported function<br> <li> Removed biome-ignore lint comments for cleaner code<br> <li> Maintains existing <code>emptySplitApi</code> export for public API</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/122/files#diff-c49b681d3724056d7e6b3d8b865f06c4445056505196c61f6a57954afb51b201">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

