### PR TITLE
Fix Zoom notification newlines in publish workflow

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -598,6 +598,9 @@ jobs:
           MESSAGE="${MESSAGE}Commit: ${COMMIT_SHORT}\n"
           MESSAGE="${MESSAGE}View: ${TAG_URL}"
           
+          # Convert \n escape sequences to actual newlines
+          MESSAGE=$(printf "%b" "$MESSAGE")
+          
           curl -X POST "${{ secrets.ZOOM_WEBHOOK_URL }}" \
             -H "Authorization: ${{ secrets.ZOOM_WEBHOOK_TOKEN }}" \
             -H "Content-Type: text/plain" \


### PR DESCRIPTION
### **User description**
## Summary

Fixes the Zoom notification in the publish-on-tag workflow to display actual newlines instead of literal `\n` characters.

**Before:** `Release 0.0.16:\n✅ @terreno/api@0.0.16 published\n✅ @terreno/ui@0.0.16 published\n...`

**After:**
```
Release 0.0.16:
✅ @terreno/api@0.0.16 published
✅ @terreno/ui@0.0.16 published
...
```

The fix uses `printf "%b"` to interpret the `\n` escape sequences as actual newlines before sending to the Zoom webhook.

## Review & Testing Checklist for Human

- [ ] Verify the `printf "%b"` approach is correct for converting escape sequences (it is standard bash)
- [ ] Test by creating a new release tag to confirm the Zoom notification displays properly formatted

### Notes

This change cannot be tested locally since the workflow only triggers on tag pushes. The fix will need to be verified on the next release.

Link to Devin run: https://app.devin.ai/sessions/7d00f9529e2a4499ad574847d963f545
Requested by: Josh Gachnang (@joshgachnang)


___

### **PR Type**
Bug fix


___

### **Description**
- Convert literal `\n` escape sequences to actual newlines in Zoom notifications

- Use `printf "%b"` to properly interpret escape sequences before webhook submission

- Fixes publish-on-tag workflow notification formatting issue


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MESSAGE with literal \n"] -- "printf %b conversion" --> B["MESSAGE with actual newlines"]
  B -- "curl POST" --> C["Zoom Webhook"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publish-on-tag.yml</strong><dd><code>Convert escape sequences to actual newlines</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/publish-on-tag.yml

<ul><li>Added <code>printf "%b"</code> command to convert escape sequences in MESSAGE <br>variable<br> <li> Processes MESSAGE before sending to Zoom webhook via curl<br> <li> Ensures newlines display correctly in Zoom notification instead of <br>literal <code>\n</code> characters</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/161/files#diff-3a2a0ef5b398d8921949de046ae90293fafd7418f7b0de036363e92f78aa5d1a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

