### PR TITLE
Add pull_request_target trigger for Dependabot deployments

### DIFF
--- a/.github/workflows/mcp-server-deploy.yml
+++ b/.github/workflows/mcp-server-deploy.yml
@@ -7,6 +7,12 @@ on:
     paths:
       - "mcp-server/**"
       - ".github/workflows/mcp-server-deploy.yml"
+  pull_request_target:
+    branches:
+      - master
+    paths:
+      - "mcp-server/**"
+      - ".github/workflows/mcp-server-deploy.yml"
   workflow_dispatch:
     inputs:
       environment:
@@ -27,6 +33,8 @@ jobs:
   test:
     name: Test before deploy
     runs-on: ubuntu-latest
+    # Only run for Dependabot PRs when triggered by pull_request_target, or for push/workflow_dispatch
+    if: github.event_name != 'pull_request_target' || github.actor == 'dependabot[bot]'
     defaults:
       run:
         working-directory: mcp-server
@@ -54,6 +62,8 @@ jobs:
     name: Build and Deploy to GCP
     runs-on: ubuntu-latest
     needs: test
+    # Only run for Dependabot PRs when triggered by pull_request_target, or for push/workflow_dispatch
+    if: github.event_name != 'pull_request_target' || github.actor == 'dependabot[bot]'
     defaults:
       run:
         working-directory: mcp-server


### PR DESCRIPTION
### **User description**
## Summary

Enables Dependabot PRs to deploy to GCP by adding a `pull_request_target` trigger to the MCP Server Deploy workflow. This trigger runs in the context of the base branch (master), which has access to secrets that Dependabot PRs cannot access with standard triggers.

Both the `test` and `build-and-deploy` jobs now include a condition that only allows `pull_request_target` events from `dependabot[bot]`, while continuing to allow `push` and `workflow_dispatch` events as before.

## Review & Testing Checklist for Human

- [ ] **Security review**: Verify the `github.actor == 'dependabot[bot]'` check is sufficient to prevent malicious actors from exploiting `pull_request_target`. Non-Dependabot PRs via this trigger will be skipped.
- [ ] **Test with actual Dependabot PR**: Wait for the next Dependabot PR affecting `mcp-server/**` to verify the deployment works correctly with secrets access.

### Notes

This is part of a larger effort to update Deploy Docker workflows across multiple repos (flourish, terreno, zoom-notifier).

Link to Devin run: https://app.devin.ai/sessions/54929c060c2c48d59f4fea3a7212e5ec
Requested by: Josh Gachnang (@joshgachnang)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `pull_request_target` trigger to enable Dependabot PRs to deploy to GCP

- Restrict `pull_request_target` events to only run for Dependabot bot actor

- Maintain existing `push` and `workflow_dispatch` trigger functionality

- Add conditional checks to both `test` and `build-and-deploy` jobs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow Triggers"] -->|push/workflow_dispatch| B["Run all jobs"]
  A -->|pull_request_target| C{"Actor is dependabot[bot]?"}
  C -->|Yes| B
  C -->|No| D["Skip jobs"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mcp-server-deploy.yml</strong><dd><code>Add pull_request_target trigger with Dependabot-only conditions</code></dd></summary>
<hr>

.github/workflows/mcp-server-deploy.yml

<ul><li>Added <code>pull_request_target</code> trigger with branch and path filters <br>matching existing <code>push</code> trigger<br> <li> Added conditional <code>if</code> statement to <code>test</code> job to allow only Dependabot <br>PRs via <code>pull_request_target</code><br> <li> Added conditional <code>if</code> statement to <code>build-and-deploy</code> job with same <br>Dependabot-only restriction<br> <li> Conditions allow all <code>push</code> and <code>workflow_dispatch</code> events while filtering <br><code>pull_request_target</code> by actor</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/162/files#diff-1d3ff650e86009ff59f900b373da394068be15ac488595456098e147577b3a21">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

