### PR TITLE
Update MCP deploy to use Artifact Registry and Workload Identity Federation

### DIFF
--- a/.github/workflows/mcp-server-deploy.yml
+++ b/.github/workflows/mcp-server-deploy.yml
@@ -28,6 +28,7 @@ env:
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   GCP_REGION: us-east1
   GCP_MCP_SERVICE_NAME: terreno-mcp
+  GCP_ARTIFACT_REGISTRY: ${{ secrets.GCP_ARTIFACT_REGISTRY }}
 
 jobs:
   test:
@@ -95,30 +96,31 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 
-      - name: Configure Docker for gcr.io
+      - name: Configure Docker for Artifact Registry
         run: |
-          gcloud auth configure-docker gcr.io --quiet
+          gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev --quiet
 
       - name: Build Docker image locally
         working-directory: .
         run: |
           docker build \
             --file mcp-server/Dockerfile \
-            --tag gcr.io/${{ env.GCP_PROJECT_ID }}/${{ env.GCP_MCP_SERVICE_NAME }}:${{ github.sha }} \
-            --tag gcr.io/${{ env.GCP_PROJECT_ID }}/${{ env.GCP_MCP_SERVICE_NAME }}:latest \
+            --tag ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GCP_ARTIFACT_REGISTRY }}/${{ env.GCP_MCP_SERVICE_NAME }}:${{ github.sha }} \
+            --tag ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GCP_ARTIFACT_REGISTRY }}/${{ env.GCP_MCP_SERVICE_NAME }}:latest \
             .
 
       - name: Push Docker image
         run: |
-          docker push gcr.io/${{ env.GCP_PROJECT_ID }}/${{ env.GCP_MCP_SERVICE_NAME }}:${{ github.sha }}
-          docker push gcr.io/${{ env.GCP_PROJECT_ID }}/${{ env.GCP_MCP_SERVICE_NAME }}:latest
+          docker push ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GCP_ARTIFACT_REGISTRY }}/${{ env.GCP_MCP_SERVICE_NAME }}:${{ github.sha }}
+          docker push ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GCP_ARTIFACT_REGISTRY }}/${{ env.GCP_MCP_SERVICE_NAME }}:latest
 
       - name: Deploy to Cloud Run
         id: deploy
@@ -126,7 +128,7 @@ jobs:
         with:
           service: ${{ env.GCP_MCP_SERVICE_NAME }}
           region: ${{ env.GCP_REGION }}
-          image: gcr.io/${{ env.GCP_PROJECT_ID }}/${{ env.GCP_MCP_SERVICE_NAME }}:${{ github.sha }}
+          image: ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GCP_ARTIFACT_REGISTRY }}/${{ env.GCP_MCP_SERVICE_NAME }}:${{ github.sha }}
           flags: |
             --cpu=1
             --memory=512Mi


### PR DESCRIPTION
### **User description**
## Summary

Updates the MCP server deployment workflow to use Google Artifact Registry instead of Google Container Registry (gcr.io), and switches authentication from service account key (credentials_json) to Workload Identity Federation. This aligns the deployment configuration with the setup documented in the mcp-server README.

Changes:
- Switch container registry from `gcr.io` to `us-east1-docker.pkg.dev` (Artifact Registry)
- Replace `credentials_json` auth with `workload_identity_provider` and `service_account`
- Add `GCP_ARTIFACT_REGISTRY` environment variable for the repository name

## Review & Testing Checklist for Human

- [ ] **Verify GitHub secrets are configured**: This PR requires three new secrets that must be set up before merging: `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`, and `GCP_ARTIFACT_REGISTRY`
- [ ] **Verify Artifact Registry exists**: Ensure the Artifact Registry repository exists in `us-east1` region (the workflow uses `${{ env.GCP_REGION }}-docker.pkg.dev` which resolves to `us-east1-docker.pkg.dev`)
- [ ] **Verify Workload Identity Federation is configured**: The GCP project must have Workload Identity Federation set up for GitHub Actions with appropriate IAM bindings for the service account
- [ ] **Test deployment**: After merging, trigger a manual workflow dispatch or push to mcp-server to verify the deployment succeeds

### Notes

This is an infrastructure change that cannot be validated until the workflow actually runs. The old `GCP_SA_KEY` secret is no longer used by this workflow after this change.

Link to Devin run: https://app.devin.ai/sessions/9cccbafae7704da4994b069826c6e8ca
Requested by: Josh Gachnang (@joshgachnang)


___

### **PR Type**
Enhancement


___

### **Description**
- Switch container registry from GCR to Artifact Registry

- Replace service account key with Workload Identity Federation

- Update Docker authentication and image tag references

- Add GCP_ARTIFACT_REGISTRY environment variable configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GCP Authentication"] -->|"credentials_json"| B["Old: GCR.io"]
  A -->|"WIF + Service Account"| C["New: Artifact Registry"]
  B -->|"gcr.io/project/service"| D["Docker Image Tags"]
  C -->|"region-docker.pkg.dev/project/repo/service"| D
  D --> E["Cloud Run Deployment"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mcp-server-deploy.yml</strong><dd><code>Migrate from GCR to Artifact Registry with WIF auth</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/mcp-server-deploy.yml

<ul><li>Added <code>GCP_ARTIFACT_REGISTRY</code> environment variable from secrets<br> <li> Replaced <code>credentials_json</code> authentication with <br><code>workload_identity_provider</code> and <code>service_account</code><br> <li> Updated Docker authentication to use Artifact Registry endpoint (<code>${{ </code><br><code>env.GCP_REGION }}-docker.pkg.dev</code>)<br> <li> Changed all Docker image tags from <code>gcr.io</code> format to Artifact Registry <br>format with repository path<br> <li> Updated Cloud Run deployment to reference new Artifact Registry image <br>location</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/163/files#diff-1d3ff650e86009ff59f900b373da394068be15ac488595456098e147577b3a21">+10/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

