### PR TITLE
Fix Hyperlink not using key

### DIFF
--- a/ui/src/Hyperlink.tsx
+++ b/ui/src/Hyperlink.tsx
@@ -63,11 +63,7 @@ class HyperlinkComponent extends React.Component<HyperlinkProps> {
     const elements = [];
     let _lastIndex = 0;
 
-    const componentProps = {
-      ...component.props,
-      key: undefined,
-      ref: undefined,
-    };
+    const {key: _key, ref: _ref, ...componentProps} = component.props;
 
     try {
       linkifyIt.match(component.props.children).forEach(({index, lastIndex, text, url}: any) => {
@@ -120,11 +116,7 @@ class HyperlinkComponent extends React.Component<HyperlinkProps> {
     const {props: {children} = {} as any} = component || {};
     if (!children) return component;
 
-    const componentProps = {
-      ...component.props,
-      key: undefined,
-      ref: undefined,
-    };
+    const {key: _key, ref: _ref, ...componentProps} = component.props;
 
     const linkifyIt = this.props.linkify || linkifyLib;
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace manual prop spreading with destructuring to preserve key and ref

- Avoid setting key and ref to undefined in component props

- Simplify prop extraction logic in two methods


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Manual prop spreading<br/>with undefined key/ref"] -- "Refactor to<br/>destructuring" --> B["Destructure key and ref<br/>separately from props"]
  B --> C["Preserve original<br/>component props"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Hyperlink.tsx</strong><dd><code>Refactor prop handling using destructuring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ui/src/Hyperlink.tsx

<ul><li>Replaced manual prop spreading pattern with destructuring assignment <br>in <code>parseText</code> method<br> <li> Replaced manual prop spreading pattern with destructuring assignment <br>in <code>parse</code> method<br> <li> Changed from spreading all props and explicitly setting key/ref to <br>undefined, to destructuring key and ref separately<br> <li> Improves code clarity and ensures key and ref are properly excluded <br>from componentProps</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/167/files#diff-6005876898040267463ec91b4753493bea621fb71cbbc2086b57eb8c42ceec93">+2/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

