### PR TITLE
Add AGENT=1 env var to CI test steps for quieter bun output

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -53,3 +53,4 @@ jobs:
         run: bun run test
         env:
           CI: true
+          AGENT: "1"

--- a/.github/workflows/example-backend-ci.yml
+++ b/.github/workflows/example-backend-ci.yml
@@ -59,4 +59,5 @@ jobs:
         working-directory: example-backend
         env:
           CI: true
+          AGENT: "1"
 

--- a/.github/workflows/example-frontend-ci.yml
+++ b/.github/workflows/example-frontend-ci.yml
@@ -51,4 +51,5 @@ jobs:
         working-directory: example-frontend
         env:
           CI: true
+          AGENT: "1"
 

--- a/.github/workflows/mcp-server-ci.yml
+++ b/.github/workflows/mcp-server-ci.yml
@@ -49,6 +49,7 @@ jobs:
         run: bun run test:ci
         env:
           CI: true
+          AGENT: "1"
 
   docker:
     name: Build Docker Image

--- a/.github/workflows/mcp-server-deploy.yml
+++ b/.github/workflows/mcp-server-deploy.yml
@@ -60,6 +60,7 @@ jobs:
         run: bun run test:ci
         env:
           CI: true
+          AGENT: "1"
 
   build-and-deploy:
     name: Build and Deploy to GCP

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -189,6 +189,8 @@ jobs:
 
       - name: Run tests
         run: bun run test
+        env:
+          AGENT: "1"
 
       - name: Publish to npm
         run: npm publish --access public
@@ -335,6 +337,8 @@ jobs:
 
       - name: Run tests
         run: bun run test:ci
+        env:
+          AGENT: "1"
 
       - name: Publish to npm
         run: npm publish --access public

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -58,6 +58,7 @@ jobs:
         working-directory: ui
         env:
           CI: true
+          AGENT: "1"
 
   demo-typecheck:
     name: Demo TypeScript Check (UI dependency)


### PR DESCRIPTION
## Summary

- Adds `AGENT=1` environment variable to all test steps across CI workflows
- This makes bun test output quieter in CI environments

## Changes

Updated 7 workflow files:
- `api-ci.yml`
- `ui-ci.yml`
- `mcp-server-ci.yml`
- `mcp-server-deploy.yml`
- `example-frontend-ci.yml`
- `example-backend-ci.yml`
- `publish-on-tag.yml` (both API and UI test steps)