### PR TITLE
Fix deploy failures and add CI secret validation

### DIFF
--- a/example-backend/src/instrument.ts
+++ b/example-backend/src/instrument.ts
@@ -101,9 +101,6 @@ Sentry.init({
     // including Express, mongoose, HTTP, etc. MongoDB/Mongoose instrumentation is automatic.
     // nodeProfilingIntegration(),
   ],
-  profilesSampleRate: process.env.SENTRY_PROFILES_SAMPLE_RATE
-    ? Number.parseFloat(process.env.SENTRY_PROFILES_SAMPLE_RATE)
-    : 0.1,
   tracesSampler: (samplingContext) => {
     const transactionName = samplingContext.name.toLowerCase();
     // ignore any transactions that include a match from the ignoreTraces list

--- a/rtk/src/tagGenerator.ts
+++ b/rtk/src/tagGenerator.ts
@@ -47,7 +47,9 @@ export const generateTags = (api: any, tagTypes: string[]): any => {
       if (!endpoint.toLowerCase().includes("byid")) {
         const tag = tagTypes.find((t: string) =>
           // remove "get" from the endpoint name and "ById" from the endpoint name
-          t.toLowerCase().includes(cleanEndpointStringToGenerateTag(endpoint))
+          t
+            .toLowerCase()
+            .includes(cleanEndpointStringToGenerateTag(endpoint))
         );
         if (tag) {
           tags[endpoint] = {providesTags: providesIdTags(tag)};


### PR DESCRIPTION
## Summary

- Removed `profilesSampleRate` from `Sentry.init()` in example-backend — this property doesn't exist in `@sentry/bun`'s `BunOptions` type, causing a TypeScript compilation error
- Fixed a Biome formatting issue in `rtk/src/tagGenerator.ts`
- Added a validation step to the MCP server deploy workflow that fails fast if required GCP secrets (`GCP_PROJECT_ID`, `GCP_ARTIFACT_REGISTRY`, `GCP_SA_KEY`) are missing
- Added a CI/CD rule requiring secret validation in all GitHub Actions workflows that use secrets
- Synced rules to all subpackages via rulesync

## Testing

- All packages compile successfully
- All linting passes
- All tests pass