### PR TITLE
Fix MCP deploy workflow failing on missing working directory

### DIFF
--- a/.github/workflows/mcp-server-deploy.yml
+++ b/.github/workflows/mcp-server-deploy.yml
@@ -74,7 +74,10 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - uses: actions/checkout@v6
+
       - name: Validate required secrets
+        working-directory: .
         run: |
           missing=()
           if [ -z "$GCP_PROJECT_ID" ]; then missing+=("GCP_PROJECT_ID"); fi
@@ -84,8 +87,6 @@ jobs:
             echo "::error::Missing required secrets: ${missing[*]}"
             exit 1
           fi
-
-      - uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
### **User description**
## Summary

- Moved `actions/checkout` before the "Validate required secrets" step in the `build-and-deploy` job of the MCP server deploy workflow
- Added explicit `working-directory: .` to the validation step

## Problem

The `build-and-deploy` job sets `defaults.run.working-directory: mcp-server`, but the secret validation step ran before `actions/checkout`. Since the `mcp-server/` directory only exists after the repo is checked out, the step failed with:

```
Error: An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/terreno/terreno/mcp-server'. No such file or directory
```

## Testing

- Verified the workflow YAML is valid
- All lint, compile, and test checks pass


___

### **PR Type**
Bug fix


___

### **Description**
- Moved `actions/checkout@v6` before secret validation step

- Added explicit `working-directory: .` to validation step

- Fixes "No such file or directory" error in MCP deploy workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Job starts with working-directory: mcp-server"] -->|Before| B["Validate secrets step"]
  B -->|Fails - directory doesn't exist| C["Error: No such file or directory"]
  A -->|After fix| D["Checkout repository"]
  D -->|Then| E["Validate secrets with working-directory: ."]
  E -->|Success| F["Continue deployment steps"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mcp-server-deploy.yml</strong><dd><code>Reorder checkout and add working directory override</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/mcp-server-deploy.yml

<ul><li>Moved <code>actions/checkout@v6</code> step to execute before "Validate required <br>secrets" step<br> <li> Added explicit <code>working-directory: .</code> override to the validation step to <br>use repository root<br> <li> Resolves execution failure caused by job's default <code>working-directory: </code><br><code>mcp-server</code> being unavailable before checkout</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/187/files#diff-1d3ff650e86009ff59f900b373da394068be15ac488595456098e147577b3a21">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

