### PR TITLE
Auto-merge version bump PRs after creation

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -530,6 +530,7 @@ jobs:
           fi
 
       - name: Create Pull Request
+        id: create-pr
         uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore: bump package versions to ${{ needs.check-changes.outputs.version }}"
@@ -546,6 +547,12 @@ jobs:
             ${{ needs.publish-rtk.result == 'success' && '- ✅ @terreno/rtk' || '- ⏭️ @terreno/rtk (no changes)' }}
           assignees: joshgachnang
           reviewers: joshgachnang
+
+      - name: Auto-merge version bump PR
+        if: steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --squash --delete-branch
 
   notify:
     needs: [check-changes, publish-api, publish-ui, publish-rtk]


### PR DESCRIPTION
## Summary

- Adds auto-merge step to the `publish-on-tag` workflow's `create-version-pr` job
- After the version bump PR is created by `peter-evans/create-pull-request`, it is immediately squash-merged and the branch is deleted
- The merge step only runs if a PR was actually created (skips when there are no changes)

## Why

The version bump PRs contain only trivial `package.json` version updates for packages that have already been published to npm. They don't need manual review and just add noise sitting open.

## Changes

- Added `id: create-pr` to the Create Pull Request step to capture its outputs
- Added "Auto-merge version bump PR" step that runs `gh pr merge --squash --delete-branch`

## Test plan

- [ ] Push a version tag and verify the workflow creates and immediately merges the PR
- [ ] Verify the `version-bump-*` branch is cleaned up after merge
- [ ] Verify no PR is merged when there are no version changes