### PR TITLE
docs: Document field description requirement in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,7 @@ router.get("/yourRoute/:id", [
 - All model types live in `src/modelInterfaces.ts`
 - In routes: `req.user` is `UserDocument | undefined`
 - In @terreno/api callbacks: cast with `const user = u as unknown as UserDocument`
+- Every Mongoose schema field must have a `description` property (flows to OpenAPI spec)
 
 ### @terreno/ui
 


### PR DESCRIPTION
### **User description**
## Summary

Adds documentation for the Mongoose field description convention that was introduced in PR #207 to AGENTS.md.

## Changes

- Updates the "API Conventions" section in AGENTS.md to include: "Every Mongoose schema field must have a `description` property (flows to OpenAPI spec)"

## Context

PR #207 added a new rulesync rule (`api/01-model-field-descriptions`) requiring all Mongoose schema fields to include a `description` property. This convention helps generate better API documentation since descriptions flow through to the OpenAPI spec via `mongoose-to-swagger`.

While the rule was properly added to `.rulesync/rules/` and all generated files were updated, the convention was not documented in AGENTS.md, which serves as the main onboarding documentation for developers and AI assistants.

## Testing

- [x] Verified the change aligns with existing API Conventions format
- [x] Confirmed the wording matches the rule in `.rulesync/rules/api/01-model-field-descriptions.md`
- [x] No rulesync regeneration needed (AGENTS.md is not a generated file)

## Checklist

- [x] Documentation updated (AGENTS.md)
- [x] Change is consistent with existing conventions format
- [x] No code changes required


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22040897211)

<!-- gh-aw-workflow-id: update-rules -->


___

### **PR Type**
Documentation


___

### **Description**
- Documents Mongoose field description requirement in AGENTS.md

- Aligns with PR #207 rulesync rule for API conventions

- Clarifies that descriptions flow to OpenAPI spec


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR #207 Rule:<br/>Field descriptions required"] -- "documented in" --> B["AGENTS.md<br/>API Conventions"]
  B -- "flows to" --> C["OpenAPI spec<br/>via mongoose-to-swagger"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Add Mongoose field description convention documentation</code>&nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>Added single line to API Conventions section documenting Mongoose <br>field description requirement<br> <li> Specifies that descriptions flow through to OpenAPI spec via <br>mongoose-to-swagger<br> <li> Maintains consistency with existing convention documentation format</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/209/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

