### PR TITLE
docs: Add field description examples to API documentation

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -37,7 +37,7 @@ Then you can use it in your schemas:
 
 ```typescript
 const eventSchema = new Schema({
-  eventDate: {type: Schema.Types.DateOnly},
+  eventDate: {type: Schema.Types.DateOnly, description: "The date of the event (date only, no time)"},
 });
 ```
 
@@ -46,9 +46,9 @@ const eventSchema = new Schema({
 Assuming we have a model:
 
     const foodSchema = new Schema<Food>({
-      name: String,
-      hidden: {type: Boolean, default: false},
-      ownerId: {type: "ObjectId", ref: "User"},
+      name: {type: String, description: "The name of the food item"},
+      hidden: {type: Boolean, default: false, description: "Whether the food is hidden from listings"},
+      ownerId: {type: "ObjectId", ref: "User", description: "The user who owns this food item"},
     });
     export const FoodModel = model("Food", foodSchema);
 
@@ -98,6 +98,17 @@ Now we can perform operations on the Food model in a standard REST way. We've al
     DELETE /foods/62c86d787c7e2db0bf286acd
 
 You can create your own permissions functions. Check permissions.ts for some examples of how to write them.
+
+## Model Conventions
+
+When defining Mongoose schemas, **always include a `description` field** for every property. These descriptions flow through to the OpenAPI specification via `mongoose-to-swagger`, making your generated API documentation more helpful.
+
+```typescript
+const schema = new Schema({
+  name: {type: String, required: true, description: "User's display name"},
+  email: {type: String, unique: true, description: "User's email address"},
+});
+```
 
 ## Sentry
 To enable Sentry, create a "src/sentryInstrumment.ts" file in your project.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -8,4 +8,12 @@ REST API framework built on Express and Mongoose. Provides modelRouter (CRUD end
 - `APIError`, `logger`, `asyncHandler`, `authenticateMiddleware`
 - `createOpenApiBuilder`
 
+## Conventions
+
+- Every Mongoose schema field must include a `description` property (flows to OpenAPI spec)
+- Use `Model.findExactlyOne` or `Model.findOneOrThrow` instead of `Model.findOne`
+- Define methods/statics by direct assignment: `schema.methods = {...}`
+
+## Documentation
+
 See the [api package source](../../api/src/) and [.cursor/rules/api/](../../.cursor/rules/api/) for detailed usage and conventions.


### PR DESCRIPTION
## Summary

Adds field `description` examples to API package documentation to align with the Mongoose field description convention introduced in PR #207 and documented in AGENTS.md via PR #209.

## Changes

### api/README.md
- Updated schema examples to include `description` fields on all properties
- Added new **Model Conventions** section explaining the description requirement
- Clarified that descriptions flow through to OpenAPI spec via `mongoose-to-swagger`

### docs/reference/api.md
- Added **Conventions** section listing key API package conventions
- Includes field description requirement and other important patterns
- Maintains Diátaxis reference documentation structure

## Context

While PR #209 successfully documented the field description convention in AGENTS.md (developer/AI assistant documentation), the user-facing documentation in `api/README.md` still showed schema examples **without** descriptions. This created inconsistency between:

- ✅ Internal docs (AGENTS.md, .rulesync rules, IDE rules)
- ❌ Public docs (api/README.md, docs/reference/)

This PR closes that gap by ensuring all code examples and documentation follow the established convention.

## Testing

- [x] Verified all schema examples now include descriptions
- [x] Confirmed changes align with rulesync rule format
- [x] Checked that no other schema examples exist in documentation
- [x] Validated documentation structure follows Diátaxis principles

## Checklist

- [x] All code examples updated with descriptions
- [x] New Model Conventions section added
- [x] Reference documentation enhanced
- [x] No code changes required
- [x] Documentation is consistent with AGENTS.md conventions


> AI generated by [Update Docs](https://github.com/FlourishHealth/terreno/actions/runs/22045908858)

<!-- gh-aw-workflow-id: update-docs -->