### PR TITLE
docs: Add field description convention to root rules

### DIFF
--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -198,6 +198,7 @@ router.get("/yourRoute/:id", [
 - All model types live in `src/modelInterfaces.ts`
 - In routes: `req.user` is `UserDocument | undefined`
 - In @terreno/api callbacks: cast with `const user = u as unknown as UserDocument`
+- Every Mongoose schema field must have a `description` property (flows to OpenAPI spec)
 
 ### @terreno/ui
 


### PR DESCRIPTION
## Summary

Adds the Mongoose field description requirement to the API Conventions section in `.rulesync/rules/00-root.md` to ensure consistency across all agent documentation.

## Changes

- Updates `.rulesync/rules/00-root.md` to include: "Every Mongoose schema field must have a `description` property (flows to OpenAPI spec)"

## Context

PR #209 successfully added this convention to `AGENTS.md`, which serves as the main onboarding documentation. However, the convention was not present in the root rules file (`.rulesync/rules/00-root.md`), causing a gap:

- ✅ **AGENTS.md** (line 194) - Has the convention
- ✅ **`.rulesync/rules/api/01-model-field-descriptions.md`** - Specialized rule exists  
- ❌ **`.rulesync/rules/00-root.md`** - Missing from API Conventions section
- ❌ **`.github/copilot-instructions.md`** - Missing (generated from root rules)

Since `.rulesync/rules/00-root.md` generates the Copilot instructions and serves as comprehensive guidance for Cursor/Windsurf, it should include this convention in its API Conventions section alongside other Mongoose/API patterns.

## Required Action

**Reviewers must run `bun run rules` locally and commit the regenerated files** to update:
- `.github/copilot-instructions.md`
- `.cursor/rules/00-root.mdc`
- `.windsurf/rules/00-root.mdc`
- Other generated rule files

This ensures the `rulesync-check` CI workflow passes.

## Testing

- [x] Verified the change aligns with existing API Conventions format in 00-root.md
- [x] Confirmed wording matches AGENTS.md (line 194) exactly
- [x] Change is additive (one line) with no other modifications
- [ ] Run `bun run rules` to regenerate files (to be done by reviewer)
- [ ] Verify `.github/copilot-instructions.md` includes the new convention

## Checklist

- [x] Source rule file updated (`.rulesync/rules/00-root.md`)
- [x] Change maintains consistency with AGENTS.md
- [x] No code changes required
- [x] Commit message follows conventional commits format

## Diagram

``````mermaid
flowchart TB
    A["PR #207:<br/>api/01-model-field-descriptions.md"] --> B["PR #209:<br/>AGENTS.md updated"]
    B --> C["This PR:<br/>00-root.md updated"]
    C -->|bun run rules| D[".github/copilot-instructions.md<br/>updated"]
    C -->|bun run rules| E[".cursor/rules/00-root.mdc<br/>updated"]
    C -->|bun run rules| F[".windsurf/rules/00-root.mdc<br/>updated"]
    
    style A fill:#d4edda
    style B fill:#d4edda
    style C fill:#fff3cd
    style D fill:#f8d7da
    style E fill:#f8d7da
    style F fill:#f8d7da
``````

> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22045908881)


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22045908881)

<!-- gh-aw-workflow-id: update-rules -->