### PR TITLE
docs: Add mcp-server to package list and highlight Authentication feature

### DIFF
--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -17,6 +17,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
 - **example-backend/** - Example Express backend using @terreno/api
+- **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 
 ## Development
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
 - **example-backend/** - Example Express backend using @terreno/api
+- **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 
 ## Development
 
@@ -125,6 +126,7 @@ bun run frontend:web
 REST API framework providing:
 
 - **modelRouter**: Auto-generates CRUD endpoints for Mongoose models
+- **Authentication**: JWT + GitHub OAuth with multiple strategies
 - **Permissions**: `IsAuthenticated`, `IsOwner`, `IsAdmin`, `IsAuthenticatedOrReadOnly`
 - **Query Filters**: `OwnerQueryFilter` for filtering list queries by owner
 - **setupServer**: Express server setup with auth, OpenAPI, and middleware
@@ -142,6 +144,7 @@ import {
   logger,
   asyncHandler,
   authenticateMiddleware,
+  githubUserPlugin,
 } from "@terreno/api";
 ```
 


### PR DESCRIPTION
## Summary

Updates package overview documentation to include the missing `mcp-server` package and make the Authentication feature more prominent in `@terreno/api`.

## Changes Made

### 1. Added `mcp-server` to Package Lists

**Files updated:**
- `.rulesync/rules/00-root.md` - Added mcp-server to packages section
- `AGENTS.md` - Added mcp-server to packages section

The `mcp-server` package has existed in the monorepo with:
- Full rule documentation at `.rulesync/rules/mcp-server/00-mcp-server.md`
- Package scripts: `mcp:build`, `mcp:dev`, `mcp:lint`, `mcp:start`
- Entry in `rulesync.jsonc` baseDirs
- Listed in root `package.json` workspaces

But it was **not listed** in the high-level package overviews, meaning AI assistants wouldn't know about this package.

### 2. Highlighted Authentication Feature

**Updated `AGENTS.md`:**
- Added "**Authentication**: JWT + GitHub OAuth with multiple strategies" to `@terreno/api` feature list
- Added `githubUserPlugin` to key imports example

While authentication is extensively documented in the detailed rules, it wasn't explicitly listed as a top-level feature in AGENTS.md. This change makes it more discoverable.

## Generated Files - Action Required ⚠️

**Reviewers must run the following command locally and commit the regenerated files:**

``````bash
bun run rules
``````

This will regenerate all target-specific rule files:
- `.cursor/rules/00-root.mdc`
- `.windsurf/rules/00-root.md`
- `.claude/rules/00-root.md`
- `.github/instructions/00-root.instructions.md`

Without this step, the `rulesync-check` CI workflow will fail.

## Why This Matters

- **Completeness**: All packages should be documented in overview sections
- **Discoverability**: Major features like authentication deserve explicit mention
- **Consistency**: AGENTS.md and rules should stay synchronized with the codebase
- **AI Context**: AI assistants rely on these overviews to understand available packages and features

## Verification

✅ mcp-server package exists and has rule documentation  
✅ mcp-server listed in workspaces and baseDirs  
✅ Authentication feature is well-documented in api rules  
✅ Source files in `.rulesync/rules/` updated  
⚠️ Generated files need regeneration (run `bun run rules`)

## Related

- Follows pattern from PR #217 (GitHub OAuth and UI type re-exports documentation)
- Complements existing mcp-server rule file at `.rulesync/rules/mcp-server/00-mcp-server.md`


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22068298433)

<!-- gh-aw-workflow-id: update-rules -->