### PR TITLE
Add Terraform config for GCS + CDN hosting

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,5 @@
+*.tfstate
+*.tfstate.backup
+.terraform/
+.terraform.lock.hcl
+terraform.tfvars

--- a/terraform/hosting.tf
+++ b/terraform/hosting.tf
@@ -1,0 +1,75 @@
+# GCS buckets for static site hosting
+resource "google_storage_bucket" "site" {
+  for_each = var.apps
+
+  name                        = each.value.bucket_name
+  location                    = var.region
+  force_destroy               = false
+  uniform_bucket_level_access = true
+
+  website {
+    not_found_page = "index.html"
+    # MainPageSuffix intentionally omitted to avoid GCS 301 redirects
+    # that break client-side SPA routing (e.g. /demo/ -> /demo/index.html)
+  }
+}
+
+# Public read access
+resource "google_storage_bucket_iam_member" "public_read" {
+  for_each = var.apps
+
+  bucket = google_storage_bucket.site[each.key].name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
+# CI/CD service account write access
+resource "google_storage_bucket_iam_member" "ci_write" {
+  for_each = var.apps
+
+  bucket = google_storage_bucket.site[each.key].name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${var.service_account_email}"
+}
+
+# CDN backend buckets
+resource "google_compute_backend_bucket" "cdn" {
+  for_each = var.apps
+
+  name        = each.value.backend_bucket_name
+  bucket_name = google_storage_bucket.site[each.key].name
+  enable_cdn  = true
+}
+
+# URL maps
+resource "google_compute_url_map" "site" {
+  for_each = var.apps
+
+  name            = "terreno-${each.key}-url-map"
+  default_service = google_compute_backend_bucket.cdn[each.key].id
+}
+
+# Static IPs
+resource "google_compute_global_address" "site" {
+  for_each = var.apps
+
+  name = "terreno-${each.key}-ip"
+}
+
+# HTTP proxies
+resource "google_compute_target_http_proxy" "site" {
+  for_each = var.apps
+
+  name    = "terreno-${each.key}-http-proxy"
+  url_map = google_compute_url_map.site[each.key].id
+}
+
+# Forwarding rules (HTTP)
+resource "google_compute_global_forwarding_rule" "site" {
+  for_each = var.apps
+
+  name       = "terreno-${each.key}-forwarding-rule"
+  target     = google_compute_target_http_proxy.site[each.key].id
+  ip_address = google_compute_global_address.site[each.key].address
+  port_range = "80"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "flourish-terreno-terraform-state"
+    prefix = "gcs-hosting"
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,13 @@
+output "bucket_urls" {
+  description = "GCS bucket URLs"
+  value = {
+    for key, app in var.apps : key => "gs://${google_storage_bucket.site[key].name}"
+  }
+}
+
+output "cdn_ips" {
+  description = "CDN IP addresses"
+  value = {
+    for key, app in var.apps : key => google_compute_global_address.site[key].address
+  }
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,3 @@
+project_id            = "flourish-terreno"
+region                = "us-east1"
+service_account_email = "your-sa@flourish-terreno.iam.gserviceaccount.com"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+  default     = "flourish-terreno"
+}
+
+variable "region" {
+  description = "GCP region for storage buckets"
+  type        = string
+  default     = "us-east1"
+}
+
+variable "service_account_email" {
+  description = "Service account email for CI/CD bucket access"
+  type        = string
+}
+
+variable "apps" {
+  description = "Map of app configs for GCS + CDN hosting"
+  type = map(object({
+    bucket_name          = string
+    backend_bucket_name  = string
+  }))
+  default = {
+    demo = {
+      bucket_name         = "flourish-terreno-terreno-demo"
+      backend_bucket_name = "terreno-demo-backend"
+    }
+    frontend-example = {
+      bucket_name         = "flourish-terreno-terreno-frontend-example"
+      backend_bucket_name = "terreno-frontend-example-backend"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `terraform/` directory with declarative infrastructure config for the GCS + CDN static site hosting
- Replaces the imperative `scripts/setup-gcs-hosting.sh` with Terraform resources
- Uses `for_each` over an apps map so adding a new hosted app is a single variable entry

## Resources managed

| Resource | Purpose |
|---|---|
| `google_storage_bucket` | GCS buckets for static files |
| `google_storage_bucket_iam_member` | Public read + CI/CD write access |
| `google_compute_backend_bucket` | CDN-enabled backend buckets |
| `google_compute_url_map` | URL routing |
| `google_compute_global_address` | Static IPs |
| `google_compute_target_http_proxy` | HTTP proxies |
| `google_compute_global_forwarding_rule` | Forwarding rules (port 80) |

## Usage

```bash
cd terraform
cp terraform.tfvars.example terraform.tfvars
# Edit terraform.tfvars with your service account email
terraform init
terraform plan
terraform apply
```

## Notes

- State stored in `gs://flourish-terreno-terraform-state/gcs-hosting` (bucket must be created manually first)
- `terraform.tfvars` is gitignored to avoid committing secrets
- HTTPS setup (managed SSL certs) can be added later as additional resources