### PR TITLE
docs: add mcp-server package to rules and AGENTS.md

### DIFF
--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -14,6 +14,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **api/** - REST API framework built on Express/Mongoose (`@terreno/api`)
 - **ui/** - React Native UI component library (`@terreno/ui`)
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
+- **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
 - **example-backend/** - Example Express backend using @terreno/api
@@ -38,6 +39,8 @@ bun run ui:test          # Test UI package
 bun run demo:start       # Start demo app
 bun run frontend:web     # Start frontend example
 bun run backend:dev      # Start backend example
+bun run mcp:dev          # Start MCP server in dev mode
+bun run mcp:build        # Build MCP server
 ```
 
 ## How the Packages Work Together

--- a/.rulesync/rules/01-claudecode-root.md
+++ b/.rulesync/rules/01-claudecode-root.md
@@ -14,6 +14,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **api/** - REST API framework built on Express/Mongoose (`@terreno/api`)
 - **ui/** - React Native UI component library (`@terreno/ui`)
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
+- **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
 - **example-backend/** - Example Express backend using @terreno/api
@@ -38,6 +39,8 @@ bun run ui:test          # Test UI package
 bun run demo:start       # Start demo app
 bun run frontend:web     # Start frontend example
 bun run backend:dev      # Start backend example
+bun run mcp:dev          # Start MCP server in dev mode
+bun run mcp:build        # Build MCP server
 ```
 
 ## How the Packages Work Together

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **api/** - REST API framework built on Express/Mongoose (`@terreno/api`)
 - **ui/** - React Native UI component library (`@terreno/ui`)
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
+- **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
 - **example-backend/** - Example Express backend using @terreno/api
@@ -31,6 +32,8 @@ bun run ui:test          # Test UI package
 bun run demo:start       # Start demo app
 bun run frontend:web     # Start frontend example
 bun run backend:dev      # Start backend example
+bun run mcp:dev          # Start MCP server in dev mode
+bun run mcp:build        # Build MCP server
 ```
 
 ## How the Packages Work Together


### PR DESCRIPTION
## Summary

Updates rule documentation and AGENTS.md to include the **mcp-server** package, which was previously undocumented despite being a fully integrated workspace package.

## Changes

- ✅ Add mcp-server to Packages section in `.rulesync/rules/00-root.md`
- ✅ Add mcp-server to Packages section in `.rulesync/rules/01-claudecode-root.md` 
- ✅ Add mcp-server to Packages section in `AGENTS.md`
- ✅ Add `mcp:dev` and `mcp:build` commands to package-specific commands in all three files

## Why This Matters

The mcp-server package:
- Is listed in `rulesync.jsonc` baseDirs
- Has its own rule file at `.rulesync/rules/mcp-server/00-mcp-server.md`
- Has scripts in root `package.json` (`mcp:build`, `mcp:dev`, `mcp:lint`, `mcp:start`)
- Is a workspace package in root `package.json`

But was **not documented** in the main onboarding files (AGENTS.md and root rules), creating a gap between the code structure and agent documentation.

## Post-Merge Actions

After merging, reviewers should:

1. Run `bun run rules` to regenerate `.cursorrules`, `.github/copilot-instructions.md`, and other generated files
2. Commit the regenerated files
3. Verify the `rulesync-check` workflow passes in CI

## Validation

- [x] Changes made only to source rule files (`.rulesync/rules/`) and `AGENTS.md`
- [x] Package list now matches actual workspace structure
- [x] Commands documented match those in root `package.json`
- [x] Consistent across all root rule files (00-root.md, 01-claudecode-root.md)


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22103004594)

<!-- gh-aw-workflow-id: update-rules -->