### PR TITLE
docs: Update rules with dependency management documentation

### DIFF
--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -334,4 +334,40 @@ GitHub Actions workflows that use secrets or environment variables must validate
 
 ## Dependency Management
 
-Uses [Bun Catalogs](https://bun.sh/docs/install/catalogs) - shared versions defined in root `package.json` under `catalog`. Reference with `catalog:` in workspace packages.
+### Bun Catalogs
+
+Uses [Bun Catalogs](https://bun.sh/docs/install/catalogs) for version consistency across the monorepo. Shared dependency versions are defined in the root `package.json` under the `catalog` field. Workspace packages reference catalog versions with the `catalog:` prefix.
+
+**Benefits:**
+- Single source of truth for shared dependency versions
+- Consistent versions across all packages
+- Easier updates — change once, apply everywhere
+
+### Dependabot & Auto-Merge
+
+Dependabot monitors dependencies with different update schedules and grouping strategies:
+
+| Group | Packages | Schedule | Strategy |
+|-------|----------|----------|----------|
+| GitHub Actions | Workflow dependencies | Weekly | Individual PRs |
+| Root | Catalog & dev tools | Monthly | Grouped PR |
+| Backend | api, example-backend, mcp-server | Monthly | Grouped PR |
+| Frontend | ui, rtk, demo, example-frontend | Monthly | Grouped PR |
+
+**7-Day Cooldown:** Dependabot waits 7 days after a package version is published before creating a PR (except security updates which bypass the cooldown). This protects against compromised NPM packages, which are typically detected and removed within 24 hours.
+
+**Auto-Merge Workflow:** The `dependabot-auto-merge.yml` workflow automatically approves and merges Dependabot PRs once all CI checks pass. PRs only merge after all required status checks pass, ensuring safety through comprehensive testing.
+
+### Best Practices
+
+**Update the catalog when:**
+- Multiple packages need the same dependency update
+- Major version updates require coordinated changes
+- New shared dependencies are introduced
+
+**Update individual packages when:**
+- Package-specific dependencies (not in catalog)
+- Testing new versions before promoting to catalog
+- Overriding catalog versions for specific use cases (rare)
+
+For detailed information, see [Dependency Management Documentation](../docs/explanation/dependency-management.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,4 +327,40 @@ GitHub Actions workflows that use secrets or environment variables must validate
 
 ## Dependency Management
 
-Uses [Bun Catalogs](https://bun.sh/docs/install/catalogs) - shared versions defined in root `package.json` under `catalog`. Reference with `catalog:` in workspace packages.
+### Bun Catalogs
+
+Uses [Bun Catalogs](https://bun.sh/docs/install/catalogs) for version consistency across the monorepo. Shared dependency versions are defined in the root `package.json` under the `catalog` field. Workspace packages reference catalog versions with the `catalog:` prefix.
+
+**Benefits:**
+- Single source of truth for shared dependency versions
+- Consistent versions across all packages
+- Easier updates — change once, apply everywhere
+
+### Dependabot & Auto-Merge
+
+Dependabot monitors dependencies with different update schedules and grouping strategies:
+
+| Group | Packages | Schedule | Strategy |
+|-------|----------|----------|----------|
+| GitHub Actions | Workflow dependencies | Weekly | Individual PRs |
+| Root | Catalog & dev tools | Monthly | Grouped PR |
+| Backend | api, example-backend, mcp-server | Monthly | Grouped PR |
+| Frontend | ui, rtk, demo, example-frontend | Monthly | Grouped PR |
+
+**7-Day Cooldown:** Dependabot waits 7 days after a package version is published before creating a PR (except security updates which bypass the cooldown). This protects against compromised NPM packages, which are typically detected and removed within 24 hours.
+
+**Auto-Merge Workflow:** The `dependabot-auto-merge.yml` workflow automatically approves and merges Dependabot PRs once all CI checks pass. PRs only merge after all required status checks pass, ensuring safety through comprehensive testing.
+
+### Best Practices
+
+**Update the catalog when:**
+- Multiple packages need the same dependency update
+- Major version updates require coordinated changes
+- New shared dependencies are introduced
+
+**Update individual packages when:**
+- Package-specific dependencies (not in catalog)
+- Testing new versions before promoting to catalog
+- Overriding catalog versions for specific use cases (rare)
+
+For detailed information, see [Dependency Management Documentation](../docs/explanation/dependency-management.md).


### PR DESCRIPTION
## Summary

Updates `.rulesync/rules/00-root.md` and `AGENTS.md` to include comprehensive dependency management documentation, aligning agent knowledge with the new documentation added in PR #233.

## What Changed

### Dependency Management Section Expanded

The minimal "Dependency Management" section (previously just one line about Bun Catalogs) now includes:

1. **Bun Catalogs** — Detailed explanation with benefits
2. **Dependabot & Auto-Merge** — Configuration, update groups, and workflow behavior
3. **7-Day Cooldown** — Security feature explanation and rationale
4. **Best Practices** — When to update catalog vs individual packages
5. **Reference** — Link to detailed documentation in `docs/explanation/dependency-management.md`

### Files Modified

- `.rulesync/rules/00-root.md` — Source rules for AI assistants
- `AGENTS.md` — Agent onboarding documentation

## Why This Matters

AI assistants working on the Terreno repository need to understand:
- How dependencies are managed (Bun Catalogs)
- Why Dependabot PRs may take 7 days to appear (security cooldown)
- Why some PRs auto-merge (CI-validated safety)
- When to update the catalog vs individual packages

This aligns agent context with the comprehensive documentation in PR #233.

## Follow-Up Actions Required

**Important:** After merging, run `bun run rules` to regenerate the following files:
- `.cursor/rules/00-root.mdc`
- `.claude/rules/00-root.md`
- `.windsurf/rules/00-root.md`
- `.github/copilot-instructions.md`

The `rulesync-check` workflow will verify these files are up-to-date on the PR.

## Testing

- [x] Changes align with `docs/explanation/dependency-management.md` content
- [x] Markdown syntax validated
- [x] Cross-references verified
- [x] Kept AGENTS.md in sync with rules

## Related

- Follows up on PR #233 (Add dependency management documentation)
- Addresses rules synchronization requirement from memory store


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22113315628)

<!-- gh-aw-workflow-id: update-rules -->