### PR TITLE
docs: Add mcp-server to README packages section

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ A monorepo containing shared packages for building full-stack applications.
 - **ui/** - React Native UI component library (published as `@terreno/ui`)
 - **rtk/** - Redux Toolkit Query utilities for @terreno/api backends (published as `@terreno/rtk`)
 
-### Example/Demo Apps (not published)
+### Deployed Services
+
+- **mcp-server/** - MCP (Model Context Protocol) server for AI coding assistants (deployed to `mcp.terreno.flourish.health`)
+
+### Example/Demo Apps
 
 - **example-backend/** - Example backend application using `@terreno/api`
 - **example-frontend/** - Example frontend application using `@terreno/ui` and `@terreno/rtk`


### PR DESCRIPTION
## Summary

Adds the `mcp-server` package to the root README.md packages section, ensuring consistency with the documentation in `docs/README.md`.

## Changes Made

- Added new "Deployed Services" section to distinguish `mcp-server` from npm-published packages
- Documents that `mcp-server` is deployed to `mcp.terreno.flourish.health`
- Clarifies the distinction between published packages (api, ui, rtk) and deployed services (mcp-server)

## Why This Change

The recent PR #223 updated AI assistant rules to include mcp-server, but the root README.md was missing this package entirely. The `docs/README.md` already lists mcp-server, creating an inconsistency.

This update ensures that:
1. Users browsing the repository understand the complete package ecosystem
2. The README accurately reflects all packages in the monorepo
3. The distinction between npm packages and deployed services is clear

## Related

- Follows up on PR #223 which updated AI rules for mcp-server
- Complements existing documentation in `docs/reference/mcp-server.md`


> AI generated by [Update Docs](https://github.com/FlourishHealth/terreno/actions/runs/22114310051)

<!-- gh-aw-workflow-id: update-docs -->