### PR TITLE
Add missing scripts to rules documentation

### DIFF
--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -29,18 +29,53 @@ bun run compile          # Compile all packages
 bun run lint             # Lint all packages
 bun run lint:fix         # Fix lint issues
 bun run test             # Run tests in api and ui
+bun run rules            # Generate rules from .rulesync/rules/ sources
+bun run rules:check      # Verify rules are in sync (CI check)
 ```
 
 ### Package-specific commands
 
 ```bash
-bun run api:test         # Test API package
-bun run ui:test          # Test UI package
-bun run demo:start       # Start demo app
-bun run frontend:web     # Start frontend example
-bun run backend:dev      # Start backend example
-bun run mcp:build        # Build MCP server
-bun run mcp:start        # Start MCP server
+# API package
+bun run api:compile      # Compile TypeScript
+bun run api:lint         # Lint code
+bun run api:test         # Run tests
+
+# UI package
+bun run ui:compile       # Compile TypeScript
+bun run ui:dev           # Watch mode
+bun run ui:lint          # Lint code
+bun run ui:test          # Run tests
+
+# RTK package
+bun run rtk:compile      # Compile TypeScript
+bun run rtk:dev          # Watch mode
+bun run rtk:lint         # Lint code
+bun run rtk:test         # Run tests
+
+# Demo app
+bun run demo:start       # Start Expo dev server (port 8085)
+bun run demo:web         # Start web version
+bun run demo:ios         # Start iOS simulator
+bun run demo:android     # Start Android emulator
+bun run demo:compile     # Type check
+bun run demo:lint        # Lint code
+
+# Example frontend
+bun run frontend:web     # Start web version
+bun run frontend:ios     # Start iOS simulator
+bun run frontend:android # Start Android emulator
+bun run frontend:lint    # Lint code
+
+# Example backend
+bun run backend:dev      # Start dev server with watch (port 4000)
+bun run backend:lint     # Lint code
+
+# MCP server
+bun run mcp:build        # Build the server
+bun run mcp:dev          # Development mode
+bun run mcp:start        # Start the server
+bun run mcp:lint         # Lint code
 ```
 
 ## How the Packages Work Together


### PR DESCRIPTION
## Summary

Updates `.rulesync/rules/00-root.md` to document all available npm/bun scripts that were previously missing from the agent documentation.

## Changes

### Added Documentation for Missing Scripts

**Root-level:**
- `bun run rules` - Generate rules from `.rulesync/rules/` sources
- `bun run rules:check` - Verify rules are in sync (used by CI)

**Package-specific development commands:**
- API: `api:compile`, `api:lint`
- UI: `ui:compile`, `ui:dev`, `ui:lint`
- RTK: `rtk:compile`, `rtk:dev`, `rtk:lint`, `rtk:test`
- Demo: `demo:web`, `demo:ios`, `demo:android`, `demo:compile`, `demo:lint`
- Frontend: `frontend:ios`, `frontend:android`, `frontend:lint`
- Backend: `backend:lint`
- MCP: `mcp:dev`, `mcp:lint`

## Why This Matters

The `rules` and `rules:check` scripts are critical for the rulesync workflow but were completely undocumented. Package-specific development commands help developers and AI assistants understand the full set of available tooling.

## Next Steps

**⚠️ Action Required:**

After merging this PR, reviewers or maintainers should:

1. Run `bun run rules` locally to regenerate:
   - `AGENTS.md`
   - `.cursor/rules/`
   - `.windsurf/rules/`
   - `.github/copilot-instructions.md`
   - `CLAUDE.md`

2. Commit the regenerated files

3. Verify `bun run rules:check` passes (no git diff)

This ensures the rulesync-check CI workflow will pass.

## Verification

- [x] Updated source rules in `.rulesync/rules/00-root.md`
- [x] Changes organized by package for clarity
- [x] All scripts from `package.json` now documented
- [ ] Regenerated outputs (to be done by reviewer after merge)


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22117622042)

<!-- gh-aw-workflow-id: update-rules -->