### PR TITLE
Fix CDN 404 errors during deploy by reordering asset upload steps

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -75,20 +75,30 @@ jobs:
 
       - name: Deploy to GCS
         run: |
-          # Sync all non-HTML files with long cache (excludes previews dir and HTML)
+          # Step 1: Upload new hashed assets (additive, no deletions).
+          # Using rsync WITHOUT -d so old bundles remain while the previous
+          # index.html still references them.
           gsutil -m -h "Cache-Control:public, max-age=31536000, immutable" \
-            rsync -r -d -x '_previews/.*|.*\.html$' \
+            rsync -r -x '_previews/.*|.*\.html$' \
             dist/ "gs://$BUCKET/"
 
-          # Upload root index.html with no-cache
-          # CDN's notFoundPage config handles SPA routing (404 → index.html)
+          # Step 2: Upload index.html with no-cache so browsers always fetch
+          # the latest. This atomically switches users to the new bundle hashes.
           gsutil -h "Cache-Control:no-cache, no-store, must-revalidate" \
             cp dist/index.html "gs://$BUCKET/index.html"
 
-      - name: Invalidate CDN cache
-        run: |
+          # Step 3: Invalidate CDN cache synchronously so stale index.html
+          # (referencing old hashes) is purged before we clean up old assets.
           gcloud compute url-maps invalidate-cdn-cache terreno-demo-url-map \
-            --path "/*" --async
+            --path "/index.html"
+          gcloud compute url-maps invalidate-cdn-cache terreno-demo-url-map \
+            --path "/"
+
+          # Step 4: Clean up old assets that are no longer referenced.
+          # Now safe because all CDN edges serve the new index.html.
+          gsutil -m -h "Cache-Control:public, max-age=31536000, immutable" \
+            rsync -r -d -x '_previews/.*|.*\.html$' \
+            dist/ "gs://$BUCKET/"
 
       - name: Output deploy info
         run: echo "Demo deployed to gs://$BUCKET"

--- a/.github/workflows/frontend-example-deploy.yml
+++ b/.github/workflows/frontend-example-deploy.yml
@@ -82,20 +82,30 @@ jobs:
 
       - name: Deploy to GCS
         run: |
-          # Sync all non-HTML files with long cache (excludes previews dir and HTML)
+          # Step 1: Upload new hashed assets (additive, no deletions).
+          # Using rsync WITHOUT -d so old bundles remain while the previous
+          # index.html still references them.
           gsutil -m -h "Cache-Control:public, max-age=31536000, immutable" \
-            rsync -r -d -x '_previews/.*|.*\.html$' \
+            rsync -r -x '_previews/.*|.*\.html$' \
             dist/ "gs://$BUCKET/"
 
-          # Upload root index.html with no-cache
-          # CDN's notFoundPage config handles SPA routing (404 → index.html)
+          # Step 2: Upload index.html with no-cache so browsers always fetch
+          # the latest. This atomically switches users to the new bundle hashes.
           gsutil -h "Cache-Control:no-cache, no-store, must-revalidate" \
             cp dist/index.html "gs://$BUCKET/index.html"
 
-      - name: Invalidate CDN cache
-        run: |
+          # Step 3: Invalidate CDN cache synchronously so stale index.html
+          # (referencing old hashes) is purged before we clean up old assets.
           gcloud compute url-maps invalidate-cdn-cache terreno-frontend-example-url-map \
-            --path "/*" --async
+            --path "/index.html"
+          gcloud compute url-maps invalidate-cdn-cache terreno-frontend-example-url-map \
+            --path "/"
+
+          # Step 4: Clean up old assets that are no longer referenced.
+          # Now safe because all CDN edges serve the new index.html.
+          gsutil -m -h "Cache-Control:public, max-age=31536000, immutable" \
+            rsync -r -d -x '_previews/.*|.*\.html$' \
+            dist/ "gs://$BUCKET/"
 
       - name: Output deploy info
         run: echo "Example Frontend deployed to gs://$BUCKET"


### PR DESCRIPTION
### **User description**
## Summary

- Fixes 404 errors for static JS bundles (`_expo/static/js/web/...`) when deploying to GCP CDN
- The root cause was `gsutil rsync -d` deleting old hashed bundles before the new `index.html` was uploaded, creating a window where the CDN serves an `index.html` referencing deleted assets
- Applied the fix to both `demo-deploy.yml` and `frontend-example-deploy.yml`

## What changed

The deploy step now follows a safe 4-step sequence:

1. **Upload new assets** (rsync without `-d`) — additive only, old bundles remain
2. **Upload new `index.html`** — atomically switches users to new bundle hashes
3. **Invalidate CDN cache synchronously** — purge stale `index.html` from edges (targeted invalidation of `/index.html` and `/` instead of `/*`)
4. **Clean up old assets** (rsync with `-d`) — now safe to delete since all edges serve the new `index.html`

## Testing

- Workflow YAML syntax verified
- The logic follows the standard zero-downtime static deploy pattern used by Vercel, Netlify, etc.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes CDN 404 errors by reordering asset upload steps to prevent serving stale index.html referencing deleted bundles

- Removes `-d` flag from initial rsync to keep old assets until new index.html is uploaded

- Adds synchronous CDN cache invalidation for `/index.html` and `/` instead of `/*`

- Defers asset cleanup to final step after CDN cache is purged


___



### File Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>demo-deploy.yml</strong><dd><code>Reorder asset upload steps to prevent 404 errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/demo-deploy.yml

<ul><li>Restructured deploy into 4-step sequence: upload assets, upload <br>index.html, invalidate cache, cleanup old assets<br> <li> Removed <code>-d</code> flag from first rsync to prevent premature deletion of old <br>bundles<br> <li> Changed CDN invalidation from async <code>--path "/*"</code> to synchronous <br>targeted paths <code>/index.html</code> and <code>/</code><br> <li> Added final rsync with <code>-d</code> flag to safely clean up old assets after <br>cache invalidation</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/240/files#diff-b510db4941434c2341e8e6f19b07c43ad6505f54b559a7bfd1d99de5783f2dbb">+17/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>frontend-example-deploy.yml</strong><dd><code>Reorder asset upload steps to prevent 404 errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/frontend-example-deploy.yml

<ul><li>Restructured deploy into 4-step sequence: upload assets, upload <br>index.html, invalidate cache, cleanup old assets<br> <li> Removed <code>-d</code> flag from first rsync to prevent premature deletion of old <br>bundles<br> <li> Changed CDN invalidation from async <code>--path "/*"</code> to synchronous <br>targeted paths <code>/index.html</code> and <code>/</code><br> <li> Added final rsync with <code>-d</code> flag to safely clean up old assets after <br>cache invalidation</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/240/files#diff-059ba8d14c3fff69602b5e36a5be82e7fb1c44b619e49ed491ec2e891f10cda4">+17/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

___

