### PR TITLE
docs: Add export commands to demo and example-frontend rules

### DIFF
--- a/.rulesync/rules/demo/00-demo.md
+++ b/.rulesync/rules/demo/00-demo.md
@@ -15,6 +15,7 @@ bun run start            # Start Expo dev server (port 8085)
 bun run web              # Start web version
 bun run ios              # Start iOS simulator
 bun run android          # Start Android emulator
+bun run export           # Export for web deployment
 bun run compile          # Type check
 bun run lint             # Lint code
 bun run lint:fix         # Fix lint issues

--- a/.rulesync/rules/example-frontend/00-example-frontend.md
+++ b/.rulesync/rules/example-frontend/00-example-frontend.md
@@ -15,6 +15,7 @@ bun run start            # Start Expo dev server (port 8082)
 bun run web              # Start web version
 bun run ios              # Start iOS simulator
 bun run android          # Start Android emulator
+bun run export           # Export for web deployment
 bun run sdk              # Generate API SDK from backend OpenAPI spec
 bun run test             # Run tests
 bun run lint             # Lint code


### PR DESCRIPTION
## Summary

Updates rule documentation for `demo` and `example-frontend` packages to include the `bun run export` command that is used by deployment workflows.

## Changes

- Add `bun run export` to `.rulesync/rules/demo/00-demo.md` commands section
- Add `bun run export` to `.rulesync/rules/example-frontend/00-example-frontend.md` commands section

## Context

The deployment workflows (`demo-deploy.yml` and `frontend-example-deploy.yml`) added in PR #240 use `bun run export` to build the web bundles for deployment to GCP. These commands were not documented in the package rules, creating a gap in the documentation that AI assistants use.

## Testing Required

**Important:** After reviewing this PR, run the following command locally to regenerate the downstream rule files and commit the results:

``````bash
bun run rules
``````

This will update:
- `.cursor/rules/demo/00-demo.mdc`
- `.cursor/rules/example-frontend/00-example-frontend.mdc`
- `.claude/rules/demo/00-demo.md`
- `.claude/rules/example-frontend/00-example-frontend.md`
- `.windsurf/rules/demo/00-demo.md`
- `.windsurf/rules/example-frontend/00-example-frontend.md`
- `.github/instructions/demo/00-demo.instructions.md`
- `.github/instructions/example-frontend/00-example-frontend.instructions.md`
- `.github/copilot-instructions.md`

After running the command, commit any changes and the CI check (`rulesync-check.yml`) will pass.

## Why This Matters

AI coding assistants rely on these rule files to understand available commands when working on deployment scripts, build processes, or package documentation. Missing commands create gaps in their knowledge.


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22158224581)

<!-- gh-aw-workflow-id: update-rules -->