### PR TITLE
docs(mcp-server): Document Sentry environment variables in rules

### DIFF
--- a/.rulesync/rules/mcp-server/00-mcp-server.md
+++ b/.rulesync/rules/mcp-server/00-mcp-server.md
@@ -24,6 +24,7 @@ bun run lint             # Lint code
 ```
 src/
   index.ts               # Express HTTP server with JSON-RPC handlers
+  instrument.ts          # Sentry initialization (must be imported first)
   tools.ts               # Code generation tools (models, routes, screens, forms)
   prompts.ts             # Multi-step workflow prompts (CRUD, auth, components)
   resources.ts           # Documentation resources loaded from markdown
@@ -70,6 +71,17 @@ Resources are loaded from markdown files with dynamic path resolution.
 - Handles: ListResources, ReadResource, ListTools, CallTool, ListPrompts, GetPrompt
 - Configurable port and host via environment variables
 - Health check endpoint at root
+- Sentry error tracking and performance monitoring
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SENTRY_DSN` | Yes (prod) | — | Sentry project DSN for error tracking |
+| `APP_ENV` | No | `development` | Sentry environment tag |
+| `SENTRY_TRACES_SAMPLE_RATE` | No | `0.1` | Performance traces sample rate (0–1) |
+
+**Note**: `SENTRY_DSN` is required in production (throws on missing), no-op in development/test.
 
 ## Adding a New Tool
 


### PR DESCRIPTION
## Summary

Updates `.rulesync/rules/mcp-server/00-mcp-server.md` to document the Sentry integration added in PR #243.

## Changes

- Add `instrument.ts` to file structure documentation
- Document environment variables: `SENTRY_DSN`, `APP_ENV`, `SENTRY_TRACES_SAMPLE_RATE`
- Note Sentry error tracking and performance monitoring in server description
- Include production requirement for `SENTRY_DSN`

## Reviewer Action Required

After approving this PR, please run the following locally to regenerate the rules files and commit them:

``````bash
bun run rules
git add .
git commit -m "chore: regenerate rules files"
git push
``````

This will update:
- `.cursor/rules/mcp-server/00-mcp-server.mdc`
- `.github/copilot-instructions.md`
- `.github/instructions/mcp-server/00-mcp-server.instructions.md`
- `.claude/rules/mcp-server/00-mcp-server.md`
- `.windsurfrules` (if configured)

The CI check `rulesync-check` will pass once these generated files are committed.

## Context

This aligns the agent documentation with the code changes from #243 where Sentry error tracking was added to the MCP server.


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22169864831)

<!-- gh-aw-workflow-id: update-rules -->