### PR TITLE
docs: Add Sentry error tracking environment variables for MCP server

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -7,6 +7,7 @@ Comprehensive guide to environment variables used across Terreno packages and ex
 - [@terreno/api (Backend)](#terrenoapi-backend)
 - [@terreno/rtk (Frontend State)](#terrenortk-frontend-state)
 - [@terreno/ui (Components)](#terrenoui-components)
+- [@terreno/mcp-server (MCP Server)](#terrenomcp-server-mcp-server)
 - [Example Backend](#example-backend)
 - [Example Frontend](#example-frontend)
 
@@ -175,6 +176,49 @@ import {TerrenoProvider} from "@terreno/ui";
 >
   <App />
 </TerrenoProvider>
+``````
+
+---
+
+## @terreno/mcp-server (MCP Server)
+
+Environment variables used by the `@terreno/mcp-server` package.
+
+### Server Configuration
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `PORT` | ❌ | `8080` | HTTP server port |
+| `MCP_HOST` or `HOST` | ❌ | `0.0.0.0` | Server host address |
+| `NODE_ENV` | ❌ | `development` | Node environment (`development`, `production`, `test`) |
+| `TERRENO_MCP_DOCS_DIR` | ❌ | `../docs` | Path to documentation directory (relative to dist/) |
+
+### Error Tracking
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SENTRY_DSN` | ✅ (production)<br/>❌ (dev/test) | - | Sentry project DSN for error tracking |
+| `APP_ENV` | ❌ | `development` | Sentry environment tag (`development`, `staging`, `production`) |
+| `SENTRY_TRACES_SAMPLE_RATE` | ❌ | `0.1` | Performance traces sample rate (0.0–1.0) |
+
+**Error Tracking Behavior:**
+
+- **Production** (`NODE_ENV=production`): `SENTRY_DSN` is required. Server throws error on startup if missing.
+- **Development/Test**: Sentry initializes as a no-op when `SENTRY_DSN` is not set.
+- Exceptions are automatically captured in MCP request handlers and fatal startup errors.
+- Performance tracing captures 10% of requests by default (configurable via `SENTRY_TRACES_SAMPLE_RATE`).
+
+### Example .env File
+
+``````bash
+# Required in production
+SENTRY_DSN=https://your-key@sentry.io/your-project
+
+# Optional configuration
+PORT=3001
+HOST=localhost
+APP_ENV=production
+SENTRY_TRACES_SAMPLE_RATE=0.2
 ``````
 
 ---

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -407,11 +407,34 @@ Returns comprehensive code style guide from project documentation.
 | `PORT` | `8080` | HTTP server port |
 | `MCP_HOST` or `HOST` | `0.0.0.0` | Server host address |
 | `TERRENO_MCP_DOCS_DIR` | `../docs` | Path to documentation directory (relative to dist/) |
+| `NODE_ENV` | `development` | Node environment (`development`, `production`, `test`) |
+
+### Error Tracking
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SENTRY_DSN` | Yes (production) | - | Sentry project DSN for error tracking |
+| `APP_ENV` | No | `development` | Sentry environment tag (`development`, `staging`, `production`) |
+| `SENTRY_TRACES_SAMPLE_RATE` | No | `0.1` | Performance traces sample rate (0.0–1.0) |
+
+**Error Tracking Behavior:**
+
+- **Production**: `SENTRY_DSN` is required. Server will throw an error on startup if missing.
+- **Development/Test**: Sentry is initialized as a no-op when `SENTRY_DSN` is not set.
+- Exceptions are automatically captured in MCP request handlers and fatal startup errors.
 
 **Example:**
 
 ``````bash
+# Development (Sentry optional)
 PORT=3001 HOST=localhost bun run start
+
+# Production (Sentry required)
+NODE_ENV=production \
+SENTRY_DSN=https://your-key@sentry.io/your-project \
+APP_ENV=production \
+SENTRY_TRACES_SAMPLE_RATE=0.2 \
+bun run start
 ``````
 
 ## Development


### PR DESCRIPTION
## Summary

Documents the new Sentry error tracking environment variables introduced in PR #243 for the MCP server.

## Changes

### `docs/reference/environment-variables.md`
- Added new section for `@terreno/mcp-server` environment variables
- Documented `SENTRY_DSN`, `APP_ENV`, and `SENTRY_TRACES_SAMPLE_RATE`
- Clarified production requirement (throws on missing `SENTRY_DSN`)
- Documented no-op behavior in development/test environments
- Added example `.env` configuration

### `docs/reference/mcp-server.md`
- Added "Error Tracking" subsection under Environment Variables
- Documented all three Sentry-related variables with defaults and descriptions
- Added production vs. development/test behavior explanation
- Updated example commands to show both dev and production usage

## Documentation Quality

✅ **Diátaxis Framework**: Technical reference documentation (information-oriented)  
✅ **Progressive Disclosure**: High-level overview first, detailed examples second  
✅ **Accessibility**: Clear tables, consistent formatting, descriptive labels  
✅ **Completeness**: Covers all new environment variables from instrument.ts  

## Testing Notes

- No code changes, documentation only
- Verified against actual implementation in `mcp-server/src/instrument.ts`
- Cross-referenced with existing environment variable documentation patterns

## Related

- Closes documentation gap from PR #243
- Aligns with [Environment Variables Reference](https://github.com/FlourishHealth/terreno/blob/master/docs/reference/environment-variables.md) style guide


> AI generated by [Update Docs](https://github.com/FlourishHealth/terreno/actions/runs/22169864816)

<!-- gh-aw-workflow-id: update-docs -->