### PR TITLE
Fix CDN 404s by disabling negative caching and invalidating all paths

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -73,6 +73,11 @@ jobs:
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 
+      - name: Ensure negative caching is disabled
+        run: |
+          gcloud compute backend-buckets update $BACKEND_BUCKET \
+            --no-negative-caching
+
       - name: Deploy to GCS
         run: |
           # Step 1: Upload new hashed assets (additive, no deletions).
@@ -87,12 +92,11 @@ jobs:
           gsutil -h "Cache-Control:no-cache, no-store, must-revalidate" \
             cp dist/index.html "gs://$BUCKET/index.html"
 
-          # Step 3: Invalidate CDN cache synchronously so stale index.html
-          # (referencing old hashes) is purged before we clean up old assets.
+          # Step 3: Invalidate entire CDN cache so stale index.html and any
+          # negatively-cached 404s for new asset hashes are purged before we
+          # clean up old assets.
           gcloud compute url-maps invalidate-cdn-cache terreno-demo-url-map \
-            --path "/index.html"
-          gcloud compute url-maps invalidate-cdn-cache terreno-demo-url-map \
-            --path "/"
+            --path "/*"
 
           # Step 4: Clean up old assets that are no longer referenced.
           # Now safe because all CDN edges serve the new index.html.

--- a/.github/workflows/frontend-example-deploy.yml
+++ b/.github/workflows/frontend-example-deploy.yml
@@ -80,6 +80,11 @@ jobs:
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 
+      - name: Ensure negative caching is disabled
+        run: |
+          gcloud compute backend-buckets update $BACKEND_BUCKET \
+            --no-negative-caching
+
       - name: Deploy to GCS
         run: |
           # Step 1: Upload new hashed assets (additive, no deletions).
@@ -94,12 +99,11 @@ jobs:
           gsutil -h "Cache-Control:no-cache, no-store, must-revalidate" \
             cp dist/index.html "gs://$BUCKET/index.html"
 
-          # Step 3: Invalidate CDN cache synchronously so stale index.html
-          # (referencing old hashes) is purged before we clean up old assets.
+          # Step 3: Invalidate entire CDN cache so stale index.html and any
+          # negatively-cached 404s for new asset hashes are purged before we
+          # clean up old assets.
           gcloud compute url-maps invalidate-cdn-cache terreno-frontend-example-url-map \
-            --path "/index.html"
-          gcloud compute url-maps invalidate-cdn-cache terreno-frontend-example-url-map \
-            --path "/"
+            --path "/*"
 
           # Step 4: Clean up old assets that are no longer referenced.
           # Now safe because all CDN edges serve the new index.html.

--- a/scripts/setup-gcs-hosting.sh
+++ b/scripts/setup-gcs-hosting.sh
@@ -115,7 +115,8 @@ create_backend_bucket() {
     echo "  Creating backend bucket $name -> gs://$bucket"
     gcloud compute backend-buckets create "$name" \
       --gcs-bucket-name="$bucket" \
-      --enable-cdn
+      --enable-cdn \
+      --no-negative-caching
   fi
 }
 


### PR DESCRIPTION
### **User description**
## Summary

- Disable Cloud CDN negative caching on backend buckets to prevent cached 404 responses for newly-deployed asset hashes
- Switch CDN invalidation from `/index.html` + `/` to `/*` (wildcard) to clear any stale cached paths
- Update setup script to create backend buckets with `--no-negative-caching`

## Problem

After deploying, users would intermittently get 404 errors for JS bundles like `/_expo/static/js/web/index-<hash>.js`. This happened because Cloud CDN was caching 404 responses (negative caching), and the CDN invalidation only cleared `/index.html` and `/` — leaving the cached 404 for the actual asset path intact.

## Changes

- **`.github/workflows/demo-deploy.yml`** and **`frontend-example-deploy.yml`**: Added step to ensure negative caching is disabled; changed invalidation to `--path "/*"`
- **`scripts/setup-gcs-hosting.sh`**: Backend buckets created with `--no-negative-caching`
- **`docs/explanation/gcp-hosting-architecture.md`**: Updated to document the negative caching policy and deploy sequence

## Immediate fix for production

```bash
gcloud compute backend-buckets update terreno-demo-backend --no-negative-caching
gcloud compute url-maps invalidate-cdn-cache terreno-demo-url-map --path "/*"
```


___

### **PR Type**
Bug fix


___

### **Description**
- Disable Cloud CDN negative caching on backend buckets to prevent cached 404 responses

- Switch CDN invalidation from `/index.html` and `/` to `/*` wildcard pattern

- Add deployment step to ensure negative caching disabled before uploading assets

- Document negative caching policy and updated deploy sequence in architecture guide


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Backend Bucket Creation"] -->|"--no-negative-caching"| B["Disable Negative Caching"]
  C["Deploy Workflow"] -->|"Update backend bucket"| B
  C -->|"Invalidate --path /*"| D["Clear All Cached Paths"]
  D -->|"Prevents stale 404s"| E["New Asset Hashes Served"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup-gcs-hosting.sh</strong><dd><code>Add negative caching flag to backend bucket creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/setup-gcs-hosting.sh

<ul><li>Added <code>--no-negative-caching</code> flag when creating backend buckets<br> <li> Ensures new backend buckets are created with negative caching disabled <br>from the start</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/247/files#diff-25579d048fee36b0c70ea083c8fb35b5cfe9a67c3ac0ef146cf39f7b16dd73c4">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>demo-deploy.yml</strong><dd><code>Add negative caching check and wildcard CDN invalidation</code>&nbsp; </dd></summary>
<hr>

.github/workflows/demo-deploy.yml

<ul><li>Added new step to ensure negative caching is disabled on backend <br>bucket before deployment<br> <li> Changed CDN invalidation from two separate paths (<code>/index.html</code> and <code>/</code>) <br>to single wildcard path (<code>/*</code>)<br> <li> Updated comments to explain the new invalidation strategy</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/247/files#diff-b510db4941434c2341e8e6f19b07c43ad6505f54b559a7bfd1d99de5783f2dbb">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>frontend-example-deploy.yml</strong><dd><code>Add negative caching check and wildcard CDN invalidation</code>&nbsp; </dd></summary>
<hr>

.github/workflows/frontend-example-deploy.yml

<ul><li>Added new step to ensure negative caching is disabled on backend <br>bucket before deployment<br> <li> Changed CDN invalidation from two separate paths (<code>/index.html</code> and <code>/</code>) <br>to single wildcard path (<code>/*</code>)<br> <li> Updated comments to explain the new invalidation strategy</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/247/files#diff-059ba8d14c3fff69602b5e36a5be82e7fb1c44b619e49ed491ec2e891f10cda4">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gcp-hosting-architecture.md</strong><dd><code>Document negative caching policy and updated deploy steps</code></dd></summary>
<hr>

docs/explanation/gcp-hosting-architecture.md

<ul><li>Added documentation explaining negative caching is disabled to prevent <br>stale 404s<br> <li> Updated deployment sequence to include negative caching check step<br> <li> Clarified that asset upload is additive and includes cleanup step with <br>deletions</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/247/files#diff-16edfd4279ebc0514130c6a940e399deeb61cfe50bcbfb386d0709b77bcd2bc4">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

