### PR TITLE
docs: Add GCP deployment documentation to agent rules

### DIFF
--- a/.cursor/rules/00-root.mdc
+++ b/.cursor/rules/00-root.mdc
@@ -316,6 +316,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -311,6 +311,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -318,6 +318,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/.rulesync/rules/01-claudecode-root.md
+++ b/.rulesync/rules/01-claudecode-root.md
@@ -189,6 +189,25 @@ Key imports:
 import {generateAuthSlice} from "@terreno/rtk";
 ```
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,6 +311,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -182,6 +182,25 @@ Key imports:
 import {generateAuthSlice} from "@terreno/rtk";
 ```
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/api/.cursor/rules/00-root.mdc
+++ b/api/.cursor/rules/00-root.mdc
@@ -316,6 +316,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/api/.github/copilot-instructions.md
+++ b/api/.github/copilot-instructions.md
@@ -311,6 +311,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -311,6 +311,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/demo/.cursor/rules/00-root.mdc
+++ b/demo/.cursor/rules/00-root.mdc
@@ -316,6 +316,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/demo/.github/copilot-instructions.md
+++ b/demo/.github/copilot-instructions.md
@@ -311,6 +311,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/demo/AGENTS.md
+++ b/demo/AGENTS.md
@@ -311,6 +311,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/example-backend/.cursor/rules/00-root.mdc
+++ b/example-backend/.cursor/rules/00-root.mdc
@@ -316,6 +316,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/example-backend/.github/copilot-instructions.md
+++ b/example-backend/.github/copilot-instructions.md
@@ -311,6 +311,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/example-backend/AGENTS.md
+++ b/example-backend/AGENTS.md
@@ -311,6 +311,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/example-frontend/.cursor/rules/00-root.mdc
+++ b/example-frontend/.cursor/rules/00-root.mdc
@@ -316,6 +316,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/example-frontend/.github/copilot-instructions.md
+++ b/example-frontend/.github/copilot-instructions.md
@@ -311,6 +311,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/example-frontend/AGENTS.md
+++ b/example-frontend/AGENTS.md
@@ -311,6 +311,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/mcp-server/.cursor/rules/00-root.mdc
+++ b/mcp-server/.cursor/rules/00-root.mdc
@@ -316,6 +316,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/mcp-server/.github/copilot-instructions.md
+++ b/mcp-server/.github/copilot-instructions.md
@@ -311,6 +311,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/mcp-server/AGENTS.md
+++ b/mcp-server/AGENTS.md
@@ -311,6 +311,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/rtk/.cursor/rules/00-root.mdc
+++ b/rtk/.cursor/rules/00-root.mdc
@@ -316,6 +316,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/rtk/.github/copilot-instructions.md
+++ b/rtk/.github/copilot-instructions.md
@@ -311,6 +311,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/rtk/AGENTS.md
+++ b/rtk/AGENTS.md
@@ -311,6 +311,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/ui/.cursor/rules/00-root.mdc
+++ b/ui/.cursor/rules/00-root.mdc
@@ -316,6 +316,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/ui/.github/copilot-instructions.md
+++ b/ui/.github/copilot-instructions.md
@@ -311,6 +311,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -311,6 +311,25 @@ const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
 - Minimize `use client`, `useEffect`, and `setState`
 - Always support React-Native Web
 
+## Deployment
+
+### GCP Static Hosting
+
+The demo and example-frontend apps deploy to Google Cloud Storage with Cloud CDN:
+
+- **Infrastructure**: GCS buckets → Backend buckets (CDN-enabled) → URL maps → Static IPs
+- **Setup script**: `scripts/setup-gcs-hosting.sh` provisions all GCP resources with `--no-negative-caching`
+- **Deployment workflows**: `.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`
+- **Cache strategy**:
+  - Hashed assets: `Cache-Control: public, max-age=31536000, immutable`
+  - index.html: `Cache-Control: no-cache, no-store, must-revalidate`
+  - CDN invalidation: `--path "/*"` (wildcard) to clear all cached paths
+- **Negative caching disabled**: Backend buckets created with `--no-negative-caching` to prevent cached 404s for new asset hashes
+
+For detailed architecture and deployment steps, see:
+- [docs/explanation/gcp-hosting-architecture.md](docs/explanation/gcp-hosting-architecture.md)
+- [docs/how-to/deploy-to-gcp.md](docs/how-to/deploy-to-gcp.md)
+
 ## CI/CD Workflows
 
 ### Required Secret Validation


### PR DESCRIPTION
## Summary

Adds deployment documentation to agent onboarding materials following PR #247's GCP deployment infrastructure changes.

## Changes

- **Added Deployment section** to `.rulesync/rules/00-root.md`, `.rulesync/rules/01-claudecode-root.md`, and `AGENTS.md`
- **Documented GCP static hosting architecture**: GCS buckets → Backend buckets (CDN) → URL maps → Static IPs
- **Key deployment conventions**:
  - Negative caching disabled on backend buckets to prevent cached 404s for new asset hashes
  - Cache strategy: Hashed assets (immutable, 1-year cache) vs index.html (no-cache)
  - CDN invalidation uses wildcard `--path "/*"` to clear all cached paths
- **Referenced detailed guides**: Points to `docs/explanation/gcp-hosting-architecture.md` and `docs/how-to/deploy-to-gcp.md`
- **Regenerated all agent documentation** for Cursor, Windsurf, Claude Code, and GitHub Copilot

## Context

PR #247 added comprehensive GCP deployment workflows and documentation but didn't update the agent rules/onboarding materials. AI assistants now have visibility into:

- Deployment infrastructure setup (via `scripts/setup-gcs-hosting.sh`)
- Deployment workflows (`.github/workflows/demo-deploy.yml` and `frontend-example-deploy.yml`)
- Cache configuration and CDN invalidation strategy
- Where to find detailed architecture and deployment guides

## Testing

- ✅ Verified rulesync generates updated files correctly with `npx rulesync generate`
- ✅ All 27 generated files updated with new Deployment section
- ✅ Links to docs/ markdown files are correct
- ✅ No syntax errors in generated Markdown

## Notes for Reviewers

The PR includes 27 modified files because rulesync generates agent documentation files for:
- Root workspace (AGENTS.md, .cursor/rules/, .github/copilot-instructions.md, CLAUDE.local.md)
- Each package workspace (api/, ui/, rtk/, demo/, example-frontend/, example-backend/, mcp-server/)

All changes stem from the single Deployment section added to the source rules in `.rulesync/rules/`.

---

**Note**: There are untracked rulesync-generated subdirectories (e.g., `api/.claude/rules/`, `api/.windsurf/`) that appear to be new. These should likely be committed in a separate PR to avoid scope creep.


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22227151275)

<!-- gh-aw-workflow-id: update-rules -->