### PR TITLE
docs: Add Implementation Plans documentation

### DIFF
--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -338,3 +338,14 @@ GitHub Actions workflows that use secrets or environment variables must validate
 ## Dependency Management
 
 Uses [Bun Catalogs](https://bun.sh/docs/install/catalogs) - shared versions defined in root `package.json` under `catalog`. Reference with `catalog:` in workspace packages.
+
+## Implementation Plans
+
+The `docs/implementationPlans/` directory contains design documents for planned features that are **not yet implemented**. These documents outline future architectural changes and new APIs. When working with the codebase:
+
+- **Check implementation plans** before suggesting major refactors - the change may already be planned
+- **Use current APIs** - implementation plans describe future features, not current functionality
+- **Reference plans in discussions** of future work or architectural decisions
+
+Current implementation plans:
+- [ModularAPI.md](../docs/implementationPlans/ModularAPI.md) - Planned `TerrenoApp` class to replace `setupServer` in @terreno/api

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,3 +331,14 @@ GitHub Actions workflows that use secrets or environment variables must validate
 ## Dependency Management
 
 Uses [Bun Catalogs](https://bun.sh/docs/install/catalogs) - shared versions defined in root `package.json` under `catalog`. Reference with `catalog:` in workspace packages.
+
+## Implementation Plans
+
+The `docs/implementationPlans/` directory contains design documents for planned features that are **not yet implemented**. These documents outline future architectural changes and new APIs. When working with the codebase:
+
+- **Check implementation plans** before suggesting major refactors - the change may already be planned
+- **Use current APIs** - implementation plans describe future features, not current functionality
+- **Reference plans in discussions** of future work or architectural decisions
+
+Current implementation plans:
+- [ModularAPI.md](docs/implementationPlans/ModularAPI.md) - Planned `TerrenoApp` class to replace `setupServer` in @terreno/api

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Documentation for the Terreno monorepo: shared packages for full-stack applicati
 - **[How-to guides](how-to/)** — Problem-oriented, practical steps
 - **[Reference](reference/)** — Technical reference for APIs and packages
 - **[Explanation](explanation/)** — Concepts and context
+- **[Implementation Plans](implementationPlans/)** — Design documents for planned features (not yet implemented)
 
 ## Packages
 

--- a/docs/implementationPlans/README.md
+++ b/docs/implementationPlans/README.md
@@ -1,0 +1,53 @@
+# Implementation Plans
+
+This directory contains **design documents** for planned features that are **not yet implemented** in the Terreno monorepo. These documents outline future architectural changes, new APIs, and breaking changes before implementation begins.
+
+## Purpose
+
+Implementation plans serve multiple purposes:
+
+1. **Design Documentation** - Detail the architecture, interfaces, and implementation approach before writing code
+2. **Team Alignment** - Ensure everyone understands the planned changes and can provide feedback
+3. **AI Assistant Context** - Help AI coding assistants understand planned future work to avoid suggesting outdated patterns
+
+## Status
+
+All documents in this directory describe **future features** unless explicitly marked as implemented. When a plan is fully implemented:
+
+- Mark it as "✅ Implemented" in this README
+- Update relevant package documentation to reflect the new APIs
+- Consider moving detailed content to reference docs
+
+## Current Plans
+
+| Plan | Status | Description |
+|------|--------|-------------|
+| [ModularAPI.md](ModularAPI.md) | 🚧 Planned | New `TerrenoApp` class to replace `setupServer` in @terreno/api |
+
+## Creating a New Implementation Plan
+
+When adding a new implementation plan:
+
+1. Create a markdown file with a descriptive name (e.g., `FeatureName.md`)
+2. Include these sections:
+   - **Overview** - What problem does this solve?
+   - **Goals** - What are the key objectives?
+   - **Architecture** - File structure, classes, interfaces
+   - **Configuration** - Options, environment variables
+   - **Implementation Tasks** - Phased breakdown of work
+   - **Breaking Changes** - What will change for users?
+   - **Migration Guide** - How do users upgrade?
+3. Add an entry to the table above
+4. Reference it in root-level documentation if it impacts overall architecture
+
+## Using Implementation Plans
+
+**For Developers:**
+- Review plans before starting work on related features
+- Update plans as the design evolves
+- Mark plans as implemented when complete
+
+**For AI Assistants:**
+- Check plans before suggesting major refactors - the change may already be designed
+- Use **current APIs** in code suggestions, not planned future APIs
+- Reference plans when discussing architectural decisions or future work


### PR DESCRIPTION
## Summary

Adds documentation for the `docs/implementationPlans/` directory to help AI assistants and developers understand planned features vs. current functionality.

## Changes

- ✅ **Added Implementation Plans section** to `.rulesync/rules/00-root.md` and `AGENTS.md`
- ✅ **Created `docs/implementationPlans/README.md`** explaining purpose, status tracking, and usage guidelines
- ✅ **Updated `docs/README.md`** structure to include Implementation Plans section
- ✅ **Referenced ModularAPI.md** as the first implementation plan example

## Why This Matters

The recent PR #149 added `docs/implementationPlans/ModularAPI.md` - a detailed design document for a planned `TerrenoApp` class to replace `setupServer`. However, this directory was not documented anywhere, creating gaps:

1. AI assistants weren't aware of planned architectural changes
2. No guidance on how to interpret implementation plans vs. current code
3. Missing index/README explaining the purpose of this directory

## Implementation Plans Purpose

Implementation plans serve as:
- **Design documentation** before implementation
- **Team alignment** on architectural changes
- **AI assistant context** to avoid suggesting outdated patterns

Key point: **Implementation plans describe FUTURE features, not current functionality.** AI assistants should use current APIs (like `setupServer`) until plans are marked as implemented.

## Action Required

**Reviewers must run `bun run rules` locally** to regenerate the following files from `.rulesync/rules/` source:
- `.cursor/rules/00-root.mdc`
- `.windsurf/rules/00-root.md` 
- `.claude/rules/00-root.md`
- `.github/copilot-instructions.md`

Commit the regenerated files so the `rulesync-check` workflow passes.

## Testing

- [x] Changes are in `.rulesync/rules/` source files (not generated files)
- [x] New README clearly explains implementation plans status and usage
- [x] AGENTS.md and root rules reference the new section
- [x] Links to ModularAPI.md are correct

---

🤖 Generated by Update Rules agent


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22236400084)

<!-- gh-aw-workflow-id: update-rules -->