### PR TITLE
docs: Update dependency version examples to match current catalog

### DIFF
--- a/docs/explanation/dependency-management.md
+++ b/docs/explanation/dependency-management.md
@@ -25,8 +25,8 @@ Shared dependency versions are defined in the root `package.json` under the `cat
 // root package.json
 {
   "catalog": {
-    "react": "18.2.0",
-    "react-native": "0.73.2"
+    "react": "19.1.0",
+    "react-native": "0.81.5"
   }
 }
 ``````


### PR DESCRIPTION
### **User description**
## Summary

Updates the dependency version examples in `docs/explanation/dependency-management.md` to reflect the current versions in the root `package.json` catalog.

## Changes

- React: `18.2.0` → `19.1.0`
- React Native: `0.73.2` → `0.81.5`

## Context

PR #260 updated the MCP server's bootstrap template with the latest frontend/backend dependency versions. This PR ensures our documentation examples remain accurate and aligned with the current state of the monorepo.

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] Documentation follows Diátaxis framework principles
- [x] Examples are accurate and reflect current codebase state
- [x] Changes are minimal and focused
- [x] No code changes required


> AI generated by [Update Docs](https://github.com/FlourishHealth/terreno/actions/runs/22265828950)

<!-- gh-aw-workflow-id: update-docs -->


___

### **PR Type**
Documentation


___

### **Description**
- Updates React version example from 18.2.0 to 19.1.0

- Updates React Native version from 0.73.2 to 0.81.5

- Aligns documentation with current monorepo catalog versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["dependency-management.md"] -- "React: 18.2.0 → 19.1.0" --> B["Updated Examples"]
  A -- "React Native: 0.73.2 → 0.81.5" --> B
  B -- "Matches PR #260 updates" --> C["Current Catalog"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependency-management.md</strong><dd><code>Update React and React Native version examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/explanation/dependency-management.md

<ul><li>Updated React version example from 18.2.0 to 19.1.0<br> <li> Updated React Native version example from 0.73.2 to 0.81.5<br> <li> Ensures documentation reflects current root package.json catalog <br>versions</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/261/files#diff-4545d72ee92723a691b5381e4d28446de6ed7365ac62b254da2a9170b48b299f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

