### PR TITLE
docs: Enhance dependency management section in rulesync rules

### DIFF
--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -338,3 +338,45 @@ GitHub Actions workflows that use secrets or environment variables must validate
 ## Dependency Management
 
 Uses [Bun Catalogs](https://bun.sh/docs/install/catalogs) - shared versions defined in root `package.json` under `catalog`. Reference with `catalog:` in workspace packages.
+
+### Bun Catalog Pattern
+
+**Benefits:**
+- Single source of truth for shared dependency versions
+- Consistent versions across all packages
+- Easier updates — change once, apply everywhere
+
+**Example:**
+
+```json
+// root package.json
+{
+  "catalog": {
+    "react": "19.1.0",
+    "react-native": "0.81.5"
+  }
+}
+```
+
+```json
+// ui/package.json
+{
+  "dependencies": {
+    "react": "catalog:",
+    "react-native": "catalog:"
+  }
+}
+```
+
+### Dependabot & Auto-Merge
+
+Terreno uses automated dependency management:
+- **7-day cooldown**: Dependabot waits 7 days after package publication before creating PRs (security updates bypass this)
+- **Auto-merge workflow**: PRs auto-merge after all CI checks pass
+- **Update groups**: Backend, Frontend, and Root packages are grouped into monthly PRs
+- **Ignored deps**: Frontend packages ignore catalog-managed dependencies to prevent duplicate PRs
+
+**When to update catalog vs individual packages:**
+- Update root `package.json` catalog for shared dependencies used across multiple packages
+- Update individual packages for package-specific dependencies not in the catalog
+- See `docs/explanation/dependency-management.md` for detailed workflow and troubleshooting


### PR DESCRIPTION
## Summary

Expands the Dependency Management section in `.rulesync/rules/00-root.md` to provide AI assistants with comprehensive context about Terreno's dependency management system.

## Changes

**Enhanced `.rulesync/rules/00-root.md`:**
- Added Bun Catalog usage pattern with code examples showing root catalog and package usage
- Documented Dependabot configuration details (7-day cooldown, auto-merge, update groups)
- Explained when to update catalog vs individual package dependencies
- Added reference to `docs/explanation/dependency-management.md` for detailed workflow

## Context

PR #261 added comprehensive dependency management documentation in `docs/explanation/dependency-management.md`. The rulesync rules only had a brief 2-line mention of Bun Catalogs, creating a gap between what's documented and what AI assistants know.

This update ensures AI assistants understand:
- How Bun catalogs work in practice (with code examples)
- Dependabot's 7-day cooldown policy for security
- Auto-merge workflow behavior
- When to update shared vs package-specific dependencies

## Regeneration Required

⚠️ **Action needed:** After merging, run `bun run rules` locally to regenerate:
- `.cursor/rules/00-root.mdc`
- `.github/copilot-instructions.md`
- `AGENTS.md`
- Other generated files from rulesync

The CI workflow `rulesync-check` will verify regeneration is complete.

## Type of Change

- [x] Documentation update (rulesync rules)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] Changes align with new `docs/explanation/dependency-management.md`
- [x] Examples use actual versions from current catalog (React 19.1.0, React Native 0.81.5)
- [x] Changes follow rulesync conventions (YAML frontmatter preserved)
- [x] Source file (`.rulesync/rules/00-root.md`) updated, not generated files
- [x] PR body documents regeneration requirement

---

> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22282193246)


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22282193246)

<!-- gh-aw-workflow-id: update-rules -->