### PR TITLE
Make docs workflow more selective and always sync rules

### DIFF
--- a/.github/workflows/daily-jsdoc-improver.lock.yml
+++ b/.github/workflows/daily-jsdoc-improver.lock.yml
@@ -971,7 +971,7 @@ jobs:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/safeoutputs/
@@ -1092,13 +1092,13 @@ jobs:
           destination: /opt/gh-aw/actions
       - name: Download agent artifacts
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-artifacts
           path: /tmp/gh-aw/threat-detection/
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/threat-detection/
@@ -1227,7 +1227,7 @@ jobs:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/safeoutputs/
@@ -1238,7 +1238,7 @@ jobs:
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/safeoutputs/agent_output.json" >> "$GITHUB_ENV"
       - name: Download patch artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-artifacts
           path: /tmp/gh-aw/

--- a/.github/workflows/daily-test-improver.lock.yml
+++ b/.github/workflows/daily-test-improver.lock.yml
@@ -970,7 +970,7 @@ jobs:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/safeoutputs/
@@ -1093,13 +1093,13 @@ jobs:
           destination: /opt/gh-aw/actions
       - name: Download agent artifacts
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-artifacts
           path: /tmp/gh-aw/threat-detection/
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/threat-detection/
@@ -1206,7 +1206,7 @@ jobs:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/safeoutputs/
@@ -1217,7 +1217,7 @@ jobs:
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/safeoutputs/agent_output.json" >> "$GITHUB_ENV"
       - name: Download patch artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-artifacts
           path: /tmp/gh-aw/

--- a/.github/workflows/update-docs.lock.yml
+++ b/.github/workflows/update-docs.lock.yml
@@ -771,7 +771,7 @@ jobs:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/safeoutputs/
@@ -890,13 +890,13 @@ jobs:
           destination: /opt/gh-aw/actions
       - name: Download agent artifacts
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-artifacts
           path: /tmp/gh-aw/threat-detection/
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/threat-detection/
@@ -1024,7 +1024,7 @@ jobs:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/safeoutputs/
@@ -1035,7 +1035,7 @@ jobs:
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/safeoutputs/agent_output.json" >> "$GITHUB_ENV"
       - name: Download patch artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-artifacts
           path: /tmp/gh-aw/

--- a/.github/workflows/update-docs.md
+++ b/.github/workflows/update-docs.md
@@ -39,89 +39,78 @@ timeout-minutes: 15
 
 <!-- Note - this file can be customized to your needs. Replace this section directly, or add further instructions here. After editing run 'gh aw compile' -->
 
-Your name is ${{ github.workflow }}. You are an **Autonomous Technical Writer & Documentation Steward** for the GitHub repository `${{ github.repository }}`.
+Your name is ${{ github.workflow }}. You are a **Documentation Steward** for `${{ github.repository }}`.
 
 ### Mission
-Ensure every code‑level change is mirrored by clear, accurate, and stylistically consistent documentation.
+Keep documentation accurate and concise. Only document things that genuinely help users — not every code change needs docs.
 
 ### Voice & Tone
-- Precise, concise, and developer‑friendly
-- Active voice, plain English, progressive disclosure (high‑level first, drill‑down examples next)
-- Empathetic toward both newcomers and power users
+- Concise, direct, developer-friendly
+- Active voice, plain English
+- Show code examples over prose when possible
 
-### Key Values
-Documentation‑as‑Code, transparency, single source of truth, continuous improvement, accessibility, internationalization‑readiness
+### When to Update Documentation
+
+**DO update docs for:**
+- New user-facing APIs, endpoints, or configuration options
+- Breaking changes or changed behavior that affects consumers
+- New packages or major new features
+- Changed setup/installation steps
+- New environment variables or deployment requirements
+
+**DO NOT update docs for:**
+- Internal refactors with no behavior change
+- Minor bug fixes
+- Code style changes or linting fixes
+- Dependency bumps (unless they change usage)
+- Test-only changes
+- Small feature additions that are self-evident from the API
 
 ### Your Workflow
 
-1. **Analyze Repository Changes**
-   
-   - On every push to master branch, examine the diff to identify changed/added/removed entities
-   - Look for new APIs, functions, classes, configuration files, or significant code changes
-   - Check existing documentation for accuracy and completeness
-   - Identify documentation gaps like failing tests: a "red build" until fixed
+1. **Analyze Changes**
 
-2. **Documentation Assessment**
-   
-   - Review existing documentation structure (look for docs/, documentation/, or similar directories)
-   - Assess documentation quality against style guidelines:
-     - Diátaxis framework (tutorials, how-to guides, technical reference, explanation)
-     - Google Developer Style Guide principles
-     - Inclusive naming conventions
-     - Microsoft Writing Style Guide standards
-   - Identify missing or outdated documentation
+   - Examine the diff to identify changed/added/removed entities
+   - Determine if changes are user-facing or internal
+   - **If changes are internal-only with no behavior change, exit immediately**
 
-3. **Create or Update Documentation**
-   
-   - Use Markdown (.md) format wherever possible
-   - Fall back to MDX only when interactive components are indispensable
-   - Follow progressive disclosure: high-level concepts first, detailed examples second
-   - Ensure content is accessible and internationalization-ready
-   - Create clear, actionable documentation that serves both newcomers and power users
+2. **Assess Documentation Impact**
 
-4. **Documentation Structure & Organization**
-   
-   - Organize content following Diátaxis methodology:
-     - **Tutorials**: Learning-oriented, hands-on lessons
-     - **How-to guides**: Problem-oriented, practical steps
-     - **Technical reference**: Information-oriented, precise descriptions
-     - **Explanation**: Understanding-oriented, clarification and discussion
-   - mastertain consistent navigation and cross-references
-   - Ensure searchability and discoverability
+   - Check existing docs in `docs/` (organized by Diátaxis: tutorials, how-to, reference, explanation)
+   - Only flag gaps for user-facing changes that would confuse someone reading the docs
+   - Prefer updating existing docs over creating new ones
 
-5. **Quality Assurance**
-   
-   - Check for broken links, missing images, or formatting issues
-   - Ensure code examples are accurate and functional
-   - Verify accessibility standards are met
+3. **Update Documentation**
 
-6. **Continuous Improvement**
-   
-   - Perform nightly sanity sweeps for documentation drift
-   - Update documentation based on user feedback in issues and discussions
-   - mastertain and improve documentation toolchain and automation
+   - Keep updates minimal and focused — a one-line API change needs a one-line doc update, not a new page
+   - Use Markdown (.md) format
+   - Favor code examples over lengthy explanations
+   - Update the relevant section in-place; don't reorganize surrounding content
+   - Documentation structure: `docs/tutorials/`, `docs/how-to/`, `docs/reference/`, `docs/explanation/`
+
+4. **Sync AI Assistant Rules**
+
+   - After making any documentation changes, run `bun install && bun run rules` from the repository root
+   - This regenerates all AI assistant rule files (.cursorrules, CLAUDE.md, .windsurfrules, .github/copilot-instructions.md) from the source files in `.rulesync/rules/`
+   - Commit the regenerated files alongside your documentation changes
+
+5. **Quality Check**
+
+   - Verify code examples are accurate
+   - Check for broken cross-references
 
 ### Output Requirements
 
-- **Create Draft Pull Requests**: When documentation needs updates, create focused draft pull requests with clear descriptions
-
-### Technical Implementation
-
-- **Hosting**: Prepare documentation for GitHub Pages deployment with branch-based workflows
-- **Automation**: Implement linting and style checking for documentation consistency
-
-### Error Handling
-
-- If documentation directories don't exist, suggest appropriate structure
-- If build tools are missing, recommend necessary packages or configuration
+- **Create Draft Pull Requests** with concise descriptions of what changed and why
 
 ### Exit Conditions
 
-- Exit if the repository has no implementation code yet (empty repository)
-- Exit if no code changes require documentation updates
-- Exit if all documentation is already up-to-date and comprehensive
+- Exit if changes are internal-only (refactors, bug fixes, test changes, dependency bumps)
+- Exit if the repository has no implementation code yet
+- Exit if all documentation is already accurate
+- **Default to NOT updating docs** — only update when there's a clear user-facing gap
 
-> NOTE: Never make direct pushes to the master branch. Always create a pull request for documentation changes.
+> NOTE: Never push directly to master. Always create a pull request.
 
-> NOTE: Treat documentation gaps like failing tests.
+> NOTE: Less is more. A concise doc update is better than a comprehensive one nobody reads.
 

--- a/.github/workflows/update-rules.lock.yml
+++ b/.github/workflows/update-rules.lock.yml
@@ -772,7 +772,7 @@ jobs:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/safeoutputs/
@@ -891,13 +891,13 @@ jobs:
           destination: /opt/gh-aw/actions
       - name: Download agent artifacts
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-artifacts
           path: /tmp/gh-aw/threat-detection/
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/threat-detection/
@@ -1025,7 +1025,7 @@ jobs:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/safeoutputs/
@@ -1036,7 +1036,7 @@ jobs:
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/safeoutputs/agent_output.json" >> "$GITHUB_ENV"
       - name: Download patch artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-artifacts
           path: /tmp/gh-aw/

--- a/.github/workflows/update-rules.md
+++ b/.github/workflows/update-rules.md
@@ -77,8 +77,9 @@ Rules-as-Code, single source of truth (.rulesync/rules/), consistency across Cur
    - Use Markdown; preserve existing YAML frontmatter and structure
 
 4. **Regenerate and Verify**
-   
-   - After editing .rulesync/rules/, the workflow or PR description should instruct to run `bun run rules` to regenerate .cursorrules, CLAUDE.md, .windsurfrules, .github/copilot-instructions.md
+
+   - After editing .rulesync/rules/, run `bun install && bun run rules` from the repository root to regenerate all output files (.cursorrules, CLAUDE.md, .windsurfrules, .github/copilot-instructions.md, .github/instructions/)
+   - Commit the regenerated files alongside your rule source changes
    - Ensure no broken references (e.g. paths, package names, script names)
    - Keep cross-references between AGENTS.md, docs/, and .rulesync/rules/ consistent
 


### PR DESCRIPTION
### **User description**
## Summary

- Rewrites the `update-docs` agentic workflow to be more selective about when to create documentation PRs. Adds explicit DO/DON'T criteria — skip internal refactors, bug fixes, dependency bumps, test-only changes, and self-evident API additions.
- Adds a "Sync AI Assistant Rules" step to `update-docs` so it runs `bun install && bun run rules` after any documentation changes, committing the regenerated rule files alongside docs.
- Updates `update-rules` workflow to actually run `bun run rules` and commit the output, instead of just mentioning it in PR descriptions.
- Recompiles all `.lock.yml` workflow files via `gh aw compile`.

## Breaking changes

None.

## Testing

- Verified `gh aw compile` succeeds with 0 errors on all 4 workflows.
- Lock file diffs are limited to the intended workflow content changes plus minor action pin updates from the compiler.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Rewrites `update-docs` workflow to be selective about documentation creation
  - Skip internal refactors, bug fixes, dependency bumps, test-only changes
  - Only document user-facing APIs, breaking changes, new packages

- Adds "Sync AI Assistant Rules" step to `update-docs` workflow
  - Runs `bun install && bun run rules` after doc changes
  - Commits regenerated rule files alongside documentation

- Updates `update-rules` workflow to actually execute `bun run rules`
  - Commits output files instead of just mentioning in PR descriptions

- Recompiles all `.lock.yml` workflow files with action pin updates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Code Changes"] --> B["Analyze Change Type"]
  B --> C{User-Facing?}
  C -->|No| D["Exit - Skip Docs"]
  C -->|Yes| E["Update Documentation"]
  E --> F["Run bun rules"]
  F --> G["Commit Docs + Rules"]
  G --> H["Create Draft PR"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update-docs.md</strong><dd><code>Rewrite docs workflow with selectivity and rules sync</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/update-docs.md

<ul><li>Rewrites workflow instructions to be selective about documentation <br>updates<br> <li> Adds explicit DO/DON'T criteria for when to create documentation<br> <li> Adds step 4 to sync AI Assistant Rules via <code>bun install && bun run </code><br><code>rules</code><br> <li> Simplifies mission statement and removes verbose guidance<br> <li> Emphasizes minimal, focused documentation updates over comprehensive <br>changes</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/267/files#diff-92bc5890a4fd599906d89aff25390620514e86db8f5a28adaec234796a0efe52">+56/-67</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>update-rules.md</strong><dd><code>Update rules workflow to execute and commit output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/update-rules.md

<ul><li>Updates step 4 to explicitly run <code>bun install && bun run rules</code> from <br>repository root<br> <li> Adds instruction to commit regenerated files alongside rule source <br>changes<br> <li> Clarifies that output files must be committed, not just mentioned in <br>PR descriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/267/files#diff-647bc8ec9e7b8d0e3590a6739e7be37bb952ff69582837f0cdd34ed3b9bb3152">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>daily-jsdoc-improver.lock.yml</strong><dd><code>Downgrade download-artifact action to v6.0.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/daily-jsdoc-improver.lock.yml

<ul><li>Updates <code>actions/download-artifact</code> from v7.0.0 to v6.0.0 across <br>multiple job steps<br> <li> Changes action hash from <code>37930b1c2abaa49bbe596cd826c3c89aef350131</code> to <br><code>018cc2cf5baa6db3ef3c5f8a56943fffe632ef53</code><br> <li> Affects 4 separate download-artifact steps in the workflow</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/267/files#diff-948d120439643cd058041e6e4c87319b26fdf3c7fa05d0f2721868daba6b07b5">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>daily-test-improver.lock.yml</strong><dd><code>Downgrade download-artifact action to v6.0.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/daily-test-improver.lock.yml

<ul><li>Updates <code>actions/download-artifact</code> from v7.0.0 to v6.0.0 across <br>multiple job steps<br> <li> Changes action hash from <code>37930b1c2abaa49bbe596cd826c3c89aef350131</code> to <br><code>018cc2cf5baa6db3ef3c5f8a56943fffe632ef53</code><br> <li> Affects 4 separate download-artifact steps in the workflow</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/267/files#diff-876e87a86ccc087e8a545175db28aa6b9292551c299055972024b4f251c0be67">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>update-docs.lock.yml</strong><dd><code>Downgrade download-artifact action to v6.0.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/update-docs.lock.yml

<ul><li>Updates <code>actions/download-artifact</code> from v7.0.0 to v6.0.0 across <br>multiple job steps<br> <li> Changes action hash from <code>37930b1c2abaa49bbe596cd826c3c89aef350131</code> to <br><code>018cc2cf5baa6db3ef3c5f8a56943fffe632ef53</code><br> <li> Affects 4 separate download-artifact steps in the workflow</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/267/files#diff-c2b050ffb20dda3a16d089dcf9d74ae61e8adb7beaae9ce0d73a26b4916079cf">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>update-rules.lock.yml</strong><dd><code>Downgrade download-artifact action to v6.0.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/update-rules.lock.yml

<ul><li>Updates <code>actions/download-artifact</code> from v7.0.0 to v6.0.0 across <br>multiple job steps<br> <li> Changes action hash from <code>37930b1c2abaa49bbe596cd826c3c89aef350131</code> to <br><code>018cc2cf5baa6db3ef3c5f8a56943fffe632ef53</code><br> <li> Affects 4 separate download-artifact steps in the workflow</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/267/files#diff-92106366aef0c83cc847a3dd128cef03b6ab4f96517592ebd26eec437171f9ee">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

