### PR TITLE
docs: Add comprehensive documentation for admin packages

### DIFF
--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -14,6 +14,8 @@ A monorepo containing shared packages for building full-stack applications with 
 - **api/** - REST API framework built on Express/Mongoose (`@terreno/api`)
 - **ui/** - React Native UI component library (`@terreno/ui`)
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
+- **admin-backend/** - Admin panel backend plugin (`@terreno/admin-backend`)
+- **admin-frontend/** - Admin panel React Native UI components (`@terreno/admin-frontend`)
 - **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage

--- a/.rulesync/rules/admin-backend/00-admin-backend.md
+++ b/.rulesync/rules/admin-backend/00-admin-backend.md
@@ -1,0 +1,131 @@
+---
+description: '@terreno/admin-backend - Admin panel backend plugin'
+applyTo: '**/*'
+---
+# @terreno/admin-backend
+
+Backend plugin for `@terreno/api` that provides automatic admin panel functionality. This is a **backend-only** package — no React, no UI components, no frontend code.
+
+## Commands
+
+```bash
+bun run compile          # Compile TypeScript
+bun run dev              # Watch mode
+bun run lint             # Lint code
+bun run lint:fix         # Fix lint issues
+```
+
+## Architecture
+
+### File Structure
+
+```
+src/
+  adminApp.ts            # AdminApp plugin class
+  index.ts               # Package exports
+```
+
+## AdminApp Plugin
+
+Implements `TerrenoPlugin` pattern with `register(app: express.Application)` method.
+
+### Configuration
+
+```typescript
+import {AdminApp} from "@terreno/admin-backend";
+
+new AdminApp({
+  models: [
+    {
+      model: Todo,                    // Mongoose model
+      routePath: "/todos",            // Route path (e.g., /admin/todos)
+      displayName: "Todos",           // Human-readable name
+      listFields: ["title", "completed", "ownerId", "created"],
+      defaultSort: "-created",        // Optional, defaults to "-created"
+    },
+  ],
+  basePath: "/admin",                 // Optional, defaults to "/admin"
+}).register(app);
+```
+
+### Generated Endpoints
+
+#### GET /admin/config
+
+Returns model metadata for all registered models:
+
+```typescript
+{
+  models: [
+    {
+      name: "Todo",
+      routePath: "/admin/todos",
+      displayName: "Todos",
+      listFields: ["title", "completed", "ownerId", "created"],
+      defaultSort: "-created",
+      fields: {
+        title: {type: "string", required: true, description: "..."},
+        completed: {type: "boolean", required: false, default: false},
+        ownerId: {type: "string", required: true, ref: "User"},
+      }
+    }
+  ]
+}
+```
+
+#### CRUD Routes
+
+For each model, mounts `modelRouter` with admin-only permissions:
+
+- `GET /admin/{routePath}` — List with pagination
+- `POST /admin/{routePath}` — Create
+- `GET /admin/{routePath}/:id` — Read
+- `PATCH /admin/{routePath}/:id` — Update
+- `DELETE /admin/{routePath}/:id` — Delete
+
+All routes require `Permissions.IsAdmin` (user must have `admin: true`).
+
+## Field Metadata Extraction
+
+Uses `getOpenApiSpecForModel()` from `@terreno/api` to extract field information:
+
+- **Type**: Derived from Mongoose schema types
+- **Required**: From schema validation rules
+- **Description**: From field `description` property (always include descriptions)
+- **Enum**: From schema enum arrays
+- **Default**: Schema default values
+- **Ref**: Relationship references (extracted from schema path options)
+
+## Integration Pattern
+
+```typescript
+// In your server setup
+import {setupServer} from "@terreno/api";
+import {AdminApp} from "@terreno/admin-backend";
+
+const app = setupServer({
+  userModel: User,
+  addRoutes: (router, options) => {
+    // Your other routes
+  },
+});
+
+// Register admin plugin AFTER setupServer
+new AdminApp({
+  models: [...],
+}).register(app);
+```
+
+## Conventions
+
+- Use TypeScript with ES modules
+- Prefer const arrow functions
+- Named exports preferred
+- Follow @terreno/api conventions for error handling and logging
+- All admin routes require `IsAdmin` permission
+- Model field descriptions are mandatory (flow through to OpenAPI spec)
+
+## Related Packages
+
+- `@terreno/api` - Core API framework (required peer dependency)
+- `@terreno/admin-frontend` - React Native admin UI components

--- a/.rulesync/rules/admin-frontend/00-admin-frontend.md
+++ b/.rulesync/rules/admin-frontend/00-admin-frontend.md
@@ -1,0 +1,179 @@
+---
+description: '@terreno/admin-frontend - Admin panel React Native UI components'
+applyTo: '**/*'
+---
+# @terreno/admin-frontend
+
+React Native admin panel UI components for `@terreno/api` backends. This is a **frontend-only** package — no Express, no Mongoose, no backend code.
+
+## Commands
+
+```bash
+bun run compile          # Compile TypeScript
+bun run dev              # Watch mode
+bun run lint             # Lint code
+bun run lint:fix         # Fix lint issues
+```
+
+## Architecture
+
+### File Structure
+
+```
+src/
+  index.tsx              # Package exports
+  types.ts               # TypeScript interfaces
+  useAdminConfig.ts      # Hook for fetching admin config
+  useAdminApi.ts         # Hook for dynamic RTK Query endpoints
+  AdminModelList.tsx     # Model card grid
+  AdminModelTable.tsx    # DataTable with pagination
+  AdminModelForm.tsx     # Dynamic create/edit form
+  AdminFieldRenderer.tsx # Field type to UI component mapper
+  AdminRefField.tsx      # ObjectId reference selector
+```
+
+## Components
+
+### AdminModelList
+
+Card grid showing all registered models. Fetches config from `GET {baseUrl}/config`.
+
+```typescript
+<AdminModelList baseUrl="/admin" api={terrenoApi} />
+```
+
+### AdminModelTable
+
+Paginated DataTable for a specific model.
+
+```typescript
+<AdminModelTable 
+  baseUrl="/admin" 
+  api={terrenoApi} 
+  modelName="Todo" 
+/>
+```
+
+**Features:**
+- Pagination with configurable page size
+- Column sorting
+- Date formatting (Luxon)
+- Row click → edit form
+- Create button in header
+
+### AdminModelForm
+
+Dynamic form for creating or editing model instances.
+
+```typescript
+<AdminModelForm 
+  baseUrl="/admin"
+  api={terrenoApi}
+  modelName="Todo"
+  mode="create"
+/>
+
+<AdminModelForm 
+  baseUrl="/admin"
+  api={terrenoApi}
+  modelName="Todo"
+  mode="edit"
+  itemId="507f1f77bcf86cd799439011"
+/>
+```
+
+**Features:**
+- Field type mapping via `AdminFieldRenderer`
+- Required field validation
+- Default values in create mode
+- Delete with confirmation (edit mode)
+- Toast notifications
+
+## Hooks
+
+### useAdminConfig
+
+Fetches admin configuration from backend.
+
+```typescript
+const {config, isLoading, error} = useAdminConfig(api, "/admin");
+// config.models: AdminModelConfig[]
+```
+
+### useAdminApi
+
+Dynamically injects RTK Query endpoints for a model.
+
+```typescript
+const {
+  useListQuery,
+  useReadQuery,
+  useCreateMutation,
+  useUpdateMutation,
+  useDeleteMutation,
+} = useAdminApi(api, "/admin/todos", "Todo");
+```
+
+## Field Type Mapping
+
+`AdminFieldRenderer` maps OpenAPI types to @terreno/ui components:
+
+| OpenAPI Type | UI Component | Notes |
+|-------------|-------------|-------|
+| `boolean` | `BooleanField` | Checkbox |
+| `string` (enum) | `SelectField` | Dropdown |
+| `string` (ref) | `AdminRefField` | Related model selector |
+| `string` (date/time) | `DateTimeField` | ISO string picker |
+| `number`, `integer` | `NumberField` | Numeric input |
+| `string` (default) | `TextField` | Text input |
+
+## System Fields
+
+These fields are auto-excluded from forms:
+- `_id`, `id`, `__v`
+- `created`, `updated`, `deleted`
+
+Defined in `SYSTEM_FIELDS` constant.
+
+## Expo Router Integration
+
+```typescript
+// app/admin/index.tsx - Model list
+export default function AdminScreen() {
+  return <AdminModelList baseUrl="/admin" api={terrenoApi} />;
+}
+
+// app/admin/[model]/index.tsx - Model table
+export default function AdminModelScreen() {
+  const {model} = useLocalSearchParams<{model: string}>();
+  return <AdminModelTable baseUrl="/admin" api={terrenoApi} modelName={model} />;
+}
+
+// app/admin/[model]/create.tsx - Create form
+export default function AdminCreateScreen() {
+  const {model} = useLocalSearchParams<{model: string}>();
+  return <AdminModelForm baseUrl="/admin" api={terrenoApi} modelName={model} mode="create" />;
+}
+
+// app/admin/[model]/[id].tsx - Edit form
+export default function AdminEditScreen() {
+  const {model, id} = useLocalSearchParams<{model: string; id: string}>();
+  return <AdminModelForm baseUrl="/admin" api={terrenoApi} modelName={model} mode="edit" itemId={id} />;
+}
+```
+
+## Conventions
+
+- Use @terreno/ui components (Box, Page, Card, DataTable, form fields) — never raw View/Text
+- Use RTK Query hooks from `useAdminApi` for all API calls
+- Use `useCallback` for event handlers
+- Handle loading, error, and empty states
+- Use `console.info/debug/warn/error` for permanent logs
+- Use Luxon for date operations
+- Always support React Native Web
+
+## Related Packages
+
+- `@terreno/admin-backend` - Backend plugin (required)
+- `@terreno/ui` - UI component library (required)
+- `@terreno/rtk` - RTK Query utilities (required)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A monorepo containing shared packages for building full-stack applications.
 - **api/** - REST API framework built on Express/Mongoose (published as `@terreno/api`)
 - **ui/** - React Native UI component library (published as `@terreno/ui`)
 - **rtk/** - Redux Toolkit Query utilities for @terreno/api backends (published as `@terreno/rtk`)
+- **admin-backend/** - Admin panel backend plugin for `@terreno/api` (published as `@terreno/admin-backend`)
+- **admin-frontend/** - Admin panel React Native UI components (published as `@terreno/admin-frontend`)
 
 ### Deployed Services
 

--- a/admin-backend/README.md
+++ b/admin-backend/README.md
@@ -1,0 +1,169 @@
+# @terreno/admin-backend
+
+Backend plugin for `@terreno/api` that provides automatic admin panel functionality. Exposes model metadata via REST API and mounts admin-only CRUD routes for registered Mongoose models.
+
+## Features
+
+- **Model Metadata Endpoint**: `GET /admin/config` returns field types, validation rules, relationships, and display configuration
+- **Admin-Only CRUD Routes**: Automatic REST endpoints with `IsAdmin` permission guards
+- **OpenAPI Integration**: Field metadata extracted from Mongoose schemas using `getOpenApiSpecForModel`
+- **Plugin Architecture**: Implements `TerrenoPlugin` pattern for clean integration with `setupServer`
+
+## Installation
+
+```bash
+bun add @terreno/admin-backend
+```
+
+## Usage
+
+### Basic Setup
+
+Register the `AdminApp` plugin in your server setup:
+
+``````typescript
+import {setupServer} from "@terreno/api";
+import {AdminApp} from "@terreno/admin-backend";
+import {User, Todo} from "./models";
+
+const app = setupServer({
+  userModel: User,
+  addRoutes: (router, options) => {
+    // Your other routes
+  },
+});
+
+new AdminApp({
+  models: [
+    {
+      model: Todo,
+      routePath: "/todos",
+      displayName: "Todos",
+      listFields: ["title", "completed", "ownerId", "created"],
+      defaultSort: "-created",
+    },
+    {
+      model: User,
+      routePath: "/users",
+      displayName: "Users",
+      listFields: ["email", "name", "admin", "created"],
+    },
+  ],
+}).register(app);
+``````
+
+### Configuration Options
+
+#### AdminApp Options
+
+| Option | Type | Required | Default | Description |
+|--------|------|----------|---------|-------------|
+| `models` | `AdminModelConfig[]` | Yes | - | Array of models to expose in admin panel |
+| `basePath` | `string` | No | `/admin` | Base path for all admin routes |
+
+#### AdminModelConfig
+
+| Option | Type | Required | Default | Description |
+|--------|------|----------|---------|-------------|
+| `model` | `Model<any>` | Yes | - | Mongoose model to expose |
+| `routePath` | `string` | Yes | - | Route path (e.g., `/todos`) |
+| `displayName` | `string` | Yes | - | Human-readable name for UI |
+| `listFields` | `string[]` | Yes | - | Fields to show in list view |
+| `defaultSort` | `string` | No | `-created` | Default sort order |
+
+### Generated Endpoints
+
+#### Configuration Endpoint
+
+**GET /admin/config**
+
+Returns metadata for all registered models:
+
+``````json
+{
+  "models": [
+    {
+      "name": "Todo",
+      "routePath": "/admin/todos",
+      "displayName": "Todos",
+      "listFields": ["title", "completed", "ownerId", "created"],
+      "defaultSort": "-created",
+      "fields": {
+        "title": {
+          "type": "string",
+          "required": true,
+          "description": "The title of the todo item"
+        },
+        "completed": {
+          "type": "boolean",
+          "required": false,
+          "default": false,
+          "description": "Whether the todo item has been completed"
+        },
+        "ownerId": {
+          "type": "string",
+          "required": true,
+          "ref": "User",
+          "description": "The user who owns this todo"
+        }
+      }
+    }
+  ]
+}
+``````
+
+#### CRUD Endpoints
+
+For each registered model, the following endpoints are created with `IsAdmin` permissions:
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/admin/{routePath}` | List items with pagination |
+| POST | `/admin/{routePath}` | Create new item |
+| GET | `/admin/{routePath}/:id` | Get single item |
+| PATCH | `/admin/{routePath}/:id` | Update item |
+| DELETE | `/admin/{routePath}/:id` | Delete item |
+
+## Field Metadata
+
+Field metadata is automatically extracted from Mongoose schemas:
+
+- **Type**: Mapped from Mongoose schema types (String → "string", Boolean → "boolean", ObjectId → "string")
+- **Required**: Derived from schema validation rules
+- **Description**: Pulled from field `description` property (always use descriptions on model fields)
+- **Enum**: Extracted from schema enum arrays
+- **Default**: Schema default values
+- **Ref**: Relationship references extracted from schema path options
+
+## Permissions
+
+All admin endpoints require the user to have `admin: true` in their user document. Uses `@terreno/api` permission system:
+
+- `Permissions.IsAdmin` applied to all CRUD operations
+- Unauthenticated requests return 401
+- Non-admin authenticated users return 403
+
+## Integration with Frontend
+
+Pair with `@terreno/admin-frontend` for a complete admin panel solution:
+
+``````typescript
+// Backend
+new AdminApp({models: [...]}).register(app);
+
+// Frontend (see @terreno/admin-frontend docs)
+import {AdminModelList, AdminModelTable, AdminModelForm} from "@terreno/admin-frontend";
+``````
+
+## Example
+
+See `example-backend/src/server.ts` for a complete working example with Todo and User models.
+
+## Related Packages
+
+- `@terreno/api` - Core API framework (required peer dependency)
+- `@terreno/admin-frontend` - React Native admin UI components
+
+## License
+
+Apache-2.0

--- a/admin-frontend/README.md
+++ b/admin-frontend/README.md
@@ -1,0 +1,270 @@
+# @terreno/admin-frontend
+
+React Native admin panel UI components for `@terreno/api` backends. Provides dynamic screens that automatically generate DataTables, forms, and list views from backend model metadata.
+
+## Features
+
+- **Dynamic Screen Components**: Auto-generated UI based on OpenAPI model schemas
+- **Full CRUD Operations**: List, create, read, update, and delete with RTK Query hooks
+- **Type-Safe Forms**: Field type mapping to appropriate UI components
+- **Relationship Support**: SelectField for ObjectId references with auto-fetch
+- **Data Tables**: Pagination, sorting, and date formatting (via Luxon)
+- **Expo Router Compatible**: Drop-in screens for Expo Router navigation
+
+## Installation
+
+``````bash
+bun add @terreno/admin-frontend
+``````
+
+**Peer Dependencies**: `react`, `react-redux`, `@reduxjs/toolkit`
+
+## Usage
+
+### Basic Setup
+
+Register your admin backend with `@terreno/admin-backend`, then use the frontend components:
+
+``````typescript
+import {AdminModelList, AdminModelTable, AdminModelForm} from "@terreno/admin-frontend";
+import {terrenoApi} from "@/store/sdk";
+
+// List view - shows all registered models as cards
+<AdminModelList baseUrl="/admin" api={terrenoApi} />
+
+// Table view - paginated DataTable for a specific model
+<AdminModelTable 
+  baseUrl="/admin" 
+  api={terrenoApi} 
+  modelName="Todo" 
+/>
+
+// Form view - create or edit a model instance
+<AdminModelForm 
+  baseUrl="/admin"
+  api={terrenoApi}
+  modelName="Todo"
+  mode="create"
+/>
+
+<AdminModelForm 
+  baseUrl="/admin"
+  api={terrenoApi}
+  modelName="Todo"
+  mode="edit"
+  itemId="507f1f77bcf86cd799439011"
+/>
+``````
+
+### Expo Router Integration
+
+Create admin screens in your Expo Router app:
+
+``````typescript
+// app/admin/index.tsx - Model list
+import {AdminModelList} from "@terreno/admin-frontend";
+import {terrenoApi} from "@/store/sdk";
+
+export default function AdminScreen() {
+  return <AdminModelList baseUrl="/admin" api={terrenoApi} />;
+}
+
+// app/admin/[model]/index.tsx - Model table
+import {AdminModelTable} from "@terreno/admin-frontend";
+import {useLocalSearchParams} from "expo-router";
+import {terrenoApi} from "@/store/sdk";
+
+export default function AdminModelScreen() {
+  const {model} = useLocalSearchParams<{model: string}>();
+  return <AdminModelTable baseUrl="/admin" api={terrenoApi} modelName={model} />;
+}
+
+// app/admin/[model]/create.tsx - Create form
+import {AdminModelForm} from "@terreno/admin-frontend";
+import {useLocalSearchParams} from "expo-router";
+import {terrenoApi} from "@/store/sdk";
+
+export default function AdminCreateScreen() {
+  const {model} = useLocalSearchParams<{model: string}>();
+  return <AdminModelForm baseUrl="/admin" api={terrenoApi} modelName={model} mode="create" />;
+}
+
+// app/admin/[model]/[id].tsx - Edit form
+import {AdminModelForm} from "@terreno/admin-frontend";
+import {useLocalSearchParams} from "expo-router";
+import {terrenoApi} from "@/store/sdk";
+
+export default function AdminEditScreen() {
+  const {model, id} = useLocalSearchParams<{model: string; id: string}>();
+  return <AdminModelForm baseUrl="/admin" api={terrenoApi} modelName={model} mode="edit" itemId={id} />;
+}
+``````
+
+## Components
+
+### AdminModelList
+
+Grid of cards showing all registered models.
+
+**Props:**
+- `baseUrl` (string, required) - Admin base URL (e.g., `/admin`)
+- `api` (RTK Query API, required) - Redux Toolkit Query API instance
+
+**Features:**
+- Auto-fetches model config from `GET {baseUrl}/config`
+- Card navigation to model tables
+- Loading and error states
+
+### AdminModelTable
+
+DataTable view with pagination and sorting.
+
+**Props:**
+- `baseUrl` (string, required) - Admin base URL
+- `api` (RTK Query API, required) - RTK Query API instance
+- `modelName` (string, required) - Model name (e.g., `"Todo"`)
+
+**Features:**
+- Paginated list with configurable page size
+- Column sorting
+- Date field formatting (ISO → human-readable via Luxon)
+- Row click navigation to edit form
+- Create button in header
+- Loading skeleton and empty states
+
+### AdminModelForm
+
+Dynamic create/edit form with validation.
+
+**Props:**
+- `baseUrl` (string, required) - Admin base URL
+- `api` (RTK Query API, required) - RTK Query API instance
+- `modelName` (string, required) - Model name
+- `mode` (`"create" | "edit"`, required) - Form mode
+- `itemId` (string, optional) - Item ID for edit mode
+
+**Features:**
+- Field type mapping (see Field Renderer section)
+- Required field validation
+- Default values in create mode
+- Delete with confirmation modal (edit mode only)
+- Auto-navigation after save/delete
+- Toast notifications for errors
+
+### AdminFieldRenderer
+
+Maps OpenAPI field types to `@terreno/ui` form components.
+
+**Type Mapping:**
+
+| OpenAPI Type | UI Component | Notes |
+|-------------|-------------|-------|
+| `boolean` | `BooleanField` | Checkbox |
+| `string` (enum) | `SelectField` | Dropdown with enum options |
+| `string` (ref) | `AdminRefField` | Related model selector |
+| `string` (date/time) | `DateTimeField` | ISO string with date picker |
+| `number`, `integer` | `NumberField` | Numeric input |
+| `string` (default) | `TextField` | Text input |
+
+### AdminRefField
+
+SelectField for ObjectId references that fetches related items.
+
+**Features:**
+- Auto-fetches first 100 items from referenced model
+- Uses `displayName` or fallback fields for labels
+- Shows loading state while fetching
+- Handles missing/invalid references
+
+## Hooks
+
+### useAdminConfig
+
+Fetches admin configuration from backend.
+
+``````typescript
+import {useAdminConfig} from "@terreno/admin-frontend";
+
+const {config, isLoading, error} = useAdminConfig(api, "/admin");
+// config.models: AdminModelConfig[]
+``````
+
+### useAdminApi
+
+Dynamically injects RTK Query endpoints for a model.
+
+``````typescript
+import {useAdminApi} from "@terreno/admin-frontend";
+
+const {
+  useListQuery,
+  useReadQuery,
+  useCreateMutation,
+  useUpdateMutation,
+  useDeleteMutation,
+} = useAdminApi(api, "/admin/todos", "Todo");
+
+const {data, isLoading} = useListQuery({page: 1, limit: 20});
+const [createTodo] = useCreateMutation();
+``````
+
+## Configuration
+
+Admin configuration is fetched from `GET {baseUrl}/config`. Expected response:
+
+``````typescript
+{
+  models: [
+    {
+      name: "Todo",
+      routePath: "/admin/todos",
+      displayName: "Todos",
+      listFields: ["title", "completed", "ownerId", "created"],
+      defaultSort: "-created",
+      fields: {
+        title: {type: "string", required: true, description: "..."},
+        completed: {type: "boolean", required: false, default: false},
+        ownerId: {type: "string", required: true, ref: "User"},
+      }
+    }
+  ]
+}
+``````
+
+## Styling
+
+All components use `@terreno/ui` primitives:
+- `Box` for layout
+- `Page` for screen structure
+- `Card` for model cards
+- `DataTable` for lists
+- `TextField`, `BooleanField`, `SelectField`, `DateTimeField`, `NumberField` for forms
+- `Button` for actions
+- `Modal` for confirmations
+- `Toast` for notifications
+
+Customize via `TerrenoProvider` theme configuration.
+
+## System Fields
+
+These fields are automatically excluded from forms:
+- `_id`, `id`, `__v`
+- `created`, `updated`, `deleted` (timestamps)
+
+## Permissions
+
+Admin operations require `IsAdmin` permission on the backend. Frontend components display error messages for 401/403 responses.
+
+## Example
+
+See `example-frontend/app/admin/` for complete Expo Router integration.
+
+## Related Packages
+
+- `@terreno/admin-backend` - Backend plugin (required)
+- `@terreno/ui` - UI component library (required)
+- `@terreno/rtk` - RTK Query utilities (required)
+
+## License
+
+Apache-2.0

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/dyoshikawa/rulesync/refs/heads/main/config-schema.json",
   "targets": ["cursor", "windsurf", "claudecode", "copilot"],
   "features": ["rules"],
-  "baseDirs": [".", "api", "ui", "rtk", "demo", "example-frontend", "example-backend", "mcp-server"],
+  "baseDirs": [".", "api", "ui", "rtk", "demo", "example-frontend", "example-backend", "mcp-server", "admin-backend", "admin-frontend"],
   "delete": true,
   "verbose": false
 }


### PR DESCRIPTION
## Summary

Adds complete documentation for the newly added `@terreno/admin-backend` and `@terreno/admin-frontend` packages introduced in PR #246.

## Changes

### Package Documentation

- **admin-backend/README.md**: Complete reference documentation including:
  - Installation and basic setup
  - Configuration options and interfaces
  - Generated endpoints (config endpoint + CRUD routes)
  - Field metadata extraction from Mongoose schemas
  - Permissions model (IsAdmin)
  - Integration pattern with setupServer
  - Example usage

- **admin-frontend/README.md**: Complete component documentation including:
  - Installation and peer dependencies
  - Component API reference (AdminModelList, AdminModelTable, AdminModelForm)
  - Hooks documentation (useAdminConfig, useAdminApi)
  - Field type mapping (OpenAPI types to UI components)
  - Expo Router integration examples
  - Styling and theming information

### AI Assistant Rules

- **.rulesync/rules/admin-backend/00-admin-backend.md**: AI coding rules for the admin backend package
- **.rulesync/rules/admin-frontend/00-admin-frontend.md**: AI coding rules for the admin frontend package
- **rulesync.jsonc**: Added admin-backend and admin-frontend to baseDirs array

### Repository Documentation

- **README.md**: Updated Published Packages section to list admin-backend and admin-frontend
- **.rulesync/rules/00-root.md**: Updated Packages section to include admin packages

## Documentation Standards

All documentation follows the Diátaxis framework:
- **Technical Reference**: Precise API descriptions, parameters, return types
- **How-to Guides**: Practical setup and integration examples
- **Explanation**: Architecture and design pattern explanations

Written in plain English with progressive disclosure (high-level concepts first, detailed examples second).

## Note on Generated Files

The rulesync-generated files (AGENTS.md, .github/copilot-instructions.md) will be automatically updated when CI runs `bun rules`. This PR includes the source rule files but not the generated outputs—they will be regenerated in CI.

## Testing

- [x] Documentation is accurate and matches actual code behavior
- [x] All code examples are syntactically correct
- [x] Cross-references between packages are accurate
- [ ] CI will verify rulesync files are properly generated

## Related

- Closes documentation gap for PR #246
- Complements the admin packages implementation


> AI generated by [Update Docs](https://github.com/FlourishHealth/terreno/actions/runs/22282552827)

<!-- gh-aw-workflow-id: update-docs -->