### PR TITLE
docs: Add rulesync rules for admin-backend, admin-frontend, and api-health packages

### DIFF
--- a/.rulesync/rules/admin-backend/00-admin-backend.md
+++ b/.rulesync/rules/admin-backend/00-admin-backend.md
@@ -1,0 +1,82 @@
+---
+description: '@terreno/admin-backend - Admin panel backend plugin for @terreno/api'
+applyTo: '**/*'
+---
+# @terreno/admin-backend
+
+Admin panel backend plugin for @terreno/api that auto-generates CRUD endpoints with metadata for admin interfaces. This is a **backend-only** package — no React, no UI components, no frontend code.
+
+## Commands
+
+```bash
+bun run compile          # Compile TypeScript
+bun run dev              # Watch mode
+bun run lint             # Lint code
+bun run lint:fix         # Fix lint issues
+```
+
+## Purpose
+
+Provides Express middleware that exposes admin-friendly metadata endpoints for Mongoose models. Works in tandem with @terreno/admin-frontend to build full-featured admin panels without custom code.
+
+## Key Exports
+
+### AdminApp
+
+```typescript
+import {AdminApp} from "@terreno/admin-backend";
+
+const adminApp = new AdminApp({
+  basePath: "/admin",  // Default: /admin
+  models: [
+    {
+      model: User,
+      routePath: "users",
+      displayName: "Users",
+      listFields: ["email", "name", "created"],
+      defaultSort: "-created",
+    },
+    {
+      model: Todo,
+      routePath: "todos",
+      displayName: "Todos",
+      listFields: ["title", "completed", "ownerId"],
+      defaultSort: "-created",
+    },
+  ],
+});
+
+// Register with Express app (after auth setup)
+adminApp.register(app);
+```
+
+### Generated Endpoints
+
+- `GET /admin/config` — Returns model metadata (fields, types, required, enum values, references) extracted from OpenAPI schemas
+- Model CRUD routes are created via `modelRouter` with `IsAdmin` permission
+
+### AdminModelConfig
+
+```typescript
+interface AdminModelConfig {
+  model: Model<any>;           // Mongoose model
+  routePath: string;           // URL path segment (e.g., "users")
+  displayName: string;         // Human-readable name
+  listFields: string[];        // Fields to show in list view
+  defaultSort?: string;        // Default sort (e.g., "-created")
+}
+```
+
+## Integration with @terreno/api
+
+AdminApp is a TerrenoPlugin that registers routes via the `register(app)` method. It uses:
+- `getOpenApiSpecForModel()` to extract field metadata
+- `modelRouter()` to create standard CRUD endpoints with admin-only permissions
+- Mongoose schema introspection for field types, required flags, enums, and references
+
+## Conventions
+
+- All admin routes require `IsAdmin` permission
+- Admin routes are namespaced under `/admin` by default (configurable via `basePath`)
+- Field metadata is derived from Mongoose schemas via OpenAPI introspection
+- Use with @terreno/admin-frontend for a complete admin interface

--- a/.rulesync/rules/admin-frontend/00-admin-frontend.md
+++ b/.rulesync/rules/admin-frontend/00-admin-frontend.md
@@ -1,0 +1,144 @@
+---
+description: '@terreno/admin-frontend - Admin panel frontend screens for @terreno/api backends'
+applyTo: '**/*'
+---
+# @terreno/admin-frontend
+
+React Native admin panel screens for @terreno/api backends. Provides drop-in components for listing, viewing, creating, and editing model instances. This is a **frontend-only** package — no Express, no Mongoose, no backend code.
+
+## Commands
+
+```bash
+bun run compile          # Compile TypeScript
+bun run dev              # Watch mode
+bun run lint             # Lint code
+bun run lint:fix         # Fix lint issues
+```
+
+## Purpose
+
+Pre-built admin UI components that connect to @terreno/admin-backend endpoints. Handles CRUD operations, field rendering (text, date, boolean, references), validation, and list views with minimal configuration.
+
+## Key Exports
+
+### AdminModelList
+
+```typescript
+import {AdminModelList} from "@terreno/admin-frontend";
+
+<AdminModelList
+  modelName="users"
+  baseUrl="/admin"
+  navigation={navigation}
+/>
+```
+
+List screen with:
+- Table view of configured listFields
+- Sorting and pagination
+- Row click to detail/edit screen
+- Create button
+
+### AdminModelForm
+
+```typescript
+import {AdminModelForm} from "@terreno/admin-frontend";
+
+<AdminModelForm
+  modelName="users"
+  baseUrl="/admin"
+  itemId={id}  // Omit for create
+  navigation={navigation}
+/>
+```
+
+Auto-generated form with:
+- Field type detection (text, boolean, date, number, reference)
+- Validation from schema required/enum
+- Save/cancel actions
+- Reference field autocomplete
+
+### AdminFieldRenderer
+
+```typescript
+import {AdminFieldRenderer} from "@terreno/admin-frontend";
+
+<AdminFieldRenderer
+  field={fieldConfig}
+  value={value}
+  onChange={setValue}
+/>
+```
+
+Renders appropriate field component based on type:
+- String → TextField
+- Boolean → CheckBox
+- Date → DateTimeField
+- Number → NumberField
+- Reference → AdminRefField (autocomplete dropdown)
+- Enum → SelectField
+
+### Hooks
+
+```typescript
+// Fetch admin config (model metadata)
+const {config, isLoading, error} = useAdminConfig({baseUrl: "/admin"});
+
+// Pre-configured RTK Query API for admin endpoints
+const {useGetConfigQuery, useGetItemsQuery, useGetItemQuery, useCreateItemMutation, useUpdateItemMutation, useDeleteItemMutation} = useAdminApi({baseUrl: "/admin"});
+```
+
+## Integration Flow
+
+1. Backend exposes `/admin/config` via @terreno/admin-backend
+2. Frontend fetches config on mount with `useAdminConfig`
+3. Config provides field metadata (type, required, enum, refs) for each model
+4. Components render fields dynamically based on metadata
+5. CRUD operations use RTK Query hooks from `useAdminApi`
+
+## AdminScreenProps
+
+```typescript
+interface AdminScreenProps {
+  modelName: string;       // Model key from config (e.g., "users")
+  baseUrl?: string;        // Base URL for admin API (default: "/admin")
+  navigation: any;         // React Navigation prop
+  itemId?: string;         // For edit/detail screens
+}
+```
+
+## Types
+
+### AdminModelConfig
+
+```typescript
+interface AdminModelConfig {
+  name: string;            // Model name
+  routePath: string;       // API route path
+  displayName: string;     // Human-readable name
+  listFields: string[];    // Fields for list view
+  defaultSort: string;     // Default sort order
+  fields: Record<string, AdminFieldConfig>;
+}
+```
+
+### AdminFieldConfig
+
+```typescript
+interface AdminFieldConfig {
+  type: string;            // "string" | "boolean" | "number" | "date" | "array" | "object"
+  required: boolean;
+  description?: string;
+  enum?: string[];
+  default?: any;
+  ref?: string;            // Reference to another model
+}
+```
+
+## Conventions
+
+- Use @terreno/ui components for rendering (Box, Text, Button, TextField, etc.)
+- All components are React Native Web compatible
+- Field rendering is extensible via AdminFieldRenderer
+- System fields (_id, created, updated) are hidden from forms
+- References auto-fetch options from the referenced model's list endpoint

--- a/.rulesync/rules/api-health/00-api-health.md
+++ b/.rulesync/rules/api-health/00-api-health.md
@@ -1,0 +1,127 @@
+---
+description: '@terreno/api-health - Health check plugin for @terreno/api'
+applyTo: '**/*'
+---
+# @terreno/api-health
+
+Health check endpoint plugin for @terreno/api backends. Provides a simple GET endpoint for uptime monitoring, load balancers, and orchestration platforms. This is a **backend-only** package — no React, no UI components, no frontend code.
+
+## Commands
+
+```bash
+bun run compile          # Compile TypeScript
+bun run dev              # Watch mode
+bun run test             # Run tests
+bun run lint             # Lint code
+bun run lint:fix         # Fix lint issues
+```
+
+## Purpose
+
+Adds a configurable health check endpoint to Express apps. Supports custom health checks (e.g., database connectivity, external service availability) and standard HTTP status codes for healthy/unhealthy responses.
+
+## Key Exports
+
+### HealthApp
+
+```typescript
+import {HealthApp} from "@terreno/api-health";
+
+const healthApp = new HealthApp({
+  enabled: true,           // Default: true
+  path: "/health",         // Default: /health
+  check: async () => {
+    // Custom health check logic
+    const dbHealthy = await mongoose.connection.db.admin().ping();
+    return {
+      healthy: dbHealthy,
+      details: {database: "connected", timestamp: new Date().toISOString()},
+    };
+  },
+});
+
+// Register with Express app
+healthApp.register(app);
+```
+
+### HealthOptions
+
+```typescript
+interface HealthOptions {
+  enabled?: boolean;      // Enable/disable health endpoint (default: true)
+  path?: string;          // Endpoint path (default: "/health")
+  check?: () => Promise<HealthCheckResult> | HealthCheckResult;
+}
+```
+
+### HealthCheckResult
+
+```typescript
+interface HealthCheckResult {
+  healthy: boolean;       // Overall health status
+  details?: Record<string, any>;  // Optional diagnostic info
+}
+```
+
+## Behavior
+
+### Without Custom Check
+
+```bash
+GET /health
+# 200 OK
+{"healthy": true}
+```
+
+### With Custom Check (healthy)
+
+```bash
+GET /health
+# 200 OK
+{"healthy": true, "details": {"database": "connected", "timestamp": "2026-02-22T20:00:00.000Z"}}
+```
+
+### With Custom Check (unhealthy)
+
+```bash
+GET /health
+# 503 Service Unavailable
+{"healthy": false, "details": {"database": "disconnected"}}
+```
+
+### With Custom Check (error)
+
+```bash
+GET /health
+# 503 Service Unavailable
+{"healthy": false, "details": {"error": "Connection timeout"}}
+```
+
+## Integration with @terreno/api
+
+HealthApp implements the TerrenoPlugin interface, so it can be registered via `setupServer`:
+
+```typescript
+import {HealthApp} from "@terreno/api-health";
+import {setupServer} from "@terreno/api";
+
+setupServer({
+  userModel: User,
+  plugins: [
+    new HealthApp({
+      check: async () => {
+        const dbOk = mongoose.connection.readyState === 1;
+        return {healthy: dbOk, details: {database: dbOk ? "connected" : "disconnected"}};
+      },
+    }),
+  ],
+});
+```
+
+## Conventions
+
+- Health endpoint is unauthenticated (public access)
+- Returns 200 for healthy, 503 for unhealthy
+- Custom check function can be async or sync
+- Errors in custom check are caught and returned as unhealthy
+- Use `enabled: false` to disable in development or when not needed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,9 @@ A monorepo containing shared packages for building full-stack applications with 
 - **api/** - REST API framework built on Express/Mongoose (`@terreno/api`)
 - **ui/** - React Native UI component library (`@terreno/ui`)
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
+- **admin-backend/** - Admin panel backend plugin for @terreno/api (`@terreno/admin-backend`)
+- **admin-frontend/** - Admin panel frontend screens for @terreno/api backends (`@terreno/admin-frontend`)
+- **api-health/** - Health check plugin for @terreno/api (`@terreno/api-health`)
 - **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
@@ -34,6 +37,9 @@ bun run frontend:web     # Start frontend example
 bun run backend:dev      # Start backend example
 bun run mcp:build        # Build MCP server
 bun run mcp:start        # Start MCP server
+bun run admin-backend:compile  # Compile admin backend
+bun run admin-frontend:compile # Compile admin frontend
+bun run api-health:test        # Test health check plugin
 ```
 
 ## How the Packages Work Together

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/dyoshikawa/rulesync/refs/heads/main/config-schema.json",
   "targets": ["cursor", "windsurf", "claudecode", "copilot"],
   "features": ["rules"],
-  "baseDirs": [".", "api", "ui", "rtk", "demo", "example-frontend", "example-backend", "mcp-server"],
+  "baseDirs": [".", "api", "ui", "rtk", "demo", "example-frontend", "example-backend", "mcp-server", "admin-backend", "admin-frontend", "api-health"],
   "delete": true,
   "verbose": false
 }


### PR DESCRIPTION
## Summary

Adds rulesync source rules and AGENTS.md documentation for three packages that were missing from agent documentation:

- **`@terreno/admin-backend`** - Admin panel backend plugin for `@terreno/api`
- **`@terreno/admin-frontend`** - Admin panel frontend screens for `@terreno/api` backends
- **`@terreno/api-health`** - Health check plugin for `@terreno/api`

These packages exist in the repository with substantial implementation (1100+ lines total) and are included in workspace configuration and root package.json scripts, but were not documented for AI assistants.

## Changes

### Source Files (need regeneration)
- Added `admin-backend`, `admin-frontend`, `api-health` to `rulesync.jsonc` baseDirs
- Created `.rulesync/rules/admin-backend/00-admin-backend.md` - documents AdminApp class, plugin architecture, metadata endpoints
- Created `.rulesync/rules/admin-frontend/00-admin-frontend.md` - documents AdminModelList, AdminModelForm, field rendering
- Created `.rulesync/rules/api-health/00-api-health.md` - documents HealthApp plugin, health check customization
- Updated `AGENTS.md` to include the three packages in the Packages section and package-specific commands

### Action Required by Reviewers

**The generated output files were not committed because they require Bun to regenerate.** Please run the following locally after pulling this branch:

``````bash
bun install
bun run rules
git add .cursor/rules/ .windsurf/rules/ .github/copilot-instructions.md .github/instructions/ .claude/
git commit -m "Regenerate rulesync output files"
``````

This will regenerate:
- `.cursor/rules/*.mdc`
- `.windsurf/rules/*.mdc`  
- `.github/copilot-instructions.md`
- `.github/instructions/*.md`
- `.claude/CLAUDE.md`

The `rulesync-check` workflow will fail until these files are committed.

## Context

These packages were added to the repository but never included in the rulesync configuration or agent documentation. They provide important functionality:

- **admin-backend**: Express plugin that auto-generates admin CRUD endpoints with metadata
- **admin-frontend**: React Native components for building admin UIs with minimal code
- **api-health**: Health check endpoint plugin for uptime monitoring

Without this documentation, AI assistants had no awareness of these packages when generating or reviewing Terreno code.


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22284489095)

<!-- gh-aw-workflow-id: update-rules -->