### PR TITLE
docs: Add reference documentation for admin packages

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -7,6 +7,8 @@ Technical reference for Terreno packages and APIs. Information-oriented, precise
 - [@terreno/api](api.md) — modelRouter, auth, permissions, setupServer
 - [@terreno/ui](ui.md) — Components, theming, layout
 - [@terreno/rtk](rtk.md) — Auth slice, SDK codegen, token handling
+- [@terreno/admin-backend](admin-backend.md) — Auto-generated admin CRUD endpoints
+- [@terreno/admin-frontend](admin-frontend.md) — Admin panel UI components
 - [@terreno/mcp-server](mcp-server.md) — AI coding assistant integration (MCP)
 
 ## Configuration

--- a/docs/reference/admin-backend.md
+++ b/docs/reference/admin-backend.md
@@ -1,0 +1,122 @@
+# @terreno/admin-backend
+
+Backend plugin that auto-generates admin CRUD endpoints for Mongoose models. Works with `@terreno/admin-frontend` to provide a complete admin panel solution.
+
+## Quick Start
+
+``````typescript
+import {AdminApp} from "@terreno/admin-backend";
+import {User, Todo} from "./models";
+
+const admin = new AdminApp({
+  basePath: "/admin",
+  models: [
+    {
+      model: User,
+      routePath: "/users",
+      displayName: "Users",
+      listFields: ["email", "name", "admin"],
+      defaultSort: "-created",
+    },
+    {
+      model: Todo,
+      routePath: "/todos",
+      displayName: "Todos",
+      listFields: ["title", "completed", "ownerId"],
+    },
+  ],
+});
+
+admin.register(app);
+``````
+
+This creates:
+- `GET /admin/config` — Model metadata endpoint
+- Standard CRUD routes for each model at `{basePath}{routePath}`
+- All routes protected with `Permissions.IsAdmin`
+
+## AdminApp Options
+
+``````typescript
+interface AdminOptions {
+  models: AdminModelConfig[];
+  basePath?: string;  // Default: "/admin"
+}
+
+interface AdminModelConfig {
+  model: Model<any>;
+  routePath: string;      // e.g., "/users"
+  displayName: string;    // e.g., "Users"
+  listFields: string[];   // Fields shown in table
+  defaultSort?: string;   // Default: "-created"
+}
+``````
+
+## Generated Routes
+
+For each model, creates standard modelRouter CRUD endpoints:
+
+- `GET {basePath}{routePath}` — List (paginated, sortable)
+- `POST {basePath}{routePath}` — Create
+- `GET {basePath}{routePath}/:id` — Read
+- `PATCH {basePath}{routePath}/:id` — Update
+- `DELETE {basePath}{routePath}/:id` — Delete
+
+## Config Endpoint
+
+`GET {basePath}/config` returns metadata for all registered models:
+
+``````typescript
+{
+  models: [
+    {
+      name: "User",
+      routePath: "/admin/users",
+      displayName: "Users",
+      listFields: ["email", "name", "admin"],
+      defaultSort: "-created",
+      fields: {
+        email: {
+          type: "string",
+          required: true,
+          description: "User email address"
+        },
+        admin: {
+          type: "boolean",
+          required: false,
+          default: false
+        }
+      }
+    }
+  ]
+}
+``````
+
+Field metadata includes:
+- `type` — Field type (string, number, boolean, date, objectid, etc.)
+- `required` — Whether field is required
+- `description` — From schema (ensure all fields have descriptions!)
+- `enum` — Enum values if applicable
+- `default` — Default value
+- `ref` — Referenced model name for ObjectId refs
+
+## Permissions
+
+All admin routes use `Permissions.IsAdmin`, which checks `user.admin === true`.
+
+**Important:** Only expose models that should be editable via admin panel. Avoid sensitive internal models.
+
+## Best Practices
+
+- Add `description` to all model fields — flows through to admin UI
+- Use `listFields` to control which columns appear in table views
+- Set `defaultSort` to control initial ordering (usually `"-created"`)
+- Keep `routePath` simple and pluralized (`"/users"`, `"/todos"`)
+
+## Integration
+
+Works seamlessly with `@terreno/admin-frontend`. The frontend uses the `/admin/config` endpoint to:
+- Discover available models
+- Generate forms with proper field types
+- Render references as clickable links
+- Validate required fields

--- a/docs/reference/admin-frontend.md
+++ b/docs/reference/admin-frontend.md
@@ -1,0 +1,205 @@
+# @terreno/admin-frontend
+
+React Native components for building admin panels that connect to `@terreno/admin-backend`.
+
+## Quick Start
+
+``````typescript
+// app/admin/index.tsx
+import {AdminModelList} from "@terreno/admin-frontend";
+import {api} from "@/store/openApiSdk";
+
+export default function AdminScreen() {
+  return <AdminModelList baseUrl="/admin" api={api} />;
+}
+``````
+
+## Components
+
+### AdminModelList
+
+Entry screen showing all available models as cards.
+
+``````typescript
+<AdminModelList
+  baseUrl="/admin"
+  api={api}
+/>
+``````
+
+Fetches config from `{baseUrl}/config` and displays clickable model cards.
+
+### AdminModelTable
+
+Table view for a specific model with pagination, sorting, and actions.
+
+``````typescript
+<AdminModelTable
+  baseUrl="/admin"
+  api={api}
+  modelName="User"
+/>
+``````
+
+Features:
+- DataTable with columns from backend `listFields`
+- Click row to edit
+- "Create New" button
+- Pagination controls
+- Reference fields render as clickable links
+
+### AdminModelForm
+
+Create or edit form for a model instance.
+
+``````typescript
+<AdminModelForm
+  baseUrl="/admin"
+  api={api}
+  modelName="User"
+  id="507f1f77bcf86cd799439011"  // Optional for edit mode
+/>
+``````
+
+Auto-generates fields from model schema:
+- `string` → TextField
+- `boolean` → BooleanField
+- `number` → NumberField
+- `date` → DateTimeField
+- `objectid` (ref) → SelectField
+- `enum` → SelectField with options
+
+System fields (`_id`, `__v`, `created`, `updated`, `deleted`) are automatically skipped.
+
+### AdminFieldRenderer
+
+Renders field values in table cells with formatting.
+
+``````typescript
+<AdminFieldRenderer
+  value={value}
+  field={fieldConfig}
+  modelName="User"
+  baseUrl="/admin"
+/>
+``````
+
+Handles booleans, dates, ObjectId refs, arrays, objects, and null/undefined.
+
+### AdminRefField
+
+Renders reference fields as clickable links.
+
+``````typescript
+<AdminRefField
+  value={userId}
+  refModel="User"
+  baseUrl="/admin"
+/>
+``````
+
+## Hooks
+
+### useAdminConfig
+
+Fetches admin configuration from backend.
+
+``````typescript
+const {config, isLoading, error} = useAdminConfig(api, baseUrl);
+``````
+
+Returns model metadata from `{baseUrl}/config`.
+
+### useAdminApi
+
+Generates RTK Query hooks for CRUD operations.
+
+``````typescript
+const {
+  useListQuery,
+  useGetQuery,
+  useCreateMutation,
+  useUpdateMutation,
+  useDeleteMutation,
+} = useAdminApi(api, baseUrl, modelName);
+
+const {data, isLoading} = useListQuery({limit: 20, page: 1});
+const [create] = useCreateMutation();
+await create({email: "user@example.com"}).unwrap();
+``````
+
+## Expo Router Setup
+
+``````typescript
+// app/admin/_layout.tsx
+import {Stack} from "expo-router";
+
+export default function AdminLayout() {
+  return <Stack screenOptions={{headerShown: false}} />;
+}
+
+// app/admin/index.tsx - Model list
+import {AdminModelList} from "@terreno/admin-frontend";
+export default () => <AdminModelList baseUrl="/admin" api={api} />;
+
+// app/admin/[modelName]/index.tsx - Model table
+import {AdminModelTable} from "@terreno/admin-frontend";
+export default () => {
+  const {modelName} = useLocalSearchParams();
+  return <AdminModelTable baseUrl="/admin" api={api} modelName={modelName} />;
+};
+
+// app/admin/[modelName]/new.tsx - Create form
+import {AdminModelForm} from "@terreno/admin-frontend";
+export default () => {
+  const {modelName} = useLocalSearchParams();
+  return <AdminModelForm baseUrl="/admin" api={api} modelName={modelName} />;
+};
+
+// app/admin/[modelName]/[id].tsx - Edit form
+import {AdminModelForm} from "@terreno/admin-frontend";
+export default () => {
+  const {modelName, id} = useLocalSearchParams();
+  return <AdminModelForm baseUrl="/admin" api={api} modelName={modelName} id={id} />;
+};
+``````
+
+## Protecting Admin Routes
+
+``````typescript
+// app/_layout.tsx
+import {useSelectCurrentUser} from "@/store/openApiSdk";
+import {Redirect} from "expo-router";
+
+function RootLayout() {
+  const user = useSelectCurrentUser();
+  const pathname = usePathname();
+  
+  if (!user?.admin && pathname.startsWith("/admin")) {
+    return <Redirect href="/" />;
+  }
+  
+  return <Stack />;
+}
+``````
+
+## Custom Field Renderers
+
+Extend `AdminFieldRenderer` for custom field types:
+
+``````typescript
+const CustomFieldRenderer = ({value, field, ...props}) => {
+  if (field.type === "myCustomType") {
+    return <MyCustomComponent value={value} />;
+  }
+  return <AdminFieldRenderer value={value} field={field} {...props} />;
+};
+``````
+
+## Integration
+
+Expects backend to provide:
+1. `GET {baseUrl}/config` — Model metadata
+2. CRUD routes at `{basePath}{routePath}` for each model
+3. Admin authentication (`IsAdmin` permission)
+4. Paginated responses: `{data, page, limit, total, more}`


### PR DESCRIPTION
### **User description**
## Summary

Adds user-facing reference documentation for `@terreno/admin-backend` and `@terreno/admin-frontend` packages in the `docs/reference/` directory.

## Background

These admin packages were introduced in PR #246 and received comprehensive AI assistant rules (rulesync) in PR #266. However, they were missing user-facing documentation in `docs/reference/` where other packages (api, ui, rtk, mcp-server) are documented.

## Changes

- **`docs/reference/admin-backend.md`** — Complete reference for the backend admin plugin
  - AdminApp usage and configuration
  - Generated routes and endpoints
  - Config endpoint metadata structure
  - Permissions and best practices
  
- **`docs/reference/admin-frontend.md`** — Complete reference for frontend admin components
  - Components: AdminModelList, AdminModelTable, AdminModelForm, etc.
  - Hooks: useAdminConfig, useAdminApi
  - Expo Router setup examples
  - Protected routes pattern
  
- **`docs/reference/README.md`** — Added admin packages to the package list

## Documentation Style

Follows existing reference doc patterns:
- Quick start code examples at the top
- API reference with TypeScript interfaces
- Integration patterns
- Best practices
- Concise and example-driven (not prose-heavy)

## Note on Rulesync

This PR does not include regenerated AI assistant rule files (`.cursor/rules/`, `.windsurf/rules/`, `.github/copilot-instructions.md`, etc.) because the GitHub Actions environment lacks the required Node.js version for rulesync.

**Action needed:** After merging, please run `bun run rules` locally to regenerate these files, or the next rulesync-related workflow will regenerate them automatically.

## Verification

- ✅ Documentation covers all exported components and APIs
- ✅ Code examples are accurate and follow repo conventions
- ✅ Cross-references between admin-backend and admin-frontend are correct
- ✅ Consistent with existing reference doc style (api.md, ui.md, rtk.md)
- ✅ Minimal and focused — only what users need to know


> AI generated by [Update Docs](https://github.com/FlourishHealth/terreno/actions/runs/22286163925)

<!-- gh-aw-workflow-id: update-docs -->


___

### **PR Type**
Documentation


___

### **Description**
- Adds comprehensive reference documentation for admin packages

- Documents AdminApp backend plugin with CRUD endpoint generation

- Documents React Native admin UI components and hooks

- Updates package reference index with admin package links


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["docs/reference/README.md"] -->|"adds links"| B["Admin Packages Index"]
  C["admin-backend.md"] -->|"documents"| D["AdminApp Plugin"]
  D -->|"generates"| E["CRUD Routes + Config Endpoint"]
  F["admin-frontend.md"] -->|"documents"| G["Admin UI Components"]
  G -->|"consumes"| E
  H["Hooks useAdminConfig useAdminApi"] -->|"integrates with"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add admin packages to reference index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/reference/README.md

<ul><li>Added two new entries to the package reference list<br> <li> Links to admin-backend.md and admin-frontend.md documentation<br> <li> Maintains consistent formatting with existing package entries</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/273/files#diff-72db60f9730e86ffd0427d6494f18697699f122899ebafc71cda3a9fceeae3ac">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>admin-backend.md</strong><dd><code>Backend admin plugin reference documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/reference/admin-backend.md

<ul><li>Complete reference for AdminApp backend plugin with quick start <br>example<br> <li> Documents AdminOptions and AdminModelConfig interfaces<br> <li> Details generated CRUD routes and config endpoint structure<br> <li> Explains field metadata, permissions, and best practices<br> <li> Covers integration with admin-frontend package</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/273/files#diff-56eb93d215b90e1cf439921328edca7b554b2f18e85e0f93d575f78a0912dc0f">+122/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>admin-frontend.md</strong><dd><code>Frontend admin components and hooks reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/reference/admin-frontend.md

<ul><li>Complete reference for React Native admin UI components<br> <li> Documents five main components: AdminModelList, AdminModelTable, <br>AdminModelForm, AdminFieldRenderer, AdminRefField<br> <li> Covers two hooks: useAdminConfig and useAdminApi with usage examples<br> <li> Provides Expo Router setup patterns for admin routes<br> <li> Includes admin route protection pattern and custom field renderer <br>extension</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/273/files#diff-4c51135e1532906093b99445cb91c94d35c31148e7ff3dc9c78e896ad98421fe">+205/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

