### PR TITLE
Add rulesync rules for api-health package

### DIFF
--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -16,6 +16,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
 - **admin-backend/** - Admin panel backend plugin for @terreno/api (`@terreno/admin-backend`)
 - **admin-frontend/** - Admin panel frontend screens for @terreno/api backends (`@terreno/admin-frontend`)
+- **api-health/** - Health check plugin for @terreno/api (`@terreno/api-health`)
 - **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
@@ -45,6 +46,8 @@ bun run mcp:build        # Build MCP server
 bun run mcp:start        # Start MCP server
 bun run admin-backend:compile   # Compile admin backend
 bun run admin-frontend:compile  # Compile admin frontend
+bun run api-health:compile      # Compile api-health
+bun run api-health:test         # Test api-health
 ```
 
 ## How the Packages Work Together

--- a/.rulesync/rules/01-claudecode-root.md
+++ b/.rulesync/rules/01-claudecode-root.md
@@ -16,6 +16,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
 - **admin-backend/** - Admin panel backend plugin for @terreno/api (`@terreno/admin-backend`)
 - **admin-frontend/** - Admin panel frontend screens for @terreno/api backends (`@terreno/admin-frontend`)
+- **api-health/** - Health check plugin for @terreno/api (`@terreno/api-health`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
 - **example-backend/** - Example Express backend using @terreno/api
@@ -42,6 +43,8 @@ bun run frontend:web     # Start frontend example
 bun run backend:dev      # Start backend example
 bun run admin-backend:compile   # Compile admin backend
 bun run admin-frontend:compile  # Compile admin frontend
+bun run api-health:compile      # Compile api-health
+bun run api-health:test         # Test api-health
 ```
 
 ## How the Packages Work Together

--- a/.rulesync/rules/api-health/00-api-health.md
+++ b/.rulesync/rules/api-health/00-api-health.md
@@ -1,0 +1,232 @@
+---
+description: '@terreno/api-health - Health check plugin for @terreno/api'
+applyTo: '**/*'
+---
+# @terreno/api-health
+
+Health check plugin for @terreno/api that provides configurable health check endpoints for Express applications. This is a **backend-only** package — no React, no UI components, no frontend code.
+
+## Commands
+
+```bash
+bun run compile          # Compile TypeScript
+bun run dev              # Watch mode (TypeScript watch)
+bun run lint             # Lint code
+bun run lint:fix         # Fix lint issues
+bun run test             # Run tests
+bun run test:ci          # Run tests (CI mode)
+```
+
+## Architecture
+
+### File Structure
+
+```
+src/
+  index.ts               # Package exports
+  healthApp.ts           # HealthApp class - implements TerrenoPlugin interface
+  healthApp.test.ts      # Test suite
+```
+
+### Key Concepts
+
+The health check plugin provides:
+- **HealthApp class**: Implements the `TerrenoPlugin` interface from @terreno/api
+- **Configurable endpoint**: Customize path and health check logic
+- **Status codes**: Returns 200 for healthy, 503 for unhealthy
+- **Custom checks**: Optional health check function for database, cache, or other service validation
+- **Error handling**: Catches errors from custom check functions and returns 503
+
+## Usage
+
+### Basic Health Check
+
+```typescript
+import {HealthApp} from "@terreno/api-health";
+import {setupServer} from "@terreno/api";
+
+setupServer({
+  userModel: User,
+  plugins: [new HealthApp()],
+});
+
+// Creates GET /health endpoint that returns {healthy: true}
+```
+
+### Custom Path
+
+```typescript
+const health = new HealthApp({
+  path: "/status",  // Default is "/health"
+});
+
+// Creates GET /status endpoint
+```
+
+### Custom Health Check
+
+```typescript
+const health = new HealthApp({
+  check: async () => {
+    // Check database connection
+    const dbHealthy = await mongoose.connection.db.admin().ping();
+    
+    // Check Redis/cache
+    const cacheHealthy = await redis.ping();
+    
+    return {
+      healthy: dbHealthy && cacheHealthy,
+      details: {
+        database: dbHealthy ? "connected" : "disconnected",
+        cache: cacheHealthy ? "connected" : "disconnected",
+      },
+    };
+  },
+});
+
+// Returns 200 if healthy, 503 if unhealthy
+```
+
+### Disable Health Check
+
+```typescript
+const health = new HealthApp({
+  enabled: false,  // Does not register the health endpoint
+});
+```
+
+## HealthApp Options
+
+```typescript
+interface HealthOptions {
+  enabled?: boolean;     // Enable/disable health endpoint (default: true)
+  path?: string;         // Health check path (default: "/health")
+  check?: () => Promise<HealthCheckResult> | HealthCheckResult;  // Custom health check
+}
+
+interface HealthCheckResult {
+  healthy: boolean;      // Health status
+  details?: Record<string, any>;  // Optional details (database status, version, etc.)
+}
+```
+
+## Integration with setupServer
+
+The HealthApp implements the `TerrenoPlugin` interface, which requires a `register(app: express.Application)` method. This allows it to be used with @terreno/api's plugin system:
+
+```typescript
+import {HealthApp} from "@terreno/api-health";
+import {setupServer} from "@terreno/api";
+
+setupServer({
+  userModel: User,
+  plugins: [
+    new HealthApp({
+      check: async () => {
+        const healthy = mongoose.connection.readyState === 1;
+        return {
+          healthy,
+          details: {
+            mongodb: healthy ? "connected" : "disconnected",
+            uptime: process.uptime(),
+            version: process.env.APP_VERSION,
+          },
+        };
+      },
+    }),
+  ],
+  addRoutes: (router) => {
+    // Your routes
+  },
+});
+```
+
+## Response Examples
+
+### Healthy (200)
+
+```json
+{
+  "healthy": true
+}
+```
+
+### Healthy with Details (200)
+
+```json
+{
+  "healthy": true,
+  "details": {
+    "database": "connected",
+    "cache": "connected",
+    "uptime": 12345.67,
+    "version": "1.0.0"
+  }
+}
+```
+
+### Unhealthy (503)
+
+```json
+{
+  "healthy": false,
+  "details": {
+    "database": "disconnected",
+    "cache": "connected"
+  }
+}
+```
+
+### Error During Check (503)
+
+```json
+{
+  "healthy": false,
+  "details": {
+    "error": "Connection timeout"
+  }
+}
+```
+
+## Testing
+
+```typescript
+import {describe, expect, it} from "bun:test";
+import express from "express";
+import supertest from "supertest";
+import {HealthApp} from "@terreno/api-health";
+
+describe("HealthApp", () => {
+  it("returns healthy: true by default", async () => {
+    const app = express();
+    new HealthApp().register(app);
+    
+    const res = await supertest(app).get("/health").expect(200);
+    expect(res.body).toEqual({healthy: true});
+  });
+
+  it("calls custom check function", async () => {
+    const app = express();
+    new HealthApp({
+      check: () => ({
+        healthy: true,
+        details: {db: "connected"},
+      }),
+    }).register(app);
+    
+    const res = await supertest(app).get("/health").expect(200);
+    expect(res.body.details.db).toBe("connected");
+  });
+});
+```
+
+## Conventions
+
+- Use `HealthApp` class as a plugin in setupServer
+- Never expose sensitive information in health check responses (credentials, internal IPs, etc.)
+- Health checks should be fast (< 1 second) to avoid timeout issues with load balancers
+- Use 200 for healthy, 503 for unhealthy (standard HTTP status codes for health checks)
+- Catch all errors in custom check functions to prevent health endpoint from crashing
+- Use `logger.info/warn/error/debug` for permanent logs
+- Testing: bun test with expect, supertest for HTTP requests
+- Never include React, UI components, or frontend code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
 - **admin-backend/** - Admin panel backend plugin for @terreno/api (`@terreno/admin-backend`)
 - **admin-frontend/** - Admin panel frontend screens for @terreno/api backends (`@terreno/admin-frontend`)
+- **api-health/** - Health check plugin for @terreno/api (`@terreno/api-health`)
 - **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
@@ -38,6 +39,8 @@ bun run mcp:build        # Build MCP server
 bun run mcp:start        # Start MCP server
 bun run admin-backend:compile   # Compile admin backend
 bun run admin-frontend:compile  # Compile admin frontend
+bun run api-health:compile      # Compile api-health
+bun run api-health:test         # Test api-health
 ```
 
 ## How the Packages Work Together


### PR DESCRIPTION
## Summary

This PR adds comprehensive rulesync rules and documentation for the `@terreno/api-health` package, which was missing from the rules system.

## Changes

### New Rule File

- **`.rulesync/rules/api-health/00-api-health.md`** (232 lines)
  - Documents the HealthApp class and its usage
  - Explains health check configuration options
  - Provides integration examples with setupServer
  - Details response formats and status codes
  - Includes testing patterns and conventions

### Updated Files

- **`.rulesync/rules/00-root.md`**: Added api-health to packages list and commands section
- **`.rulesync/rules/01-claudecode-root.md`**: Added api-health to packages list and commands section  
- **`AGENTS.md`**: Added api-health to packages list and commands section

## Next Steps

**Important:** Before merging, please run `bun run rules` locally to regenerate the tool-specific rule files:

``````bash
bun run rules
``````

This will generate/update:
- `.cursor/rules/api-health/00-api-health.mdc`
- `.windsurf/rules/api-health/00-api-health.md`
- `.claude/rules/api-health/00-api-health.md`
- `.github/instructions/api-health/00-api-health.instructions.md`
- Updated `.github/copilot-instructions.md`

After regeneration, commit the generated files and the CI check (`rulesync-check`) will pass.

## Verification

- ✅ Rule file follows existing conventions (YAML frontmatter, markdown structure)
- ✅ Documentation is comprehensive and aligned with actual code
- ✅ AGENTS.md and root rules updated consistently
- ✅ Package commands added to all relevant documentation files
- ✅ Backend-only conventions clearly stated (no React/UI code)

## Background

The `@terreno/api-health` package provides a health check plugin for `@terreno/api` backends. It implements the `TerrenoPlugin` interface and allows configurable health check endpoints with custom validation logic. This package existed in the repository but was missing comprehensive rules documentation, which could lead to inconsistent usage by AI assistants.

> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22286163918)

&lt;!-- gh-aw-workflow-id: update-rules --&gt;


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22286163918)

<!-- gh-aw-workflow-id: update-rules -->