### PR TITLE
IP: modelRouter MCP tool generation

### DIFF
--- a/docs/implementationPlans/model-router-mcp.md
+++ b/docs/implementationPlans/model-router-mcp.md
@@ -9,6 +9,8 @@ Add MCP (Model Context Protocol) tool generation to `@terreno/api`'s `modelRoute
 This makes every Terreno app instantly AI-native: any model becomes callable by LLMs with the same permission, filtering, and population guarantees as REST.
 
 **Key design decisions:**
+- Safe defaults: `methods` defaults to `['list', 'read']` (read-only), `maxLimit` defaults to 50
+- `excludeFields` allows hiding sensitive/regulated fields from MCP tool schemas and responses
 - MCP config lives on each `modelRouter` call (per-model opt-in)
 - `TerrenoApp` aggregates all MCP-enabled models into a single `/mcp` endpoint
 - `modelRouter` return type is unchanged — MCP registration is a side effect (same pattern as OpenAPI)
@@ -29,9 +31,12 @@ No new Mongoose models or database changes. New TypeScript interfaces added to `
 // api/src/mcp/types.ts
 
 export interface MCPConfig {
-  methods: Array<'create' | 'list' | 'read' | 'update' | 'delete'>;
+  methods?: Array<'create' | 'list' | 'read' | 'update' | 'delete'>; // Default: ['list', 'read']
   description?: string;            // Override auto-generated model description
   toolPrefix?: string;             // Override tool name prefix (default: pluralized model name)
+  excludeFields?: string[];        // Fields to hide from MCP tool schemas and responses
+                                   // e.g. ['internalNote', '__v', 'metadata.secretKey']
+  maxLimit?: number;               // Max items returned by list tool (default: 50)
   mcpResponseHandler?: (          // MCP-specific serialization (separate from REST responseHandler)
     value: any,
     method: 'create' | 'list' | 'read' | 'update' | 'delete',
@@ -81,7 +86,7 @@ For each model with `mcp` config, tools are generated based on `mcp.methods`:
 
 | Tool Name | Generates When | Input Schema | Output |
 |-----------|---------------|--------------|--------|
-| `{prefix}_list` | `'list'` in methods | `{ query?, page?, limit?, sort?, populate? }` | `{ data, total, page, more }` |
+| `{prefix}_list` | `'list'` in methods | `{ query?, page?, limit?, sort?, populate? }` | `{ data, total, page, more }` (limit capped at `maxLimit`, default 50) |
 | `{prefix}_read` | `'read'` in methods | `{ id, populate? }` | `{ data }` |
 | `{prefix}_create` | `'create'` in methods | Model fields from Mongoose schema | `{ data }` |
 | `{prefix}_update` | `'update'` in methods | `{ id, ...partial model fields }` | `{ data }` |
@@ -95,12 +100,13 @@ For each model with `mcp` config, tools are generated based on `mcp.methods`:
 4. For read/update/delete: load document, run object-level permission check
 5. Apply `queryFilter` for list operations
 6. Apply `populatePaths` (default) + optional extra `populate` param from tool input
-7. Serialize through `mcpResponseHandler` if provided, otherwise default serialization
+7. Strip `excludeFields` from response data
+8. Serialize through `mcpResponseHandler` if provided, otherwise default serialization
 
 ### Tool Description Auto-generation
 
 Generated from model name, field names/types, and `queryFields`. Example:
-> "List todo items. Filterable by: completed, status, ownerId. Sortable. Paginated (default 100, max 500)."
+> "List todo items. Filterable by: completed, status, ownerId. Sortable. Paginated (default 50, max controlled by maxLimit)."
 
 `mcp.description` overrides the auto-generated description.
 

--- a/docs/tasks/model-router-mcp.md
+++ b/docs/tasks/model-router-mcp.md
@@ -7,7 +7,7 @@
 ### Phase 1: Core MCP Infrastructure
 
 - [ ] **Task 1.1**: Define MCP types and interfaces
-  - Description: Create `MCPConfig` interface, `MCPRegistryEntry`, and add `mcp?: MCPConfig` to `ModelRouterOptions`. Create the `api/src/mcp/` directory structure.
+  - Description: Create `MCPConfig` interface (with `methods` defaulting to `['list', 'read']`, `excludeFields` for hiding sensitive fields, `maxLimit` defaulting to 50), `MCPRegistryEntry`, and add `mcp?: MCPConfig` to `ModelRouterOptions`. Create the `api/src/mcp/` directory structure.
   - Files: `api/src/mcp/types.ts`, `api/src/mcp/index.ts`, `api/src/api.ts` (add mcp to ModelRouterOptions)
   - Depends on: none
   - Acceptance: Types compile, existing tests still pass, `mcp` is an optional field on `ModelRouterOptions`
@@ -19,10 +19,10 @@
   - Acceptance: Calling `modelRouter(Todo, { ..., mcp: { methods: ['list', 'read'] } })` adds entries to the registry. `getMCPTools()` returns CoreTool objects.
 
 - [ ] **Task 1.3**: Generate Zod schemas from Mongoose models
-  - Description: Build a utility that converts a Mongoose model's schema into Zod schemas suitable for MCP tool `inputSchema`. Handle common field types (String, Number, Boolean, Date, ObjectId, Array, Mixed). Generate separate schemas for create (required fields), update (all optional + id required), read (id + optional populate), list (queryFields + pagination), and delete (id only).
+  - Description: Build a utility that converts a Mongoose model's schema into Zod schemas suitable for MCP tool `inputSchema`. Handle common field types (String, Number, Boolean, Date, ObjectId, Array, Mixed). Generate separate schemas for create (required fields), update (all optional + id required), read (id + optional populate), list (queryFields + pagination), and delete (id only). Respect `excludeFields` — omit listed fields from all generated schemas.
   - Files: `api/src/mcp/schemaGenerator.ts`, `api/src/mcp/schemaGenerator.test.ts`
   - Depends on: Task 1.1
-  - Acceptance: Given a Mongoose model, produces valid Zod schemas for each CRUD method. Tests cover all common field types.
+  - Acceptance: Given a Mongoose model, produces valid Zod schemas for each CRUD method. Tests cover all common field types. `excludeFields` removes specified fields from schemas.
 
 - [ ] **Task 1.4**: Generate MCP tool definitions from registry entries
   - Description: Build tool generator that takes an `MCPRegistryEntry` and produces both `@modelcontextprotocol/sdk` `Tool` objects (JSON Schema input) and Vercel `ai` SDK `CoreTool` objects. Auto-generate descriptions from model name, fields, and queryFields. Apply `toolPrefix` naming (`{prefix}_{method}`). Only generate tools for methods listed in `mcp.methods`.
@@ -31,10 +31,10 @@
   - Acceptance: Registry entry with `methods: ['list', 'read']` produces exactly `todos_list` and `todos_read` tools with correct schemas and descriptions.
 
 - [ ] **Task 1.5**: Implement MCP tool handlers (CRUD execution)
-  - Description: Build the execute functions for each CRUD tool. Each handler: (1) extracts user from auth context, (2) checks permissions via `checkPermissions()`, (3) for read/update/delete: loads document and checks object-level permissions, (4) applies queryFilter and population for list, (5) runs pre/post hooks, (6) serializes via `mcpResponseHandler` or default. Reuse internal logic from REST handlers but decoupled from Express req/res.
+  - Description: Build the execute functions for each CRUD tool. Each handler: (1) extracts user from auth context, (2) checks permissions via `checkPermissions()`, (3) for read/update/delete: loads document and checks object-level permissions, (4) applies queryFilter and population for list, (5) enforces `maxLimit` cap on list results (default 50), (6) runs pre/post hooks, (7) strips `excludeFields` from response data, (8) serializes via `mcpResponseHandler` or default. Reuse internal logic from REST handlers but decoupled from Express req/res.
   - Files: `api/src/mcp/handlers.ts`, `api/src/mcp/handlers.test.ts`
   - Depends on: Task 1.4
-  - Acceptance: Each CRUD handler works with correct permission checks, population, filtering. Tests cover: successful CRUD, permission denied (403), not found (404), validation errors, owner filtering, population.
+  - Acceptance: Each CRUD handler works with correct permission checks, population, filtering. List enforces maxLimit. excludeFields are stripped from responses. Tests cover: successful CRUD, permission denied (403), not found (404), validation errors, owner filtering, population, maxLimit enforcement, excludeFields stripping.
 
 - [ ] **Task 1.6**: Auth-agnostic user extraction for MCP
   - Description: Build middleware/utility that extracts user from MCP transport headers using whichever auth provider is configured (JWT via passport or Better Auth via `auth.api.getSession()`). Should mirror `authenticateMiddleware` behavior but work with raw headers instead of Express req.


### PR DESCRIPTION
Fixes FH-794

## Summary

- Adds implementation plan and task breakdown for auto-generating MCP tools from modelRouter configurations
- Each modelRouter can opt-in to exposing CRUD operations as MCP tools via an `mcp` config option
- TerrenoApp aggregates all MCP-enabled models into a single `/mcp` endpoint on server start
- Auth-agnostic: works with both JWT and Better Auth
- Includes frontend integration plan for both RTK Query hooks and `@ai-sdk/react` useChat()

## Details

**Plan:** `docs/implementationPlans/model-router-mcp.md`
**Tasks:** `docs/tasks/model-router-mcp.md` (15 tasks across 3 phases)

### Phases
1. Core MCP infrastructure in `@terreno/api` (9 tasks)
2. Frontend integration in `@terreno/rtk` (3 tasks)
3. Examples and polish (3 tasks)

## Test plan

- [ ] Documentation only — no code changes to test