### PR TITLE
docs(rules): Add `@terreno/api-health` package documentation

### DIFF
--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -16,6 +16,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
 - **admin-backend/** - Admin panel backend plugin for @terreno/api (`@terreno/admin-backend`)
 - **admin-frontend/** - Admin panel frontend screens for @terreno/api backends (`@terreno/admin-frontend`)
+- **api-health/** - Health check plugin for @terreno/api (`@terreno/api-health`)
 - **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
@@ -45,6 +46,7 @@ bun run mcp:build        # Build MCP server
 bun run mcp:start        # Start MCP server
 bun run admin-backend:compile   # Compile admin backend
 bun run admin-frontend:compile  # Compile admin frontend
+bun run api-health:test  # Test api-health package
 ```
 
 ## How the Packages Work Together

--- a/.rulesync/rules/api-health/00-api-health.md
+++ b/.rulesync/rules/api-health/00-api-health.md
@@ -1,0 +1,157 @@
+---
+description: '@terreno/api-health - Health check plugin for @terreno/api'
+applyTo: '**/*'
+---
+# @terreno/api-health
+
+Health check plugin for @terreno/api backends. Implements the TerrenoPlugin interface to provide customizable health check endpoints. This is a **backend-only** package — no React, no UI components, no frontend code.
+
+## Commands
+
+```bash
+bun run compile          # Compile TypeScript
+bun run dev              # Watch mode (TypeScript watch)
+bun run lint             # Lint code
+bun run lint:fix         # Fix lint issues
+bun run test             # Run tests
+bun run test:ci          # Run tests (CI mode)
+```
+
+## Architecture
+
+### File Structure
+
+```
+src/
+  index.ts               # Package exports (HealthApp, types)
+  healthApp.ts           # HealthApp class implementing TerrenoPlugin
+  healthApp.test.ts      # Test suite
+```
+
+## HealthApp Plugin
+
+Implements the `TerrenoPlugin` interface from @terreno/api to provide health check endpoints.
+
+### Usage
+
+```typescript
+import {HealthApp} from "@terreno/api-health";
+import {setupServer} from "@terreno/api";
+
+const healthCheck = new HealthApp({
+  path: "/health",       // Optional, defaults to "/health"
+  enabled: true,         // Optional, defaults to true
+  check: async () => ({  // Optional custom health check
+    healthy: true,
+    details: {db: "connected", uptime: process.uptime()},
+  }),
+});
+
+setupServer({
+  userModel: User,
+  addRoutes: (router) => {
+    healthCheck.register(router as any);
+  },
+});
+```
+
+### Options
+
+```typescript
+interface HealthOptions {
+  enabled?: boolean;     // Enable/disable health endpoint (default: true)
+  path?: string;         // Health check path (default: "/health")
+  check?: () => Promise<HealthCheckResult> | HealthCheckResult;  // Custom health check function
+}
+
+interface HealthCheckResult {
+  healthy: boolean;      // Overall health status
+  details?: Record<string, any>;  // Additional health details
+}
+```
+
+### Behavior
+
+- **Default response**: Returns `{healthy: true}` with 200 status when no custom check is provided
+- **Custom check (healthy)**: Returns check result with 200 status
+- **Custom check (unhealthy)**: Returns check result with 503 status
+- **Custom check (error)**: Returns `{healthy: false, details: {error: message}}` with 503 status
+- **Disabled**: When `enabled: false`, no route is registered
+
+### Response Examples
+
+```typescript
+// Default (no custom check)
+GET /health → 200 {healthy: true}
+
+// Custom check returning healthy
+GET /health → 200 {healthy: true, details: {db: "connected"}}
+
+// Custom check returning unhealthy
+GET /health → 503 {healthy: false, details: {db: "disconnected"}}
+
+// Custom check throwing error
+GET /health → 503 {healthy: false, details: {error: "DB connection failed"}}
+```
+
+## Plugin Pattern
+
+HealthApp demonstrates the TerrenoPlugin pattern for creating reusable @terreno/api extensions:
+
+```typescript
+import type {TerrenoPlugin} from "@terreno/api";
+import type express from "express";
+
+export class HealthApp implements TerrenoPlugin {
+  private options: HealthOptions;
+
+  constructor(options?: HealthOptions) {
+    this.options = options ?? {};
+  }
+
+  register(app: express.Application): void {
+    // Add routes, middleware, or services
+  }
+}
+```
+
+**Benefits:**
+- Reusable across multiple Terreno projects
+- Testable in isolation
+- Optional/configurable functionality
+- Clean separation of concerns
+
+## Testing
+
+```typescript
+import {describe, expect, it} from "bun:test";
+import express from "express";
+import supertest from "supertest";
+import {HealthApp} from "@terreno/api-health";
+
+const createApp = (healthApp: HealthApp): express.Express => {
+  const app = express();
+  healthApp.register(app);
+  return app;
+};
+
+it("returns healthy: true by default", async () => {
+  const app = createApp(new HealthApp());
+  const res = await supertest(app).get("/health").expect(200);
+  expect(res.body).toEqual({healthy: true});
+});
+```
+
+- Framework: bun test with expect
+- HTTP testing: supertest
+- Test all options: default, custom path, enabled/disabled, custom checks, errors
+
+## Conventions
+
+- Implements TerrenoPlugin interface from @terreno/api
+- Uses TypeScript with ES modules
+- Prefer const arrow functions
+- Use `express.Application` type for app parameter
+- Use `logger.info/warn/error/debug` for permanent logs (if logging is needed)
+- Handle both sync and async custom check functions
+- Catch and convert errors to health check failures (503)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
 - **admin-backend/** - Admin panel backend plugin for @terreno/api (`@terreno/admin-backend`)
 - **admin-frontend/** - Admin panel frontend screens for @terreno/api backends (`@terreno/admin-frontend`)
+- **api-health/** - Health check plugin for @terreno/api (`@terreno/api-health`)
 - **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
@@ -38,6 +39,7 @@ bun run mcp:build        # Build MCP server
 bun run mcp:start        # Start MCP server
 bun run admin-backend:compile   # Compile admin backend
 bun run admin-frontend:compile  # Compile admin frontend
+bun run api-health:test  # Test api-health package
 ```
 
 ## How the Packages Work Together


### PR DESCRIPTION
## Summary

Adds complete documentation for the `@terreno/api-health` package that was missing from the rulesync source rules and agent documentation.

## Identified Gap

The `@terreno/api-health` package exists in the repository with:
- Source code in `api-health/` directory
- Package entry in root `package.json` with scripts (`api-health:compile`, `api-health:lint`, `api-health:test`)
- Mentions in `docs/reference/api.md` as an example TerrenoPlugin implementation

However, it was **missing** from:
- `.rulesync/rules/` directory (no api-health rules)
- Package listings in `00-root.md` and `AGENTS.md`
- Package-specific commands in both files

## Changes

1. **Created `.rulesync/rules/api-health/00-api-health.md`**
   - Complete package documentation following established patterns
   - HealthApp plugin interface and usage examples
   - Options, behavior, and response examples
   - Plugin pattern explanation (matching docs/reference/api.md)
   - Testing patterns and conventions

2. **Updated `.rulesync/rules/00-root.md`**
   - Added `@terreno/api-health` to Packages section
   - Added `bun run api-health:test` to package-specific commands

3. **Updated `AGENTS.md`**
   - Added `@terreno/api-health` to Packages section
   - Added `bun run api-health:test` to package-specific commands

## Action Required

**Reviewers:** After pulling this branch, run the following to regenerate all generated files:

``````bash
bun run rules
``````

Then commit the regenerated files:
- `.cursor/rules/api-health/00-api-health.mdc`
- `.windsurf/rules/api-health/00-api-health.md`
- `.claude/rules/api-health/00-api-health.md`
- `.github/instructions/api-health/00-api-health.instructions.md`
- `.github/copilot-instructions.md` (updated with api-health content)

This ensures the `rulesync-check` workflow passes.

## Context

This update ensures AI assistants (Cursor, Windsurf, Copilot, Claude Code) have complete documentation for all Terreno packages, including the health check plugin that implements the TerrenoPlugin extensibility pattern.

## Type of Change

- [x] Documentation update (rules)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

---

> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/$\{\{ github.run_id }})


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22288167880)

<!-- gh-aw-workflow-id: update-rules -->