### PR TITLE
docs: Add TerrenoApp and modelRouter overload documentation

### DIFF
--- a/.claude/rules/api/00-api.md
+++ b/.claude/rules/api/00-api.md
@@ -28,6 +28,8 @@ src/
   permissions.ts         # Permission system
   errors.ts              # APIError and error middleware
   expressServer.ts       # setupServer and middleware stack
+  terrenoApp.ts          # TerrenoApp class with register pattern
+  terrenoPlugin.ts       # TerrenoPlugin interface for extensibility
   openApiBuilder.ts      # Fluent OpenAPI middleware builder
   openApi.ts             # OpenAPI spec generation
   logger.ts              # Winston-based logging
@@ -40,9 +42,63 @@ src/
   tests/bunSetup.ts      # Test environment setup
 ```
 
+## Server Setup
+
+### TerrenoApp (Recommended)
+
+Fluent API with a register pattern:
+
+```typescript
+import {TerrenoApp, modelRouter} from "@terreno/api";
+
+const todoRouter = modelRouter("/todos", Todo, {
+  permissions: {...},
+  queryFilter: OwnerQueryFilter,
+});
+
+const app = new TerrenoApp({userModel: User})
+  .register(todoRouter)
+  .register(userRouter)
+  .start();
+```
+
+Methods:
+- `register(registration)` — Register `ModelRouterRegistration` or `TerrenoPlugin`
+- `addMiddleware(fn)` — Add Express middleware
+- `build()` — Build Express app without listening
+- `start()` — Build and start server
+
+### setupServer (Legacy)
+
+Callback-based pattern:
+
+```typescript
+import {setupServer, modelRouter} from "@terreno/api";
+
+setupServer({
+  userModel: User,
+  addRoutes: (router) => {
+    router.use("/todos", modelRouter(Todo, options));
+  },
+});
+```
+
+Both patterns create the same middleware stack (CORS, auth, logging, OpenAPI).
+
 ## modelRouter
 
 Auto-generates RESTful CRUD APIs for Mongoose models with permissions, population, filtering, and lifecycle hooks.
+
+**Two signatures:**
+
+```typescript
+// 1. Router signature (for setupServer):
+router.use("/todos", modelRouter(Todo, options));
+
+// 2. Registration signature (for TerrenoApp):
+const todoRouter = modelRouter("/todos", Todo, options);
+app.register(todoRouter);
+```
 
 ### Generated Endpoints
 
@@ -201,6 +257,85 @@ import {OwnerQueryFilter} from "@terreno/api";
 // Produces: {ownerId: user.id}
 ```
 
+## Request Validation
+
+Runtime validation of incoming requests against OpenAPI schemas using AJV. Validation is opt-in and can be enabled globally or per-route.
+
+### Enabling Validation
+
+```typescript
+import {configureOpenApiValidator, setupServer} from "@terreno/api";
+
+// Enable validation before setting up the server
+configureOpenApiValidator({
+  removeAdditional: true,
+  coerceTypes: true,
+  logValidationErrors: true,
+  onAdditionalPropertiesRemoved: (props, req) => {
+    logger.warn(`Stripped properties: ${props.join(", ")} on ${req.method} ${req.path}`);
+  },
+});
+
+setupServer({
+  userModel: User,
+  addRoutes: (router) => {
+    // Routes will automatically validate when enabled
+  },
+});
+```
+
+Options: `validateRequests` (default: true), `validateResponses` (default: false), `coerceTypes` (default: true), `removeAdditional` (default: true), `logValidationErrors` (default: true).
+
+### Using with modelRouter
+
+When validation is enabled globally, modelRouter automatically validates create and update requests based on the Mongoose schema.
+
+### Manual Validation
+
+For custom routes:
+
+```typescript
+import {validateRequestBody, validateQueryParams, createValidator} from "@terreno/api";
+
+// Validate request body
+router.post("/search", [
+  validateRequestBody({
+    query: {type: "string", required: true},
+    filters: {type: "object"},
+  }),
+  asyncHandler(async (req, res) => {
+    const {query, filters} = req.body;  // Validated and type-coerced
+    return res.json({results: []});
+  }),
+]);
+
+// Validate query parameters
+router.get("/items", [
+  validateQueryParams({
+    limit: {type: "number"},
+    status: {type: "string", enum: ["active", "inactive"]},
+  }),
+  asyncHandler(async (req, res) => {
+    const {limit, status} = req.query;  // Validated and type-coerced
+    return res.json({items: []});
+  }),
+]);
+
+// Validate both body and query
+router.post("/search", [
+  createValidator({
+    body: {query: {type: "string", required: true}},
+    query: {limit: {type: "number"}, page: {type: "number"}},
+  }),
+  asyncHandler(async (req, res) => {
+    // Both req.body and req.query are validated
+    return res.json({results: []});
+  }),
+]);
+```
+
+Validation errors throw `APIError` with field-level details.
+
 ## Custom Routes with OpenAPI Builder
 
 For non-CRUD endpoints, use the fluent builder to generate OpenAPI documentation:
@@ -313,6 +448,62 @@ setupServer({
 
 - `ENABLE_SWAGGER=true` — Enable Swagger UI at `/swagger`
 - `USE_SENTRY_LOGGING=true` — Send errors to Sentry
+
+## Extensibility
+
+### TerrenoPlugin Interface
+
+The `TerrenoPlugin` interface provides a standard way to extend Terreno applications with reusable functionality:
+
+```typescript
+import type {TerrenoPlugin} from "@terreno/api";
+import type express from "express";
+
+export interface TerrenoPlugin {
+  register(app: express.Application): void;
+}
+```
+
+**Creating a plugin:**
+
+```typescript
+import type {TerrenoPlugin} from "@terreno/api";
+
+export class MyPlugin implements TerrenoPlugin {
+  private options: MyPluginOptions;
+
+  constructor(options?: MyPluginOptions) {
+    this.options = options ?? {};
+  }
+
+  register(app: express.Application): void {
+    // Add routes, middleware, or other setup
+    app.get("/my-plugin/status", (_req, res) => {
+      res.json({status: "ok"});
+    });
+  }
+}
+```
+
+**Using a plugin:**
+
+```typescript
+import {setupServer} from "@terreno/api";
+import {MyPlugin} from "./plugins/myPlugin";
+
+const myPlugin = new MyPlugin({enabled: true});
+
+setupServer({
+  userModel: User,
+  addRoutes: (router) => {
+    myPlugin.register(router as any);
+  },
+});
+```
+
+**Example:** See `@terreno/api-health` for a complete plugin implementation with health check endpoints.
+
+**Common patterns:** Route registration, middleware injection, conditional setup, service initialization.
 
 ## Logging
 

--- a/.claude/rules/example-backend/00-example-backend.md
+++ b/.claude/rules/example-backend/00-example-backend.md
@@ -51,6 +51,21 @@ src/
 
 ## Server Setup
 
+Uses the new `TerrenoApp` pattern:
+
+```typescript
+import {TerrenoApp} from "@terreno/api";
+import {todoRouter} from "./api/todos";
+import {userRouter} from "./api/users";
+
+const app = new TerrenoApp({userModel: User})
+  .register(todoRouter)
+  .register(userRouter)
+  .start();
+```
+
+**Legacy pattern (still supported):**
+
 ```typescript
 import {setupServer} from "@terreno/api";
 
@@ -132,6 +147,29 @@ export interface UserModel extends DefaultModel<UserDocument>, UserStatics {
 ## Route Patterns
 
 ### Owner-based CRUD (Todo)
+
+**TerrenoApp pattern:**
+
+```typescript
+export const todoRouter = modelRouter("/todos", Todo, {
+  permissions: {
+    create: [Permissions.IsAuthenticated],
+    list: [Permissions.IsAuthenticated],
+    read: [Permissions.IsOwner],
+    update: [Permissions.IsOwner],
+    delete: [Permissions.IsOwner],
+  },
+  preCreate: (body, req) => ({
+    ...body,
+    ownerId: (req.user as UserDocument)?._id,
+  }),
+  queryFilter: OwnerQueryFilter,
+  queryFields: ["completed", "ownerId"],
+  sort: "-created",
+});
+```
+
+**Legacy pattern:**
 
 ```typescript
 export const addTodoRoutes = (router, options?) => {

--- a/.cursor/rules/api/00-api.mdc
+++ b/.cursor/rules/api/00-api.mdc
@@ -29,6 +29,8 @@ src/
   permissions.ts         # Permission system
   errors.ts              # APIError and error middleware
   expressServer.ts       # setupServer and middleware stack
+  terrenoApp.ts          # TerrenoApp class with register pattern
+  terrenoPlugin.ts       # TerrenoPlugin interface for extensibility
   openApiBuilder.ts      # Fluent OpenAPI middleware builder
   openApi.ts             # OpenAPI spec generation
   logger.ts              # Winston-based logging
@@ -41,9 +43,63 @@ src/
   tests/bunSetup.ts      # Test environment setup
 ```
 
+## Server Setup
+
+### TerrenoApp (Recommended)
+
+Fluent API with a register pattern:
+
+```typescript
+import {TerrenoApp, modelRouter} from "@terreno/api";
+
+const todoRouter = modelRouter("/todos", Todo, {
+  permissions: {...},
+  queryFilter: OwnerQueryFilter,
+});
+
+const app = new TerrenoApp({userModel: User})
+  .register(todoRouter)
+  .register(userRouter)
+  .start();
+```
+
+Methods:
+- `register(registration)` — Register `ModelRouterRegistration` or `TerrenoPlugin`
+- `addMiddleware(fn)` — Add Express middleware
+- `build()` — Build Express app without listening
+- `start()` — Build and start server
+
+### setupServer (Legacy)
+
+Callback-based pattern:
+
+```typescript
+import {setupServer, modelRouter} from "@terreno/api";
+
+setupServer({
+  userModel: User,
+  addRoutes: (router) => {
+    router.use("/todos", modelRouter(Todo, options));
+  },
+});
+```
+
+Both patterns create the same middleware stack (CORS, auth, logging, OpenAPI).
+
 ## modelRouter
 
 Auto-generates RESTful CRUD APIs for Mongoose models with permissions, population, filtering, and lifecycle hooks.
+
+**Two signatures:**
+
+```typescript
+// 1. Router signature (for setupServer):
+router.use("/todos", modelRouter(Todo, options));
+
+// 2. Registration signature (for TerrenoApp):
+const todoRouter = modelRouter("/todos", Todo, options);
+app.register(todoRouter);
+```
 
 ### Generated Endpoints
 
@@ -202,6 +258,85 @@ import {OwnerQueryFilter} from "@terreno/api";
 // Produces: {ownerId: user.id}
 ```
 
+## Request Validation
+
+Runtime validation of incoming requests against OpenAPI schemas using AJV. Validation is opt-in and can be enabled globally or per-route.
+
+### Enabling Validation
+
+```typescript
+import {configureOpenApiValidator, setupServer} from "@terreno/api";
+
+// Enable validation before setting up the server
+configureOpenApiValidator({
+  removeAdditional: true,
+  coerceTypes: true,
+  logValidationErrors: true,
+  onAdditionalPropertiesRemoved: (props, req) => {
+    logger.warn(`Stripped properties: ${props.join(", ")} on ${req.method} ${req.path}`);
+  },
+});
+
+setupServer({
+  userModel: User,
+  addRoutes: (router) => {
+    // Routes will automatically validate when enabled
+  },
+});
+```
+
+Options: `validateRequests` (default: true), `validateResponses` (default: false), `coerceTypes` (default: true), `removeAdditional` (default: true), `logValidationErrors` (default: true).
+
+### Using with modelRouter
+
+When validation is enabled globally, modelRouter automatically validates create and update requests based on the Mongoose schema.
+
+### Manual Validation
+
+For custom routes:
+
+```typescript
+import {validateRequestBody, validateQueryParams, createValidator} from "@terreno/api";
+
+// Validate request body
+router.post("/search", [
+  validateRequestBody({
+    query: {type: "string", required: true},
+    filters: {type: "object"},
+  }),
+  asyncHandler(async (req, res) => {
+    const {query, filters} = req.body;  // Validated and type-coerced
+    return res.json({results: []});
+  }),
+]);
+
+// Validate query parameters
+router.get("/items", [
+  validateQueryParams({
+    limit: {type: "number"},
+    status: {type: "string", enum: ["active", "inactive"]},
+  }),
+  asyncHandler(async (req, res) => {
+    const {limit, status} = req.query;  // Validated and type-coerced
+    return res.json({items: []});
+  }),
+]);
+
+// Validate both body and query
+router.post("/search", [
+  createValidator({
+    body: {query: {type: "string", required: true}},
+    query: {limit: {type: "number"}, page: {type: "number"}},
+  }),
+  asyncHandler(async (req, res) => {
+    // Both req.body and req.query are validated
+    return res.json({results: []});
+  }),
+]);
+```
+
+Validation errors throw `APIError` with field-level details.
+
 ## Custom Routes with OpenAPI Builder
 
 For non-CRUD endpoints, use the fluent builder to generate OpenAPI documentation:
@@ -314,6 +449,62 @@ setupServer({
 
 - `ENABLE_SWAGGER=true` — Enable Swagger UI at `/swagger`
 - `USE_SENTRY_LOGGING=true` — Send errors to Sentry
+
+## Extensibility
+
+### TerrenoPlugin Interface
+
+The `TerrenoPlugin` interface provides a standard way to extend Terreno applications with reusable functionality:
+
+```typescript
+import type {TerrenoPlugin} from "@terreno/api";
+import type express from "express";
+
+export interface TerrenoPlugin {
+  register(app: express.Application): void;
+}
+```
+
+**Creating a plugin:**
+
+```typescript
+import type {TerrenoPlugin} from "@terreno/api";
+
+export class MyPlugin implements TerrenoPlugin {
+  private options: MyPluginOptions;
+
+  constructor(options?: MyPluginOptions) {
+    this.options = options ?? {};
+  }
+
+  register(app: express.Application): void {
+    // Add routes, middleware, or other setup
+    app.get("/my-plugin/status", (_req, res) => {
+      res.json({status: "ok"});
+    });
+  }
+}
+```
+
+**Using a plugin:**
+
+```typescript
+import {setupServer} from "@terreno/api";
+import {MyPlugin} from "./plugins/myPlugin";
+
+const myPlugin = new MyPlugin({enabled: true});
+
+setupServer({
+  userModel: User,
+  addRoutes: (router) => {
+    myPlugin.register(router as any);
+  },
+});
+```
+
+**Example:** See `@terreno/api-health` for a complete plugin implementation with health check endpoints.
+
+**Common patterns:** Route registration, middleware injection, conditional setup, service initialization.
 
 ## Logging
 

--- a/.cursor/rules/example-backend/00-example-backend.mdc
+++ b/.cursor/rules/example-backend/00-example-backend.mdc
@@ -52,6 +52,21 @@ src/
 
 ## Server Setup
 
+Uses the new `TerrenoApp` pattern:
+
+```typescript
+import {TerrenoApp} from "@terreno/api";
+import {todoRouter} from "./api/todos";
+import {userRouter} from "./api/users";
+
+const app = new TerrenoApp({userModel: User})
+  .register(todoRouter)
+  .register(userRouter)
+  .start();
+```
+
+**Legacy pattern (still supported):**
+
 ```typescript
 import {setupServer} from "@terreno/api";
 
@@ -133,6 +148,29 @@ export interface UserModel extends DefaultModel<UserDocument>, UserStatics {
 ## Route Patterns
 
 ### Owner-based CRUD (Todo)
+
+**TerrenoApp pattern:**
+
+```typescript
+export const todoRouter = modelRouter("/todos", Todo, {
+  permissions: {
+    create: [Permissions.IsAuthenticated],
+    list: [Permissions.IsAuthenticated],
+    read: [Permissions.IsOwner],
+    update: [Permissions.IsOwner],
+    delete: [Permissions.IsOwner],
+  },
+  preCreate: (body, req) => ({
+    ...body,
+    ownerId: (req.user as UserDocument)?._id,
+  }),
+  queryFilter: OwnerQueryFilter,
+  queryFields: ["completed", "ownerId"],
+  sort: "-created",
+});
+```
+
+**Legacy pattern:**
 
 ```typescript
 export const addTodoRoutes = (router, options?) => {

--- a/.github/instructions/api/00-api.instructions.md
+++ b/.github/instructions/api/00-api.instructions.md
@@ -28,6 +28,8 @@ src/
   permissions.ts         # Permission system
   errors.ts              # APIError and error middleware
   expressServer.ts       # setupServer and middleware stack
+  terrenoApp.ts          # TerrenoApp class with register pattern
+  terrenoPlugin.ts       # TerrenoPlugin interface for extensibility
   openApiBuilder.ts      # Fluent OpenAPI middleware builder
   openApi.ts             # OpenAPI spec generation
   logger.ts              # Winston-based logging
@@ -40,9 +42,63 @@ src/
   tests/bunSetup.ts      # Test environment setup
 ```
 
+## Server Setup
+
+### TerrenoApp (Recommended)
+
+Fluent API with a register pattern:
+
+```typescript
+import {TerrenoApp, modelRouter} from "@terreno/api";
+
+const todoRouter = modelRouter("/todos", Todo, {
+  permissions: {...},
+  queryFilter: OwnerQueryFilter,
+});
+
+const app = new TerrenoApp({userModel: User})
+  .register(todoRouter)
+  .register(userRouter)
+  .start();
+```
+
+Methods:
+- `register(registration)` — Register `ModelRouterRegistration` or `TerrenoPlugin`
+- `addMiddleware(fn)` — Add Express middleware
+- `build()` — Build Express app without listening
+- `start()` — Build and start server
+
+### setupServer (Legacy)
+
+Callback-based pattern:
+
+```typescript
+import {setupServer, modelRouter} from "@terreno/api";
+
+setupServer({
+  userModel: User,
+  addRoutes: (router) => {
+    router.use("/todos", modelRouter(Todo, options));
+  },
+});
+```
+
+Both patterns create the same middleware stack (CORS, auth, logging, OpenAPI).
+
 ## modelRouter
 
 Auto-generates RESTful CRUD APIs for Mongoose models with permissions, population, filtering, and lifecycle hooks.
+
+**Two signatures:**
+
+```typescript
+// 1. Router signature (for setupServer):
+router.use("/todos", modelRouter(Todo, options));
+
+// 2. Registration signature (for TerrenoApp):
+const todoRouter = modelRouter("/todos", Todo, options);
+app.register(todoRouter);
+```
 
 ### Generated Endpoints
 
@@ -201,6 +257,85 @@ import {OwnerQueryFilter} from "@terreno/api";
 // Produces: {ownerId: user.id}
 ```
 
+## Request Validation
+
+Runtime validation of incoming requests against OpenAPI schemas using AJV. Validation is opt-in and can be enabled globally or per-route.
+
+### Enabling Validation
+
+```typescript
+import {configureOpenApiValidator, setupServer} from "@terreno/api";
+
+// Enable validation before setting up the server
+configureOpenApiValidator({
+  removeAdditional: true,
+  coerceTypes: true,
+  logValidationErrors: true,
+  onAdditionalPropertiesRemoved: (props, req) => {
+    logger.warn(`Stripped properties: ${props.join(", ")} on ${req.method} ${req.path}`);
+  },
+});
+
+setupServer({
+  userModel: User,
+  addRoutes: (router) => {
+    // Routes will automatically validate when enabled
+  },
+});
+```
+
+Options: `validateRequests` (default: true), `validateResponses` (default: false), `coerceTypes` (default: true), `removeAdditional` (default: true), `logValidationErrors` (default: true).
+
+### Using with modelRouter
+
+When validation is enabled globally, modelRouter automatically validates create and update requests based on the Mongoose schema.
+
+### Manual Validation
+
+For custom routes:
+
+```typescript
+import {validateRequestBody, validateQueryParams, createValidator} from "@terreno/api";
+
+// Validate request body
+router.post("/search", [
+  validateRequestBody({
+    query: {type: "string", required: true},
+    filters: {type: "object"},
+  }),
+  asyncHandler(async (req, res) => {
+    const {query, filters} = req.body;  // Validated and type-coerced
+    return res.json({results: []});
+  }),
+]);
+
+// Validate query parameters
+router.get("/items", [
+  validateQueryParams({
+    limit: {type: "number"},
+    status: {type: "string", enum: ["active", "inactive"]},
+  }),
+  asyncHandler(async (req, res) => {
+    const {limit, status} = req.query;  // Validated and type-coerced
+    return res.json({items: []});
+  }),
+]);
+
+// Validate both body and query
+router.post("/search", [
+  createValidator({
+    body: {query: {type: "string", required: true}},
+    query: {limit: {type: "number"}, page: {type: "number"}},
+  }),
+  asyncHandler(async (req, res) => {
+    // Both req.body and req.query are validated
+    return res.json({results: []});
+  }),
+]);
+```
+
+Validation errors throw `APIError` with field-level details.
+
 ## Custom Routes with OpenAPI Builder
 
 For non-CRUD endpoints, use the fluent builder to generate OpenAPI documentation:
@@ -313,6 +448,62 @@ setupServer({
 
 - `ENABLE_SWAGGER=true` — Enable Swagger UI at `/swagger`
 - `USE_SENTRY_LOGGING=true` — Send errors to Sentry
+
+## Extensibility
+
+### TerrenoPlugin Interface
+
+The `TerrenoPlugin` interface provides a standard way to extend Terreno applications with reusable functionality:
+
+```typescript
+import type {TerrenoPlugin} from "@terreno/api";
+import type express from "express";
+
+export interface TerrenoPlugin {
+  register(app: express.Application): void;
+}
+```
+
+**Creating a plugin:**
+
+```typescript
+import type {TerrenoPlugin} from "@terreno/api";
+
+export class MyPlugin implements TerrenoPlugin {
+  private options: MyPluginOptions;
+
+  constructor(options?: MyPluginOptions) {
+    this.options = options ?? {};
+  }
+
+  register(app: express.Application): void {
+    // Add routes, middleware, or other setup
+    app.get("/my-plugin/status", (_req, res) => {
+      res.json({status: "ok"});
+    });
+  }
+}
+```
+
+**Using a plugin:**
+
+```typescript
+import {setupServer} from "@terreno/api";
+import {MyPlugin} from "./plugins/myPlugin";
+
+const myPlugin = new MyPlugin({enabled: true});
+
+setupServer({
+  userModel: User,
+  addRoutes: (router) => {
+    myPlugin.register(router as any);
+  },
+});
+```
+
+**Example:** See `@terreno/api-health` for a complete plugin implementation with health check endpoints.
+
+**Common patterns:** Route registration, middleware injection, conditional setup, service initialization.
 
 ## Logging
 

--- a/.github/instructions/example-backend/00-example-backend.instructions.md
+++ b/.github/instructions/example-backend/00-example-backend.instructions.md
@@ -51,6 +51,21 @@ src/
 
 ## Server Setup
 
+Uses the new `TerrenoApp` pattern:
+
+```typescript
+import {TerrenoApp} from "@terreno/api";
+import {todoRouter} from "./api/todos";
+import {userRouter} from "./api/users";
+
+const app = new TerrenoApp({userModel: User})
+  .register(todoRouter)
+  .register(userRouter)
+  .start();
+```
+
+**Legacy pattern (still supported):**
+
 ```typescript
 import {setupServer} from "@terreno/api";
 
@@ -132,6 +147,29 @@ export interface UserModel extends DefaultModel<UserDocument>, UserStatics {
 ## Route Patterns
 
 ### Owner-based CRUD (Todo)
+
+**TerrenoApp pattern:**
+
+```typescript
+export const todoRouter = modelRouter("/todos", Todo, {
+  permissions: {
+    create: [Permissions.IsAuthenticated],
+    list: [Permissions.IsAuthenticated],
+    read: [Permissions.IsOwner],
+    update: [Permissions.IsOwner],
+    delete: [Permissions.IsOwner],
+  },
+  preCreate: (body, req) => ({
+    ...body,
+    ownerId: (req.user as UserDocument)?._id,
+  }),
+  queryFilter: OwnerQueryFilter,
+  queryFields: ["completed", "ownerId"],
+  sort: "-created",
+});
+```
+
+**Legacy pattern:**
 
 ```typescript
 export const addTodoRoutes = (router, options?) => {

--- a/.rulesync/rules/api/00-api.md
+++ b/.rulesync/rules/api/00-api.md
@@ -30,6 +30,8 @@ src/
   permissions.ts         # Permission system
   errors.ts              # APIError and error middleware
   expressServer.ts       # setupServer and middleware stack
+  terrenoApp.ts          # TerrenoApp class with register pattern
+  terrenoPlugin.ts       # TerrenoPlugin interface for extensibility
   openApiBuilder.ts      # Fluent OpenAPI middleware builder
   openApi.ts             # OpenAPI spec generation
   logger.ts              # Winston-based logging
@@ -42,9 +44,63 @@ src/
   tests/bunSetup.ts      # Test environment setup
 ```
 
+## Server Setup
+
+### TerrenoApp (Recommended)
+
+Fluent API with a register pattern:
+
+```typescript
+import {TerrenoApp, modelRouter} from "@terreno/api";
+
+const todoRouter = modelRouter("/todos", Todo, {
+  permissions: {...},
+  queryFilter: OwnerQueryFilter,
+});
+
+const app = new TerrenoApp({userModel: User})
+  .register(todoRouter)
+  .register(userRouter)
+  .start();
+```
+
+Methods:
+- `register(registration)` — Register `ModelRouterRegistration` or `TerrenoPlugin`
+- `addMiddleware(fn)` — Add Express middleware
+- `build()` — Build Express app without listening
+- `start()` — Build and start server
+
+### setupServer (Legacy)
+
+Callback-based pattern:
+
+```typescript
+import {setupServer, modelRouter} from "@terreno/api";
+
+setupServer({
+  userModel: User,
+  addRoutes: (router) => {
+    router.use("/todos", modelRouter(Todo, options));
+  },
+});
+```
+
+Both patterns create the same middleware stack (CORS, auth, logging, OpenAPI).
+
 ## modelRouter
 
 Auto-generates RESTful CRUD APIs for Mongoose models with permissions, population, filtering, and lifecycle hooks.
+
+**Two signatures:**
+
+```typescript
+// 1. Router signature (for setupServer):
+router.use("/todos", modelRouter(Todo, options));
+
+// 2. Registration signature (for TerrenoApp):
+const todoRouter = modelRouter("/todos", Todo, options);
+app.register(todoRouter);
+```
 
 ### Generated Endpoints
 

--- a/.rulesync/rules/example-backend/00-example-backend.md
+++ b/.rulesync/rules/example-backend/00-example-backend.md
@@ -53,6 +53,21 @@ src/
 
 ## Server Setup
 
+Uses the new `TerrenoApp` pattern:
+
+```typescript
+import {TerrenoApp} from "@terreno/api";
+import {todoRouter} from "./api/todos";
+import {userRouter} from "./api/users";
+
+const app = new TerrenoApp({userModel: User})
+  .register(todoRouter)
+  .register(userRouter)
+  .start();
+```
+
+**Legacy pattern (still supported):**
+
 ```typescript
 import {setupServer} from "@terreno/api";
 
@@ -134,6 +149,29 @@ export interface UserModel extends DefaultModel<UserDocument>, UserStatics {
 ## Route Patterns
 
 ### Owner-based CRUD (Todo)
+
+**TerrenoApp pattern:**
+
+```typescript
+export const todoRouter = modelRouter("/todos", Todo, {
+  permissions: {
+    create: [Permissions.IsAuthenticated],
+    list: [Permissions.IsAuthenticated],
+    read: [Permissions.IsOwner],
+    update: [Permissions.IsOwner],
+    delete: [Permissions.IsOwner],
+  },
+  preCreate: (body, req) => ({
+    ...body,
+    ownerId: (req.user as UserDocument)?._id,
+  }),
+  queryFilter: OwnerQueryFilter,
+  queryFields: ["completed", "ownerId"],
+  sort: "-created",
+});
+```
+
+**Legacy pattern:**
 
 ```typescript
 export const addTodoRoutes = (router, options?) => {

--- a/.windsurf/rules/example-backend/00-example-backend.md
+++ b/.windsurf/rules/example-backend/00-example-backend.md
@@ -47,6 +47,21 @@ src/
 
 ## Server Setup
 
+Uses the new `TerrenoApp` pattern:
+
+```typescript
+import {TerrenoApp} from "@terreno/api";
+import {todoRouter} from "./api/todos";
+import {userRouter} from "./api/users";
+
+const app = new TerrenoApp({userModel: User})
+  .register(todoRouter)
+  .register(userRouter)
+  .start();
+```
+
+**Legacy pattern (still supported):**
+
 ```typescript
 import {setupServer} from "@terreno/api";
 
@@ -128,6 +143,29 @@ export interface UserModel extends DefaultModel<UserDocument>, UserStatics {
 ## Route Patterns
 
 ### Owner-based CRUD (Todo)
+
+**TerrenoApp pattern:**
+
+```typescript
+export const todoRouter = modelRouter("/todos", Todo, {
+  permissions: {
+    create: [Permissions.IsAuthenticated],
+    list: [Permissions.IsAuthenticated],
+    read: [Permissions.IsOwner],
+    update: [Permissions.IsOwner],
+    delete: [Permissions.IsOwner],
+  },
+  preCreate: (body, req) => ({
+    ...body,
+    ownerId: (req.user as UserDocument)?._id,
+  }),
+  queryFilter: OwnerQueryFilter,
+  queryFields: ["completed", "ownerId"],
+  sort: "-created",
+});
+```
+
+**Legacy pattern:**
 
 ```typescript
 export const addTodoRoutes = (router, options?) => {


### PR DESCRIPTION
### **User description**
## Summary

Documents the new `TerrenoApp` class and `modelRouter` overload introduced in #272.

## Changes

### Documentation Updates

- **docs/reference/api.md**: Added "Server Setup" section documenting both `TerrenoApp` (recommended) and `setupServer` (legacy) patterns
- **.rulesync/rules/api/00-api.md**: Added server setup section and documented both modelRouter signatures
- **.rulesync/rules/example-backend/00-example-backend.md**: Updated to show TerrenoApp pattern as primary, with legacy pattern noted

### Regenerated Files

Ran `npx rulesync generate` to propagate changes to all AI assistant rule files:
- `.cursor/rules/api/00-api.mdc`
- `.cursor/rules/example-backend/00-example-backend.mdc`
- `.windsurf/rules/api/00-api.md`
- `.windsurf/rules/example-backend/00-example-backend.md`
- `.claude/rules/api/00-api.md`
- `.claude/rules/example-backend/00-example-backend.md`
- `.github/instructions/api/00-api.instructions.md`
- `.github/instructions/example-backend/00-example-backend.instructions.md`

## What's Documented

**TerrenoApp class:**
```typescript
const app = new TerrenoApp({userModel: User})
  .register(todoRouter)
  .register(userRouter)
  .start();
```

**modelRouter overload:**
```typescript
// Registration signature (for TerrenoApp):
const todoRouter = modelRouter("/todos", Todo, options);

// Router signature (for setupServer):
router.use("/todos", modelRouter(Todo, options));
```

Both patterns create the same middleware stack and are fully supported.


> AI generated by [Update Docs](https://github.com/FlourishHealth/terreno/actions/runs/22288395316)

<!-- gh-aw-workflow-id: update-docs -->


___

### **PR Type**
Documentation


___

### **Description**
- Document new `TerrenoApp` class with fluent register pattern

- Document `modelRouter` overload accepting path as first argument

- Add request validation section with AJV configuration examples

- Add extensibility section documenting `TerrenoPlugin` interface

- Update example-backend to show both `TerrenoApp` and legacy patterns

- Regenerate all AI assistant rule files via rulesync


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Source Rules<br/>.rulesync/rules"] -->|rulesync generate| B["AI Assistant Rules<br/>.cursor, .windsurf, .claude"]
  A -->|rulesync generate| C["GitHub Instructions<br/>.github/instructions"]
  A -->|manual edit| D["Public Docs<br/>docs/reference/api.md"]
  B --> E["Updated Documentation"]
  C --> E
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>api.md</strong><dd><code>Add server setup and extensibility documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/278/files#diff-370381df31c8d799afe0208a3b1f1c161b3f48ad3c5b5813e481c42f46161797">+54/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>00-api.md</strong><dd><code>Document TerrenoApp, validation, and plugins</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/278/files#diff-125eb82366794b81bd3c5a4cb124a63e3ab57efd5bc151f46e794f73c7f0aafc">+56/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>00-example-backend.md</strong><dd><code>Show TerrenoApp pattern with legacy fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/278/files#diff-c761fe0f484c210782651c72736029278af2e126b774923af803b203e4ded35b">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>00-api.md</strong><dd><code>Regenerated API documentation for Claude</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/278/files#diff-d82ad6417db1a726df58c3250f0504e4fef849e3902fcb414f87342751451a6a">+191/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>00-example-backend.md</strong><dd><code>Regenerated example backend for Claude</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/278/files#diff-0a4e570568c7920787291baa08cb3fcd113364ab5710ca4d2c224c3d7d5ed8fa">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>00-api.mdc</strong><dd><code>Regenerated API documentation for Cursor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/278/files#diff-be509c3d438655d2e8b0489104a084ae8f4520e76acddabaf7f03c82c4628052">+191/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>00-example-backend.mdc</strong><dd><code>Regenerated example backend for Cursor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/278/files#diff-cd6bb07492a96222ce1cda33dad5480756d8bb0a331dfddff9e4391b98f7f810">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>00-api.md</strong><dd><code>Regenerated API documentation for Windsurf</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/278/files#diff-82638ea0a9979169676e589992faa65a71cebe38e7444f3673fd299a2af637a7">+191/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>00-example-backend.md</strong><dd><code>Regenerated example backend for Windsurf</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/278/files#diff-3fb220c2016da819a91af5b271058b2b5d96f74fb641030b57408979241c36e7">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>00-api.instructions.md</strong><dd><code>Regenerated API instructions for GitHub</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/278/files#diff-c63214a101c82294292a939133afc3851ebea2e1b866283a3c41feb8b9b2654b">+191/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>00-example-backend.instructions.md</strong><dd><code>Regenerated example backend instructions for GitHub</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/278/files#diff-dec9f9e5f48ed50d2f34d6caef5ead51042f3efbd0ca8f6fa637c5c3af001fd2">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

