### PR TITLE
docs: add api-health package and TerrenoApp documentation

### DIFF
--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -16,6 +16,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
 - **admin-backend/** - Admin panel backend plugin for @terreno/api (`@terreno/admin-backend`)
 - **admin-frontend/** - Admin panel frontend screens for @terreno/api backends (`@terreno/admin-frontend`)
+- **api-health/** - Health check plugin for @terreno/api (`@terreno/api-health`)
 - **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
@@ -45,6 +46,8 @@ bun run mcp:build        # Build MCP server
 bun run mcp:start        # Start MCP server
 bun run admin-backend:compile   # Compile admin backend
 bun run admin-frontend:compile  # Compile admin frontend
+bun run api-health:compile      # Compile api-health
+bun run api-health:test         # Test api-health
 ```
 
 ## How the Packages Work Together

--- a/.rulesync/rules/api-health/00-api-health.md
+++ b/.rulesync/rules/api-health/00-api-health.md
@@ -1,0 +1,128 @@
+---
+targets: ["cursor", "windsurf", "copilot", "claudecode"]
+description: "@terreno/api-health - Health check plugin for @terreno/api"
+globs: ["**/*"]
+---
+
+# @terreno/api-health
+
+Health check plugin for @terreno/api backends. Provides a simple health check endpoint with optional custom health checks. This is a **backend-only** package — no React, no UI components, no frontend code.
+
+## Commands
+
+```bash
+bun run compile          # Compile TypeScript
+bun run dev              # Watch mode
+bun run test             # Run tests
+bun run lint             # Lint code
+bun run lint:fix         # Fix lint issues
+```
+
+## Architecture
+
+### File Structure
+
+```
+src/
+  index.ts               # Package exports
+  healthApp.ts           # HealthApp class implementing TerrenoPlugin
+  healthApp.test.ts      # Tests
+```
+
+## HealthApp
+
+A TerrenoPlugin that adds a health check endpoint to your API.
+
+### Basic Usage
+
+```typescript
+import {TerrenoApp} from "@terreno/api";
+import {HealthApp} from "@terreno/api-health";
+
+const app = new TerrenoApp({userModel: User})
+  .register(new HealthApp())
+  .start();
+
+// GET /health -> {healthy: true}
+```
+
+### Custom Health Checks
+
+```typescript
+import {HealthApp} from "@terreno/api-health";
+import mongoose from "mongoose";
+
+const app = new TerrenoApp({userModel: User})
+  .register(new HealthApp({
+    path: "/api/health",  // Default: "/health"
+    enabled: true,         // Default: true
+    check: async () => {
+      // Custom health check logic
+      const dbConnected = mongoose.connection.readyState === 1;
+      return {
+        healthy: dbConnected,
+        details: {
+          database: dbConnected ? "connected" : "disconnected",
+          timestamp: new Date().toISOString(),
+        },
+      };
+    },
+  }))
+  .start();
+
+// GET /api/health -> {healthy: true, details: {...}}
+// Returns 200 if healthy, 503 if not
+```
+
+## Types
+
+```typescript
+interface HealthCheckResult {
+  healthy: boolean;
+  details?: Record<string, any>;
+}
+
+interface HealthOptions {
+  enabled?: boolean;                                      // Enable/disable health check (default: true)
+  path?: string;                                          // Endpoint path (default: "/health")
+  check?: () => Promise<HealthCheckResult> | HealthCheckResult;  // Custom health check
+}
+```
+
+## Response Codes
+
+- **200 OK** — Health check passed (healthy: true)
+- **503 Service Unavailable** — Health check failed (healthy: false or error thrown)
+
+## Error Handling
+
+If the custom check function throws an error:
+
+```json
+{
+  "healthy": false,
+  "details": {
+    "error": "Database connection failed"
+  }
+}
+```
+
+## Conventions
+
+- Use TypeScript with ES modules
+- Prefer const arrow functions
+- Named exports preferred
+- Use `logger.info/warn/error/debug` for permanent logs (from @terreno/api)
+- Testing: bun test with expect, supertest for HTTP requests
+
+## Integration with TerrenoApp
+
+HealthApp implements the `TerrenoPlugin` interface:
+
+```typescript
+interface TerrenoPlugin {
+  register(app: express.Application): void;
+}
+```
+
+This allows it to be registered with `TerrenoApp.register()` alongside model routers and other plugins (AdminApp, custom middleware, etc.).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
 - **admin-backend/** - Admin panel backend plugin for @terreno/api (`@terreno/admin-backend`)
 - **admin-frontend/** - Admin panel frontend screens for @terreno/api backends (`@terreno/admin-frontend`)
+- **api-health/** - Health check plugin for @terreno/api (`@terreno/api-health`)
 - **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
@@ -38,6 +39,8 @@ bun run mcp:build        # Build MCP server
 bun run mcp:start        # Start MCP server
 bun run admin-backend:compile   # Compile admin backend
 bun run admin-frontend:compile  # Compile admin frontend
+bun run api-health:compile      # Compile api-health
+bun run api-health:test         # Test api-health
 ```
 
 ## How the Packages Work Together


### PR DESCRIPTION
## Summary

Updates rules and agent documentation to reflect recent changes from #272:

- New `@terreno/api-health` package with `HealthApp` plugin
- New `TerrenoApp` class and register pattern in `@terreno/api`
- New `modelRouter` path-first overload for use with `TerrenoApp`
- Updated `example-backend` to use `TerrenoApp` pattern

## Changes

### New Documentation

- **`.rulesync/rules/api-health/00-api-health.md`** — Complete documentation for the new HealthApp plugin including usage patterns, types, and error handling

### Updated Documentation

- **`.rulesync/rules/00-root.md`** — Added api-health to package list and commands
- **`.rulesync/rules/api/00-api.md`** — Added TerrenoApp section documenting:
  - TerrenoApp class and methods
  - TerrenoPlugin interface
  - New modelRouter overload (path-first)
  - Built-in plugins
  - Removed duplicate Extensibility section
- **`.rulesync/rules/example-backend/00-example-backend.md`** — Updated to show both:
  - New TerrenoApp pattern (current)
  - Legacy setupServer pattern (still supported)
- **`AGENTS.md`** — Added api-health to package list and commands

## Action Required

⚠️ **The generated files need to be regenerated before this PR can be merged.**

Please run locally:

``````bash
bun run rules
``````

Then commit the regenerated files:
- `.cursor/rules/`
- `.claude/rules/`
- `.windsurf/rules/`
- `.github/copilot-instructions.md`
- `.github/instructions/`

The `rulesync-check` CI workflow will fail until this is done.

## Verification

After regenerating:
- [ ] Run `bun run rules`
- [ ] Verify no uncommitted changes remain (`git status`)
- [ ] Confirm rulesync-check CI passes


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22288395324)

<!-- gh-aw-workflow-id: update-rules -->