### PR TITLE
docs: Add `@terreno/api-health` to rulesync rules and AGENTS.md

### DIFF
--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -16,6 +16,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
 - **admin-backend/** - Admin panel backend plugin for @terreno/api (`@terreno/admin-backend`)
 - **admin-frontend/** - Admin panel frontend screens for @terreno/api backends (`@terreno/admin-frontend`)
+- **api-health/** - Health check plugin for @terreno/api (`@terreno/api-health`)
 - **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
@@ -45,6 +46,9 @@ bun run mcp:build        # Build MCP server
 bun run mcp:start        # Start MCP server
 bun run admin-backend:compile   # Compile admin backend
 bun run admin-frontend:compile  # Compile admin frontend
+bun run api-health:compile      # Compile api-health package
+bun run api-health:lint         # Lint api-health package
+bun run api-health:test         # Test api-health package
 ```
 
 ## How the Packages Work Together

--- a/.rulesync/rules/api-health/00-api-health.md
+++ b/.rulesync/rules/api-health/00-api-health.md
@@ -1,0 +1,209 @@
+---
+description: '@terreno/api-health - Health check plugin for @terreno/api'
+applyTo: '**/*'
+---
+# @terreno/api-health
+
+Health check plugin for @terreno/api that provides a simple, extensible health check endpoint. This is a **backend-only** package — no React, no UI components, no frontend code.
+
+## Commands
+
+```bash
+bun run compile          # Compile TypeScript
+bun run dev              # Watch mode (TypeScript watch)
+bun run lint             # Lint code
+bun run lint:fix         # Fix lint issues
+bun run test             # Run tests
+bun run test:ci          # Run tests (CI mode)
+```
+
+## Architecture
+
+### File Structure
+
+```
+src/
+  healthApp.ts           # HealthApp class - TerrenoPlugin implementation
+  healthApp.test.ts      # Test suite
+  index.ts               # Package exports
+```
+
+## Key Exports
+
+```typescript
+import {
+  HealthApp,             // TerrenoPlugin for health check endpoint
+  HealthOptions,         // Configuration options
+  HealthCheckResult,     // Health check result type
+} from "@terreno/api-health";
+```
+
+## Usage
+
+### Simple Health Check
+
+Always returns healthy status:
+
+```typescript
+import {TerrenoApp} from "@terreno/api";
+import {HealthApp} from "@terreno/api-health";
+
+const app = new TerrenoApp({userModel: User})
+  .register(new HealthApp())
+  .start();
+
+// GET /health returns {healthy: true}
+```
+
+### Custom Health Check
+
+With database connection test:
+
+```typescript
+import {HealthApp} from "@terreno/api-health";
+import mongoose from "mongoose";
+
+const healthApp = new HealthApp({
+  path: "/api/health",
+  check: async () => {
+    try {
+      await mongoose.connection.db.admin().ping();
+      return {
+        healthy: true,
+        details: {database: "connected"},
+      };
+    } catch (error) {
+      return {
+        healthy: false,
+        details: {database: "disconnected", error: (error as Error).message},
+      };
+    }
+  },
+});
+
+const app = new TerrenoApp({userModel: User})
+  .register(healthApp)
+  .start();
+```
+
+### Legacy setupServer Pattern
+
+```typescript
+import {setupServer} from "@terreno/api";
+import {HealthApp} from "@terreno/api-health";
+
+const healthCheck = new HealthApp();
+
+setupServer({
+  userModel: User,
+  addRoutes: (router) => {
+    healthCheck.register(router as any);
+  },
+});
+```
+
+## HealthApp Options
+
+```typescript
+interface HealthOptions {
+  enabled?: boolean;      // Enable/disable endpoint (default: true)
+  path?: string;          // Endpoint path (default: "/health")
+  check?: () => Promise<HealthCheckResult> | HealthCheckResult;  // Custom check
+}
+
+interface HealthCheckResult {
+  healthy: boolean;       // Health status
+  details?: Record<string, any>;  // Additional details
+}
+```
+
+## Response Behavior
+
+- **200 OK**: Health check passed (`healthy: true`)
+- **503 Service Unavailable**: Health check failed (`healthy: false`) or check function threw error
+- Custom check errors are caught and returned as `{healthy: false, details: {error: message}}`
+
+## TerrenoPlugin Implementation
+
+HealthApp implements the `TerrenoPlugin` interface from @terreno/api:
+
+```typescript
+export class HealthApp implements TerrenoPlugin {
+  constructor(options?: HealthOptions);
+  register(app: express.Application): void;
+}
+```
+
+This pattern allows:
+- Clean registration with `TerrenoApp.register()`
+- Conditional setup based on options
+- Encapsulated route and middleware configuration
+- Reusable plugin distribution
+
+## Common Patterns
+
+### Multi-Service Health Check
+
+Check database, cache, and external services:
+
+```typescript
+const healthApp = new HealthApp({
+  check: async () => {
+    const results = await Promise.allSettled([
+      checkDatabase(),
+      checkRedis(),
+      checkExternalAPI(),
+    ]);
+
+    const [db, cache, api] = results;
+    const healthy = results.every(r => r.status === "fulfilled" && r.value);
+
+    return {
+      healthy,
+      details: {
+        database: db.status === "fulfilled" ? "ok" : "error",
+        cache: cache.status === "fulfilled" ? "ok" : "error",
+        api: api.status === "fulfilled" ? "ok" : "error",
+      },
+    };
+  },
+});
+```
+
+### Kubernetes Liveness/Readiness
+
+Use different paths for liveness and readiness probes:
+
+```typescript
+const liveness = new HealthApp({path: "/health/live"});
+const readiness = new HealthApp({
+  path: "/health/ready",
+  check: async () => {
+    const dbReady = await checkDatabaseReady();
+    return {healthy: dbReady, details: {database: dbReady ? "ready" : "not ready"}};
+  },
+});
+
+const app = new TerrenoApp({userModel: User})
+  .register(liveness)
+  .register(readiness)
+  .start();
+```
+
+### Disable in Development
+
+```typescript
+const healthApp = new HealthApp({
+  enabled: process.env.NODE_ENV === "production",
+});
+```
+
+## Conventions
+
+- Use TypeScript with ES modules
+- Prefer const arrow functions
+- Use `logger.info/warn/error/debug` for permanent logs
+- Testing: bun test with expect, supertest for HTTP
+- Never mock @terreno/api — test against real Express app
+- Health check functions should be fast (< 1s timeout recommended)
+- Return detailed error information in `details` field for debugging


### PR DESCRIPTION
## Overview

This PR adds comprehensive documentation for the `@terreno/api-health` package to the rulesync rules system. The package was previously missing from AI assistant documentation despite being a working package with scripts in root package.json and referenced in the codebase.

## Changes Made

### 1. Created `.rulesync/rules/api-health/00-api-health.md`
- Comprehensive documentation of the HealthApp plugin class
- Usage examples (simple and custom health checks)
- Configuration options (HealthOptions, HealthCheckResult interfaces)
- Common patterns (multi-service checks, Kubernetes liveness/readiness, conditional enablement)
- TerrenoPlugin implementation details
- Package commands (compile, lint, test)

### 2. Updated `.rulesync/rules/00-root.md`
- Added `@terreno/api-health` to the packages list with description
- Added `api-health:*` commands to package-specific commands section

## Required Action for Reviewers

⚠️ **Important:** After reviewing, please run the following command locally to regenerate all output files:

```bash
bun run rules
```

This will regenerate:
- `AGENTS.md`
- `.cursorrules`
- `.windsurfrules`
- `CLAUDE.md`
- `.github/copilot-instructions.md`
- `.github/instructions/`

Then commit the regenerated files so that the `rulesync-check` CI workflow passes.

## Context

The `@terreno/api-health` package:
- ✅ Exists as a working package with proper structure
- ✅ Has scripts in root package.json (api-health:compile, api-health:lint, api-health:test)
- ✅ Is referenced in docs/reference/api.md as an example TerrenoPlugin implementation
- ❌ Was missing from AGENTS.md and rulesync rules

This creates a documentation gap for AI assistants working with the codebase.

## Related Files
- Source code: `api-health/src/healthApp.ts`
- Tests: `api-health/src/healthApp.test.ts`
- API reference: `docs/reference/api.md` (already references this package)


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22310728120)

<!-- gh-aw-workflow-id: update-rules -->