### PR TITLE
docs: Add `@terreno/api-health` package documentation to agent rules

### DIFF
--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -16,6 +16,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
 - **admin-backend/** - Admin panel backend plugin for @terreno/api (`@terreno/admin-backend`)
 - **admin-frontend/** - Admin panel frontend screens for @terreno/api backends (`@terreno/admin-frontend`)
+- **api-health/** - Health check plugin for @terreno/api (`@terreno/api-health`)
 - **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
@@ -45,6 +46,8 @@ bun run mcp:build        # Build MCP server
 bun run mcp:start        # Start MCP server
 bun run admin-backend:compile   # Compile admin backend
 bun run admin-frontend:compile  # Compile admin frontend
+bun run api-health:compile      # Compile api-health package
+bun run api-health:test         # Test api-health package
 ```
 
 ## How the Packages Work Together

--- a/.rulesync/rules/01-claudecode-root.md
+++ b/.rulesync/rules/01-claudecode-root.md
@@ -16,6 +16,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
 - **admin-backend/** - Admin panel backend plugin for @terreno/api (`@terreno/admin-backend`)
 - **admin-frontend/** - Admin panel frontend screens for @terreno/api backends (`@terreno/admin-frontend`)
+- **api-health/** - Health check plugin for @terreno/api (`@terreno/api-health`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
 - **example-backend/** - Example Express backend using @terreno/api
@@ -42,6 +43,8 @@ bun run frontend:web     # Start frontend example
 bun run backend:dev      # Start backend example
 bun run admin-backend:compile   # Compile admin backend
 bun run admin-frontend:compile  # Compile admin frontend
+bun run api-health:compile      # Compile api-health package
+bun run api-health:test         # Test api-health package
 ```
 
 ## How the Packages Work Together

--- a/.rulesync/rules/api-health/00-api-health.md
+++ b/.rulesync/rules/api-health/00-api-health.md
@@ -1,0 +1,254 @@
+---
+targets: ["cursor", "windsurf", "copilot", "claudecode"]
+description: "@terreno/api-health - Health check plugin for @terreno/api"
+globs: ["**/*"]
+---
+
+# @terreno/api-health
+
+Health check plugin for @terreno/api that provides a simple health endpoint. This is a **backend-only** package — no React, no UI components, no frontend code.
+
+## Commands
+
+````bash
+bun run compile          # Compile TypeScript
+bun run dev              # Watch mode (TypeScript watch)
+bun run lint             # Lint code
+bun run lint:fix         # Fix lint issues
+bun run test             # Run tests
+bun run test:ci          # Run tests in CI mode
+````
+
+## Architecture
+
+### File Structure
+
+````
+src/
+  healthApp.ts           # HealthApp class - TerrenoPlugin implementation
+  healthApp.test.ts      # Health endpoint tests
+  index.ts               # Package exports
+````
+
+### Key Concepts
+
+The api-health package provides:
+- **HealthApp class**: TerrenoPlugin that registers a health check endpoint
+- **Simple health checks**: Default always-healthy response
+- **Custom health logic**: Optional check function for database/service validation
+- **Standard responses**: 200 for healthy, 503 for unhealthy
+
+## Usage
+
+### Basic Health Check
+
+````typescript
+import {HealthApp} from "@terreno/api-health";
+import {TerrenoApp} from "@terreno/api";
+
+const app = new TerrenoApp({userModel: User})
+  .register(new HealthApp())
+  .start();
+
+// Creates GET /health endpoint that returns {healthy: true}
+````
+
+### Custom Health Check
+
+````typescript
+import {HealthApp} from "@terreno/api-health";
+import mongoose from "mongoose";
+
+const healthApp = new HealthApp({
+  path: "/api/health",  // Optional, default: "/health"
+  check: async () => {
+    try {
+      await mongoose.connection.db.admin().ping();
+      return {healthy: true, details: {database: "connected"}};
+    } catch (error) {
+      return {healthy: false, details: {database: "disconnected"}};
+    }
+  },
+});
+
+const app = new TerrenoApp({userModel: User})
+  .register(healthApp)
+  .start();
+````
+
+### Disabling Health Check
+
+````typescript
+const healthApp = new HealthApp({
+  enabled: false,  // Disables the health endpoint
+});
+````
+
+## Configuration Options
+
+````typescript
+interface HealthOptions {
+  enabled?: boolean;    // Enable/disable health endpoint (default: true)
+  path?: string;        // Health endpoint path (default: "/health")
+  check?: () => Promise<HealthCheckResult> | HealthCheckResult;  // Custom check function
+}
+
+interface HealthCheckResult {
+  healthy: boolean;     // Whether the service is healthy
+  details?: Record<string, any>;  // Optional additional details
+}
+````
+
+## Response Format
+
+### Healthy Response (200)
+
+````json
+{
+  "healthy": true,
+  "details": {
+    "database": "connected"
+  }
+}
+````
+
+### Unhealthy Response (503)
+
+````json
+{
+  "healthy": false,
+  "details": {
+    "database": "disconnected"
+  }
+}
+````
+
+## TerrenoPlugin Pattern
+
+HealthApp is an example implementation of the TerrenoPlugin interface:
+
+````typescript
+import type {TerrenoPlugin} from "@terreno/api";
+import type express from "express";
+
+export class HealthApp implements TerrenoPlugin {
+  register(app: express.Application): void {
+    // Register routes, middleware, or other setup
+  }
+}
+````
+
+This pattern allows for modular, reusable functionality that can be registered with TerrenoApp.
+
+## Common Use Cases
+
+### Kubernetes Liveness/Readiness Probes
+
+````yaml
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 4000
+  initialDelaySeconds: 10
+  periodSeconds: 5
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 4000
+  initialDelaySeconds: 5
+  periodSeconds: 3
+````
+
+### Database Connection Check
+
+````typescript
+const healthApp = new HealthApp({
+  check: async () => {
+    try {
+      const pingResult = await mongoose.connection.db.admin().ping();
+      const dbState = mongoose.connection.readyState; // 1 = connected
+      return {
+        healthy: dbState === 1,
+        details: {
+          database: dbState === 1 ? "connected" : "disconnected",
+          ping: pingResult,
+        },
+      };
+    } catch (error) {
+      return {
+        healthy: false,
+        details: {error: error.message},
+      };
+    }
+  },
+});
+````
+
+### Multi-Service Health Check
+
+````typescript
+const healthApp = new HealthApp({
+  check: async () => {
+    const checks = await Promise.allSettled([
+      checkDatabase(),
+      checkRedis(),
+      checkS3(),
+    ]);
+    
+    const allHealthy = checks.every(
+      (result) => result.status === "fulfilled" && result.value === true
+    );
+    
+    return {
+      healthy: allHealthy,
+      details: {
+        database: checks[0].status === "fulfilled" ? "ok" : "error",
+        redis: checks[1].status === "fulfilled" ? "ok" : "error",
+        s3: checks[2].status === "fulfilled" ? "ok" : "error",
+      },
+    };
+  },
+});
+````
+
+## Testing
+
+````typescript
+import {HealthApp} from "@terreno/api-health";
+import {expect, describe, it} from "bun:test";
+import express from "express";
+import request from "supertest";
+
+describe("HealthApp", () => {
+  it("returns healthy by default", async () => {
+    const app = express();
+    const healthApp = new HealthApp();
+    healthApp.register(app);
+    
+    const res = await request(app).get("/health");
+    expect(res.status).toBe(200);
+    expect(res.body.healthy).toBe(true);
+  });
+  
+  it("returns custom health check result", async () => {
+    const app = express();
+    const healthApp = new HealthApp({
+      check: async () => ({healthy: false, details: {reason: "test"}}),
+    });
+    healthApp.register(app);
+    
+    const res = await request(app).get("/health");
+    expect(res.status).toBe(503);
+    expect(res.body.healthy).toBe(false);
+  });
+});
+````
+
+## Conventions
+
+- Use `HealthApp` to add health checks to @terreno/api applications
+- Always provide meaningful details in custom health checks
+- Use 200 for healthy, 503 for unhealthy (standard HTTP status codes)
+- Use `logger.info/warn/error/debug` for permanent logs
+- Testing: bun test with expect, supertest for HTTP requests


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the `@terreno/api-health` package to the agent rules system. The api-health package was missing from AGENTS.md and the rulesync rules, creating a gap in agent-facing documentation.

## Changes

### Source Rule Updates
- ✅ Added `@terreno/api-health` to package list in `.rulesync/rules/00-root.md`
- ✅ Added `@terreno/api-health` to package list in `.rulesync/rules/01-claudecode-root.md`
- ✅ Created `.rulesync/rules/api-health/00-api-health.md` with comprehensive package documentation
- ✅ Added api-health commands (`compile`, `test`) to package-specific commands section

### New Documentation Includes
- Package architecture and file structure
- Basic and advanced usage examples
- Configuration options and response formats
- TerrenoPlugin pattern documentation (useful reference for plugin development)
- Common use cases (Kubernetes probes, database checks, multi-service health)
- Testing examples
- Conventions

## Action Required

**Important**: Before merging, a reviewer must:

1. Pull this branch locally
2. Run `bun install && bun run rules` to regenerate output files
3. Commit the regenerated files:
   - `AGENTS.md`
   - `.cursor/rules/`
   - `.github/copilot-instructions.md`
   - `.claude/rules/`
4. Push the regenerated files to this branch

This is required because the rulesync generation tool requires Bun, which is not available in the GitHub Actions environment for this workflow.

## Why This Matters

The `@terreno/api-health` package:
- Already exists in the monorepo (version 0.0.14)
- Has scripts in root `package.json` (api-health:compile, api-health:test, api-health:lint)
- Is referenced in `docs/reference/api.md`
- Provides a complete TerrenoPlugin example implementation
- But was undocumented in agent-facing rules

This gap meant AI coding assistants (Cursor, Copilot, Claude Code, Windsurf) were unaware of this package and its capabilities.

## Verification

After running `bun run rules`:
- ✅ AGENTS.md should list api-health in packages section
- ✅ `.cursor/rules/api-health/` should exist with generated rule
- ✅ `.github/copilot-instructions.md` should include api-health documentation
- ✅ CI `rulesync-check` workflow should pass


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22310793876)

<!-- gh-aw-workflow-id: update-rules -->