### PR TITLE
docs: Add `@terreno/ai` and `@terreno/api-health` to rules and agent documentation

### DIFF
--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -14,8 +14,10 @@ A monorepo containing shared packages for building full-stack applications with 
 - **api/** - REST API framework built on Express/Mongoose (`@terreno/api`)
 - **ui/** - React Native UI component library (`@terreno/ui`)
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
+- **ai/** - AI service layer for GPT chat, request logging, and admin tools (`@terreno/ai`)
 - **admin-backend/** - Admin panel backend plugin for @terreno/api (`@terreno/admin-backend`)
 - **admin-frontend/** - Admin panel frontend screens for @terreno/api backends (`@terreno/admin-frontend`)
+- **api-health/** - Health check plugin for @terreno/api (`@terreno/api-health`)
 - **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
@@ -36,7 +38,10 @@ bun run test             # Run tests in api and ui
 ### Package-specific commands
 
 ```bash
+bun run ai:test          # Test AI package
+bun run ai:compile       # Compile AI package
 bun run api:test         # Test API package
+bun run api-health:test  # Test API health plugin
 bun run ui:test          # Test UI package
 bun run demo:start       # Start demo app
 bun run frontend:web     # Start frontend example

--- a/.rulesync/rules/api-health/00-api-health.md
+++ b/.rulesync/rules/api-health/00-api-health.md
@@ -1,0 +1,194 @@
+---
+targets: ["cursor", "windsurf", "copilot", "claudecode"]
+description: "@terreno/api-health - Health check plugin for @terreno/api"
+globs: ["**/*"]
+---
+
+# @terreno/api-health
+
+Health check plugin for @terreno/api backends. Provides a simple, extensible TerrenoPlugin for adding health check endpoints to Express applications. This is a **backend-only** package — no React, no UI components, no frontend code.
+
+## Commands
+
+````bash
+bun run compile          # Compile TypeScript
+bun run dev              # Watch mode
+bun run test             # Run tests
+bun run lint             # Lint code
+bun run lint:fix         # Fix lint issues
+````
+
+## Architecture
+
+### File Structure
+
+````
+src/
+  index.ts               # Package exports
+  healthApp.ts           # HealthApp class (TerrenoPlugin implementation)
+  healthApp.test.ts      # Tests for HealthApp
+````
+
+## HealthApp
+
+TerrenoPlugin that provides a health check endpoint with optional custom health check logic.
+
+### Basic Usage
+
+````typescript
+import {HealthApp} from "@terreno/api-health";
+import {TerrenoApp} from "@terreno/api";
+
+const app = new TerrenoApp({userModel: User})
+  .register(new HealthApp())
+  .start();
+
+// Creates GET /health endpoint that returns {healthy: true}
+````
+
+### Custom Health Check
+
+````typescript
+import {HealthApp} from "@terreno/api-health";
+import mongoose from "mongoose";
+
+const healthApp = new HealthApp({
+  path: "/api/health",
+  check: async () => {
+    try {
+      await mongoose.connection.db.admin().ping();
+      return {healthy: true, details: {database: "connected"}};
+    } catch (error) {
+      return {healthy: false, details: {database: "disconnected"}};
+    }
+  },
+});
+
+const app = new TerrenoApp({userModel: User})
+  .register(healthApp)
+  .start();
+````
+
+## Configuration Options
+
+````typescript
+interface HealthOptions {
+  enabled?: boolean;      // Enable/disable endpoint (default: true)
+  path?: string;          // Endpoint path (default: "/health")
+  check?: () => Promise<HealthCheckResult> | HealthCheckResult;
+}
+
+interface HealthCheckResult {
+  healthy: boolean;       // Health status
+  details?: Record<string, any>;  // Optional details
+}
+````
+
+## Response Format
+
+**Healthy (200):**
+````json
+{
+  "healthy": true,
+  "details": {
+    "database": "connected",
+    "cache": "available"
+  }
+}
+````
+
+**Unhealthy (503):**
+````json
+{
+  "healthy": false,
+  "details": {
+    "database": "disconnected",
+    "error": "Connection timeout"
+  }
+}
+````
+
+## Integration with TerrenoApp
+
+HealthApp implements the TerrenoPlugin interface, making it compatible with the TerrenoApp register pattern:
+
+````typescript
+import {TerrenoApp} from "@terreno/api";
+import {HealthApp} from "@terreno/api-health";
+
+const app = new TerrenoApp({userModel: User})
+  .register(new HealthApp({
+    path: "/health",
+    check: async () => {
+      // Custom health checks
+      const dbOk = await checkDatabase();
+      const redisOk = await checkRedis();
+      return {
+        healthy: dbOk && redisOk,
+        details: {database: dbOk, redis: redisOk},
+      };
+    },
+  }))
+  .start();
+````
+
+## Use Cases
+
+- **Kubernetes/Docker health probes**: Simple endpoint for liveness/readiness checks
+- **Load balancer health checks**: Monitor application availability
+- **Monitoring systems**: Automated health status collection
+- **Dependency validation**: Check database, cache, or external service connections
+
+## Conventions
+
+- Returns 200 for healthy, 503 for unhealthy
+- Always returns JSON response with `healthy` boolean
+- Custom checks should never throw — wrap in try/catch and return `{healthy: false}`
+- Use `details` object for diagnostic information
+- Health endpoint should be fast (< 100ms) — avoid expensive checks
+- Use TypeScript with ES modules
+- Prefer const arrow functions
+- Use `logger.info/warn/error/debug` for permanent logs (if using @terreno/api logging)
+
+## Testing
+
+- Framework: bun test with expect
+- HTTP testing: supertest
+- Test both healthy and unhealthy states
+- Test custom check function integration
+- Verify HTTP status codes (200, 503)
+- Never mock @terreno/api or express — test against real functionality
+
+### Test Pattern
+
+````typescript
+import {describe, expect, it} from "bun:test";
+import express from "express";
+import request from "supertest";
+import {HealthApp} from "./healthApp";
+
+describe("HealthApp", () => {
+  it("returns healthy by default", async () => {
+    const app = express();
+    new HealthApp().register(app);
+    const res = await request(app).get("/health");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({healthy: true});
+  });
+
+  it("supports custom health checks", async () => {
+    const app = express();
+    new HealthApp({
+      check: async () => ({healthy: false, details: {error: "test"}}),
+    }).register(app);
+    const res = await request(app).get("/health");
+    expect(res.status).toBe(503);
+    expect(res.body.healthy).toBe(false);
+  });
+});
+````
+
+## Related Packages
+
+- **@terreno/api**: TerrenoPlugin interface and TerrenoApp class
+- **express**: HTTP server framework

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,10 @@ A monorepo containing shared packages for building full-stack applications with 
 - **api/** - REST API framework built on Express/Mongoose (`@terreno/api`)
 - **ui/** - React Native UI component library (`@terreno/ui`)
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
+- **ai/** - AI service layer for GPT chat, request logging, and admin tools (`@terreno/ai`)
 - **admin-backend/** - Admin panel backend plugin for @terreno/api (`@terreno/admin-backend`)
 - **admin-frontend/** - Admin panel frontend screens for @terreno/api backends (`@terreno/admin-frontend`)
+- **api-health/** - Health check plugin for @terreno/api (`@terreno/api-health`)
 - **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
@@ -29,7 +31,10 @@ bun run test             # Run tests in api and ui
 ### Package-specific commands
 
 ```bash
+bun run ai:test          # Test AI package
+bun run ai:compile       # Compile AI package
 bun run api:test         # Test API package
+bun run api-health:test  # Test API health plugin
 bun run ui:test          # Test UI package
 bun run demo:start       # Start demo app
 bun run frontend:web     # Start frontend example

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ A monorepo containing shared packages for building full-stack applications.
 - **api/** - REST API framework built on Express/Mongoose (published as `@terreno/api`)
 - **ui/** - React Native UI component library (published as `@terreno/ui`)
 - **rtk/** - Redux Toolkit Query utilities for @terreno/api backends (published as `@terreno/rtk`)
+- **ai/** - AI service layer for GPT chat, request logging, and admin tools (published as `@terreno/ai`)
+- **admin-backend/** - Admin panel backend plugin for @terreno/api (published as `@terreno/admin-backend`)
+- **admin-frontend/** - Admin panel frontend screens for @terreno/api backends (published as `@terreno/admin-frontend`)
+- **api-health/** - Health check plugin for @terreno/api (published as `@terreno/api-health`)
 
 ### Deployed Services
 


### PR DESCRIPTION
## Summary

Adds comprehensive rules documentation and agent onboarding content for two new packages introduced in PR #208:

- **`@terreno/ai`** — AI service layer for GPT chat, request logging, and admin tools
- **`@terreno/api-health`** — Health check plugin for `@terreno/api`

## Changes Made

### New Rules Files
- **Created** `.rulesync/rules/api-health/00-api-health.md` — Complete documentation for the `@terreno/api-health` package including:
  - HealthApp TerrenoPlugin implementation details  
  - Configuration options and usage examples
  - Integration patterns with TerrenoApp
  - Testing conventions and patterns

### Updated Files
- **Updated** `.rulesync/rules/00-root.md`:
  - Added `@terreno/ai` and `@terreno/api-health` to packages list
  - Added new package-specific commands (`ai:test`, `ai:compile`, `api-health:test`)

- **Updated** `AGENTS.md`:
  - Added `@terreno/ai` and `@terreno/api-health` to packages list
  - Added new package-specific commands for consistency

- **Updated** `README.md`:
  - Added `@terreno/ai`, `@terreno/admin-backend`, `@terreno/admin-frontend`, and `@terreno/api-health` to Published Packages section

## Why These Changes

The recent merge of PR #208 added the `ai/` and `api-health/` packages to the monorepo. While the `ai` package had rules created in that PR, the `api-health` package was missing rules documentation. Additionally, neither package was listed in the root rules or AGENTS.md packages section, creating a gap for AI assistants working on the repository.

## Generated Files Not Included

**Important:** This PR includes only the **source** rule files in `.rulesync/rules/`. The generated output files (`.cursor/rules/`, `.windsurfrules`, `CLAUDE.md`, `.github/copilot-instructions.md`, `.github/instructions/`) are **not** included because rulesync requires Node.js ≥22 to run and the CI environment has Node.js v20.

## Action Required from Reviewer

**Before merging**, the reviewer must:

1. Pull this branch locally
2. Run `bun run rules` to regenerate all output files
3. Commit the generated files
4. Push to this branch

This will ensure the `rulesync-check` CI workflow passes.

Alternatively, the repository could:
- Upgrade the workflow runner to use Node.js 22+
- Add a workflow that auto-commits generated files after rule changes

## Testing

- Verified rule file structure and frontmatter format
- Verified content accuracy against actual package source code
- All new commands exist in root `package.json` scripts section

## Related

- Closes gaps from #208 (Add `@terreno/ai`)


> AI generated by [Update Rules](https://github.com/FlourishHealth/terreno/actions/runs/22311578563)

<!-- gh-aw-workflow-id: update-rules -->