### PR TITLE
Add Google Secret Manager integration to Configuration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -239,6 +239,7 @@
         "@google-cloud/logging": "^11.2.1",
         "@google-cloud/logging-winston": "^6.0.1",
         "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",
+        "@google-cloud/secret-manager": "^5.6.0",
         "@google-cloud/trace-agent": "^8.0.0",
         "@opentelemetry/instrumentation-express": "^0.57.1",
         "@opentelemetry/instrumentation-http": "^0.208.0",
@@ -994,6 +995,8 @@
     "@google-cloud/projectify": ["@google-cloud/projectify@4.0.0", "", {}, "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA=="],
 
     "@google-cloud/promisify": ["@google-cloud/promisify@4.0.0", "", {}, "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g=="],
+
+    "@google-cloud/secret-manager": ["@google-cloud/secret-manager@5.6.0", "", { "dependencies": { "google-gax": "^4.0.3" } }, "sha512-0daW/OXQEVc6VQKPyJTQNyD+563I/TYQ7GCQJx4dq3lB666R9FUPvqHx9b/o/qQtZ5pfuoCbGZl3krpxgTSW8Q=="],
 
     "@google-cloud/storage": ["@google-cloud/storage@7.19.0", "", { "dependencies": { "@google-cloud/paginator": "^5.0.0", "@google-cloud/projectify": "^4.0.0", "@google-cloud/promisify": "<4.1.0", "abort-controller": "^3.0.0", "async-retry": "^1.3.3", "duplexify": "^4.1.3", "fast-xml-parser": "^5.3.4", "gaxios": "^6.0.2", "google-auth-library": "^9.6.3", "html-entities": "^2.5.2", "mime": "^3.0.0", "p-limit": "^3.0.1", "retry-request": "^7.0.0", "teeny-request": "^9.0.0", "uuid": "^8.0.0" } }, "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ=="],
 

--- a/example-backend/package.json
+++ b/example-backend/package.json
@@ -4,6 +4,7 @@
     "@google-cloud/logging": "^11.2.1",
     "@google-cloud/logging-winston": "^6.0.1",
     "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0",
+    "@google-cloud/secret-manager": "^5.6.0",
     "@google-cloud/trace-agent": "^8.0.0",
     "@opentelemetry/instrumentation-express": "^0.57.1",
     "@opentelemetry/instrumentation-http": "^0.208.0",

--- a/example-backend/src/conf.ts
+++ b/example-backend/src/conf.ts
@@ -41,6 +41,12 @@ Configuration.register("BACKEND_SERVICE", {
   type: "string",
 });
 
+Configuration.register("GCP_PROJECT_ID", {
+  description: "Google Cloud Platform project ID for Secret Manager",
+  envVar: "GCP_PROJECT_ID",
+  type: "string",
+});
+
 Configuration.register("PR_NUMBER", {
   description: "Pull request number",
   envVar: "PR_NUMBER",

--- a/example-backend/src/models/configuration.ts
+++ b/example-backend/src/models/configuration.ts
@@ -1,3 +1,4 @@
+import {SecretManagerServiceClient} from "@google-cloud/secret-manager";
 import * as Sentry from "@sentry/bun";
 import {logger} from "@terreno/api";
 import mongoose from "mongoose";
@@ -10,7 +11,7 @@ import {addDefaultPlugins} from "./modelPlugins";
 interface ConfigDefinition {
   envVar?: string; // Environment variable name
   defaultValue?: ConfigValueType; // Default value if not set
-  type?: "string" | "number" | "boolean"; // Type for conversion
+  type?: "string" | "number" | "boolean" | "secret"; // Type for conversion
   validator?: (value: ConfigValueType) => boolean; // Optional validator function
   description?: string; // Documentation
 }
@@ -30,6 +31,24 @@ const runtimeOverrides = new Map<string, ConfigValueType>();
  * Maintains an always-available cached version of database config values
  */
 const dbCache = new Map<string, ConfigValueType>();
+
+/**
+ * Secrets cache for Google Secret Manager values
+ * Stores resolved secret values keyed by configuration key
+ */
+const secretsCache = new Map<string, string>();
+
+/**
+ * Lazily-initialized Google Secret Manager client
+ */
+let gsmClient: SecretManagerServiceClient | null = null;
+
+const getGsmClient = (): SecretManagerServiceClient => {
+  if (!gsmClient) {
+    gsmClient = new SecretManagerServiceClient();
+  }
+  return gsmClient;
+};
 
 /**
  * Change stream for watching configuration changes
@@ -74,7 +93,12 @@ export class Configuration {
       return runtimeOverrides.get(key) as T;
     }
 
-    // Check database cache (second priority)
+    // Check secrets cache (second priority, for secret-type configs)
+    if (secretsCache.has(key)) {
+      return secretsCache.get(key) as T;
+    }
+
+    // Check database cache (third priority)
     if (dbCache.has(key)) {
       const cachedValue = dbCache.get(key);
       // Convert null to undefined for consistency
@@ -195,7 +219,7 @@ export class Configuration {
    */
   private static convertValue(
     value: string | undefined,
-    type: "string" | "number" | "boolean"
+    type: "string" | "number" | "boolean" | "secret"
   ): ConfigValueType {
     if (value === undefined) {
       return null;
@@ -211,6 +235,98 @@ export class Configuration {
       default:
         return value;
     }
+  }
+
+  /**
+   * Fetch a single secret from Google Secret Manager
+   * Supports both short names (resolved via GCP_PROJECT_ID) and full resource paths
+   */
+  static async fetchSecret(secretName: string): Promise<string> {
+    const client = getGsmClient();
+
+    let resourceName: string;
+    if (secretName.startsWith("projects/")) {
+      resourceName = secretName.endsWith("/versions/latest")
+        ? secretName
+        : `${secretName}/versions/latest`;
+    } else {
+      const projectId = Configuration.get<string>("GCP_PROJECT_ID");
+      if (!projectId) {
+        throw new Error("GCP_PROJECT_ID is required to resolve secret names");
+      }
+      resourceName = `projects/${projectId}/secrets/${secretName}/versions/latest`;
+    }
+
+    const [version] = await client.accessSecretVersion({name: resourceName});
+    const payload = version.payload?.data;
+    if (!payload) {
+      throw new Error(`Secret ${secretName} has no payload data`);
+    }
+    return typeof payload === "string" ? payload : new TextDecoder().decode(payload);
+  }
+
+  /**
+   * Load all secret-type configurations from Google Secret Manager into cache
+   */
+  static async loadSecrets(): Promise<void> {
+    const secretConfigs = await ConfigurationDB.find({type: "secret"});
+    if (secretConfigs.length === 0) {
+      return;
+    }
+
+    const results = await Promise.allSettled(
+      secretConfigs.map(async (config) => {
+        const secretValue = await Configuration.fetchSecret(String(config.value));
+        secretsCache.set(config.key, secretValue);
+      })
+    );
+
+    let successCount = 0;
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        successCount++;
+      } else {
+        logger.error(`Failed to load secret: ${result.reason}`);
+      }
+    }
+
+    logger.info(
+      `Loaded ${successCount}/${secretConfigs.length} secrets from Google Secret Manager`
+    );
+  }
+
+  /**
+   * Refresh all cached secrets from Google Secret Manager
+   */
+  static async refreshSecrets(): Promise<void> {
+    secretsCache.clear();
+    await Configuration.loadSecrets();
+  }
+
+  /**
+   * Refresh a single secret by configuration key
+   */
+  static async refreshSecret(key: string): Promise<void> {
+    const config = await ConfigurationDB.findOne({key, type: "secret"});
+    if (!config) {
+      logger.warn(`No secret-type configuration found for key: ${key}`);
+      return;
+    }
+
+    try {
+      const secretValue = await Configuration.fetchSecret(String(config.value));
+      secretsCache.set(key, secretValue);
+      logger.debug(`Refreshed secret: ${key}`);
+    } catch (error: unknown) {
+      logger.error(`Failed to refresh secret ${key}: ${error}`);
+    }
+  }
+
+  /**
+   * Get all cached secret keys (for debugging — does not expose values)
+   */
+  static getSecretKeys(): string[] {
+    return Array.from(secretsCache.keys());
   }
 
   /**
@@ -273,6 +389,11 @@ export class Configuration {
             if (doc) {
               dbCache.set(doc.key, doc.value);
               logger.debug(`Configuration cache updated: ${doc.key} = ${doc.value}`);
+              if (doc.type === "secret") {
+                Configuration.refreshSecret(doc.key).catch((error: unknown) => {
+                  logger.error(`Failed to refresh secret ${doc.key}: ${error}`);
+                });
+              }
             }
           } else if (change.operationType === "delete") {
             // Reload all configs on delete since we don't have the key directly
@@ -284,6 +405,11 @@ export class Configuration {
             if (doc) {
               dbCache.set(doc.key, doc.value);
               logger.debug(`Configuration cache replaced: ${doc.key} = ${doc.value}`);
+              if (doc.type === "secret") {
+                Configuration.refreshSecret(doc.key).catch((error: unknown) => {
+                  logger.error(`Failed to refresh secret ${doc.key}: ${error}`);
+                });
+              }
             }
           }
         } catch (error: unknown) {
@@ -360,6 +486,13 @@ export class Configuration {
       // Load existing configuration from database
       await Configuration.loadFromDB();
 
+      // Load secrets from Google Secret Manager (non-fatal on failure)
+      try {
+        await Configuration.loadSecrets();
+      } catch (error: unknown) {
+        logger.warn(`Failed to load secrets from Google Secret Manager: ${error}`);
+      }
+
       // Start watching for changes (may fail if replica set not available)
       const changeStreamAvailable = await Configuration.startWatching();
       if (!changeStreamAvailable) {
@@ -381,6 +514,8 @@ export class Configuration {
   static async shutdown(): Promise<void> {
     Configuration.stopWatching();
     dbCache.clear();
+    secretsCache.clear();
+    gsmClient = null;
     isInitialized = false;
     logger.info("Configuration system shutdown");
   }
@@ -426,7 +561,7 @@ const configurationSchema = new mongoose.Schema<ConfigurationDocument, Configura
     },
     type: {
       description: "Data type of the configuration value",
-      enum: ["string", "number", "boolean"],
+      enum: ["string", "number", "boolean", "secret"],
       required: true,
       type: String,
     },

--- a/example-backend/src/types/models/configurationTypes.ts
+++ b/example-backend/src/types/models/configurationTypes.ts
@@ -29,6 +29,6 @@ export type ConfigurationDocument = DefaultDoc &
   ConfigurationMethods & {
     key: string;
     value: ConfigValueType;
-    type: "string" | "number" | "boolean";
+    type: "string" | "number" | "boolean" | "secret";
     description?: string;
   };


### PR DESCRIPTION
### **User description**
## Summary

Adds a `"secret"` type to the Configuration system in `example-backend`. When a configuration entry has type `"secret"`, its DB value is treated as a Google Secret Manager secret name. During `initialize()`, all secret-type configs are fetched from GSM and cached in-memory so that `Configuration.get()` remains synchronous.

**Priority chain:** runtime override > secrets cache > DB cache > env var > default

## Changes

- Add `@google-cloud/secret-manager` dependency
- Add `"secret"` to the configuration type enum (schema + TypeScript types)
- Add `secretsCache` map and lazy GSM client initialization
- Add `fetchSecret()` — resolves secrets from GSM (supports short names via `GCP_PROJECT_ID` and full resource paths)
- Add `loadSecrets()` — bulk-loads all secret-type configs from GSM into cache
- Add `refreshSecrets()` / `refreshSecret(key)` — re-fetch cached secrets on demand
- Add `getSecretKeys()` — debug method exposing cached keys (not values)
- Update `initialize()` to call `loadSecrets()` after DB load (wrapped in try/catch for graceful degradation)
- Update change stream handler to trigger `refreshSecret()` when secret-type configs change
- Update `shutdown()` to clear secrets cache and GSM client
- Register `GCP_PROJECT_ID` configuration key in `conf.ts`
- Add tests for secret type schema, cache behavior, and error handling

## Testing

- All existing tests pass (3 pre-existing failures unrelated to this change)
- New tests cover: schema accepts secret type, DB filtering by type, secrets cache access, GCP_PROJECT_ID validation, full resource path handling
- Type compilation passes across all packages
- Lint passes


___

### **PR Type**
Enhancement


___

### **Description**
- Add Google Secret Manager integration to Configuration system

- Support "secret" type storing GSM secret names in MongoDB

- Fetch and cache secret values in-memory during initialization

- Implement refresh methods for on-demand secret updates

- Add GCP_PROJECT_ID configuration key and comprehensive tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Configuration System"] -->|"register GCP_PROJECT_ID"| B["GCP_PROJECT_ID Config"]
  A -->|"add secret type"| C["Secret Type Support"]
  C -->|"fetchSecret"| D["Google Secret Manager"]
  D -->|"cache values"| E["secretsCache Map"]
  E -->|"get method"| F["Synchronous Access"]
  A -->|"loadSecrets on init"| E
  A -->|"watch changes"| G["Change Stream"]
  G -->|"refreshSecret"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conf.ts</strong><dd><code>Register GCP_PROJECT_ID configuration key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example-backend/src/conf.ts

<ul><li>Register new <code>GCP_PROJECT_ID</code> configuration key with environment <br>variable mapping<br> <li> Provide description for Google Cloud Platform project ID used by <br>Secret Manager</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/294/files#diff-2fd0c2b4a079fcfcb9bbae99e89967056b85b6fc0ffad76479c70c7993aca1e5">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.ts</strong><dd><code>Implement Google Secret Manager integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example-backend/src/models/configuration.ts

<ul><li>Import <code>SecretManagerServiceClient</code> from <code>@google-cloud/secret-manager</code><br> <li> Add <code>secretsCache</code> map and lazy-initialized GSM client with <br><code>getGsmClient()</code> helper<br> <li> Update <code>get()</code> method to check secrets cache with second priority after <br>runtime overrides<br> <li> Add <code>fetchSecret()</code> method supporting both short names and full resource <br>paths<br> <li> Add <code>loadSecrets()</code> to bulk-load all secret-type configs from GSM into <br>cache<br> <li> Add <code>refreshSecrets()</code> and <code>refreshSecret(key)</code> for on-demand cache <br>updates<br> <li> Add <code>getSecretKeys()</code> debug method exposing cached secret keys without <br>values<br> <li> Update <code>initialize()</code> to call <code>loadSecrets()</code> with graceful error handling<br> <li> Update change stream handler to trigger <code>refreshSecret()</code> when <br>secret-type configs change<br> <li> Update <code>shutdown()</code> to clear secrets cache and reset GSM client<br> <li> Update schema enum to include "secret" type<br> <li> Update <code>convertValue()</code> type signature to include "secret"</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/294/files#diff-673bd9c2bdbc52f86485ee722134ff5f9905bb48cacd24628cf5022a7eefb433">+139/-4</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>configurationTypes.ts</strong><dd><code>Update configuration type definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example-backend/src/types/models/configurationTypes.ts

<ul><li>Update <code>ConfigurationDocument</code> type to include "secret" in the type <br>union<br> <li> Align TypeScript types with schema changes</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/294/files#diff-06ccebe982128c549d0b246b47a1932b047d137e2127b5221f3b1976457e6c30">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.test.ts</strong><dd><code>Add comprehensive secret type tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example-backend/src/models/configuration.test.ts

<ul><li>Add test suite for secret type functionality<br> <li> Test <code>getSecretKeys()</code> returns empty array when no secrets cached<br> <li> Test <code>fetchSecret()</code> throws error when <code>GCP_PROJECT_ID</code> is missing<br> <li> Test <code>fetchSecret()</code> accepts full resource paths without <code>GCP_PROJECT_ID</code><br> <li> Add schema tests verifying "secret" type acceptance in MongoDB<br> <li> Add tests for querying secret-type configurations from database</ul>


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/294/files#diff-eb85de06310bef682c4cb79451068b2c57f50a3cf84bba3320136e070315d8ef">+84/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add Google Secret Manager dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example-backend/package.json

- Add `@google-cloud/secret-manager` dependency version `^5.6.0`


</details>


  </td>
  <td><a href="https://github.com/FlourishHealth/terreno/pull/294/files#diff-3a57e0c4dd6180111374f99ed42d814dec491febf6d0acf98bd5d81f4e01a23c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

