### PR TITLE
Add admin dashboards and graphing system

### DIFF
--- a/admin-backend/package.json
+++ b/admin-backend/package.json
@@ -8,7 +8,8 @@
     "@terreno/api": "workspace:*",
     "express": "^5.2.1",
     "luxon": "catalog:",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "zod": "^3.24.0"
   },
   "description": "Admin panel backend plugin for @terreno/api",
   "devDependencies": {
@@ -31,7 +32,13 @@
   ],
   "license": "Apache-2.0",
   "peerDependencies": {
+    "ai": ">=4.0.0",
     "mongoose": ">=8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "ai": {
+      "optional": true
+    }
   },
   "main": "dist/index.js",
   "name": "@terreno/admin-backend",

--- a/admin-backend/src/adminApp.ts
+++ b/admin-backend/src/adminApp.ts
@@ -96,6 +96,7 @@ interface AdminConfigResponse {
   customScreens?: {displayName: string; name: string}[];
   models: AdminModelMeta[];
   scripts: AdminScriptMeta[];
+  dataSources?: {name: string; displayName: string}[];
 }
 
 const extractFieldMeta = (
@@ -244,6 +245,10 @@ export class AdminApp {
         {
           displayName: "Version Config",
           name: "version-config",
+        },
+        {
+          displayName: "Dashboards",
+          name: "dashboards",
         },
       ],
       models: configModels,

--- a/admin-backend/src/dashboard/chartTypes.ts
+++ b/admin-backend/src/dashboard/chartTypes.ts
@@ -1,0 +1,210 @@
+import {z} from "zod";
+
+// ─── Primitive enums ────────────────────────────────────────────────────────
+
+export type ChartType =
+  | "bar"
+  | "bar-horizontal"
+  | "bar-stacked"
+  | "bar-grouped"
+  | "line"
+  | "line-multi"
+  | "area"
+  | "area-stacked"
+  | "pie"
+  | "donut"
+  | "scatter"
+  | "bubble"
+  | "heatmap"
+  | "combo";
+
+export type Aggregation =
+  | "count"
+  | "sum"
+  | "avg"
+  | "min"
+  | "max"
+  | "countDistinct"
+  | "runningTotal"
+  | "rank";
+
+export type DateTrunc = "year" | "quarter" | "month" | "week" | "day" | "hour";
+
+// ─── Axis & filter interfaces ────────────────────────────────────────────────
+
+export interface AxisConfig {
+  field: string;
+  label?: string;
+  aggregation?: Aggregation;
+  dateTrunc?: DateTrunc;
+}
+
+export type FilterConfig =
+  | {
+      type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
+      field: string;
+      value: string | number | boolean | null;
+    }
+  | {type: "in" | "nin"; field: string; values: (string | number | boolean | null)[]}
+  | {type: "dateRange"; field: string; from?: string; to?: string}
+  | {type: "relative"; field: string; unit: DateTrunc; amount: number};
+
+// ─── Main ChartConfig ────────────────────────────────────────────────────────
+
+export interface ChartConfig {
+  type: ChartType;
+  title: string;
+  dataSource: string;
+  x: AxisConfig;
+  y: AxisConfig | AxisConfig[];
+  color?: {field: string; label?: string};
+  size?: AxisConfig;
+  filters?: FilterConfig[];
+  sort?: {field: string; direction: "asc" | "desc"};
+  limit?: number;
+}
+
+// ─── Data source config (registered at startup, never persisted) ─────────────
+
+export interface SimpleSource {
+  type: "model";
+  modelName: string;
+  displayName: string;
+  /** Fields exposed to the query engine — required to prevent sensitive data leakage */
+  allowedFields: string[];
+}
+
+export interface EnrichedSource {
+  type: "enriched";
+  name: string;
+  displayName: string;
+  /** Root model name for permissions validation (must be admin-accessible) */
+  baseModel: string;
+  pipeline: object[];
+  outputFields: Record<
+    string,
+    {
+      type: "string" | "number" | "date" | "boolean";
+      description: string;
+      role: "dimension" | "measure";
+    }
+  >;
+}
+
+export type DataSourceConfig = SimpleSource | EnrichedSource;
+
+export interface DataSourceMeta {
+  name: string;
+  displayName: string;
+  fields: Record<
+    string,
+    {
+      type: "string" | "number" | "date" | "boolean";
+      description: string;
+      role: "dimension" | "measure";
+    }
+  >;
+}
+
+// ─── Zod schemas ─────────────────────────────────────────────────────────────
+
+const chartTypeValues: [ChartType, ...ChartType[]] = [
+  "bar",
+  "bar-horizontal",
+  "bar-stacked",
+  "bar-grouped",
+  "line",
+  "line-multi",
+  "area",
+  "area-stacked",
+  "pie",
+  "donut",
+  "scatter",
+  "bubble",
+  "heatmap",
+  "combo",
+];
+
+const aggregationValues: [Aggregation, ...Aggregation[]] = [
+  "count",
+  "sum",
+  "avg",
+  "min",
+  "max",
+  "countDistinct",
+  "runningTotal",
+  "rank",
+];
+
+const dateTruncValues: [DateTrunc, ...DateTrunc[]] = [
+  "year",
+  "quarter",
+  "month",
+  "week",
+  "day",
+  "hour",
+];
+
+// Filter values are constrained to primitives to prevent operator injection
+const filterValueSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+
+const axisConfigSchema = z.object({
+  aggregation: z.enum(aggregationValues).optional(),
+  dateTrunc: z.enum(dateTruncValues).optional(),
+  field: z.string().min(1),
+  label: z.string().optional(),
+});
+
+const filterConfigSchema = z.discriminatedUnion("type", [
+  z.object({
+    field: z.string().min(1),
+    type: z.enum(["eq", "ne", "gt", "gte", "lt", "lte"]),
+    value: filterValueSchema,
+  }),
+  z.object({
+    field: z.string().min(1),
+    type: z.enum(["in", "nin"]),
+    values: z.array(filterValueSchema),
+  }),
+  z.object({
+    field: z.string().min(1),
+    from: z.string().optional(),
+    to: z.string().optional(),
+    type: z.literal("dateRange"),
+  }),
+  z.object({
+    amount: z.number().int().positive(),
+    field: z.string().min(1),
+    type: z.literal("relative"),
+    unit: z.enum(dateTruncValues),
+  }),
+]);
+
+export const chartConfigSchema = z.object({
+  color: z
+    .object({
+      field: z.string().min(1),
+      label: z.string().optional(),
+    })
+    .optional(),
+  dataSource: z.string().min(1),
+  filters: z.array(filterConfigSchema).optional(),
+  limit: z.number().int().min(1).max(5000).optional(),
+  size: axisConfigSchema.optional(),
+  sort: z
+    .object({
+      direction: z.enum(["asc", "desc"]),
+      field: z.string().min(1),
+    })
+    .optional(),
+  title: z.string().min(1),
+  type: z.enum(chartTypeValues),
+  x: axisConfigSchema,
+  y: z.union([axisConfigSchema, z.array(axisConfigSchema).min(1)]),
+});
+
+export type ChartConfigInput = z.infer<typeof chartConfigSchema>;
+
+export const validateChartConfig = (raw: unknown): ChartConfig => {
+  return chartConfigSchema.parse(raw) as ChartConfig;
+};

--- a/admin-backend/src/dashboard/dashboard.ts
+++ b/admin-backend/src/dashboard/dashboard.ts
@@ -1,0 +1,99 @@
+import {createdUpdatedPlugin, findExactlyOne, findOneOrNone, isDeletedPlugin} from "@terreno/api";
+import {randomUUID} from "crypto";
+import mongoose from "mongoose";
+
+import type {ChartConfig} from "./chartTypes";
+
+// ─── Document / Model interfaces ────────────────────────────────────────────
+
+export type DashboardWidgetDocument = {
+  widgetId: string;
+  chart: ChartConfig;
+};
+
+import type {FindExactlyOnePlugin, FindOneOrNonePlugin} from "@terreno/api";
+
+export type DashboardStatics = FindExactlyOnePlugin<DashboardDocument> &
+  FindOneOrNonePlugin<DashboardDocument>;
+
+export type DashboardDocument = mongoose.Document<mongoose.Types.ObjectId> & {
+  created: Date;
+  deleted: boolean;
+  description?: string;
+  title: string;
+  updated: Date;
+  userId: mongoose.Types.ObjectId;
+  widgets: DashboardWidgetDocument[];
+};
+
+export type DashboardModel = mongoose.Model<DashboardDocument> & DashboardStatics;
+
+// ─── Schema ──────────────────────────────────────────────────────────────────
+
+const dashboardWidgetSchema = new mongoose.Schema<DashboardWidgetDocument>(
+  {
+    chart: {
+      description: "Full ChartConfig for this widget",
+      required: true,
+      type: mongoose.Schema.Types.Mixed,
+    },
+    widgetId: {
+      description: "Unique widget identifier (uuid v4), server-generated",
+      required: true,
+      type: String,
+    },
+  },
+  {_id: false}
+);
+
+const dashboardSchema = new mongoose.Schema<DashboardDocument, DashboardModel>(
+  {
+    description: {
+      description: "Optional description of the dashboard",
+      type: String,
+    },
+    title: {
+      description: "Dashboard title",
+      required: true,
+      trim: true,
+      type: String,
+    },
+    userId: {
+      description: "Admin user who created or last modified this dashboard",
+      index: true,
+      ref: "User",
+      required: true,
+      type: mongoose.Schema.Types.ObjectId,
+    },
+    widgets: {
+      default: [],
+      description: "Ordered list of chart widgets on this dashboard",
+      type: [dashboardWidgetSchema],
+    },
+  },
+  {strict: "throw", toJSON: {virtuals: true}, toObject: {virtuals: true}}
+);
+
+dashboardSchema.plugin(createdUpdatedPlugin);
+dashboardSchema.plugin(isDeletedPlugin);
+dashboardSchema.plugin(findOneOrNone);
+dashboardSchema.plugin(findExactlyOne);
+
+dashboardSchema.index({created: -1});
+dashboardSchema.index({created: -1, userId: 1});
+
+// Ensure widgetIds are always server-generated uuids
+dashboardSchema.pre("save", function () {
+  for (const widget of this.widgets) {
+    if (!widget.widgetId) {
+      widget.widgetId = randomUUID();
+    }
+  }
+});
+
+export const Dashboard = mongoose.model<DashboardDocument, DashboardModel>(
+  "Dashboard",
+  dashboardSchema
+);
+
+export const generateWidgetId = (): string => randomUUID();

--- a/admin-backend/src/dashboard/dashboardApp.ts
+++ b/admin-backend/src/dashboard/dashboardApp.ts
@@ -1,0 +1,58 @@
+import {logger} from "@terreno/api";
+import type express from "express";
+import mongoose from "mongoose";
+
+import type {DataSourceConfig} from "./chartTypes";
+import {addDashboardRoutes} from "./dashboardRoutes";
+
+export interface DashboardAppOptions {
+  dataSources: DataSourceConfig[];
+}
+
+/**
+ * TerrenoPlugin that adds dashboard CRUD routes and the query execution endpoint.
+ * Mount after AdminApp so that /admin routes are already registered.
+ *
+ * @example
+ * ```typescript
+ * const dashboardApp = new DashboardApp({dataSources: [...]});
+ * new TerrenoApp({userModel: User})
+ *   .register(admin)
+ *   .register(dashboardApp)
+ *   .start();
+ * ```
+ */
+export class DashboardApp {
+  private dataSources: DataSourceConfig[];
+  private supportsWindowFields = false;
+  private mongodbVersion = "unknown";
+
+  constructor(options: DashboardAppOptions) {
+    this.dataSources = options.dataSources;
+  }
+
+  async register(app: express.Application): Promise<void> {
+    // Detect MongoDB version at startup — default to false on failure
+    try {
+      const admin = mongoose.connection.db?.admin();
+      if (admin) {
+        const info = await admin.serverInfo();
+        this.mongodbVersion = info.version ?? "unknown";
+        const major = Number.parseInt(this.mongodbVersion.split(".")[0] ?? "0", 10);
+        this.supportsWindowFields = major >= 5;
+        logger.info(
+          `DashboardApp: MongoDB ${this.mongodbVersion}, supportsWindowFields=${this.supportsWindowFields}`
+        );
+      }
+    } catch (err) {
+      logger.warn("DashboardApp: Could not detect MongoDB version, disabling window fields", {err});
+      this.supportsWindowFields = false;
+    }
+
+    addDashboardRoutes(app, {
+      dataSources: this.dataSources,
+      mongodbVersion: this.mongodbVersion,
+      supportsWindowFields: this.supportsWindowFields,
+    });
+  }
+}

--- a/admin-backend/src/dashboard/dashboardQueryEngine.test.ts
+++ b/admin-backend/src/dashboard/dashboardQueryEngine.test.ts
@@ -1,0 +1,311 @@
+import {describe, expect, it} from "bun:test";
+
+import type {ChartConfig, DataSourceConfig} from "./chartTypes";
+import {buildFilterStage, buildPipeline} from "./dashboardQueryEngine";
+
+const mockSimpleSource: DataSourceConfig = {
+  allowedFields: ["status", "amount", "created", "email", "count"],
+  displayName: "Test Model",
+  modelName: "TestModel",
+  type: "model",
+};
+
+const mockEnrichedSource: DataSourceConfig = {
+  baseModel: "TestModel",
+  displayName: "Test Enriched",
+  name: "TestEnriched",
+  outputFields: {
+    amount: {description: "Amount", role: "measure", type: "number"},
+    status: {description: "Status", role: "dimension", type: "string"},
+  },
+  pipeline: [{$match: {active: true}}],
+  type: "enriched",
+};
+
+const baseConfig: ChartConfig = {
+  dataSource: "TestModel",
+  limit: 100,
+  sort: {direction: "asc", field: "x"},
+  title: "Test Chart",
+  type: "bar",
+  x: {field: "status"},
+  y: {aggregation: "count", field: "count"},
+};
+
+const defaultOptions = {
+  dataSources: [mockSimpleSource, mockEnrichedSource],
+  supportsWindowFields: true,
+};
+
+// ─── Filter stage tests ───────────────────────────────────────────────────────
+
+describe("buildFilterStage", () => {
+  it("builds eq filter", () => {
+    expect(buildFilterStage({field: "status", type: "eq", value: "active"})).toEqual({
+      status: {$eq: "active"},
+    });
+  });
+
+  it("builds ne filter", () => {
+    expect(buildFilterStage({field: "status", type: "ne", value: "deleted"})).toEqual({
+      status: {$ne: "deleted"},
+    });
+  });
+
+  it("builds gt filter", () => {
+    expect(buildFilterStage({field: "amount", type: "gt", value: 100})).toEqual({
+      amount: {$gt: 100},
+    });
+  });
+
+  it("builds gte filter", () => {
+    expect(buildFilterStage({field: "amount", type: "gte", value: 0})).toEqual({
+      amount: {$gte: 0},
+    });
+  });
+
+  it("builds lt filter", () => {
+    expect(buildFilterStage({field: "amount", type: "lt", value: 50})).toEqual({
+      amount: {$lt: 50},
+    });
+  });
+
+  it("builds lte filter", () => {
+    expect(buildFilterStage({field: "amount", type: "lte", value: 1000})).toEqual({
+      amount: {$lte: 1000},
+    });
+  });
+
+  it("builds in filter", () => {
+    expect(buildFilterStage({field: "status", type: "in", values: ["active", "pending"]})).toEqual({
+      status: {$in: ["active", "pending"]},
+    });
+  });
+
+  it("builds nin filter", () => {
+    expect(buildFilterStage({field: "status", type: "nin", values: ["deleted"]})).toEqual({
+      status: {$nin: ["deleted"]},
+    });
+  });
+
+  it("builds dateRange filter with from and to", () => {
+    const result = buildFilterStage({
+      field: "created",
+      from: "2024-01-01",
+      to: "2024-12-31",
+      type: "dateRange",
+    });
+    expect(result).toEqual({
+      created: {$gte: "2024-01-01", $lte: "2024-12-31"},
+    });
+  });
+
+  it("builds dateRange filter with only from", () => {
+    const result = buildFilterStage({field: "created", from: "2024-01-01", type: "dateRange"});
+    expect(result).toEqual({created: {$gte: "2024-01-01"}});
+  });
+
+  it("builds relative filter", () => {
+    const result = buildFilterStage({amount: 30, field: "created", type: "relative", unit: "day"});
+    expect(result.created).toBeDefined();
+    expect((result.created as any).$gte).toBeInstanceOf(Date);
+  });
+
+  it("handles null value in eq filter", () => {
+    expect(buildFilterStage({field: "email", type: "eq", value: null})).toEqual({
+      email: {$eq: null},
+    });
+  });
+
+  it("handles boolean value in eq filter", () => {
+    expect(buildFilterStage({field: "status", type: "eq", value: true})).toEqual({
+      status: {$eq: true},
+    });
+  });
+});
+
+// ─── Pipeline builder tests ───────────────────────────────────────────────────
+
+describe("buildPipeline", () => {
+  it("builds a basic bar chart pipeline for simple source", () => {
+    const pipeline = buildPipeline(baseConfig, defaultOptions, mockSimpleSource);
+    expect(pipeline.length).toBeGreaterThan(0);
+
+    // Should have $group stage
+    const groupStage = pipeline.find((s) => "$group" in s);
+    expect(groupStage).toBeDefined();
+
+    // Should have $limit
+    const limitStage = pipeline.find((s) => "$limit" in s);
+    expect(limitStage).toBeDefined();
+    expect((limitStage as any).$limit).toBe(100);
+  });
+
+  it("prepends enriched source base pipeline", () => {
+    const config: ChartConfig = {...baseConfig, dataSource: "TestEnriched"};
+    const pipeline = buildPipeline(config, defaultOptions, mockEnrichedSource);
+
+    const firstStage = pipeline[0];
+    expect(firstStage).toEqual({$match: {active: true}});
+  });
+
+  it("adds $addFields for dateTrunc on x axis", () => {
+    const config: ChartConfig = {
+      ...baseConfig,
+      x: {dateTrunc: "month", field: "created"},
+    };
+    const pipeline = buildPipeline(config, defaultOptions, mockSimpleSource);
+    const addFieldsStage = pipeline.find(
+      (s) => "$addFields" in s && (s as any).$addFields.__trunc_created
+    );
+    expect(addFieldsStage).toBeDefined();
+    expect((addFieldsStage as any).$addFields.__trunc_created).toMatchObject({
+      $dateTrunc: {date: "$created", unit: "month"},
+    });
+  });
+
+  it("groups by color dimension when color is set", () => {
+    const config: ChartConfig = {
+      ...baseConfig,
+      color: {field: "status"},
+      x: {field: "email"},
+    };
+    const pipeline = buildPipeline(config, defaultOptions, mockSimpleSource);
+    const groupStage = pipeline.find((s) => "$group" in s) as any;
+    expect(groupStage.$group._id.color).toBe("$status");
+  });
+
+  it("handles multiple y axes", () => {
+    const config: ChartConfig = {
+      ...baseConfig,
+      y: [
+        {aggregation: "sum", field: "amount"},
+        {aggregation: "count", field: "count"},
+      ],
+    };
+    const pipeline = buildPipeline(config, defaultOptions, mockSimpleSource);
+    const groupStage = pipeline.find((s) => "$group" in s) as any;
+    expect(groupStage.$group.y0).toBeDefined();
+    expect(groupStage.$group.y1).toBeDefined();
+  });
+
+  it("builds countDistinct via $addToSet + $size", () => {
+    const config: ChartConfig = {
+      ...baseConfig,
+      y: {aggregation: "countDistinct", field: "email"},
+    };
+    const pipeline = buildPipeline(config, defaultOptions, mockSimpleSource);
+    const groupStage = pipeline.find((s) => "$group" in s) as any;
+    expect(groupStage.$group.y).toEqual({$addToSet: "$email"});
+
+    // Should have a $addFields after $group to compute $size
+    const groupIdx = pipeline.indexOf(groupStage);
+    const sizeStage = pipeline[groupIdx + 1] as any;
+    expect(sizeStage.$addFields?.y).toEqual({$size: "$y"});
+  });
+
+  it("includes $match stage when filters are provided", () => {
+    const config: ChartConfig = {
+      ...baseConfig,
+      filters: [{field: "status", type: "eq", value: "active"}],
+    };
+    const pipeline = buildPipeline(config, defaultOptions, mockSimpleSource);
+    const matchStage = pipeline.find((s) => "$match" in s) as any;
+    expect(matchStage).toBeDefined();
+    expect(matchStage.$match.$and[0]).toEqual({status: {$eq: "active"}});
+  });
+
+  it("applies custom sort", () => {
+    const config: ChartConfig = {
+      ...baseConfig,
+      sort: {direction: "desc", field: "y"},
+    };
+    const pipeline = buildPipeline(config, defaultOptions, mockSimpleSource);
+    const sortStage = pipeline.find((s) => "$sort" in s) as any;
+    expect(sortStage.$sort.y).toBe(-1);
+  });
+
+  it("adds $setWindowFields for runningTotal when supportsWindowFields=true", () => {
+    const config: ChartConfig = {
+      ...baseConfig,
+      y: {aggregation: "runningTotal", field: "amount"},
+    };
+    const pipeline = buildPipeline(config, defaultOptions, mockSimpleSource);
+    const windowStage = pipeline.find((s) => "$setWindowFields" in s);
+    expect(windowStage).toBeDefined();
+  });
+
+  it("throws when runningTotal used without MongoDB 5+ support", () => {
+    const config: ChartConfig = {
+      ...baseConfig,
+      y: {aggregation: "runningTotal", field: "amount"},
+    };
+    const options = {...defaultOptions, supportsWindowFields: false};
+    expect(() => buildPipeline(config, options, mockSimpleSource)).toThrow(
+      "runningTotal and rank aggregations require MongoDB 5+"
+    );
+  });
+
+  it("adds $setWindowFields for rank", () => {
+    const config: ChartConfig = {
+      ...baseConfig,
+      y: {aggregation: "rank", field: "amount"},
+    };
+    const pipeline = buildPipeline(config, defaultOptions, mockSimpleSource);
+    const windowStage = pipeline.find((s) => "$setWindowFields" in s) as any;
+    expect(windowStage).toBeDefined();
+    const outputKey = Object.keys(windowStage.$setWindowFields.output)[0];
+    expect(outputKey).toBe("y_rank");
+  });
+
+  it("throws when field not in allowedFields for simple source", () => {
+    const config: ChartConfig = {
+      ...baseConfig,
+      x: {field: "password"},
+    };
+    expect(() => buildPipeline(config, defaultOptions, mockSimpleSource)).toThrow(
+      "Field 'password' is not allowed"
+    );
+  });
+
+  it("caps limit at MAX_LIMIT (5000)", () => {
+    const config: ChartConfig = {...baseConfig, limit: 99999};
+    const pipeline = buildPipeline(config, defaultOptions, mockSimpleSource);
+    const limitStage = pipeline.find((s) => "$limit" in s) as any;
+    expect(limitStage.$limit).toBe(5000);
+  });
+
+  it("uses default limit of 1000 when not specified", () => {
+    const config: ChartConfig = {...baseConfig, limit: undefined};
+    const pipeline = buildPipeline(config, defaultOptions, mockSimpleSource);
+    const limitStage = pipeline.find((s) => "$limit" in s) as any;
+    expect(limitStage.$limit).toBe(1000);
+  });
+
+  it("includes all date trunc units", () => {
+    const units = ["year", "quarter", "month", "week", "day", "hour"] as const;
+    for (const unit of units) {
+      const config: ChartConfig = {
+        ...baseConfig,
+        x: {dateTrunc: unit, field: "created"},
+      };
+      const pipeline = buildPipeline(config, defaultOptions, mockSimpleSource);
+      const addFieldsStage = pipeline.find(
+        (s) => "$addFields" in s && (s as any).$addFields.__trunc_created
+      ) as any;
+      expect(addFieldsStage.$addFields.__trunc_created.$dateTrunc.unit).toBe(unit);
+    }
+  });
+
+  it("builds all aggregation types except window fields", () => {
+    const aggs = ["count", "sum", "avg", "min", "max", "countDistinct"] as const;
+    for (const aggregation of aggs) {
+      const config: ChartConfig = {
+        ...baseConfig,
+        y: {aggregation, field: "amount"},
+      };
+      // Should not throw
+      expect(() => buildPipeline(config, defaultOptions, mockSimpleSource)).not.toThrow();
+    }
+  });
+});

--- a/admin-backend/src/dashboard/dashboardQueryEngine.ts
+++ b/admin-backend/src/dashboard/dashboardQueryEngine.ts
@@ -1,0 +1,432 @@
+import {APIError} from "@terreno/api";
+import mongoose from "mongoose";
+
+import type {AxisConfig, ChartConfig, DataSourceConfig, FilterConfig} from "./chartTypes";
+
+const DEFAULT_LIMIT = 1000;
+const MAX_LIMIT = 5000;
+const QUERY_MAX_TIME_MS = 30_000;
+
+// ─── Public interfaces ────────────────────────────────────────────────────────
+
+export interface QueryEngineOptions {
+  dataSources: DataSourceConfig[];
+  supportsWindowFields: boolean;
+}
+
+export interface QueryResult {
+  data: Record<string, unknown>[];
+  meta: {
+    total: number;
+    truncated: boolean;
+    mongodbVersion: string;
+  };
+}
+
+// ─── Filter → $match stage ───────────────────────────────────────────────────
+
+const buildFilterStage = (filter: FilterConfig): Record<string, unknown> => {
+  if (filter.type === "eq") {
+    return {[filter.field]: {$eq: filter.value}};
+  }
+  if (filter.type === "ne") {
+    return {[filter.field]: {$ne: filter.value}};
+  }
+  if (filter.type === "gt") {
+    return {[filter.field]: {$gt: filter.value}};
+  }
+  if (filter.type === "gte") {
+    return {[filter.field]: {$gte: filter.value}};
+  }
+  if (filter.type === "lt") {
+    return {[filter.field]: {$lt: filter.value}};
+  }
+  if (filter.type === "lte") {
+    return {[filter.field]: {$lte: filter.value}};
+  }
+  if (filter.type === "in") {
+    return {[filter.field]: {$in: filter.values}};
+  }
+  if (filter.type === "nin") {
+    return {[filter.field]: {$nin: filter.values}};
+  }
+  if (filter.type === "dateRange") {
+    const cond: Record<string, string> = {};
+    if (filter.from) {
+      cond.$gte = filter.from;
+    }
+    if (filter.to) {
+      cond.$lte = filter.to;
+    }
+    return {[filter.field]: cond};
+  }
+  if (filter.type === "relative") {
+    const now = new Date();
+    const from = new Date(now);
+    const unit = filter.unit;
+    const amount = filter.amount;
+    if (unit === "hour") {
+      from.setHours(from.getHours() - amount);
+    } else if (unit === "day") {
+      from.setDate(from.getDate() - amount);
+    } else if (unit === "week") {
+      from.setDate(from.getDate() - amount * 7);
+    } else if (unit === "month") {
+      from.setMonth(from.getMonth() - amount);
+    } else if (unit === "quarter") {
+      from.setMonth(from.getMonth() - amount * 3);
+    } else if (unit === "year") {
+      from.setFullYear(from.getFullYear() - amount);
+    }
+    return {[filter.field]: {$gte: from}};
+  }
+  throw new APIError({status: 400, title: "Unknown filter type"});
+};
+
+// ─── Aggregation expression builder ─────────────────────────────────────────
+
+const buildAggregationExpr = (axis: AxisConfig): Record<string, unknown> => {
+  const {aggregation, field} = axis;
+
+  if (!aggregation || aggregation === "count") {
+    return {$sum: 1};
+  }
+  if (aggregation === "sum") {
+    return {$sum: `$${field}`};
+  }
+  if (aggregation === "avg") {
+    return {$avg: `$${field}`};
+  }
+  if (aggregation === "min") {
+    return {$min: `$${field}`};
+  }
+  if (aggregation === "max") {
+    return {$max: `$${field}`};
+  }
+  if (aggregation === "countDistinct") {
+    // Two-pass: $addToSet then $size at projection stage
+    return {$addToSet: `$${field}`};
+  }
+  // runningTotal and rank are handled via $setWindowFields — return sum as placeholder
+  if (aggregation === "runningTotal" || aggregation === "rank") {
+    return {$sum: `$${field}`};
+  }
+  throw new APIError({status: 400, title: `Unknown aggregation: ${aggregation}`});
+};
+
+// ─── Date trunc helper ────────────────────────────────────────────────────────
+
+const buildDateTruncExpr = (field: string, unit: string): Record<string, unknown> => {
+  return {
+    $dateTrunc: {
+      date: `$${field}`,
+      unit,
+    },
+  };
+};
+
+// ─── Pipeline builder ────────────────────────────────────────────────────────
+
+const buildPipeline = (
+  config: ChartConfig,
+  options: QueryEngineOptions,
+  resolvedSource: DataSourceConfig
+): mongoose.PipelineStage[] => {
+  const pipeline: mongoose.PipelineStage[] = [];
+  const limit = Math.min(config.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+
+  // For enriched sources, prepend the base pipeline
+  if (resolvedSource.type === "enriched") {
+    pipeline.push(...(resolvedSource.pipeline as mongoose.PipelineStage[]));
+  }
+
+  // Stage 1: $match — apply filters
+  const filterConditions: Record<string, unknown>[] = [];
+
+  // For simple sources, restrict to allowedFields via $project (applied first below if needed)
+  if (resolvedSource.type === "model" && config.filters) {
+    for (const filter of config.filters) {
+      if (!resolvedSource.allowedFields.includes(filter.field)) {
+        throw new APIError({
+          status: 400,
+          title: `Field '${filter.field}' is not allowed for this data source`,
+        });
+      }
+      filterConditions.push(buildFilterStage(filter));
+    }
+  } else if (config.filters) {
+    for (const filter of config.filters) {
+      filterConditions.push(buildFilterStage(filter));
+    }
+  }
+
+  if (filterConditions.length > 0) {
+    pipeline.push({$match: {$and: filterConditions}});
+  }
+
+  // Validate fields for simple sources
+  if (resolvedSource.type === "model") {
+    const xField = Array.isArray(config.x) ? config.x.field : config.x.field;
+    if (!resolvedSource.allowedFields.includes(xField)) {
+      throw new APIError({
+        status: 400,
+        title: `Field '${xField}' is not allowed for this data source`,
+      });
+    }
+    const yAxes = Array.isArray(config.y) ? config.y : [config.y];
+    for (const axis of yAxes) {
+      if (axis.aggregation !== "count" && !resolvedSource.allowedFields.includes(axis.field)) {
+        throw new APIError({
+          status: 400,
+          title: `Field '${axis.field}' is not allowed for this data source`,
+        });
+      }
+    }
+    if (config.color && !resolvedSource.allowedFields.includes(config.color.field)) {
+      throw new APIError({
+        status: 400,
+        title: `Field '${config.color.field}' is not allowed for this data source`,
+      });
+    }
+  }
+
+  // Stage 2: $addFields — apply $dateTrunc to date dimensions
+  const addFieldsStage: Record<string, unknown> = {};
+  const xAxis = config.x;
+  if (xAxis.dateTrunc) {
+    addFieldsStage[`__trunc_${xAxis.field}`] = buildDateTruncExpr(xAxis.field, xAxis.dateTrunc);
+  }
+
+  if (Object.keys(addFieldsStage).length > 0) {
+    pipeline.push({$addFields: addFieldsStage});
+  }
+
+  // Stage 3: $group — by X (and color if present), aggregate Y measures
+  const xGroupField = xAxis.dateTrunc ? `$__trunc_${xAxis.field}` : `$${xAxis.field}`;
+  const groupId: Record<string, unknown> = {x: xGroupField};
+
+  if (config.color) {
+    groupId.color = `$${config.color.field}`;
+  }
+
+  const groupStage: Record<string, unknown> = {_id: groupId};
+
+  const yAxes = Array.isArray(config.y) ? config.y : [config.y];
+  const countDistinctFields: string[] = [];
+
+  for (let i = 0; i < yAxes.length; i++) {
+    const axis = yAxes[i];
+    const key = yAxes.length === 1 ? "y" : `y${i}`;
+    groupStage[key] = buildAggregationExpr(axis);
+    if (axis.aggregation === "countDistinct") {
+      countDistinctFields.push(key);
+    }
+  }
+
+  pipeline.push({$group: groupStage as mongoose.PipelineStage.Group["$group"]});
+
+  // Post-group: compute $size for countDistinct fields
+  if (countDistinctFields.length > 0) {
+    const sizeFields: Record<string, unknown> = {};
+    for (const key of countDistinctFields) {
+      sizeFields[key] = {$size: `$${key}`};
+    }
+    pipeline.push({$addFields: sizeFields});
+  }
+
+  // Stage 4: $setWindowFields — for runningTotal / rank (MongoDB 5+ only)
+  const windowAxes = yAxes.filter(
+    (a) => a.aggregation === "runningTotal" || a.aggregation === "rank"
+  );
+
+  if (windowAxes.length > 0) {
+    if (!options.supportsWindowFields) {
+      throw new APIError({
+        status: 400,
+        title: "runningTotal and rank aggregations require MongoDB 5+",
+      });
+    }
+
+    for (let i = 0; i < yAxes.length; i++) {
+      const axis = yAxes[i];
+      if (axis.aggregation !== "runningTotal" && axis.aggregation !== "rank") {
+        continue;
+      }
+      const key = yAxes.length === 1 ? "y" : `y${i}`;
+
+      if (axis.aggregation === "runningTotal") {
+        pipeline.push({
+          $setWindowFields: {
+            output: {
+              [`${key}_running`]: {
+                $sum: `$${key}`,
+                window: {documents: ["unbounded", "current"] as ["unbounded", "current"]},
+              },
+            },
+            sortBy: {[key]: 1 as const},
+          },
+        });
+      } else {
+        pipeline.push({
+          $setWindowFields: {
+            output: {
+              [`${key}_rank`]: {$rank: {}},
+            },
+            sortBy: {[key]: 1 as const},
+          },
+        });
+      }
+    }
+  }
+
+  // Stage 5: $sort
+  if (config.sort) {
+    const direction = config.sort.direction === "asc" ? 1 : -1;
+    pipeline.push({$sort: {[config.sort.field]: direction}});
+  } else {
+    // Default sort by x for time series readability
+    pipeline.push({$sort: {"_id.x": 1}});
+  }
+
+  // Stage 6: $limit
+  pipeline.push({$limit: limit});
+
+  // Stage 7: $project — flatten _id to usable output shape
+  const projectStage: Record<string, unknown> = {
+    _id: 0,
+    x: "$_id.x",
+  };
+  if (config.color) {
+    projectStage.color = "$_id.color";
+  }
+  for (let i = 0; i < yAxes.length; i++) {
+    const key = yAxes.length === 1 ? "y" : `y${i}`;
+    const axis = yAxes[i];
+    if (axis.aggregation === "runningTotal") {
+      projectStage[key] = `$${key}_running`;
+    } else if (axis.aggregation === "rank") {
+      projectStage[key] = `$${key}_rank`;
+    } else {
+      projectStage[key] = 1;
+    }
+  }
+  pipeline.push({$project: projectStage});
+
+  return pipeline;
+};
+
+// ─── Auto-bucketing ───────────────────────────────────────────────────────────
+
+const DATE_TRUNC_ORDER: ChartConfig["x"]["dateTrunc"][] = [
+  "hour",
+  "day",
+  "week",
+  "month",
+  "quarter",
+  "year",
+];
+
+const coarsenDateTrunc = (
+  current: ChartConfig["x"]["dateTrunc"]
+): ChartConfig["x"]["dateTrunc"] | undefined => {
+  if (!current) {
+    return undefined;
+  }
+  const idx = DATE_TRUNC_ORDER.indexOf(current);
+  if (idx === -1 || idx === DATE_TRUNC_ORDER.length - 1) {
+    return undefined;
+  }
+  return DATE_TRUNC_ORDER[idx + 1];
+};
+
+// ─── Public query executor ────────────────────────────────────────────────────
+
+export const executeQuery = async (
+  config: ChartConfig,
+  options: QueryEngineOptions,
+  mongodbVersion: string
+): Promise<QueryResult> => {
+  const {dataSources, supportsWindowFields} = options;
+
+  // Resolve data source
+  const resolvedSource = dataSources.find((ds) => {
+    if (ds.type === "model") {
+      return ds.modelName === config.dataSource;
+    }
+    return ds.name === config.dataSource;
+  });
+
+  if (!resolvedSource) {
+    throw new APIError({
+      status: 400,
+      title: `Unknown data source: '${config.dataSource}'`,
+    });
+  }
+
+  // Resolve the Mongoose model
+  let model: mongoose.Model<any>;
+  try {
+    const modelName =
+      resolvedSource.type === "model" ? resolvedSource.modelName : resolvedSource.baseModel;
+    model = mongoose.model(modelName);
+  } catch {
+    throw new APIError({
+      status: 400,
+      title: `Model not found: '${resolvedSource.type === "model" ? resolvedSource.modelName : resolvedSource.baseModel}'`,
+    });
+  }
+
+  const limit = Math.min(config.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+
+  // Auto-bucketing: coarsen date granularity if needed
+  let workingConfig = config;
+  if (workingConfig.x.dateTrunc) {
+    // Estimate cardinality with a count query — limit to avoid expensive scans
+    const countPipeline: mongoose.PipelineStage[] = [];
+    if (resolvedSource.type === "enriched") {
+      countPipeline.push(...(resolvedSource.pipeline as mongoose.PipelineStage[]));
+    }
+    countPipeline.push({
+      $group: {_id: buildDateTruncExpr(workingConfig.x.field, workingConfig.x.dateTrunc)},
+    });
+    countPipeline.push({$count: "total"});
+
+    const countResult = await model
+      .aggregate(countPipeline)
+      .option({allowDiskUse: true, maxTimeMS: QUERY_MAX_TIME_MS});
+
+    const estimatedCount = countResult[0]?.total ?? 0;
+
+    if (estimatedCount > limit && workingConfig.x.dateTrunc) {
+      const coarser = coarsenDateTrunc(workingConfig.x.dateTrunc);
+      if (coarser) {
+        workingConfig = {
+          ...workingConfig,
+          x: {...workingConfig.x, dateTrunc: coarser},
+        };
+      }
+    }
+  }
+
+  const pipeline = buildPipeline(
+    workingConfig,
+    {dataSources, supportsWindowFields},
+    resolvedSource
+  );
+
+  const data = await model
+    .aggregate(pipeline)
+    .option({allowDiskUse: true, maxTimeMS: QUERY_MAX_TIME_MS});
+
+  return {
+    data,
+    meta: {
+      mongodbVersion,
+      total: data.length,
+      truncated: data.length >= limit,
+    },
+  };
+};
+
+// Export for testing
+export {buildFilterStage, buildPipeline};

--- a/admin-backend/src/dashboard/dashboardRoutes.ts
+++ b/admin-backend/src/dashboard/dashboardRoutes.ts
@@ -1,0 +1,312 @@
+import {
+  APIError,
+  asyncHandler,
+  authenticateMiddleware,
+  checkPermissions,
+  Permissions,
+} from "@terreno/api";
+import {randomUUID} from "crypto";
+import type express from "express";
+import mongoose from "mongoose";
+
+import type {ChartConfig, DataSourceConfig, DataSourceMeta} from "./chartTypes";
+import {validateChartConfig} from "./chartTypes";
+import {Dashboard} from "./dashboard";
+import {executeQuery} from "./dashboardQueryEngine";
+
+const BASE_PATH = "/admin";
+
+export interface DashboardRouteOptions {
+  dataSources: DataSourceConfig[];
+  supportsWindowFields: boolean;
+  mongodbVersion: string;
+}
+
+const requireAdmin = async (req: express.Request): Promise<void> => {
+  if (!(await checkPermissions("read", [Permissions.IsAdmin], req.user as any))) {
+    throw new APIError({status: 403, title: "Admin access required"});
+  }
+};
+
+/** Validate and resolve ChartConfig from request body, throwing 400 on failure */
+const parseChartConfig = (body: unknown): ChartConfig => {
+  try {
+    return validateChartConfig(body);
+  } catch (err) {
+    throw new APIError({
+      detail: err instanceof Error ? err.message : String(err),
+      status: 400,
+      title: "Invalid ChartConfig",
+    });
+  }
+};
+
+/** Validate a list of widget chart configs — used at save time */
+const validateWidgets = (widgets: unknown[]): ChartConfig[] => {
+  if (!Array.isArray(widgets)) {
+    throw new APIError({status: 400, title: "widgets must be an array"});
+  }
+  return widgets.map((w, i) => {
+    const widget = w as {chart?: unknown};
+    if (!widget.chart) {
+      throw new APIError({status: 400, title: `Widget at index ${i} is missing 'chart'`});
+    }
+    try {
+      return validateChartConfig(widget.chart);
+    } catch (err) {
+      throw new APIError({
+        detail: err instanceof Error ? err.message : String(err),
+        status: 400,
+        title: `Widget at index ${i} has invalid ChartConfig`,
+      });
+    }
+  });
+};
+
+const buildSourceMeta = (source: DataSourceConfig): DataSourceMeta => {
+  if (source.type === "model") {
+    // For simple sources, derive field types from the Mongoose schema
+    const fields: DataSourceMeta["fields"] = {};
+    try {
+      const model = mongoose.model(source.modelName);
+      for (const fieldName of source.allowedFields) {
+        const path = model.schema.path(fieldName);
+        const pathType = path?.instance ?? "String";
+        const schemaType =
+          pathType === "Number"
+            ? "number"
+            : pathType === "Date"
+              ? "date"
+              : pathType === "Boolean"
+                ? "boolean"
+                : "string";
+        fields[fieldName] = {
+          description: (path as any)?.options?.description ?? fieldName,
+          role: schemaType === "number" ? "measure" : "dimension",
+          type: schemaType,
+        };
+      }
+    } catch {
+      // Model not registered yet — return empty fields
+    }
+    return {
+      displayName: source.displayName,
+      fields,
+      name: source.modelName,
+    };
+  }
+
+  return {
+    displayName: source.displayName,
+    fields: source.outputFields,
+    name: source.name,
+  };
+};
+
+export const addDashboardRoutes = (
+  app: express.Application,
+  options: DashboardRouteOptions
+): void => {
+  const {dataSources, mongodbVersion, supportsWindowFields} = options;
+
+  // GET /admin/dashboards — List all dashboards (paginated, sorted by -updated)
+  app.get(
+    `${BASE_PATH}/dashboards`,
+    authenticateMiddleware(),
+    asyncHandler(async (req, res) => {
+      await requireAdmin(req);
+
+      const page = Math.max(1, Number.parseInt(String(req.query.page ?? "1"), 10));
+      const limit = Math.min(
+        100,
+        Math.max(1, Number.parseInt(String(req.query.limit ?? "20"), 10))
+      );
+      const skip = (page - 1) * limit;
+
+      const [data, total] = await Promise.all([
+        Dashboard.find({deleted: false}).sort({updated: -1}).skip(skip).limit(limit).lean(),
+        Dashboard.countDocuments({deleted: false}),
+      ]);
+
+      return res.json({
+        data,
+        limit,
+        more: total > page * limit,
+        page,
+        total,
+      });
+    })
+  );
+
+  // POST /admin/dashboards — Create dashboard
+  app.post(
+    `${BASE_PATH}/dashboards`,
+    authenticateMiddleware(),
+    asyncHandler(async (req, res) => {
+      await requireAdmin(req);
+
+      const user = req.user as {_id: mongoose.Types.ObjectId} | undefined;
+      if (!user?._id) {
+        throw new APIError({status: 401, title: "Authenticated user required"});
+      }
+
+      const body = req.body as {title?: unknown; description?: unknown; widgets?: unknown};
+
+      if (!body.title || typeof body.title !== "string" || body.title.trim() === "") {
+        throw new APIError({status: 400, title: "title is required"});
+      }
+
+      const rawWidgets = (body.widgets as unknown[]) ?? [];
+      const validatedCharts = validateWidgets(rawWidgets);
+
+      const widgets = validatedCharts.map((chart) => ({
+        chart,
+        widgetId: randomUUID(),
+      }));
+
+      const dashboard = await Dashboard.create({
+        description: typeof body.description === "string" ? body.description : undefined,
+        title: body.title.trim(),
+        userId: user._id,
+        widgets,
+      });
+
+      return res.status(201).json(dashboard.toJSON());
+    })
+  );
+
+  // GET /admin/dashboards/:id — Get dashboard
+  app.get(
+    `${BASE_PATH}/dashboards/:id`,
+    authenticateMiddleware(),
+    asyncHandler(async (req, res) => {
+      await requireAdmin(req);
+
+      const dashboard = await Dashboard.findOneOrNone({
+        _id: req.params.id,
+        deleted: false,
+      });
+
+      if (!dashboard) {
+        throw new APIError({status: 404, title: "Dashboard not found"});
+      }
+
+      return res.json(dashboard.toJSON());
+    })
+  );
+
+  // PATCH /admin/dashboards/:id — Update dashboard
+  app.patch(
+    `${BASE_PATH}/dashboards/:id`,
+    authenticateMiddleware(),
+    asyncHandler(async (req, res) => {
+      await requireAdmin(req);
+
+      const user = req.user as {_id: mongoose.Types.ObjectId} | undefined;
+      if (!user?._id) {
+        throw new APIError({status: 401, title: "Authenticated user required"});
+      }
+
+      const dashboard = await Dashboard.findOneOrNone({
+        _id: req.params.id,
+        deleted: false,
+      });
+
+      if (!dashboard) {
+        throw new APIError({status: 404, title: "Dashboard not found"});
+      }
+
+      const body = req.body as {title?: unknown; description?: unknown; widgets?: unknown};
+
+      if (body.title !== undefined) {
+        if (typeof body.title !== "string" || body.title.trim() === "") {
+          throw new APIError({status: 400, title: "title must be a non-empty string"});
+        }
+        dashboard.title = body.title.trim();
+      }
+
+      if (body.description !== undefined) {
+        if (body.description === null || body.description === "") {
+          dashboard.description = undefined;
+        } else if (typeof body.description === "string") {
+          dashboard.description = body.description;
+        }
+      }
+
+      if (body.widgets !== undefined) {
+        const rawWidgets = body.widgets as unknown[];
+        const validatedCharts = validateWidgets(rawWidgets);
+        dashboard.widgets = validatedCharts.map((chart, i) => {
+          const existing = (rawWidgets[i] as {widgetId?: string}).widgetId;
+          return {
+            chart,
+            widgetId: existing || randomUUID(),
+          };
+        });
+      }
+
+      dashboard.userId = user._id;
+      await dashboard.save();
+
+      return res.json(dashboard.toJSON());
+    })
+  );
+
+  // DELETE /admin/dashboards/:id — Soft-delete
+  app.delete(
+    `${BASE_PATH}/dashboards/:id`,
+    authenticateMiddleware(),
+    asyncHandler(async (req, res) => {
+      await requireAdmin(req);
+
+      const dashboard = await Dashboard.findOneOrNone({
+        _id: req.params.id,
+        deleted: false,
+      });
+
+      if (!dashboard) {
+        throw new APIError({status: 404, title: "Dashboard not found"});
+      }
+
+      dashboard.deleted = true;
+      await dashboard.save();
+
+      return res.status(204).send();
+    })
+  );
+
+  // POST /admin/dashboards/query — Execute ChartConfig → aggregation result
+  app.post(
+    `${BASE_PATH}/dashboards/query`,
+    authenticateMiddleware(),
+    asyncHandler(async (req, res) => {
+      await requireAdmin(req);
+
+      const chartConfig = parseChartConfig(req.body);
+
+      const result = await executeQuery(
+        chartConfig,
+        {dataSources, supportsWindowFields},
+        mongodbVersion
+      );
+
+      return res.json(result);
+    })
+  );
+
+  // GET /admin/dashboards/sources — List registered sources + field metadata
+  app.get(
+    `${BASE_PATH}/dashboards/sources`,
+    authenticateMiddleware(),
+    asyncHandler(async (req, res) => {
+      await requireAdmin(req);
+
+      const sources: DataSourceMeta[] = dataSources.map(buildSourceMeta);
+
+      return res.json({
+        data: sources,
+        supportsWindowFields,
+      });
+    })
+  );
+};

--- a/admin-backend/src/dashboard/dashboardTools.ts
+++ b/admin-backend/src/dashboard/dashboardTools.ts
@@ -1,0 +1,120 @@
+import {randomUUID} from "crypto";
+import type mongoose from "mongoose";
+import {z} from "zod";
+
+import type {ChartConfig, DataSourceConfig} from "./chartTypes";
+import {chartConfigSchema, validateChartConfig} from "./chartTypes";
+import {Dashboard} from "./dashboard";
+import type {QueryEngineOptions} from "./dashboardQueryEngine";
+import {executeQuery} from "./dashboardQueryEngine";
+
+// ─── Tool option types ────────────────────────────────────────────────────────
+
+export interface DashboardToolOptions {
+  dataSources: DataSourceConfig[];
+  supportsWindowFields: boolean;
+  mongodbVersion: string;
+  /** Admin user ID injected per-request */
+  userId: mongoose.Types.ObjectId;
+}
+
+// ─── Shared validation ────────────────────────────────────────────────────────
+
+/**
+ * Validates a ChartConfig and throws a user-readable error on failure.
+ * Shared between route handler and AI tool executor to avoid duplication.
+ */
+export {validateChartConfig};
+
+// ─── Tool factories ───────────────────────────────────────────────────────────
+
+/**
+ * Creates a Vercel AI SDK tool that generates a chart inline in GPT chat.
+ * The tool runs the query and returns {chartConfig, data} — the frontend renders
+ * the result as an inline ChartWidget via DashboardToolResult.
+ */
+export const createGenerateChartTool = (options: DashboardToolOptions) => {
+  return {
+    description: "Generate a chart from model data and display it inline in the chat",
+    execute: async ({chartConfig}: {chartConfig: z.infer<typeof chartConfigSchema>}) => {
+      const validated = validateChartConfig(chartConfig);
+      const queryOptions: QueryEngineOptions = {
+        dataSources: options.dataSources,
+        supportsWindowFields: options.supportsWindowFields,
+      };
+      const result = await executeQuery(validated, queryOptions, options.mongodbVersion);
+      return {
+        chartConfig: validated,
+        data: result.data,
+        meta: result.meta,
+      };
+    },
+    parameters: z.object({
+      chartConfig: chartConfigSchema,
+    }),
+  };
+};
+
+/**
+ * Creates a Vercel AI SDK tool that persists a dashboard to the database.
+ * Returns {dashboardId, title, widgetCount} — the frontend renders a
+ * "View Dashboard →" link via DashboardToolResult.
+ */
+export const createDashboardTool = (options: DashboardToolOptions) => {
+  return {
+    description: "Create a persistent admin dashboard with one or more charts",
+    execute: async ({
+      description,
+      title,
+      widgets,
+    }: {
+      title: string;
+      description?: string;
+      widgets: Array<{chart: z.infer<typeof chartConfigSchema>}>;
+    }) => {
+      // Validate all widget configs before saving
+      const validatedWidgets = widgets.map((w, i) => {
+        const chart = validateChartConfig(w.chart);
+        return {
+          chart,
+          widgetId: randomUUID(),
+        };
+      });
+
+      const dashboard = await Dashboard.create({
+        description,
+        title,
+        userId: options.userId,
+        widgets: validatedWidgets,
+      });
+
+      return {
+        dashboardId: dashboard._id.toString(),
+        title: dashboard.title,
+        widgetCount: validatedWidgets.length,
+      };
+    },
+    parameters: z.object({
+      description: z.string().optional(),
+      title: z.string().min(1),
+      widgets: z
+        .array(
+          z.object({
+            chart: chartConfigSchema,
+          })
+        )
+        .min(1),
+    }),
+  };
+};
+
+/**
+ * Returns a Record<string, Tool> compatible with addGptRoutes `tools` option.
+ * Pass this to `createRequestTools` to inject the per-request userId.
+ */
+export const createDashboardGptTools = (options: DashboardToolOptions): Record<string, unknown> => {
+  return {
+    createDashboard: createDashboardTool(options),
+    generateChart: createGenerateChartTool(options),
+  };
+};

--- a/admin-backend/src/dashboard/index.ts
+++ b/admin-backend/src/dashboard/index.ts
@@ -1,0 +1,29 @@
+export type {
+  Aggregation,
+  AxisConfig,
+  ChartConfig,
+  ChartConfigInput,
+  ChartType,
+  DataSourceConfig,
+  DataSourceMeta,
+  DateTrunc,
+  EnrichedSource,
+  FilterConfig,
+  SimpleSource,
+} from "./chartTypes";
+export {chartConfigSchema, validateChartConfig} from "./chartTypes";
+export type {DashboardDocument, DashboardModel, DashboardWidgetDocument} from "./dashboard";
+export {Dashboard, generateWidgetId} from "./dashboard";
+export type {DashboardAppOptions} from "./dashboardApp";
+export {DashboardApp} from "./dashboardApp";
+export type {QueryEngineOptions, QueryResult} from "./dashboardQueryEngine";
+export {executeQuery} from "./dashboardQueryEngine";
+export type {DashboardRouteOptions} from "./dashboardRoutes";
+export {addDashboardRoutes} from "./dashboardRoutes";
+export type {DashboardToolOptions} from "./dashboardTools";
+export {
+  createDashboardGptTools,
+  createDashboardTool,
+  createGenerateChartTool,
+  validateChartConfig as validateChartConfigForTool,
+} from "./dashboardTools";

--- a/admin-backend/src/index.ts
+++ b/admin-backend/src/index.ts
@@ -1,6 +1,37 @@
 export type {AdminModelConfig, AdminOptions, AdminScriptConfig} from "./adminApp";
 export {AdminApp} from "./adminApp";
 export type {
+  Aggregation,
+  AxisConfig,
+  ChartConfig,
+  ChartConfigInput,
+  ChartType,
+  DashboardAppOptions,
+  DashboardDocument,
+  DashboardModel,
+  DashboardRouteOptions,
+  DashboardToolOptions,
+  DashboardWidgetDocument,
+  DataSourceConfig,
+  DataSourceMeta,
+  DateTrunc,
+  EnrichedSource,
+  FilterConfig,
+  QueryEngineOptions,
+  QueryResult,
+  SimpleSource,
+} from "./dashboard";
+export {
+  chartConfigSchema,
+  createDashboardGptTools,
+  createDashboardTool,
+  createGenerateChartTool,
+  Dashboard,
+  DashboardApp,
+  generateWidgetId,
+  validateChartConfig,
+} from "./dashboard";
+export type {
   DocumentFile,
   DocumentListResponse,
   DocumentStorageOptions,

--- a/admin-frontend/package.json
+++ b/admin-frontend/package.json
@@ -4,7 +4,8 @@
     "expo-router": "catalog:",
     "lodash": "catalog:",
     "luxon": "catalog:",
-    "react-native": "catalog:"
+    "react-native": "catalog:",
+    "recharts": "^2.15.0"
   },
   "description": "Admin panel frontend screens for @terreno/api backends",
   "devDependencies": {

--- a/admin-frontend/src/ChartWidget.tsx
+++ b/admin-frontend/src/ChartWidget.tsx
@@ -1,0 +1,436 @@
+import {Box, Spinner, Text, useTheme} from "@terreno/ui";
+import React from "react";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ComposedChart,
+  Legend,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import type {ChartConfig, ChartType} from "./types";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ChartWidgetProps {
+  chartConfig: ChartConfig;
+  data: Record<string, unknown>[];
+  isLoading?: boolean;
+  error?: unknown;
+  testID?: string;
+}
+
+// ─── Color palette ────────────────────────────────────────────────────────────
+
+const CHART_COLORS = [
+  "#6366f1",
+  "#22c55e",
+  "#f59e0b",
+  "#ef4444",
+  "#3b82f6",
+  "#a855f7",
+  "#14b8a6",
+  "#f97316",
+  "#84cc16",
+  "#06b6d4",
+];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const getYKey = (index: number, total: number): string => (total === 1 ? "y" : `y${index}`);
+
+const getYLabel = (chartConfig: ChartConfig, index: number): string => {
+  const yAxes = Array.isArray(chartConfig.y) ? chartConfig.y : [chartConfig.y];
+  const axis = yAxes[index];
+  if (!axis) {
+    return `y${index}`;
+  }
+  return axis.label ?? axis.field;
+};
+
+const getXLabel = (chartConfig: ChartConfig): string => chartConfig.x.label ?? chartConfig.x.field;
+
+// ─── Chart renderers ──────────────────────────────────────────────────────────
+
+const renderBarChart = (
+  chartConfig: ChartConfig,
+  data: Record<string, unknown>[],
+  type: ChartType
+) => {
+  const yAxes = Array.isArray(chartConfig.y) ? chartConfig.y : [chartConfig.y];
+  const isHorizontal = type === "bar-horizontal";
+  const isStacked = type === "bar-stacked";
+  const isGrouped = type === "bar-grouped";
+
+  return (
+    <ResponsiveContainer height={300} width="100%">
+      <BarChart data={data} layout={isHorizontal ? "vertical" : "horizontal"}>
+        <CartesianGrid strokeDasharray="3 3" />
+        {isHorizontal ? (
+          <>
+            <XAxis type="number" />
+            <YAxis dataKey="x" type="category" width={120} />
+          </>
+        ) : (
+          <>
+            <XAxis dataKey="x" />
+            <YAxis />
+          </>
+        )}
+        <Tooltip />
+        {yAxes.length > 1 && <Legend />}
+        {yAxes.map((axis, i) => (
+          <Bar
+            dataKey={getYKey(i, yAxes.length)}
+            fill={CHART_COLORS[i % CHART_COLORS.length]}
+            key={axis.field}
+            name={getYLabel(chartConfig, i)}
+            stackId={isStacked ? "stack" : isGrouped ? undefined : undefined}
+          />
+        ))}
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};
+
+const renderLineChart = (
+  chartConfig: ChartConfig,
+  data: Record<string, unknown>[],
+  type: ChartType
+) => {
+  const yAxes = Array.isArray(chartConfig.y) ? chartConfig.y : [chartConfig.y];
+  const isMulti = type === "line-multi";
+
+  if (isMulti && chartConfig.color) {
+    // Group data by color dimension
+    const colorKey = "color";
+    const colorValues = [...new Set(data.map((d) => String(d[colorKey])))];
+    const pivot: Record<string, Record<string, unknown>> = {};
+    for (const row of data) {
+      const xKey = String(row.x);
+      if (!pivot[xKey]) {
+        pivot[xKey] = {x: row.x};
+      }
+      const colorVal = String(row[colorKey]);
+      pivot[xKey][colorVal] = row.y;
+    }
+    const pivotedData = Object.values(pivot);
+
+    return (
+      <ResponsiveContainer height={300} width="100%">
+        <LineChart data={pivotedData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="x" />
+          <YAxis />
+          <Tooltip />
+          <Legend />
+          {colorValues.map((colorVal, i) => (
+            <Line
+              dataKey={colorVal}
+              dot={false}
+              key={colorVal}
+              name={colorVal}
+              stroke={CHART_COLORS[i % CHART_COLORS.length]}
+              type="monotone"
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    );
+  }
+
+  return (
+    <ResponsiveContainer height={300} width="100%">
+      <LineChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="x" />
+        <YAxis />
+        <Tooltip />
+        {yAxes.length > 1 && <Legend />}
+        {yAxes.map((axis, i) => (
+          <Line
+            dataKey={getYKey(i, yAxes.length)}
+            dot={false}
+            key={axis.field}
+            name={getYLabel(chartConfig, i)}
+            stroke={CHART_COLORS[i % CHART_COLORS.length]}
+            type="monotone"
+          />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
+  );
+};
+
+const renderAreaChart = (
+  chartConfig: ChartConfig,
+  data: Record<string, unknown>[],
+  type: ChartType
+) => {
+  const yAxes = Array.isArray(chartConfig.y) ? chartConfig.y : [chartConfig.y];
+  const isStacked = type === "area-stacked";
+
+  return (
+    <ResponsiveContainer height={300} width="100%">
+      <AreaChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="x" />
+        <YAxis />
+        <Tooltip />
+        {yAxes.length > 1 && <Legend />}
+        {yAxes.map((axis, i) => (
+          <Area
+            dataKey={getYKey(i, yAxes.length)}
+            fill={CHART_COLORS[i % CHART_COLORS.length]}
+            key={axis.field}
+            name={getYLabel(chartConfig, i)}
+            stackId={isStacked ? "stack" : undefined}
+            stroke={CHART_COLORS[i % CHART_COLORS.length]}
+            type="monotone"
+          />
+        ))}
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+};
+
+const renderPieChart = (
+  data: Record<string, unknown>[],
+  type: ChartType,
+  _chartConfig: ChartConfig
+) => {
+  const isDonut = type === "donut";
+  const chartData = data.map((d) => ({
+    name: String(d.color ?? d.x),
+    value: Number(d.y),
+  }));
+
+  return (
+    <ResponsiveContainer height={300} width="100%">
+      <PieChart>
+        <Pie
+          cx="50%"
+          cy="50%"
+          data={chartData}
+          dataKey="value"
+          innerRadius={isDonut ? "40%" : undefined}
+          label={({name, percent}: {name: string; percent: number}) =>
+            `${name} ${(percent * 100).toFixed(0)}%`
+          }
+          outerRadius="80%"
+        >
+          {chartData.map((_entry, i) => (
+            <Cell fill={CHART_COLORS[i % CHART_COLORS.length]} key={`cell-${i}`} />
+          ))}
+        </Pie>
+        <Tooltip />
+        <Legend />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+};
+
+const renderScatterChart = (data: Record<string, unknown>[], chartConfig: ChartConfig) => {
+  const colorGroups = chartConfig.color
+    ? [...new Set(data.map((d) => String(d.color ?? "default")))]
+    : ["default"];
+
+  return (
+    <ResponsiveContainer height={300} width="100%">
+      <ScatterChart>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis
+          dataKey="x"
+          label={{offset: -5, position: "insideBottom", value: getXLabel(chartConfig)}}
+          type="number"
+        />
+        <YAxis
+          dataKey="y"
+          label={{angle: -90, position: "insideLeft", value: getYLabel(chartConfig, 0)}}
+          type="number"
+        />
+        <Tooltip cursor={{strokeDasharray: "3 3"}} />
+        {colorGroups.length > 1 && <Legend />}
+        {colorGroups.map((group, i) => {
+          const groupData = chartConfig.color
+            ? data.filter((d) => String(d.color ?? "default") === group)
+            : data;
+          return (
+            <Scatter
+              data={groupData as any[]}
+              fill={CHART_COLORS[i % CHART_COLORS.length]}
+              key={group}
+              name={group}
+            />
+          );
+        })}
+      </ScatterChart>
+    </ResponsiveContainer>
+  );
+};
+
+const renderBubbleChart = (data: Record<string, unknown>[], _chartConfig: ChartConfig) => {
+  return (
+    <ResponsiveContainer height={300} width="100%">
+      <ScatterChart>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="x" type="number" />
+        <YAxis dataKey="y" type="number" />
+        <Tooltip cursor={{strokeDasharray: "3 3"}} />
+        <Scatter
+          data={data.map((d) => ({...d, z: d.size ?? d.y}))}
+          fill={CHART_COLORS[0]}
+          name="Data"
+        />
+      </ScatterChart>
+    </ResponsiveContainer>
+  );
+};
+
+const renderHeatmap = (data: Record<string, unknown>[], chartConfig: ChartConfig) => {
+  // Recharts doesn't have a native heatmap — render as stacked bar approximation
+  return (
+    <ResponsiveContainer height={300} width="100%">
+      <BarChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="x" />
+        <YAxis />
+        <Tooltip />
+        <Bar dataKey="y" fill={CHART_COLORS[0]} name={getYLabel(chartConfig, 0)} stackId="heat" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};
+
+const renderComboChart = (data: Record<string, unknown>[], chartConfig: ChartConfig) => {
+  const yAxes = Array.isArray(chartConfig.y) ? chartConfig.y : [chartConfig.y];
+
+  return (
+    <ResponsiveContainer height={300} width="100%">
+      <ComposedChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="x" />
+        <YAxis />
+        <Tooltip />
+        <Legend />
+        {yAxes.map((axis, i) =>
+          i === 0 ? (
+            <Bar
+              dataKey={getYKey(i, yAxes.length)}
+              fill={CHART_COLORS[0]}
+              key={axis.field}
+              name={getYLabel(chartConfig, i)}
+            />
+          ) : (
+            <Line
+              dataKey={getYKey(i, yAxes.length)}
+              dot={false}
+              key={axis.field}
+              name={getYLabel(chartConfig, i)}
+              stroke={CHART_COLORS[i % CHART_COLORS.length]}
+              type="monotone"
+            />
+          )
+        )}
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+};
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+const ChartWidgetInner = ({chartConfig, data, error, isLoading, testID}: ChartWidgetProps) => {
+  const {theme} = useTheme();
+
+  if (isLoading) {
+    return (
+      <Box alignItems="center" justifyContent="center" padding={4} testID={testID}>
+        <Spinner />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box
+        alignItems="center"
+        border="error"
+        justifyContent="center"
+        padding={4}
+        rounding="md"
+        testID={testID}
+      >
+        <Text color="error">Failed to load chart data</Text>
+      </Box>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <Box alignItems="center" justifyContent="center" padding={4} testID={testID}>
+        <Text color="secondaryDark" testID={testID ? `${testID}-empty` : undefined}>
+          No data available
+        </Text>
+      </Box>
+    );
+  }
+
+  const {type} = chartConfig;
+
+  let chart: React.ReactNode;
+
+  if (
+    type === "bar" ||
+    type === "bar-horizontal" ||
+    type === "bar-stacked" ||
+    type === "bar-grouped"
+  ) {
+    chart = renderBarChart(chartConfig, data, type);
+  } else if (type === "line" || type === "line-multi") {
+    chart = renderLineChart(chartConfig, data, type);
+  } else if (type === "area" || type === "area-stacked") {
+    chart = renderAreaChart(chartConfig, data, type);
+  } else if (type === "pie" || type === "donut") {
+    chart = renderPieChart(data, type, chartConfig);
+  } else if (type === "scatter") {
+    chart = renderScatterChart(data, chartConfig);
+  } else if (type === "bubble") {
+    chart = renderBubbleChart(data, chartConfig);
+  } else if (type === "heatmap") {
+    chart = renderHeatmap(data, chartConfig);
+  } else if (type === "combo") {
+    chart = renderComboChart(data, chartConfig);
+  } else {
+    chart = (
+      <Box padding={4} testID={testID}>
+        <Text color="secondaryDark">Unsupported chart type: {type}</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box testID={testID}>
+      <Box marginBottom={2}>
+        <Text bold size="md">
+          {chartConfig.title}
+        </Text>
+      </Box>
+      {chart}
+    </Box>
+  );
+};
+
+export const ChartWidget = React.memo(ChartWidgetInner);

--- a/admin-frontend/src/DashboardBuilder.tsx
+++ b/admin-frontend/src/DashboardBuilder.tsx
@@ -1,0 +1,408 @@
+import type {Api} from "@reduxjs/toolkit/query/react";
+import {Box, Button, Card, Heading, Spinner, Text, TextField} from "@terreno/ui";
+import {useRouter} from "expo-router";
+import React, {useEffect, useState} from "react";
+import {AxisConfigForm} from "./builder/AxisConfigForm";
+import {ChartTypeSelector} from "./builder/ChartTypeSelector";
+import {DataSourcePicker} from "./builder/DataSourcePicker";
+import {FieldList} from "./builder/FieldList";
+import {FilterBuilder} from "./builder/FilterBuilder";
+import {SortConfig} from "./builder/SortConfig";
+import {ChartWidget} from "./ChartWidget";
+import type {ChartConfig} from "./types";
+import type {DashboardWidget} from "./useDashboardApi";
+import {useDashboardApi} from "./useDashboardApi";
+
+// ─── Widget editor state ──────────────────────────────────────────────────────
+
+const defaultChartConfig = (): ChartConfig => ({
+  dataSource: "",
+  limit: 1000,
+  title: "New Chart",
+  type: "bar",
+  x: {field: ""},
+  y: {aggregation: "count", field: ""},
+});
+
+// ─── Widget preview card ──────────────────────────────────────────────────────
+
+interface WidgetPreviewProps {
+  chartConfig: ChartConfig;
+  api: Api<any, any, any, any>;
+  isEnabled: boolean;
+}
+
+const WidgetPreview: React.FC<WidgetPreviewProps> = ({api, chartConfig, isEnabled}) => {
+  const {useDashboardQueryQuery} = useDashboardApi(api);
+  const {data, error, isLoading} = useDashboardQueryQuery(chartConfig, {skip: !isEnabled});
+
+  return (
+    <ChartWidget
+      chartConfig={chartConfig}
+      data={data?.data ?? []}
+      error={error}
+      isLoading={isLoading}
+      testID="builder-preview-chart"
+    />
+  );
+};
+
+// ─── Widget editor ────────────────────────────────────────────────────────────
+
+interface WidgetEditorProps {
+  chart: ChartConfig;
+  onChange: (chart: ChartConfig) => void;
+  api: Api<any, any, any, any>;
+  supportsWindowFields: boolean;
+}
+
+const WidgetEditor: React.FC<WidgetEditorProps> = ({
+  api,
+  chart,
+  onChange,
+  supportsWindowFields,
+}) => {
+  const {useSourcesQuery} = useDashboardApi(api);
+  const {data: sourcesData, isLoading: sourcesLoading} = useSourcesQuery();
+
+  const sources = sourcesData?.data ?? [];
+  const selectedSource = sources.find((s) => s.name === chart.dataSource);
+  const fields = selectedSource?.fields ?? {};
+
+  const yAxes = Array.isArray(chart.y) ? chart.y : [chart.y];
+
+  // Debounced preview — the parent handles debouncing via a ref
+  const isPreviewEnabled =
+    !!chart.dataSource &&
+    !!chart.x.field &&
+    yAxes.some((a) => !!a.field || a.aggregation === "count");
+
+  return (
+    <Box gap={4}>
+      <TextField
+        onChange={(title) => onChange({...chart, title})}
+        testID="widget-editor-title"
+        title="Chart Title"
+        value={chart.title}
+      />
+
+      <DataSourcePicker
+        isLoading={sourcesLoading}
+        onChange={(dataSource) =>
+          onChange({...chart, dataSource, x: {field: ""}, y: {aggregation: "count", field: ""}})
+        }
+        sources={sources}
+        testID="widget-editor-source"
+        value={chart.dataSource}
+      />
+
+      {selectedSource && (
+        <>
+          <Box>
+            <Box marginBottom={2}>
+              <Text bold size="sm">
+                Available Fields
+              </Text>
+            </Box>
+            <FieldList fields={fields} testID="widget-editor-fields" />
+          </Box>
+
+          <ChartTypeSelector
+            onChange={(type) => onChange({...chart, type})}
+            testID="widget-editor-chart-type"
+            value={chart.type}
+          />
+
+          <AxisConfigForm
+            fields={fields}
+            label="X"
+            onChange={(x) => onChange({...chart, x})}
+            showAggregation={false}
+            supportsWindowFields={supportsWindowFields}
+            testID="widget-editor-x-axis"
+            value={chart.x}
+          />
+
+          <AxisConfigForm
+            fields={fields}
+            label="Y"
+            onChange={(y) => onChange({...chart, y})}
+            showAggregation
+            supportsWindowFields={supportsWindowFields}
+            testID="widget-editor-y-axis"
+            value={yAxes[0]}
+          />
+
+          <FilterBuilder
+            fields={fields}
+            filters={chart.filters ?? []}
+            onChange={(filters) => onChange({...chart, filters})}
+            testID="widget-editor-filters"
+          />
+
+          <SortConfig
+            fields={fields}
+            onChange={(sort) => onChange({...chart, sort})}
+            testID="widget-editor-sort"
+            value={chart.sort}
+          />
+
+          <Box border="default" padding={3} rounding="md">
+            <Box marginBottom={2}>
+              <Text bold size="sm">
+                Live Preview
+              </Text>
+            </Box>
+            <WidgetPreview api={api} chartConfig={chart} isEnabled={isPreviewEnabled} />
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+};
+
+// ─── Main builder ─────────────────────────────────────────────────────────────
+
+export interface DashboardBuilderProps {
+  api: Api<any, any, any, any>;
+  dashboardId?: string;
+  testID?: string;
+}
+
+export const DashboardBuilder: React.FC<DashboardBuilderProps> = ({api, dashboardId, testID}) => {
+  const router = useRouter();
+  const {
+    useGetDashboardQuery,
+    useCreateDashboardMutation,
+    useUpdateDashboardMutation,
+    useSourcesQuery,
+  } = useDashboardApi(api);
+
+  const isEditing = !!dashboardId;
+  const {data: existingDashboard, isLoading: dashboardLoading} = useGetDashboardQuery(
+    dashboardId ?? "",
+    {skip: !dashboardId}
+  );
+  const {data: sourcesData} = useSourcesQuery();
+  const supportsWindowFields = sourcesData?.supportsWindowFields ?? false;
+
+  const [createDashboard, {isLoading: isCreating}] = useCreateDashboardMutation();
+  const [updateDashboard, {isLoading: isUpdating}] = useUpdateDashboardMutation();
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [widgets, setWidgets] = useState<DashboardWidget[]>([]);
+  const [activeWidgetIndex, setActiveWidgetIndex] = useState<number | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Initialize form from existing dashboard
+  useEffect(() => {
+    if (existingDashboard) {
+      setTitle(existingDashboard.title);
+      setDescription(existingDashboard.description ?? "");
+      setWidgets(existingDashboard.widgets);
+    }
+  }, [existingDashboard]);
+
+  const addWidget = () => {
+    const newWidget: DashboardWidget = {
+      chart: defaultChartConfig(),
+      widgetId: `widget-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    };
+    setWidgets((prev) => [...prev, newWidget]);
+    setActiveWidgetIndex(widgets.length);
+  };
+
+  const removeWidget = (index: number) => {
+    setWidgets((prev) => prev.filter((_, i) => i !== index));
+    setActiveWidgetIndex(null);
+  };
+
+  const updateWidget = (index: number, chart: ChartConfig) => {
+    setWidgets((prev) => prev.map((w, i) => (i === index ? {...w, chart} : w)));
+  };
+
+  const moveWidget = (index: number, direction: "up" | "down") => {
+    const newWidgets = [...widgets];
+    const targetIndex = direction === "up" ? index - 1 : index + 1;
+    if (targetIndex < 0 || targetIndex >= newWidgets.length) {
+      return;
+    }
+    [newWidgets[index], newWidgets[targetIndex]] = [newWidgets[targetIndex], newWidgets[index]];
+    setWidgets(newWidgets);
+    setActiveWidgetIndex(targetIndex);
+  };
+
+  const handleSave = async () => {
+    setSaveError(null);
+    if (!title.trim()) {
+      setSaveError("Title is required");
+      return;
+    }
+
+    try {
+      const payload = {
+        description: description || undefined,
+        title: title.trim(),
+        widgets: widgets.map((w) => ({chart: w.chart, widgetId: w.widgetId})),
+      };
+
+      if (isEditing && dashboardId) {
+        await updateDashboard({...payload, id: dashboardId});
+        router.replace(`/admin/dashboards/${dashboardId}`);
+      } else {
+        const result = (await createDashboard(payload)) as any;
+        const id = result?.data?._id;
+        if (id) {
+          router.replace(`/admin/dashboards/${id}`);
+        } else {
+          router.replace("/admin/dashboards");
+        }
+      }
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Failed to save dashboard");
+    }
+  };
+
+  if (isEditing && dashboardLoading) {
+    return (
+      <Box alignItems="center" justifyContent="center" padding={6} testID={testID}>
+        <Spinner />
+      </Box>
+    );
+  }
+
+  const activeWidget = activeWidgetIndex !== null ? widgets[activeWidgetIndex] : null;
+
+  return (
+    <Box padding={4} testID={testID ?? "dashboard-builder"}>
+      <Box alignItems="center" direction="row" justifyContent="between" marginBottom={4}>
+        <Heading size="lg">{isEditing ? "Edit Dashboard" : "New Dashboard"}</Heading>
+        <Box direction="row" gap={2}>
+          <Button
+            onClick={() => router.back()}
+            testID="builder-cancel-button"
+            text="Cancel"
+            variant="secondary"
+          />
+          <Button
+            loading={isCreating || isUpdating}
+            onClick={handleSave}
+            testID="builder-save-button"
+            text={isEditing ? "Save Changes" : "Create Dashboard"}
+            variant="primary"
+          />
+        </Box>
+      </Box>
+
+      {saveError && (
+        <Box border="error" marginBottom={4} padding={3} rounding="md">
+          <Text color="error">{saveError}</Text>
+        </Box>
+      )}
+
+      <Box direction="row" gap={4}>
+        {/* Left panel: dashboard metadata + widget list */}
+        <Box style={{flex: 1}}>
+          <Card marginBottom={4} padding={4}>
+            <Box gap={3}>
+              <TextField
+                onChange={setTitle}
+                testID="builder-title-input"
+                title="Dashboard Title"
+                value={title}
+              />
+              <TextField
+                multiline
+                onChange={setDescription}
+                placeholder="Optional description"
+                testID="builder-description-input"
+                title="Description"
+                value={description}
+              />
+            </Box>
+          </Card>
+
+          <Box alignItems="center" direction="row" justifyContent="between" marginBottom={2}>
+            <Text bold>Widgets</Text>
+            <Button
+              iconName="plus"
+              onClick={addWidget}
+              testID="builder-add-widget-button"
+              text="Add Widget"
+              variant="secondary"
+            />
+          </Box>
+
+          {widgets.length === 0 ? (
+            <Text color="secondaryDark" size="sm">
+              No widgets added yet.
+            </Text>
+          ) : (
+            widgets.map((widget, index) => (
+              <Card
+                accessibilityHint="Edit this widget"
+                accessibilityLabel={widget.chart.title || `Widget ${index + 1}`}
+                key={widget.widgetId}
+                marginBottom={2}
+                onClick={() => setActiveWidgetIndex(index === activeWidgetIndex ? null : index)}
+                padding={3}
+                testID={`builder-widget-card-${index}`}
+              >
+                <Box alignItems="center" direction="row" justifyContent="between">
+                  <Text bold size="sm">
+                    {widget.chart.title || `Widget ${index + 1}`}
+                  </Text>
+                  <Box direction="row" gap={1}>
+                    <Button
+                      disabled={index === 0}
+                      iconName="arrow-up"
+                      onClick={() => moveWidget(index, "up")}
+                      testID={`builder-widget-up-${index}`}
+                      text=""
+                      variant="muted"
+                    />
+                    <Button
+                      disabled={index === widgets.length - 1}
+                      iconName="arrow-down"
+                      onClick={() => moveWidget(index, "down")}
+                      testID={`builder-widget-down-${index}`}
+                      text=""
+                      variant="muted"
+                    />
+                    <Button
+                      iconName="trash"
+                      onClick={() => removeWidget(index)}
+                      testID={`builder-widget-delete-${index}`}
+                      text=""
+                      variant="destructive"
+                    />
+                  </Box>
+                </Box>
+              </Card>
+            ))
+          )}
+        </Box>
+
+        {/* Right panel: widget editor */}
+        {activeWidget !== null && activeWidgetIndex !== null && (
+          <Box style={{flex: 2}}>
+            <Card padding={4}>
+              <Box marginBottom={4}>
+                <Text bold size="lg">
+                  Edit Widget
+                </Text>
+              </Box>
+              <WidgetEditor
+                api={api}
+                chart={activeWidget.chart}
+                onChange={(chart) => updateWidget(activeWidgetIndex, chart)}
+                supportsWindowFields={supportsWindowFields}
+              />
+            </Card>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/admin-frontend/src/DashboardList.tsx
+++ b/admin-frontend/src/DashboardList.tsx
@@ -1,0 +1,88 @@
+import type {Api} from "@reduxjs/toolkit/query/react";
+import {Box, Button, Card, Heading, Spinner, Text} from "@terreno/ui";
+import {useRouter} from "expo-router";
+import {DateTime} from "luxon";
+import React from "react";
+
+import {useDashboardApi} from "./useDashboardApi";
+
+export interface DashboardListProps {
+  api: Api<any, any, any, any>;
+  testID?: string;
+}
+
+export const DashboardList: React.FC<DashboardListProps> = ({api, testID}) => {
+  const router = useRouter();
+  const {useListDashboardsQuery} = useDashboardApi(api);
+  const {data, isLoading, error} = useListDashboardsQuery();
+
+  if (isLoading) {
+    return (
+      <Box alignItems="center" justifyContent="center" padding={6} testID={testID}>
+        <Spinner />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box padding={4} testID={testID}>
+        <Text color="error">Failed to load dashboards</Text>
+      </Box>
+    );
+  }
+
+  const dashboards = data?.data ?? [];
+
+  return (
+    <Box gap={4} padding={4} testID={testID ?? "dashboard-list"}>
+      <Box alignItems="center" direction="row" justifyContent="between">
+        <Heading size="lg">Dashboards</Heading>
+        <Button
+          onClick={() => router.push("/admin/dashboards/new")}
+          testID="dashboard-list-create-button"
+          text="Create New"
+          variant="primary"
+        />
+      </Box>
+
+      {dashboards.length === 0 ? (
+        <Box alignItems="center" padding={8} testID="dashboard-list-empty">
+          <Text color="secondaryDark">No dashboards yet. Create your first dashboard.</Text>
+        </Box>
+      ) : (
+        <Box gap={3}>
+          {dashboards.map((dashboard) => (
+            <Card
+              accessibilityHint="Opens this dashboard"
+              accessibilityLabel={dashboard.title}
+              key={dashboard._id}
+              onClick={() => router.push(`/admin/dashboards/${dashboard._id}`)}
+              padding={4}
+              testID={`dashboard-list-item-${dashboard._id}`}
+            >
+              <Box gap={1}>
+                <Text bold size="lg">
+                  {dashboard.title}
+                </Text>
+                {dashboard.description ? (
+                  <Text color="secondaryDark" size="sm">
+                    {dashboard.description}
+                  </Text>
+                ) : null}
+                <Box direction="row" gap={4} marginTop={2}>
+                  <Text color="secondaryDark" size="sm">
+                    {dashboard.widgets.length} widget{dashboard.widgets.length !== 1 ? "s" : ""}
+                  </Text>
+                  <Text color="secondaryDark" size="sm">
+                    Updated {DateTime.fromISO(dashboard.updated).toRelative()}
+                  </Text>
+                </Box>
+              </Box>
+            </Card>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/admin-frontend/src/DashboardToolResult.tsx
+++ b/admin-frontend/src/DashboardToolResult.tsx
@@ -1,0 +1,63 @@
+import {Box, Button, Text} from "@terreno/ui";
+import {useRouter} from "expo-router";
+import React from "react";
+
+import {ChartWidget} from "./ChartWidget";
+import type {ChartConfig} from "./types";
+
+export interface DashboardToolResultData {
+  chartConfig?: ChartConfig;
+  data?: Record<string, unknown>[];
+  dashboardId?: string;
+  title?: string;
+}
+
+export interface DashboardToolResultProps {
+  result: DashboardToolResultData;
+  testID?: string;
+}
+
+/**
+ * Renders GPT tool results for generateChart and createDashboard tools.
+ * - If result has chartConfig + data → inline ChartWidget
+ * - If result has dashboardId → "View Dashboard →" link
+ */
+export const DashboardToolResult: React.FC<DashboardToolResultProps> = ({result, testID}) => {
+  const router = useRouter();
+
+  if (result.chartConfig && result.data) {
+    return (
+      <Box border="default" padding={4} rounding="md" testID={testID ?? "dashboard-tool-result"}>
+        <ChartWidget
+          chartConfig={result.chartConfig}
+          data={result.data}
+          testID="dashboard-tool-result-chart"
+        />
+      </Box>
+    );
+  }
+
+  if (result.dashboardId) {
+    return (
+      <Box
+        alignItems="center"
+        border="default"
+        direction="row"
+        gap={2}
+        padding={3}
+        rounding="md"
+        testID={testID ?? "dashboard-tool-result"}
+      >
+        <Text>Dashboard "{result.title ?? "Dashboard"}" created.</Text>
+        <Button
+          onClick={() => router.push(`/admin/dashboards/${result.dashboardId}`)}
+          testID="dashboard-tool-result-link"
+          text="View Dashboard →"
+          variant="secondary"
+        />
+      </Box>
+    );
+  }
+
+  return null;
+};

--- a/admin-frontend/src/DashboardViewer.tsx
+++ b/admin-frontend/src/DashboardViewer.tsx
@@ -1,0 +1,137 @@
+import type {Api} from "@reduxjs/toolkit/query/react";
+import {Box, Button, Heading, Modal, Spinner, Text} from "@terreno/ui";
+import {useRouter} from "expo-router";
+import React, {useState} from "react";
+
+import {ChartWidget} from "./ChartWidget";
+import type {ChartConfig} from "./types";
+import {useDashboardApi} from "./useDashboardApi";
+
+interface WidgetCardProps {
+  chartConfig: ChartConfig;
+  api: Api<any, any, any, any>;
+  widgetId: string;
+}
+
+const WidgetCard: React.FC<WidgetCardProps> = ({api, chartConfig, widgetId}) => {
+  const {useDashboardQueryQuery} = useDashboardApi(api);
+  const {data, error, isLoading} = useDashboardQueryQuery(chartConfig);
+
+  return (
+    <Box
+      border="default"
+      marginBottom={4}
+      padding={4}
+      rounding="md"
+      testID={`dashboard-widget-${widgetId}`}
+    >
+      <ChartWidget
+        chartConfig={chartConfig}
+        data={data?.data ?? []}
+        error={error}
+        isLoading={isLoading}
+        testID={`dashboard-widget-chart-${widgetId}`}
+      />
+    </Box>
+  );
+};
+
+export interface DashboardViewerProps {
+  api: Api<any, any, any, any>;
+  dashboardId: string;
+  testID?: string;
+}
+
+export const DashboardViewer: React.FC<DashboardViewerProps> = ({api, dashboardId, testID}) => {
+  const router = useRouter();
+  const {useGetDashboardQuery, useDeleteDashboardMutation} = useDashboardApi(api);
+  const {data: dashboard, isLoading, error} = useGetDashboardQuery(dashboardId);
+  const [deleteDashboard, {isLoading: isDeleting}] = useDeleteDashboardMutation();
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const handleDelete = async () => {
+    await deleteDashboard(dashboardId);
+    router.replace("/admin/dashboards");
+  };
+
+  if (isLoading) {
+    return (
+      <Box alignItems="center" justifyContent="center" padding={6} testID={testID}>
+        <Spinner />
+      </Box>
+    );
+  }
+
+  if (error || !dashboard) {
+    return (
+      <Box padding={4} testID={testID}>
+        <Text color="error">Failed to load dashboard</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box padding={4} testID={testID ?? "dashboard-viewer"}>
+      <Box alignItems="center" direction="row" justifyContent="between" marginBottom={4}>
+        <Box flex="grow">
+          <Heading size="lg" testID="dashboard-viewer-title">
+            {dashboard.title}
+          </Heading>
+          {dashboard.description ? (
+            <Text color="secondaryDark" size="sm">
+              {dashboard.description}
+            </Text>
+          ) : null}
+        </Box>
+        <Box direction="row" gap={2}>
+          <Button
+            onClick={() => router.push(`/admin/dashboards/${dashboardId}/edit`)}
+            testID="dashboard-viewer-edit-button"
+            text="Edit"
+            variant="secondary"
+          />
+          <Button
+            onClick={() => setShowDeleteConfirm(true)}
+            testID="dashboard-viewer-delete-button"
+            text="Delete"
+            variant="destructive"
+          />
+        </Box>
+      </Box>
+
+      {dashboard.widgets.length === 0 ? (
+        <Box alignItems="center" padding={8} testID="dashboard-viewer-empty">
+          <Text color="secondaryDark">This dashboard has no widgets.</Text>
+          <Button
+            onClick={() => router.push(`/admin/dashboards/${dashboardId}/edit`)}
+            text="Add Widgets"
+            variant="primary"
+          />
+        </Box>
+      ) : (
+        <Box testID="dashboard-viewer-widgets">
+          {dashboard.widgets.map((widget) => (
+            <WidgetCard
+              api={api}
+              chartConfig={widget.chart}
+              key={widget.widgetId}
+              widgetId={widget.widgetId}
+            />
+          ))}
+        </Box>
+      )}
+
+      <Modal
+        onDismiss={() => setShowDeleteConfirm(false)}
+        primaryButtonOnClick={handleDelete}
+        primaryButtonText={isDeleting ? "Deleting..." : "Delete"}
+        secondaryButtonOnClick={() => setShowDeleteConfirm(false)}
+        secondaryButtonText="Cancel"
+        title="Delete Dashboard"
+        visible={showDeleteConfirm}
+      >
+        <Text>Are you sure you want to delete "{dashboard.title}"? This cannot be undone.</Text>
+      </Modal>
+    </Box>
+  );
+};

--- a/admin-frontend/src/builder/AxisConfigForm.tsx
+++ b/admin-frontend/src/builder/AxisConfigForm.tsx
@@ -1,0 +1,98 @@
+import {Box, SelectField, Text, TextField} from "@terreno/ui";
+import React from "react";
+
+import type {Aggregation, AxisConfig, DataSourceFieldMeta, DateTrunc} from "../types";
+
+const AGGREGATION_OPTIONS: {label: string; value: Aggregation}[] = [
+  {label: "Count", value: "count"},
+  {label: "Sum", value: "sum"},
+  {label: "Average", value: "avg"},
+  {label: "Minimum", value: "min"},
+  {label: "Maximum", value: "max"},
+  {label: "Count Distinct", value: "countDistinct"},
+  {label: "Running Total", value: "runningTotal"},
+  {label: "Rank", value: "rank"},
+];
+
+const DATE_TRUNC_OPTIONS: {label: string; value: DateTrunc}[] = [
+  {label: "Year", value: "year"},
+  {label: "Quarter", value: "quarter"},
+  {label: "Month", value: "month"},
+  {label: "Week", value: "week"},
+  {label: "Day", value: "day"},
+  {label: "Hour", value: "hour"},
+];
+
+export interface AxisConfigFormProps {
+  label: string;
+  value: AxisConfig;
+  onChange: (config: AxisConfig) => void;
+  fields: Record<string, DataSourceFieldMeta>;
+  supportsWindowFields?: boolean;
+  showAggregation?: boolean;
+  testID?: string;
+}
+
+export const AxisConfigForm: React.FC<AxisConfigFormProps> = ({
+  fields,
+  label,
+  onChange,
+  showAggregation = true,
+  supportsWindowFields = false,
+  testID,
+  value,
+}) => {
+  const fieldOptions = Object.entries(fields).map(([name, field]) => ({
+    label: `${name} (${field.type})`,
+    value: name,
+  }));
+
+  const selectedField = value.field ? fields[value.field] : undefined;
+  const isDateField = selectedField?.type === "date";
+
+  const aggregationOptions = supportsWindowFields
+    ? AGGREGATION_OPTIONS
+    : AGGREGATION_OPTIONS.filter((o) => o.value !== "runningTotal" && o.value !== "rank");
+
+  return (
+    <Box gap={2} testID={testID ?? `axis-config-${label.toLowerCase()}`}>
+      <Text bold size="sm">
+        {label} Axis
+      </Text>
+
+      <SelectField
+        onChange={(field) => onChange({...value, dateTrunc: undefined, field})}
+        options={fieldOptions}
+        requireValue
+        title="Field"
+        value={value.field}
+      />
+
+      <TextField
+        onChange={(lbl) => onChange({...value, label: lbl || undefined})}
+        placeholder="Optional label"
+        testID={`${testID ?? "axis"}-label-input`}
+        title="Label"
+        value={value.label ?? ""}
+      />
+
+      {showAggregation && (
+        <SelectField
+          onChange={(agg) => onChange({...value, aggregation: (agg as Aggregation) || undefined})}
+          options={[{label: "None", value: ""}, ...aggregationOptions]}
+          title="Aggregation"
+          value={value.aggregation ?? ""}
+        />
+      )}
+
+      {isDateField && (
+        <SelectField
+          onChange={(trunc) => onChange({...value, dateTrunc: (trunc as DateTrunc) || undefined})}
+          options={[{label: "None (raw)", value: ""}, ...DATE_TRUNC_OPTIONS]}
+          title="Date Granularity"
+          value={value.dateTrunc ?? ""}
+        />
+      )}
+    </Box>
+  );
+};

--- a/admin-frontend/src/builder/ChartTypeSelector.tsx
+++ b/admin-frontend/src/builder/ChartTypeSelector.tsx
@@ -1,0 +1,41 @@
+import {Box, SelectField} from "@terreno/ui";
+import React from "react";
+
+import type {ChartType} from "../types";
+
+const CHART_TYPE_OPTIONS: {label: string; value: ChartType}[] = [
+  {label: "Bar", value: "bar"},
+  {label: "Bar (Horizontal)", value: "bar-horizontal"},
+  {label: "Bar (Stacked)", value: "bar-stacked"},
+  {label: "Bar (Grouped)", value: "bar-grouped"},
+  {label: "Line", value: "line"},
+  {label: "Line (Multi-series)", value: "line-multi"},
+  {label: "Area", value: "area"},
+  {label: "Area (Stacked)", value: "area-stacked"},
+  {label: "Pie", value: "pie"},
+  {label: "Donut", value: "donut"},
+  {label: "Scatter", value: "scatter"},
+  {label: "Bubble", value: "bubble"},
+  {label: "Heatmap", value: "heatmap"},
+  {label: "Combo (Bar + Line)", value: "combo"},
+];
+
+export interface ChartTypeSelectorProps {
+  value: ChartType;
+  onChange: (type: ChartType) => void;
+  testID?: string;
+}
+
+export const ChartTypeSelector: React.FC<ChartTypeSelectorProps> = ({onChange, testID, value}) => {
+  return (
+    <Box testID={testID ?? "chart-type-selector"}>
+      <SelectField
+        onChange={(v) => onChange(v as ChartType)}
+        options={CHART_TYPE_OPTIONS}
+        requireValue
+        title="Chart Type"
+        value={value}
+      />
+    </Box>
+  );
+};

--- a/admin-frontend/src/builder/DataSourcePicker.tsx
+++ b/admin-frontend/src/builder/DataSourcePicker.tsx
@@ -1,0 +1,50 @@
+import {Box, SelectField, Spinner, Text} from "@terreno/ui";
+import React from "react";
+
+import type {DataSourceMeta} from "../types";
+
+export interface DataSourcePickerProps {
+  sources: DataSourceMeta[];
+  isLoading?: boolean;
+  value: string;
+  onChange: (sourceName: string) => void;
+  testID?: string;
+}
+
+export const DataSourcePicker: React.FC<DataSourcePickerProps> = ({
+  isLoading,
+  onChange,
+  sources,
+  testID,
+  value,
+}) => {
+  if (isLoading) {
+    return (
+      <Box alignItems="center" padding={4} testID={testID}>
+        <Spinner />
+      </Box>
+    );
+  }
+
+  if (sources.length === 0) {
+    return (
+      <Box padding={4} testID={testID}>
+        <Text color="secondaryDark">No data sources registered.</Text>
+      </Box>
+    );
+  }
+
+  const options = sources.map((s) => ({label: s.displayName, value: s.name}));
+
+  return (
+    <Box testID={testID ?? "data-source-picker"}>
+      <SelectField
+        onChange={onChange}
+        options={options}
+        requireValue
+        title="Data Source"
+        value={value}
+      />
+    </Box>
+  );
+};

--- a/admin-frontend/src/builder/FieldList.tsx
+++ b/admin-frontend/src/builder/FieldList.tsx
@@ -1,0 +1,96 @@
+import {Badge, Box, Text} from "@terreno/ui";
+import React from "react";
+
+import type {DataSourceFieldMeta} from "../types";
+
+export interface FieldListProps {
+  fields: Record<string, DataSourceFieldMeta>;
+  onFieldClick?: (fieldName: string, field: DataSourceFieldMeta) => void;
+  testID?: string;
+}
+
+const DIMENSION_COLOR = "#3b82f6";
+const MEASURE_COLOR = "#22c55e";
+
+export const FieldList: React.FC<FieldListProps> = ({fields, onFieldClick, testID}) => {
+  const fieldEntries = Object.entries(fields);
+
+  if (fieldEntries.length === 0) {
+    return (
+      <Box padding={4} testID={testID}>
+        <Text color="secondaryDark">No fields available.</Text>
+      </Box>
+    );
+  }
+
+  const dimensions = fieldEntries.filter(([, f]) => f.role === "dimension");
+  const measures = fieldEntries.filter(([, f]) => f.role === "measure");
+
+  // Dimension color (blue) and measure color (green) — inline for label headers
+  const dimensionHeaderStyle = {color: DIMENSION_COLOR};
+  const measureHeaderStyle = {color: MEASURE_COLOR};
+
+  const renderField = ([name, field]: [string, DataSourceFieldMeta]) => {
+    const boxProps = onFieldClick
+      ? {
+          accessibilityHint: `Select ${name} field`,
+          accessibilityLabel: name,
+          onClick: () => onFieldClick(name, field),
+        }
+      : {};
+
+    return (
+      <Box
+        {...boxProps}
+        border="default"
+        direction="row"
+        gap={2}
+        key={name}
+        marginBottom={2}
+        padding={2}
+        rounding="sm"
+        testID={`field-list-item-${name}`}
+      >
+        <Box flex="grow">
+          <Text bold size="sm">
+            {name}
+          </Text>
+          {field.description ? (
+            <Text color="secondaryDark" size="sm">
+              {field.description}
+            </Text>
+          ) : null}
+        </Box>
+        <Box alignItems="center" direction="row" gap={1}>
+          <Badge status="neutral" value={field.type} />
+          <Badge status="info" value={field.role} />
+        </Box>
+      </Box>
+    );
+  };
+
+  return (
+    <Box testID={testID ?? "field-list"}>
+      {dimensions.length > 0 && (
+        <Box marginBottom={3}>
+          <Box marginBottom={2} style={dimensionHeaderStyle}>
+            <Text bold color="primary" size="sm">
+              Dimensions
+            </Text>
+          </Box>
+          {dimensions.map(renderField)}
+        </Box>
+      )}
+      {measures.length > 0 && (
+        <Box>
+          <Box marginBottom={2} style={measureHeaderStyle}>
+            <Text bold color="primary" size="sm">
+              Measures
+            </Text>
+          </Box>
+          {measures.map(renderField)}
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/admin-frontend/src/builder/FilterBuilder.tsx
+++ b/admin-frontend/src/builder/FilterBuilder.tsx
@@ -1,0 +1,231 @@
+import {Box, Button, SelectField, Text, TextField} from "@terreno/ui";
+import React from "react";
+
+import type {DataSourceFieldMeta, DateTrunc, FilterConfig} from "../types";
+
+const COMPARISON_FILTER_TYPES = ["eq", "ne", "gt", "gte", "lt", "lte"] as const;
+const SET_FILTER_TYPES = ["in", "nin"] as const;
+
+const FILTER_TYPE_OPTIONS = [
+  {label: "Equals", value: "eq"},
+  {label: "Not equals", value: "ne"},
+  {label: "Greater than", value: "gt"},
+  {label: "Greater than or equal", value: "gte"},
+  {label: "Less than", value: "lt"},
+  {label: "Less than or equal", value: "lte"},
+  {label: "In list", value: "in"},
+  {label: "Not in list", value: "nin"},
+  {label: "Date range", value: "dateRange"},
+  {label: "Relative date", value: "relative"},
+];
+
+const DATE_TRUNC_OPTIONS: {label: string; value: DateTrunc}[] = [
+  {label: "Hours", value: "hour"},
+  {label: "Days", value: "day"},
+  {label: "Weeks", value: "week"},
+  {label: "Months", value: "month"},
+  {label: "Quarters", value: "quarter"},
+  {label: "Years", value: "year"},
+];
+
+const defaultFilter = (): FilterConfig => ({
+  field: "",
+  type: "eq",
+  value: "",
+});
+
+export interface FilterBuilderProps {
+  filters: FilterConfig[];
+  onChange: (filters: FilterConfig[]) => void;
+  fields: Record<string, DataSourceFieldMeta>;
+  testID?: string;
+}
+
+export const FilterBuilder: React.FC<FilterBuilderProps> = ({
+  fields,
+  filters,
+  onChange,
+  testID,
+}) => {
+  const fieldOptions = Object.keys(fields).map((name) => ({label: name, value: name}));
+
+  const addFilter = () => {
+    onChange([...filters, defaultFilter()]);
+  };
+
+  const removeFilter = (index: number) => {
+    const updated = filters.filter((_, i) => i !== index);
+    onChange(updated);
+  };
+
+  const updateFilter = (index: number, updated: FilterConfig) => {
+    const next = [...filters];
+    next[index] = updated;
+    onChange(next);
+  };
+
+  const renderFilterRow = (filter: FilterConfig, index: number) => {
+    const isComparison = COMPARISON_FILTER_TYPES.includes(filter.type as any);
+    const isSet = SET_FILTER_TYPES.includes(filter.type as any);
+    const isDateRange = filter.type === "dateRange";
+    const isRelative = filter.type === "relative";
+
+    const baseUpdate = (partial: Partial<FilterConfig>) =>
+      updateFilter(index, {...filter, ...partial} as FilterConfig);
+
+    return (
+      <Box
+        border="default"
+        gap={2}
+        key={index}
+        marginBottom={2}
+        padding={3}
+        rounding="md"
+        testID={`filter-row-${index}`}
+      >
+        <Box alignItems="center" direction="row" gap={2}>
+          <Box flex="grow">
+            <SelectField
+              onChange={(field) => baseUpdate({field})}
+              options={fieldOptions}
+              title="Field"
+              value={filter.field}
+            />
+          </Box>
+          <Box>
+            <SelectField
+              onChange={(type) => {
+                // Reset value when switching filter type
+                if (type === "in" || type === "nin") {
+                  updateFilter(index, {
+                    field: filter.field,
+                    type: type as "in" | "nin",
+                    values: [],
+                  });
+                } else if (type === "dateRange") {
+                  updateFilter(index, {field: filter.field, type: "dateRange"});
+                } else if (type === "relative") {
+                  updateFilter(index, {
+                    amount: 30,
+                    field: filter.field,
+                    type: "relative",
+                    unit: "day",
+                  });
+                } else {
+                  updateFilter(index, {field: filter.field, type: type as any, value: ""});
+                }
+              }}
+              options={FILTER_TYPE_OPTIONS}
+              title="Type"
+              value={filter.type}
+            />
+          </Box>
+          <Button
+            iconName="trash"
+            onClick={() => removeFilter(index)}
+            testID={`filter-${index}-remove`}
+            text=""
+            variant="destructive"
+          />
+        </Box>
+
+        {isComparison && (
+          <TextField
+            onChange={(val) => baseUpdate({value: val})}
+            placeholder="Filter value"
+            testID={`filter-${index}-value`}
+            title="Value"
+            value={String((filter as any).value ?? "")}
+          />
+        )}
+
+        {isSet && (
+          <TextField
+            helperText="Comma-separated values"
+            onChange={(val) => {
+              const values = val
+                .split(",")
+                .map((v) => v.trim())
+                .filter(Boolean);
+              baseUpdate({values});
+            }}
+            placeholder="value1, value2, value3"
+            testID={`filter-${index}-values`}
+            title="Values"
+            value={((filter as any).values ?? []).join(", ")}
+          />
+        )}
+
+        {isDateRange && (
+          <Box direction="row" gap={2}>
+            <Box flex="grow">
+              <TextField
+                onChange={(from) => baseUpdate({from: from || undefined})}
+                placeholder="YYYY-MM-DD"
+                testID={`filter-${index}-from`}
+                title="From"
+                value={(filter as any).from ?? ""}
+              />
+            </Box>
+            <Box flex="grow">
+              <TextField
+                onChange={(to) => baseUpdate({to: to || undefined})}
+                placeholder="YYYY-MM-DD"
+                testID={`filter-${index}-to`}
+                title="To"
+                value={(filter as any).to ?? ""}
+              />
+            </Box>
+          </Box>
+        )}
+
+        {isRelative && (
+          <Box direction="row" gap={2}>
+            <Box flex="grow">
+              <TextField
+                onChange={(val) => baseUpdate({amount: Number.parseInt(val, 10) || 30})}
+                placeholder="30"
+                testID={`filter-${index}-amount`}
+                title="Amount"
+                value={String((filter as any).amount ?? 30)}
+              />
+            </Box>
+            <Box flex="grow">
+              <SelectField
+                onChange={(unit) => baseUpdate({unit: unit as DateTrunc})}
+                options={DATE_TRUNC_OPTIONS}
+                title="Unit"
+                value={(filter as any).unit ?? "day"}
+              />
+            </Box>
+          </Box>
+        )}
+      </Box>
+    );
+  };
+
+  return (
+    <Box testID={testID ?? "filter-builder"}>
+      <Box alignItems="center" direction="row" justifyContent="between" marginBottom={2}>
+        <Text bold size="sm">
+          Filters
+        </Text>
+        <Button
+          iconName="plus"
+          onClick={addFilter}
+          testID="filter-add-button"
+          text="Add Filter"
+          variant="secondary"
+        />
+      </Box>
+
+      {filters.length === 0 ? (
+        <Text color="secondaryDark" size="sm">
+          No filters applied
+        </Text>
+      ) : (
+        filters.map(renderFilterRow)
+      )}
+    </Box>
+  );
+};

--- a/admin-frontend/src/builder/SortConfig.tsx
+++ b/admin-frontend/src/builder/SortConfig.tsx
@@ -1,0 +1,65 @@
+import {Box, SelectField, Text} from "@terreno/ui";
+import React from "react";
+
+import type {DataSourceFieldMeta} from "../types";
+
+export interface SortConfigValue {
+  field: string;
+  direction: "asc" | "desc";
+}
+
+export interface SortConfigProps {
+  value?: SortConfigValue;
+  onChange: (sort: SortConfigValue | undefined) => void;
+  fields: Record<string, DataSourceFieldMeta>;
+  testID?: string;
+}
+
+export const SortConfig: React.FC<SortConfigProps> = ({fields, onChange, testID, value}) => {
+  const fieldOptions = [
+    {label: "None (default)", value: ""},
+    ...Object.keys(fields).map((name) => ({label: name, value: name})),
+  ];
+
+  const directionOptions = [
+    {label: "Ascending", value: "asc"},
+    {label: "Descending", value: "desc"},
+  ];
+
+  return (
+    <Box gap={2} testID={testID ?? "sort-config"}>
+      <Text bold size="sm">
+        Sort
+      </Text>
+
+      <Box direction="row" gap={2}>
+        <Box flex="grow">
+          <SelectField
+            onChange={(field) => {
+              if (!field) {
+                onChange(undefined);
+              } else {
+                onChange({direction: value?.direction ?? "asc", field});
+              }
+            }}
+            options={fieldOptions}
+            title="Sort Field"
+            value={value?.field ?? ""}
+          />
+        </Box>
+
+        {value?.field && (
+          <Box flex="grow">
+            <SelectField
+              onChange={(dir) => onChange({direction: dir as "asc" | "desc", field: value.field})}
+              options={directionOptions}
+              requireValue
+              title="Direction"
+              value={value.direction}
+            />
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/admin-frontend/src/index.tsx
+++ b/admin-frontend/src/index.tsx
@@ -6,7 +6,23 @@ export {AdminRefField} from "./AdminRefField";
 export {AdminScriptList} from "./AdminScriptList";
 export {AdminScriptRunModal} from "./AdminScriptRunModal";
 export {AdminVersionConfig} from "./AdminVersionConfig";
+export {AxisConfigForm} from "./builder/AxisConfigForm";
+export {ChartTypeSelector} from "./builder/ChartTypeSelector";
+export {DataSourcePicker} from "./builder/DataSourcePicker";
+export {FieldList} from "./builder/FieldList";
+export {FilterBuilder} from "./builder/FilterBuilder";
+export {SortConfig} from "./builder/SortConfig";
+export type {ChartWidgetProps} from "./ChartWidget";
+export {ChartWidget} from "./ChartWidget";
 export {ConfigurationScreen} from "./ConfigurationScreen";
+export type {DashboardBuilderProps} from "./DashboardBuilder";
+export {DashboardBuilder} from "./DashboardBuilder";
+export type {DashboardListProps} from "./DashboardList";
+export {DashboardList} from "./DashboardList";
+export type {DashboardToolResultData, DashboardToolResultProps} from "./DashboardToolResult";
+export {DashboardToolResult} from "./DashboardToolResult";
+export type {DashboardViewerProps} from "./DashboardViewer";
+export {DashboardViewer} from "./DashboardViewer";
 export {DocumentStorageBrowser} from "./DocumentStorageBrowser";
 export type {
   AdminConfigResponse,
@@ -14,14 +30,30 @@ export type {
   AdminModelConfig,
   AdminScreenProps,
   AdminScriptConfig,
+  Aggregation,
+  AxisConfig,
   BackgroundTask,
+  ChartConfig,
+  ChartType,
+  DataSourceFieldMeta,
+  DataSourceMeta,
+  DateTrunc,
   DocumentFile,
   DocumentListResponse,
   DocumentStorageBrowserProps,
+  FilterConfig,
 } from "./types";
 export {SYSTEM_FIELDS} from "./types";
 export {useAdminApi} from "./useAdminApi";
 export {useAdminConfig} from "./useAdminConfig";
 export {useAdminScripts} from "./useAdminScripts";
 export {useConfigurationApi} from "./useConfigurationApi";
+export type {
+  Dashboard,
+  DashboardListResponse,
+  DashboardWidget,
+  QueryResult,
+  SourcesResponse,
+} from "./useDashboardApi";
+export {useDashboardApi} from "./useDashboardApi";
 export {useDocumentStorageApi} from "./useDocumentStorageApi";

--- a/admin-frontend/src/types.ts
+++ b/admin-frontend/src/types.ts
@@ -1,5 +1,65 @@
 import type {Api} from "@reduxjs/toolkit/query/react";
 
+// ─── Chart types (mirrored from @terreno/admin-backend for frontend use) ─────
+
+export type ChartType =
+  | "bar"
+  | "bar-horizontal"
+  | "bar-stacked"
+  | "bar-grouped"
+  | "line"
+  | "line-multi"
+  | "area"
+  | "area-stacked"
+  | "pie"
+  | "donut"
+  | "scatter"
+  | "bubble"
+  | "heatmap"
+  | "combo";
+
+export type Aggregation =
+  | "count"
+  | "sum"
+  | "avg"
+  | "min"
+  | "max"
+  | "countDistinct"
+  | "runningTotal"
+  | "rank";
+
+export type DateTrunc = "year" | "quarter" | "month" | "week" | "day" | "hour";
+
+export interface AxisConfig {
+  field: string;
+  label?: string;
+  aggregation?: Aggregation;
+  dateTrunc?: DateTrunc;
+}
+
+export type FilterConfig =
+  | {
+      type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte";
+      field: string;
+      value: string | number | boolean | null;
+    }
+  | {type: "in" | "nin"; field: string; values: (string | number | boolean | null)[]}
+  | {type: "dateRange"; field: string; from?: string; to?: string}
+  | {type: "relative"; field: string; unit: DateTrunc; amount: number};
+
+export interface ChartConfig {
+  type: ChartType;
+  title: string;
+  dataSource: string;
+  x: AxisConfig;
+  y: AxisConfig | AxisConfig[];
+  color?: {field: string; label?: string};
+  size?: AxisConfig;
+  filters?: FilterConfig[];
+  sort?: {field: string; direction: "asc" | "desc"};
+  limit?: number;
+}
+
 export interface AdminFieldConfig {
   type: string;
   required: boolean;
@@ -29,10 +89,24 @@ export interface AdminScriptConfig {
   description: string;
 }
 
+export interface DataSourceFieldMeta {
+  type: "string" | "number" | "date" | "boolean";
+  description: string;
+  role: "dimension" | "measure";
+}
+
+export interface DataSourceMeta {
+  name: string;
+  displayName: string;
+  fields: Record<string, DataSourceFieldMeta>;
+}
+
 export interface AdminConfigResponse {
   customScreens?: AdminCustomScreen[];
   models: AdminModelConfig[];
   scripts: AdminScriptConfig[];
+  dataSources?: DataSourceMeta[];
+  supportsWindowFields?: boolean;
 }
 
 export interface BackgroundTaskProgress {

--- a/admin-frontend/src/useDashboardApi.ts
+++ b/admin-frontend/src/useDashboardApi.ts
@@ -1,0 +1,163 @@
+import type {Api} from "@reduxjs/toolkit/query/react";
+import {useMemo} from "react";
+
+import type {ChartConfig, DataSourceMeta} from "./types";
+
+export interface DashboardWidget {
+  widgetId: string;
+  chart: ChartConfig;
+}
+
+export interface Dashboard {
+  _id: string;
+  title: string;
+  description?: string;
+  userId: string;
+  widgets: DashboardWidget[];
+  created: string;
+  updated: string;
+  deleted: boolean;
+}
+
+export interface DashboardListResponse {
+  data: Dashboard[];
+  total: number;
+  page: number;
+  limit: number;
+  more: boolean;
+}
+
+export interface QueryResult {
+  data: Record<string, unknown>[];
+  meta: {
+    total: number;
+    truncated: boolean;
+    mongodbVersion: string;
+  };
+}
+
+export interface SourcesResponse {
+  data: DataSourceMeta[];
+  supportsWindowFields: boolean;
+}
+
+export interface CreateDashboardInput {
+  title: string;
+  description?: string;
+  widgets?: {chart: ChartConfig}[];
+}
+
+export interface UpdateDashboardInput {
+  id: string;
+  title?: string;
+  description?: string;
+  widgets?: {widgetId?: string; chart: ChartConfig}[];
+}
+
+/**
+ * RTK Query hooks for dashboard CRUD and query operations.
+ * Widget data queries use `useQueryEndpoint` pattern (not mutations) to enable
+ * 60-second caching and request deduplication across widgets.
+ */
+export const useDashboardApi = (api: Api<any, any, any, any>) => {
+  const enhanced = useMemo(() => {
+    return api.injectEndpoints({
+      endpoints: (build: any) => ({
+        // Dashboard CRUD
+        dashboardCreate: build.mutation({
+          invalidatesTags: ["dashboard"],
+          query: (body: CreateDashboardInput) => ({
+            body,
+            method: "POST",
+            url: "/admin/dashboards",
+          }),
+        }),
+        dashboardDelete: build.mutation({
+          invalidatesTags: ["dashboard"],
+          query: (id: string) => ({
+            method: "DELETE",
+            url: `/admin/dashboards/${id}`,
+          }),
+        }),
+        dashboardGet: build.query({
+          providesTags: (_result: any, _error: any, id: string) => [{id, type: "dashboard"}],
+          query: (id: string) => ({
+            method: "GET",
+            url: `/admin/dashboards/${id}`,
+          }),
+        }),
+        dashboardList: build.query({
+          providesTags: ["dashboard"],
+          query: (params: {page?: number; limit?: number} = {}) => ({
+            method: "GET",
+            params,
+            url: "/admin/dashboards",
+          }),
+        }),
+        // Query execution — use query (not mutation) to enable caching per ChartConfig
+        dashboardQuery: build.query({
+          // 60-second cache TTL
+          keepUnusedDataFor: 60,
+          query: (chartConfig: ChartConfig) => ({
+            body: chartConfig,
+            method: "POST",
+            url: "/admin/dashboards/query",
+          }),
+        }),
+        // Data sources
+        dashboardSources: build.query({
+          keepUnusedDataFor: 300,
+          query: () => ({
+            method: "GET",
+            url: "/admin/dashboards/sources",
+          }),
+        }),
+        dashboardUpdate: build.mutation({
+          invalidatesTags: (_result: any, _error: any, {id}: {id: string}) => [
+            {id, type: "dashboard"},
+            "dashboard",
+          ],
+          query: ({id, ...body}: UpdateDashboardInput) => ({
+            body,
+            method: "PATCH",
+            url: `/admin/dashboards/${id}`,
+          }),
+        }),
+      }),
+      overrideExisting: true,
+    });
+  }, [api]);
+
+  return {
+    useCreateDashboardMutation: (enhanced as any).useDashboardCreateMutation as () => [
+      (input: CreateDashboardInput) => Promise<{data: Dashboard}>,
+      {isLoading: boolean; error?: unknown},
+    ],
+    // Key for cache: serialize ChartConfig so same config reuses cache
+    useDashboardQueryQuery: (enhanced as any).useDashboardQueryQuery as (
+      chartConfig: ChartConfig,
+      options?: {skip?: boolean}
+    ) => {data?: QueryResult; isLoading: boolean; isFetching: boolean; error?: unknown},
+    useDeleteDashboardMutation: (enhanced as any).useDashboardDeleteMutation as () => [
+      (id: string) => Promise<void>,
+      {isLoading: boolean; error?: unknown},
+    ],
+    useGetDashboardQuery: (enhanced as any).useDashboardGetQuery as (
+      id: string,
+      options?: {skip?: boolean}
+    ) => {data?: Dashboard; isLoading: boolean; error?: unknown},
+    useListDashboardsQuery: (enhanced as any).useDashboardListQuery as (params?: {
+      page?: number;
+      limit?: number;
+    }) => {data?: DashboardListResponse; isLoading: boolean; error?: unknown},
+    useSourcesQuery: (enhanced as any).useDashboardSourcesQuery as () => {
+      data?: SourcesResponse;
+      isLoading: boolean;
+      error?: unknown;
+    },
+    useUpdateDashboardMutation: (enhanced as any).useDashboardUpdateMutation as () => [
+      (input: UpdateDashboardInput) => Promise<{data: Dashboard}>,
+      {isLoading: boolean; error?: unknown},
+    ],
+  };
+};

--- a/bun.lock
+++ b/bun.lock
@@ -11,13 +11,14 @@
     },
     "admin-backend": {
       "name": "@terreno/admin-backend",
-      "version": "0.7.0",
+      "version": "0.7.2",
       "dependencies": {
         "@google-cloud/storage": "^7.15.0",
         "@terreno/api": "workspace:*",
         "express": "^5.2.1",
         "luxon": "catalog:",
         "multer": "^1.4.5-lts.1",
+        "zod": "^3.24.0",
       },
       "devDependencies": {
         "@biomejs/biome": "catalog:",
@@ -31,18 +32,23 @@
         "typescript": "catalog:",
       },
       "peerDependencies": {
+        "ai": ">=4.0.0",
         "mongoose": ">=8.0.0",
       },
+      "optionalPeers": [
+        "ai",
+      ],
     },
     "admin-frontend": {
       "name": "@terreno/admin-frontend",
-      "version": "0.7.0",
+      "version": "0.7.2",
       "dependencies": {
         "@terreno/ui": "workspace:*",
         "expo-router": "catalog:",
         "lodash": "catalog:",
         "luxon": "catalog:",
         "react-native": "catalog:",
+        "recharts": "^2.15.0",
       },
       "devDependencies": {
         "@biomejs/biome": "catalog:",
@@ -66,7 +72,7 @@
     },
     "ai": {
       "name": "@terreno/ai",
-      "version": "0.7.0",
+      "version": "0.7.2",
       "dependencies": {
         "@ai-sdk/mcp": "^1.0.21",
         "@google-cloud/storage": "^7.15.0",
@@ -99,7 +105,7 @@
     },
     "api": {
       "name": "@terreno/api",
-      "version": "0.7.0",
+      "version": "0.7.2",
       "dependencies": {
         "@sentry/bun": "^10.25.0",
         "@sentry/profiling-node": "^10.25.0",
@@ -169,7 +175,7 @@
     },
     "api-health": {
       "name": "@terreno/api-health",
-      "version": "0.7.0",
+      "version": "0.7.2",
       "dependencies": {
         "@terreno/api": "workspace:*",
         "express": "^5.2.1",
@@ -369,7 +375,7 @@
     },
     "rtk": {
       "name": "@terreno/rtk",
-      "version": "0.7.0",
+      "version": "0.7.2",
       "dependencies": {
         "@better-auth/expo": "^1.2.8",
         "@react-native-async-storage/async-storage": "catalog:",
@@ -406,7 +412,7 @@
     },
     "ui": {
       "name": "@terreno/ui",
-      "version": "0.7.0",
+      "version": "0.7.2",
       "dependencies": {
         "@expo-google-fonts/nunito": "^0.4.2",
         "@expo-google-fonts/titillium-web": "^0.4.1",
@@ -1549,6 +1555,24 @@
 
     "@types/cron": ["@types/cron@2.4.3", "", { "dependencies": { "cron": "*" } }, "sha512-ViRBkoZD9Rk0hGeMdd2GHGaOaZuH9mDmwsE5/Zo53Ftwcvh7h9VJc8lIt2wdgEwS4EW5lbtTX6vlE0idCLPOyA=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
     "@types/eslint": ["@types/eslint@9.6.1", "", { "dependencies": { "@types/estree": "*", "@types/json-schema": "*" } }, "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag=="],
 
     "@types/eslint-scope": ["@types/eslint-scope@3.7.7", "", { "dependencies": { "@types/eslint": "*", "@types/estree": "*" } }, "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg=="],
@@ -2117,9 +2141,33 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "decode-uri-component": ["decode-uri-component@0.2.2", "", {}, "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="],
 
@@ -2172,6 +2220,8 @@
     "dns-packet": ["dns-packet@5.6.1", "", { "dependencies": { "@leichtgewicht/ip-codec": "^2.0.1" } }, "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw=="],
 
     "dom-converter": ["dom-converter@0.2.0", "", { "dependencies": { "utila": "~0.4" } }, "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA=="],
+
+    "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -2380,6 +2430,8 @@
     "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-equals": ["fast-equals@5.4.0", "", {}, "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="],
 
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
@@ -2618,6 +2670,8 @@
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "inline-style-prefixer": ["inline-style-prefixer@7.0.1", "", { "dependencies": { "css-in-js-utils": "^3.1.0" } }, "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "invariant": ["invariant@2.2.4", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA=="],
 
@@ -3359,7 +3413,7 @@
 
     "react-freeze": ["react-freeze@1.0.4", "", { "peerDependencies": { "react": ">=17.0.0" } }, "sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA=="],
 
-    "react-is": ["react-is@19.2.4", "", {}, "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA=="],
+    "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "react-keyed-flatten-children": ["react-keyed-flatten-children@5.1.2", "", { "peerDependencies": { "react": ">=18.0.0", "react-is": ">=18.0.0" } }, "sha512-jM6/Em2S6g8DAhFGbxlQwVfCRIhXgoQo9Ks1CyjtzCa5O/S52wW2jsj7qaASHBln86UxiP4ZBLwtLJd70glpVw=="],
 
@@ -3429,15 +3483,23 @@
 
     "react-signature-canvas": ["react-signature-canvas@1.1.0-alpha.2", "", { "dependencies": { "@babel/runtime": "^7.17.9", "@types/signature_pad": "^2.3.0", "signature_pad": "^2.3.2", "trim-canvas": "^0.1.0" }, "peerDependencies": { "@types/prop-types": "^15.7.3", "@types/react": "0.14 - 19", "prop-types": "^15.5.8", "react": "0.14 - 19", "react-dom": "0.14 - 19" }, "optionalPeers": ["@types/prop-types", "@types/react"] }, "sha512-tKUNk3Gmh04Ug4K8p5g8Is08BFUKvbXxi0PyetQ/f8OgCBzcx4vqNf9+OArY/TdNdfHtswXQNRwZD6tyELjkjQ=="],
 
+    "react-smooth": ["react-smooth@4.0.4", "", { "dependencies": { "fast-equals": "^5.0.1", "prop-types": "^15.8.1", "react-transition-group": "^4.4.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q=="],
+
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "react-test-renderer": ["react-test-renderer@19.1.0", "", { "dependencies": { "react-is": "^19.1.0", "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw=="],
 
     "react-time-picker": ["react-time-picker@8.0.2", "", { "dependencies": { "@wojtekmaj/date-utils": "^2.0.2", "clsx": "^2.0.0", "get-user-locale": "^3.0.0", "make-event-props": "^2.0.0", "react-clock": "^6.0.0", "react-fit": "^3.0.0", "update-input-width": "^1.4.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-qT0MDiPy9rFM60QrNNfZ5F9nwDBW1E9DrBtslpM46UPP/RReaWDJrGlvHVH6CjtWHUeJi5sLk1vB+dzLS8ZvnA=="],
 
+    "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g=="],
+
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "recharts": ["recharts@2.15.4", "", { "dependencies": { "clsx": "^2.0.0", "eventemitter3": "^4.0.1", "lodash": "^4.17.21", "react-is": "^18.3.1", "react-smooth": "^4.0.4", "recharts-scale": "^0.4.4", "tiny-invariant": "^1.3.1", "victory-vendor": "^36.6.8" }, "peerDependencies": { "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw=="],
+
+    "recharts-scale": ["recharts-scale@0.4.5", "", { "dependencies": { "decimal.js-light": "^2.4.1" } }, "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w=="],
 
     "recursive-readdir": ["recursive-readdir@2.2.3", "", { "dependencies": { "minimatch": "^3.0.5" } }, "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA=="],
 
@@ -3767,6 +3829,8 @@
 
     "thunky": ["thunky@1.1.0", "", {}, "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="],
 
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "tmpl": ["tmpl@1.0.5", "", {}, "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="],
@@ -3871,6 +3935,8 @@
 
     "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 
+    "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
+
     "vlq": ["vlq@1.0.1", "", {}, "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w=="],
 
     "walker": ["walker@1.0.8", "", { "dependencies": { "makeerror": "1.0.12" } }, "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ=="],
@@ -3963,7 +4029,7 @@
 
     "z-schema": ["z-schema@5.0.6", "", { "dependencies": { "lodash.get": "^4.4.2", "lodash.isequal": "^4.5.0", "validator": "^13.7.0" }, "optionalDependencies": { "commander": "^10.0.0" }, "bin": { "z-schema": "bin/z-schema" } }, "sha512-+XR1GhnWklYdfr8YaZv/iu+vY+ux7V5DS5zH1DQf6bO5ufrt/5cgNhVO5qyhsjFXvsqQb/f08DWE9b6uPscyAg=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
@@ -3988,6 +4054,10 @@
     "@babel/preset-env/@babel/plugin-transform-optional-chaining": ["@babel/plugin-transform-optional-chaining@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w=="],
 
     "@babel/preset-env/babel-plugin-polyfill-corejs3": ["babel-plugin-polyfill-corejs3@0.14.1", "", { "dependencies": { "@babel/helper-define-polyfill-provider": "^0.6.7", "core-js-compat": "^3.48.0" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-ENp89vM9Pw4kv/koBb5N2f9bDZsR0hpf3BdPMOg/pkS3pwO4dzNnQZVXtBbeyAadgm865DmQG2jMMLqmZXvuCw=="],
+
+    "@better-auth/core/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@better-auth/expo/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@expo/cli/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
@@ -4054,6 +4124,8 @@
     "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@10.3.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.0" } }, "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@opentelemetry/instrumentation/require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
@@ -4123,6 +4195,8 @@
 
     "@react-native/dev-middleware/open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
 
+    "@react-navigation/core/react-is": ["react-is@19.2.4", "", {}, "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA=="],
+
     "@sentry/node/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.211.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.211.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q=="],
 
     "@sentry/node/@opentelemetry/instrumentation-express": ["@opentelemetry/instrumentation-express@0.59.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.211.0", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-pMKV/qnHiW/Q6pmbKkxt0eIhuNEtvJ7sUAyee192HErlr+a1Jx+FZ3WjfmzhQL1geewyGEiPGkmjjAgNY8TgDA=="],
@@ -4153,6 +4227,8 @@
 
     "@terreno/example-backend/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
+    "@terreno/example-backend/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "@testing-library/react-native/pretty-format": ["pretty-format@30.3.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ=="],
 
     "@thream/socketio-jwt/jsonwebtoken": ["jsonwebtoken@9.0.2", "", { "dependencies": { "jws": "^3.2.2", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ=="],
@@ -4170,6 +4246,10 @@
     "asn1.js/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
     "babel-loader/loader-utils": ["loader-utils@2.0.4", "", { "dependencies": { "big.js": "^5.2.2", "emojis-list": "^3.0.0", "json5": "^2.1.2" } }, "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw=="],
+
+    "better-auth/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "better-call/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "browserify-sign/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
@@ -4252,6 +4332,8 @@
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "fastmcp/yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
+
+    "fastmcp/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "fbjs/promise": ["promise@7.3.1", "", { "dependencies": { "asap": "~2.0.3" } }, "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="],
 
@@ -4407,8 +4489,6 @@
 
     "postcss-unique-selectors/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
-    "pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
-
     "promise-retry/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
@@ -4430,6 +4510,8 @@
     "react-native-web/memoize-one": ["memoize-one@6.0.0", "", {}, "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="],
 
     "react-native-worklets/@babel/preset-typescript": ["@babel/preset-typescript@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ=="],
+
+    "react-test-renderer/react-is": ["react-is@19.2.4", "", {}, "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA=="],
 
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -4813,8 +4895,6 @@
 
     "@testing-library/react-native/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
 
-    "@testing-library/react-native/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
-
     "@thream/socketio-jwt/jsonwebtoken/jws": ["jws@3.2.3", "", { "dependencies": { "jwa": "^1.4.2", "safe-buffer": "^5.0.1" } }, "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g=="],
 
     "@types/minimatch/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
@@ -4913,13 +4993,9 @@
 
     "jest-diff/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
 
-    "jest-diff/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
-
     "jest-haste-map/jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "jest-matcher-utils/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
-
-    "jest-matcher-utils/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 

--- a/docs/implementationPlans/terreno-graphing.md
+++ b/docs/implementationPlans/terreno-graphing.md
@@ -1,0 +1,525 @@
+# Implementation Plan: Admin Dashboards & Graphing
+
+*When an engineer is assigned to a project but before you begin coding, you should fill in the implementation plan and get feedback from the engineering team. Once you have finished or you make any changes, tag Josh with the @ symbol so he can review. Also tag anyone else that needs to be notified, has conflicting work, etc.*
+
+---
+
+## Models
+
+### `Dashboard` (new — `@terreno/ai`)
+
+Persists admin-created dashboards with an ordered list of chart widgets.
+
+```typescript
+// ai/src/models/dashboard.ts
+
+const dashboardWidgetSchema = new mongoose.Schema(
+  {
+    widgetId: {
+      description: "Unique widget identifier (uuid v4)",
+      required: true,
+      type: String,
+    },
+    chart: {
+      description: "Full ChartConfig — chart type, data source, axis configuration, filters",
+      required: true,
+      type: mongoose.Schema.Types.Mixed,
+    },
+  },
+  { _id: false }
+);
+
+const dashboardSchema = new mongoose.Schema<DashboardDocument, DashboardModel>(
+  {
+    title: {
+      description: "Dashboard title",
+      required: true,
+      trim: true,
+      type: String,
+    },
+    description: {
+      description: "Optional description shown in the dashboard list",
+      type: String,
+    },
+    userId: {
+      description: "Admin user who created the dashboard",
+      index: true,
+      ref: "User",
+      required: true,
+      type: mongoose.Schema.Types.ObjectId,
+    },
+    widgets: {
+      default: [],
+      description: "Ordered list of chart widgets",
+      type: [dashboardWidgetSchema],
+    },
+  },
+  { strict: "throw", toJSON: { virtuals: true }, toObject: { virtuals: true } }
+);
+
+// Plugins: createdUpdatedPlugin, isDeletedPlugin, findExactlyOne, findOneOrNone
+// Virtual: ownerId → userId (IsOwner compatibility)
+```
+
+### `ChartConfig` (TypeScript interface — stored as `Mixed`, validated with Zod at API boundary)
+
+```typescript
+// ai/src/types/chartTypes.ts
+
+type ChartType =
+  | "bar" | "bar-horizontal" | "bar-stacked" | "bar-grouped"
+  | "line" | "line-multi"
+  | "area" | "area-stacked"
+  | "pie" | "donut"
+  | "scatter" | "bubble"
+  | "heatmap"
+  | "combo";
+
+type Aggregation =
+  | "count" | "sum" | "avg" | "min" | "max" | "countDistinct"
+  | "runningTotal" | "rank";  // runningTotal/rank require MongoDB 5+
+
+type DateTrunc = "year" | "quarter" | "month" | "week" | "day" | "hour";
+
+interface AxisConfig {
+  field: string;
+  label?: string;
+  aggregation?: Aggregation;
+  dateTrunc?: DateTrunc;
+}
+
+type FilterConfig =
+  | { type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte"; field: string; value: unknown }
+  | { type: "in" | "nin"; field: string; values: unknown[] }
+  | { type: "dateRange"; field: string; from?: string; to?: string }
+  | { type: "relative"; field: string; unit: DateTrunc; amount: number };
+
+interface ChartConfig {
+  type: ChartType;
+  title: string;
+  dataSource: string;          // Registered source name ("User" or "UsersWithActivity")
+  x: AxisConfig;
+  y: AxisConfig | AxisConfig[];
+  color?: { field: string; label?: string };
+  size?: AxisConfig;           // Bubble charts only
+  filters?: FilterConfig[];
+  sort?: { field: string; direction: "asc" | "desc" };
+  limit?: number;              // Default 1000, max 5000
+}
+```
+
+### `DataSourceConfig` (TypeScript interface — registered by consuming app at startup, never persisted)
+
+```typescript
+// ai/src/types/chartTypes.ts (continued)
+
+interface SimpleSource {
+  type: "model";
+  modelName: string;    // Mongoose model name (e.g. "User")
+  displayName: string;
+}
+
+interface EnrichedSource {
+  type: "enriched";
+  name: string;                // Unique name (e.g. "UsersWithActivity")
+  displayName: string;
+  baseModel: string;           // Root Mongoose model name (for permission validation)
+  pipeline: mongoose.PipelineStage[];
+  outputFields: Record<string, {
+    type: "string" | "number" | "date" | "boolean";
+    description: string;
+    role: "dimension" | "measure";
+  }>;
+}
+
+type DataSourceConfig = SimpleSource | EnrichedSource;
+```
+
+**EnrichedSource example — "Users with Conversation Counts":**
+```typescript
+{
+  type: "enriched",
+  name: "UsersWithActivity",
+  displayName: "Users (with Activity)",
+  baseModel: "User",
+  pipeline: [
+    { $lookup: { from: "gpthistories", localField: "_id", foreignField: "userId", as: "histories" } },
+    { $addFields: { conversationCount: { $size: "$histories" }, lastActiveAt: { $max: "$histories.updated" } } },
+    { $project: { histories: 0 } },
+  ],
+  outputFields: {
+    email:             { type: "string", description: "User email",          role: "dimension" },
+    created:           { type: "date",   description: "Account created",     role: "dimension" },
+    conversationCount: { type: "number", description: "Total conversations", role: "measure" },
+    lastActiveAt:      { type: "date",   description: "Last activity date",  role: "dimension" },
+  },
+}
+```
+
+---
+
+## APIs
+
+### New: `addDashboardRoutes(router, options)` — `@terreno/ai`
+
+All endpoints require `Permissions.IsAdmin`.
+
+| Method | Path | Type | Description |
+|--------|------|------|-------------|
+| `POST` | `/dashboards` | modelRouter | Create a dashboard |
+| `GET` | `/dashboards` | modelRouter | List dashboards (paginated, sorted `-updated`) |
+| `GET` | `/dashboards/:id` | modelRouter | Get a single dashboard with all widgets |
+| `PATCH` | `/dashboards/:id` | modelRouter | Update title, description, or full widgets array |
+| `DELETE` | `/dashboards/:id` | modelRouter | Soft-delete a dashboard |
+| `POST` | `/dashboards/query` | custom | Execute a `ChartConfig` → aggregation result |
+| `GET` | `/dashboards/sources` | custom | List registered data sources + field metadata |
+
+**`POST /dashboards/query`**
+- Request body: `ChartConfig` (validated with Zod — strict, 400 on any schema error)
+- Response: `{ data: ChartDataPoint[], meta: { total: number, truncated: boolean, pointCount: number } }`
+- Pipeline construction order:
+  1. Resolve data source (enriched: prepend base pipeline; simple: use model directly)
+  2. `$match` — apply `FilterConfig[]`
+  3. `$addFields` — apply `$dateTrunc` to date dimension fields
+  4. `$group` — group by X (and color if present), compute Y aggregations
+  5. `$setWindowFields` — for `runningTotal`/`rank` (MongoDB 5+ only; 400 if not available)
+  6. `$sort` + `$limit` — cap at `limit` (default 1000, max 5000)
+- Auto-bucketing: if date dimension would exceed limit, automatically coarsen granularity one level
+
+**`GET /dashboards/sources`**
+- Returns all registered data sources with their field metadata (type, role, description)
+- Used by `DashboardBuilder` to populate the field picker
+
+### Modified: `GET /admin/config` — `@terreno/admin-backend`
+
+`AdminConfigResponse` gains a `dataSources` field. `AdminApp.register()` calls `DashboardApp.getSourcesMeta()` if a `DashboardApp` instance is provided, appending it to the config response.
+
+```typescript
+// Updated AdminConfigResponse
+interface AdminConfigResponse {
+  customScreens?: { displayName: string; name: string }[];
+  models: AdminModelMeta[];
+  scripts: AdminScriptMeta[];
+  dataSources?: DataSourceMeta[];   // NEW — from DashboardApp if registered
+}
+```
+
+### `DashboardApp` plugin — `@terreno/ai`
+
+```typescript
+import { DashboardApp } from "@terreno/ai";
+
+const dashboardApp = new DashboardApp({
+  dataSources: [
+    { type: "model", modelName: "User", displayName: "Users" },
+    { type: "model", modelName: "GptHistory", displayName: "Conversations" },
+    {
+      type: "enriched",
+      name: "UsersWithActivity",
+      displayName: "Users (with Activity)",
+      baseModel: "User",
+      pipeline: [...],
+      outputFields: {...},
+    },
+  ],
+});
+
+new TerrenoApp({ userModel: User })
+  .register(adminApp)
+  .register(dashboardApp)
+  .start();
+```
+
+The `DashboardApp` constructor detects MongoDB version and stores a `supportsWindowFields: boolean` flag used by the query engine.
+
+---
+
+## UI
+
+All new components go in `@terreno/admin-frontend`. Add `recharts` as a dependency.
+
+### New Components
+
+#### `ChartWidget`
+Renders a single `ChartConfig` + `data` using Recharts. Props: `chartConfig: ChartConfig`, `data: ChartDataPoint[]`, `isLoading?: boolean`, `error?: string`. Memoized with `React.memo` and deep equality on `chartConfig`.
+
+Supports all 14 chart types via a switch on `chartConfig.type`. Uses Recharts primitives:
+- Bar → `BarChart`
+- Line / Line-multi → `LineChart`
+- Area / Area-stacked → `AreaChart`
+- Pie / Donut → `PieChart`
+- Scatter / Bubble → `ScatterChart`
+- Heatmap → `ResponsiveContainer` + SVG custom cells
+- Combo → `ComposedChart` with `Bar` + `Line`
+
+Dimensions use Terreno theme colors (maps to `theme.surface.primary`, `secondary`, etc.).
+
+#### `DashboardViewer`
+Renders a saved dashboard. Props: `dashboardId: string`, `api: Api`.
+- Fetches dashboard via `GET /dashboards/:id`
+- Each widget fires its own `POST /dashboards/query` RTK Query (parallel, 60s cache)
+- Renders widgets in order as a vertical list of `ChartWidget`s in `Card`s
+- "Edit Dashboard" button → navigates to `DashboardBuilder` in edit mode
+- Per-widget loading/error states so one slow query doesn't block the rest
+
+#### `DashboardBuilder`
+Create or edit a dashboard. Props: `dashboardId?: string` (undefined = create mode), `api: Api`.
+
+Layout:
+```
+┌─────────────────────────────────────────────┐
+│  Dashboard Title  [Description]   [Save]    │
+├──────────────────┬──────────────────────────┤
+│  Data Source     │  Chart Type              │
+│  [picker]        │  [type selector]         │
+│                  │                          │
+│  Fields          │  X Axis  [field] [trunc] │
+│  Dimensions (🔵) │  Y Axis  [field] [agg]   │
+│  - created       │  Color   [field]         │
+│  - status        │                          │
+│  Measures (🟢)   │  Filters [+ Add Filter]  │
+│  - count         │  Sort    [field] [dir]   │
+│  - total         │                          │
+│                  │  ┌────────────────────┐  │
+│                  │  │  Live Preview      │  │
+│                  │  │  [ChartWidget]     │  │
+│                  │  └────────────────────┘  │
+├──────────────────┴──────────────────────────┤
+│  Widgets  [+ Add Widget]                    │
+│  [Widget 1 title]  [edit] [↑] [↓] [delete] │
+│  [Widget 2 title]  [edit] [↑] [↓] [delete] │
+└─────────────────────────────────────────────┘
+```
+
+- Live preview queries `POST /dashboards/query` on config change (debounced 500ms)
+- "Add Widget" appends current config as a new widget
+- Widget list shows mini-title + chart type icon; click to edit that widget's config
+- Save POSTs or PATCHes the full dashboard and navigates to `DashboardViewer`
+
+#### `DashboardList`
+Lists all dashboards as cards. Props: `api: Api`, `baseUrl: string`.
+- Card: title, description (truncated), widget count, last updated
+- "Create New" button → `DashboardBuilder`
+- Registered as a `customScreen` (`{ name: "dashboards", displayName: "Dashboards" }`) in `AdminApp.register()` so it appears in the admin panel nav automatically
+
+### Navigation Flow
+
+```
+Admin Nav → "Dashboards" (customScreen)
+  → DashboardList
+      → [Create New] → DashboardBuilder (create)
+          → [Save] → DashboardViewer
+      → [click card] → DashboardViewer
+          → [Edit] → DashboardBuilder (edit)
+              → [Save] → DashboardViewer
+```
+
+### GPT Chat Integration (admin-only)
+
+The frontend GPT chat component checks for `toolResult.chartConfig` in `toolResult` SSE events. If present:
+- Calls `POST /dashboards/query` with the `chartConfig` immediately
+- Renders inline `ChartWidget` below the tool result message
+- `createDashboard` tool result shows a "View Dashboard →" link
+
+No structural changes to the GPT route — new tools are registered via the existing `tools` option in `addGptRoutes`.
+
+---
+
+## Phases
+
+### Phase 1 — Backend Core
+**Goal:** Full backend infrastructure — model, types, Zod schema, query engine, plugin.
+- `Dashboard` Mongoose model + TypeScript types
+- `ChartConfig` + `DataSourceConfig` TypeScript interfaces
+- Zod schema for `ChartConfig` (strict validation)
+- `DashboardApp` plugin with data source registry + MongoDB version detection
+- `addDashboardRoutes()` — modelRouter CRUD + `/query` + `/sources` custom endpoints
+- Query execution engine: pipeline builder, auto-bucketing, `$setWindowFields` gating
+- Export everything from `ai/src/index.ts`
+- Unit tests for pipeline builder (filter generation, date trunc, aggregations, window fields)
+
+### Phase 2 — Frontend Components
+**Goal:** ChartWidget, DashboardViewer, DashboardList wired to live data.
+- Add `recharts` dependency to `@terreno/admin-frontend`
+- `ChartWidget` component (all 14 chart types, loading/error states)
+- `DashboardViewer` screen (parallel widget queries, RTK cache)
+- `DashboardList` screen (register as `customScreen` in `AdminApp`)
+- RTK Query hooks for dashboard CRUD + `/query` endpoint
+- Update `AdminConfigResponse` to include `dataSources`
+
+### Phase 3 — Dashboard Builder
+**Goal:** Full create/edit experience.
+- `DashboardBuilder` component
+- Data source picker + field list (dimensions 🔵 / measures 🟢)
+- Chart type selector + axis/filter/sort configuration form
+- Live preview with debounced query
+- Widget add/reorder/delete
+- Save flow (create vs. edit)
+
+### Phase 4 — AI Tools
+**Goal:** GPT can generate inline charts and create persistent dashboards.
+- `generateChartTool` (inline, not persisted)
+- `createDashboardTool` (persists, uses `createRequestTools` pattern for admin userId)
+- Export `addDashboardGptTools(options)` for consuming apps
+- Frontend: detect `chartConfig` in GPT tool results → render inline `ChartWidget`
+- Frontend: render "View Dashboard →" link for `createDashboard` tool result
+- Tests for Zod schema enforcement on AI tool inputs
+
+---
+
+## Feature Flags & Migrations
+
+No feature flag needed — dashboards only appear in the admin panel and only after `DashboardApp` is registered by the consuming app. Apps that don't register it get no dashboards.
+
+No data migrations required (new model, no existing data to transform).
+
+`ChartConfig` stored as `Mixed` — add a `version: 1` field to all configs from day one to make future schema migrations traceable.
+
+---
+
+## Activity Log & User Updates
+
+None for v1.
+
+---
+
+## Not Included / Future Work
+
+- Drag-and-drop grid layout (Grafana-style) — linear list only for v1
+- Chart sharing / public URLs
+- Dashboard export (PDF / PNG)
+- Non-admin user dashboards
+- Scheduled refresh / snapshot history
+- User-defined calculated fields (formulas over existing fields)
+- Table calculations beyond `runningTotal` and `rank`
+- Cross-database joins (MongoDB aggregation pipeline only)
+- Chart annotations / reference lines
+- Dashboard-level filters (apply to all widgets at once)
+
+---
+
+## Acceptance Criteria
+
+*Run `/ip:acceptance` to generate detailed acceptance criteria.*
+
+---
+
+## Task List (Bot Consumption)
+
+*Structured task breakdown for automated implementation. Each task is independently implementable and testable.*
+
+### Phase 1: Backend Core
+
+- [ ] **Task 1.1**: ChartConfig types and Zod schema
+  - Description: Create `ai/src/types/chartTypes.ts` with all TypeScript interfaces (`ChartConfig`, `AxisConfig`, `FilterConfig`, `DataSourceConfig`, `ChartType`, `Aggregation`, `DateTrunc`). Create `ai/src/schemas/chartSchemas.ts` with strict Zod schema matching the TypeScript types. Export from `ai/src/types/index.ts`.
+  - Files: `ai/src/types/chartTypes.ts` (new), `ai/src/schemas/chartSchemas.ts` (new), `ai/src/types/index.ts` (modify)
+  - Depends on: none
+  - Acceptance: Zod schema rejects invalid ChartConfig (missing required fields, unknown chart type, invalid aggregation). TypeScript types compile without errors.
+
+- [ ] **Task 1.2**: Dashboard Mongoose model
+  - Description: Create `ai/src/models/dashboard.ts` with `DashboardDocument`, `DashboardModel` interfaces, and the Mongoose schema. Apply `createdUpdatedPlugin`, `isDeletedPlugin`, `findExactlyOne`, `findOneOrNone`. Add `ownerId` virtual. Export from `ai/src/models/index.ts`.
+  - Files: `ai/src/models/dashboard.ts` (new), `ai/src/models/index.ts` (modify), `ai/src/types/index.ts` (modify)
+  - Depends on: 1.1
+  - Acceptance: Model creates, reads, updates, soft-deletes. `ownerId` virtual returns `userId`. Schema enforces required fields.
+
+- [ ] **Task 1.3**: Query execution engine
+  - Description: Create `ai/src/service/dashboardQueryEngine.ts`. Implements `buildAggregationPipeline(chartConfig, source, options)` that produces a MongoDB `PipelineStage[]`. Handles: filter → dateTrunc addFields → group → setWindowFields (gated on MongoDB 5+) → sort → limit. Implements auto-bucketing for date dimensions that would exceed `limit`. Handles all `Aggregation` types including `countDistinct` (via `$addToSet` + `$size`).
+  - Files: `ai/src/service/dashboardQueryEngine.ts` (new)
+  - Depends on: 1.1
+  - Acceptance: Unit tests cover: filter generation for all filter types, date trunc for all DateTrunc values, all aggregation types, auto-bucketing triggers when date range / limit exceeded, window fields produce correct pipeline when `supportsWindowFields: true` and throw 400 when `false`.
+
+- [ ] **Task 1.4**: DashboardApp plugin
+  - Description: Create `ai/src/dashboardApp.ts` implementing `TerrenoPlugin`. Constructor accepts `DashboardOptions` with `dataSources: DataSourceConfig[]`. Detects MongoDB version via `mongoose.connection.db.admin().serverInfo()` at `register()` time; stores `supportsWindowFields` flag. Calls `addDashboardRoutes(app, { dataSources, supportsWindowFields })`.
+  - Files: `ai/src/dashboardApp.ts` (new), `ai/src/index.ts` (modify to export `DashboardApp`)
+  - Depends on: 1.2, 1.3
+  - Acceptance: `new DashboardApp({dataSources}).register(app)` mounts all routes. MongoDB version detection sets `supportsWindowFields` correctly.
+
+- [ ] **Task 1.5**: Dashboard CRUD routes
+  - Description: Create `ai/src/routes/dashboards.ts`. `addDashboardRoutes()` mounts modelRouter for `Dashboard` at `/dashboards` with `IsAdmin` permissions. Custom endpoint `POST /dashboards/query`: validates body with Zod ChartConfigSchema, resolves data source from registry, calls query engine, executes aggregation, returns `{data, meta}`. Custom endpoint `GET /dashboards/sources`: returns registered source names + field metadata.
+  - Files: `ai/src/routes/dashboards.ts` (new), `ai/src/routes/index.ts` (modify)
+  - Depends on: 1.3, 1.4
+  - Acceptance: CRUD endpoints return correct responses. `POST /dashboards/query` with valid config returns `{data, meta}`. Unknown data source returns 400. Invalid ChartConfig (Zod) returns 400 with field errors. Non-admin gets 403.
+
+- [ ] **Task 1.6**: Pipeline builder unit tests
+  - Description: Write `ai/src/service/dashboardQueryEngine.test.ts` with comprehensive tests for the pipeline builder. Cover all filter types, all aggregations, date trunc values, auto-bucketing, window fields gating, countDistinct implementation.
+  - Files: `ai/src/service/dashboardQueryEngine.test.ts` (new)
+  - Depends on: 1.3
+  - Acceptance: `bun run ai:test` passes. All pipeline builder branches covered.
+
+---
+
+### Phase 2: Frontend Components
+
+- [ ] **Task 2.1**: Add recharts + RTK hooks
+  - Description: Add `recharts` to `admin-frontend/package.json`. Create `admin-frontend/src/useDashboardApi.ts` with RTK Query hooks: `useListDashboardsQuery`, `useGetDashboardQuery`, `useCreateDashboardMutation`, `useUpdateDashboardMutation`, `useDeleteDashboardMutation`, `useQueryChartMutation`, `useGetSourcesQuery`. Pattern matches existing `useAdminApi.ts`.
+  - Files: `admin-frontend/package.json` (modify), `admin-frontend/src/useDashboardApi.ts` (new)
+  - Depends on: 1.5
+  - Acceptance: `recharts` importable. All hooks call correct endpoints with correct args.
+
+- [ ] **Task 2.2**: ChartWidget component
+  - Description: Create `admin-frontend/src/ChartWidget.tsx`. Props: `chartConfig: ChartConfig`, `data: ChartDataPoint[]`, `isLoading?: boolean`, `error?: string`. Switch on `chartConfig.type` to render correct Recharts component. All 14 chart types supported. Wrapped in `React.memo`. Renders `Spinner` when loading, error text when errored, "No data" state when empty. Uses Terreno theme colors from `useTheme()`.
+  - Files: `admin-frontend/src/ChartWidget.tsx` (new), `admin-frontend/src/index.tsx` (modify to export)
+  - Depends on: 2.1
+  - Acceptance: All 14 chart types render without TypeScript errors. Loading/error/empty states visible. Memoized (doesn't re-render on unrelated parent changes).
+
+- [ ] **Task 2.3**: DashboardList screen
+  - Description: Create `admin-frontend/src/DashboardList.tsx`. Fetches all dashboards with `useListDashboardsQuery`. Renders as cards (title, description, widget count, last updated). "Create New" button. "View" button per card. Registers as `customScreen` by modifying `AdminApp.register()` to append `{name: "dashboards", displayName: "Dashboards"}` to the `customScreens` array in the config response.
+  - Files: `admin-frontend/src/DashboardList.tsx` (new), `admin-frontend/src/index.tsx` (modify), `admin-backend/src/adminApp.ts` (modify to include dashboards customScreen when DashboardApp present — or always include it)
+  - Depends on: 2.1
+  - Acceptance: Dashboard list renders. "Create New" navigates to builder route. Empty state shows when no dashboards. Custom screen "Dashboards" appears in admin nav.
+
+- [ ] **Task 2.4**: DashboardViewer screen
+  - Description: Create `admin-frontend/src/DashboardViewer.tsx`. Props: `dashboardId: string`, `api`. Fetches dashboard via `useGetDashboardQuery`. For each widget, fires `useQueryChartMutation` in parallel (via `useEffect` per widget). Renders widgets as vertical list of `ChartWidget`s inside `Card`s. Per-widget loading/error. "Edit Dashboard" button. "Delete" button with confirmation.
+  - Files: `admin-frontend/src/DashboardViewer.tsx` (new), `admin-frontend/src/index.tsx` (modify)
+  - Depends on: 2.2, 2.3
+  - Acceptance: Dashboard loads. Each widget queries independently (parallel network requests visible). Slow query shows spinner for that widget only. Edit button visible. Delete with confirmation works.
+
+---
+
+### Phase 3: Dashboard Builder
+
+- [ ] **Task 3.1**: Field picker and source selector sub-components
+  - Description: Create `admin-frontend/src/builder/DataSourcePicker.tsx` (dropdown of available sources from `useGetSourcesQuery`) and `admin-frontend/src/builder/FieldList.tsx` (renders dimension fields in blue-ish style, measure fields in green-ish, per Tableau convention). Used by `DashboardBuilder`.
+  - Files: `admin-frontend/src/builder/DataSourcePicker.tsx` (new), `admin-frontend/src/builder/FieldList.tsx` (new)
+  - Depends on: 2.1
+  - Acceptance: Source picker shows all registered sources. Field list shows fields categorized by role with correct visual styling.
+
+- [ ] **Task 3.2**: Chart config form sub-components
+  - Description: Create `admin-frontend/src/builder/ChartTypeSelector.tsx` (grid of chart type icons), `admin-frontend/src/builder/AxisConfigForm.tsx` (field + aggregation + dateTrunc pickers), `admin-frontend/src/builder/FilterBuilder.tsx` (add/remove filters with field/op/value pickers), `admin-frontend/src/builder/SortConfig.tsx`.
+  - Files: `admin-frontend/src/builder/ChartTypeSelector.tsx` (new), `admin-frontend/src/builder/AxisConfigForm.tsx` (new), `admin-frontend/src/builder/FilterBuilder.tsx` (new), `admin-frontend/src/builder/SortConfig.tsx` (new)
+  - Depends on: 3.1
+  - Acceptance: Each sub-form renders correctly. Aggregation picker shows/hides `runningTotal`/`rank` based on whether `supportsWindowFields` is true (from sources metadata). DateTrunc picker only appears for date-type fields.
+
+- [ ] **Task 3.3**: DashboardBuilder main component
+  - Description: Create `admin-frontend/src/DashboardBuilder.tsx`. Props: `dashboardId?: string` (edit mode), `api`. Fetches existing dashboard if editing. Manages state: `title`, `description`, `widgets[]`, `activeWidgetIndex`. Renders left panel (DataSourcePicker + FieldList) and right panel (ChartTypeSelector + AxisConfigForm + FilterBuilder + SortConfig + live preview ChartWidget). Live preview calls `useQueryChartMutation` debounced 500ms on config change. Widget list at bottom: add/reorder (up/down)/delete. Save calls create or update mutation, navigates to viewer on success.
+  - Files: `admin-frontend/src/DashboardBuilder.tsx` (new), `admin-frontend/src/index.tsx` (modify)
+  - Depends on: 3.1, 3.2, 2.4
+  - Acceptance: Can create a dashboard end-to-end (pick source → configure chart → add widget → save → view). Live preview updates on field change (debounced). Edit mode pre-populates all fields. Reorder/delete widgets works.
+
+---
+
+### Phase 4: AI Tools
+
+- [ ] **Task 4.1**: generateChart and createDashboard tools
+  - Description: Create `ai/src/service/dashboardTools.ts`. Exports `createGenerateChartTool(options)` and `createDashboardTool(options)` where options includes the data source registry and a `getUserId` function. Both use Zod ChartConfigSchema for strict parameter validation. `generateChart` executes the query and returns `{chartConfig, data}` so the frontend can render immediately. `createDashboard` creates a `Dashboard` document and returns `{dashboardId, title, widgetCount}`.
+  - Files: `ai/src/service/dashboardTools.ts` (new)
+  - Depends on: 1.3, 1.4
+  - Acceptance: `createGenerateChartTool` returns a Vercel AI SDK `Tool` object with correct Zod schema. Invalid ChartConfig input is rejected by Zod before execute runs. `createDashboardTool` creates a Dashboard document in the DB.
+
+- [ ] **Task 4.2**: Export addDashboardGptTools
+  - Description: Create `ai/src/routes/gptDashboardTools.ts` exporting `addDashboardGptTools(options)` that returns `Record<string, Tool>` containing both tools. Consuming apps pass this to `addGptRoutes` via `createRequestTools`. Export from `ai/src/index.ts`.
+  - Files: `ai/src/routes/gptDashboardTools.ts` (new), `ai/src/index.ts` (modify)
+  - Depends on: 4.1
+  - Acceptance: Tools integrate with existing `addGptRoutes` via `tools` option. Tool calls appear in SSE stream as `{toolCall}` / `{toolResult}` events.
+
+- [ ] **Task 4.3**: Frontend: render charts from GPT tool results
+  - Description: In the consuming app's GPT chat component (or in a new `DashboardToolResult` component exported from `@terreno/admin-frontend`), detect `toolResult.result.chartConfig` and render inline `ChartWidget` with `toolResult.result.data`. For `createDashboard` results, render a "View Dashboard →" link using `toolResult.result.dashboardId`.
+  - Files: `admin-frontend/src/DashboardToolResult.tsx` (new), `admin-frontend/src/index.tsx` (modify)
+  - Depends on: 4.2, 2.2
+  - Acceptance: GPT chat renders inline chart when AI calls `generateChart`. "View Dashboard" link appears when AI calls `createDashboard`. Non-chart tool results are unaffected.
+
+- [ ] **Task 4.4**: AI tool tests
+  - Description: Write `ai/src/service/dashboardTools.test.ts`. Test that Zod schema validation rejects invalid configs. Test that `generateChart` calls the query engine. Test that `createDashboard` creates a database record.
+  - Files: `ai/src/service/dashboardTools.test.ts` (new)
+  - Depends on: 4.1
+  - Acceptance: `bun run ai:test` passes. Invalid input test cases reject before execute. DB record created for `createDashboard` success case.

--- a/docs/tasks/terreno-graphing.md
+++ b/docs/tasks/terreno-graphing.md
@@ -1,0 +1,121 @@
+# Tasks: Admin Dashboards & Graphing
+
+*Source: docs/implementationPlans/terreno-graphing.md*
+
+---
+
+### Phase 1: Backend Core
+
+- [x] **Task 1.1**: ChartConfig types and Zod schema
+  - Description: Create `admin-backend/src/dashboard/chartTypes.ts` with all TypeScript interfaces (`ChartConfig`, `AxisConfig`, `FilterConfig`, `DataSourceConfig`, `ChartType`, `Aggregation`, `DateTrunc`). Create Zod schema with `chartConfigSchema`. Export from `admin-backend/src/index.ts`.
+  - Files: `admin-backend/src/dashboard/chartTypes.ts` (new), `admin-backend/src/index.ts` (modify)
+  - Depends on: none
+  - Acceptance: Zod schema rejects invalid ChartConfig. TypeScript compiles without errors.
+
+- [x] **Task 1.2**: Dashboard Mongoose model
+  - Description: Create `admin-backend/src/dashboard/dashboard.ts` with document/model interfaces and Mongoose schema. Apply `createdUpdatedPlugin`, `isDeletedPlugin`, `findExactlyOne`, `findOneOrNone`. Pre-save hook generates widgetIds via `randomUUID()`.
+  - Files: `admin-backend/src/dashboard/dashboard.ts` (new), `admin-backend/src/index.ts` (modify)
+  - Depends on: 1.1
+  - Acceptance: Model CRUD works. Schema enforces required fields.
+
+- [x] **Task 1.3**: Query execution engine
+  - Description: Create `admin-backend/src/dashboard/dashboardQueryEngine.ts`. Builds MongoDB `PipelineStage[]` from `ChartConfig`. Handles filter → dateTrunc addFields → group → setWindowFields (gated on MongoDB 5+) → sort → limit. Auto-bucketing for date dimensions. All aggregation types including `countDistinct`. `allowDiskUse: true, maxTimeMS: 30000`.
+  - Files: `admin-backend/src/dashboard/dashboardQueryEngine.ts` (new)
+  - Depends on: 1.1
+  - Acceptance: Unit tests pass for all filter types, aggregations, date trunc, auto-bucketing, and window field gating.
+
+- [x] **Task 1.4**: DashboardApp plugin
+  - Description: Create `admin-backend/src/dashboard/dashboardApp.ts` implementing `TerrenoPlugin`. Accepts `dataSources: DataSourceConfig[]`. Detects MongoDB version at `register()` time via try/catch. Calls `addDashboardRoutes()`.
+  - Files: `admin-backend/src/dashboard/dashboardApp.ts` (new), `admin-backend/src/index.ts` (modify)
+  - Depends on: 1.2, 1.3
+  - Acceptance: Plugin mounts all routes. MongoDB version detection sets `supportsWindowFields` flag correctly.
+
+- [x] **Task 1.5**: Dashboard CRUD + query routes
+  - Description: Create `admin-backend/src/dashboard/dashboardRoutes.ts`. All 7 routes: GET/POST/GET:id/PATCH:id/DELETE:id/POST query/GET sources. All require `IsAdmin`. ChartConfig validated at save time.
+  - Files: `admin-backend/src/dashboard/dashboardRoutes.ts` (new), `admin-backend/src/index.ts` (modify)
+  - Depends on: 1.3, 1.4
+  - Acceptance: CRUD returns correct responses. `/query` with valid config returns `{data, meta}`. Unknown source → 400. Invalid ChartConfig → 400 with Zod errors. Non-admin → 403.
+
+- [x] **Task 1.6**: Pipeline builder unit tests
+  - Description: Write `admin-backend/src/dashboard/dashboardQueryEngine.test.ts`. Cover all filter types, all aggregations, all date trunc values, auto-bucketing, window field gating, countDistinct implementation.
+  - Files: `admin-backend/src/dashboard/dashboardQueryEngine.test.ts` (new)
+  - Depends on: 1.3
+  - Acceptance: `bun run admin-backend:test` passes (29 tests). All branches covered.
+
+---
+
+### Phase 2: Frontend Components
+
+- [x] **Task 2.1**: Add recharts + RTK hooks
+  - Description: Add `recharts` to `admin-frontend/package.json`. Create `admin-frontend/src/useDashboardApi.ts` with all RTK Query hooks for dashboard CRUD, `/query` (as `build.query` for 60s caching), and `/sources`.
+  - Files: `admin-frontend/package.json` (modify), `admin-frontend/src/useDashboardApi.ts` (new)
+  - Depends on: 1.5
+  - Acceptance: `recharts` importable. All hooks call correct endpoints.
+
+- [x] **Task 2.2**: ChartWidget component
+  - Description: Create `admin-frontend/src/ChartWidget.tsx`. All 14 chart types via Recharts. Loading/error/empty states. `React.memo`. Theme colors from `useTheme()`.
+  - Files: `admin-frontend/src/ChartWidget.tsx` (new), `admin-frontend/src/index.tsx` (modify)
+  - Depends on: 2.1
+  - Acceptance: All 14 chart types render. States visible. Memoized correctly.
+
+- [x] **Task 2.3**: DashboardList screen
+  - Description: Create `admin-frontend/src/DashboardList.tsx`. Cards with title/description/widget count/updated. "Create New" button. Register as `customScreen` in `AdminApp` config response.
+  - Files: `admin-frontend/src/DashboardList.tsx` (new), `admin-frontend/src/index.tsx` (modify), `admin-backend/src/adminApp.ts` (modify)
+  - Depends on: 2.1
+  - Acceptance: List renders. Empty state. "Dashboards" appears in admin nav.
+
+- [x] **Task 2.4**: DashboardViewer screen
+  - Description: Create `admin-frontend/src/DashboardViewer.tsx`. Parallel widget queries (one RTK call per widget). Per-widget loading/error. "Edit" and "Delete" buttons with confirmation modal.
+  - Files: `admin-frontend/src/DashboardViewer.tsx` (new), `admin-frontend/src/index.tsx` (modify)
+  - Depends on: 2.2, 2.3
+  - Acceptance: Widgets load in parallel. Slow query only blocks that widget. Edit/delete work.
+
+---
+
+### Phase 3: Dashboard Builder
+
+- [x] **Task 3.1**: Field picker and source selector
+  - Description: Create `admin-frontend/src/builder/DataSourcePicker.tsx` and `admin-frontend/src/builder/FieldList.tsx`. Dimensions in blue-tinted style, measures in green-tinted style (Tableau convention).
+  - Files: `admin-frontend/src/builder/DataSourcePicker.tsx` (new), `admin-frontend/src/builder/FieldList.tsx` (new)
+  - Depends on: 2.1
+  - Acceptance: Source picker lists all registered sources. Fields categorized by role with correct styling.
+
+- [x] **Task 3.2**: Chart config form sub-components
+  - Description: Create `ChartTypeSelector`, `AxisConfigForm`, `FilterBuilder`, `SortConfig` in `admin-frontend/src/builder/`. DateTrunc only for date fields. `runningTotal`/`rank` only when `supportsWindowFields` is true.
+  - Files: `admin-frontend/src/builder/ChartTypeSelector.tsx` (new), `admin-frontend/src/builder/AxisConfigForm.tsx` (new), `admin-frontend/src/builder/FilterBuilder.tsx` (new), `admin-frontend/src/builder/SortConfig.tsx` (new)
+  - Depends on: 3.1
+  - Acceptance: Each sub-form renders. Conditional fields show/hide correctly.
+
+- [x] **Task 3.3**: DashboardBuilder main component
+  - Description: Create `admin-frontend/src/DashboardBuilder.tsx`. Full create/edit flow. Live preview with `isPreviewEnabled` gate. Widget list (add/reorder/delete). Save → navigate to viewer.
+  - Files: `admin-frontend/src/DashboardBuilder.tsx` (new), `admin-frontend/src/index.tsx` (modify)
+  - Depends on: 3.1, 3.2, 2.4
+  - Acceptance: Full create flow works end-to-end. Live preview updates. Edit mode pre-populates. Reorder/delete work.
+
+---
+
+### Phase 4: AI Tools
+
+- [x] **Task 4.1**: generateChart and createDashboard tools
+  - Description: Create `admin-backend/src/dashboard/dashboardTools.ts`. Exports `createGenerateChartTool(options)` and `createDashboardTool(options)`. Strict Zod validation. `generateChart` runs query and returns `{chartConfig, data, meta}`. `createDashboard` saves Dashboard to DB and returns `{dashboardId, title, widgetCount}`.
+  - Files: `admin-backend/src/dashboard/dashboardTools.ts` (new)
+  - Depends on: 1.3, 1.4
+  - Acceptance: Both return valid Vercel AI SDK `Tool` objects. Invalid input rejected by Zod. `createDashboard` writes to DB.
+
+- [x] **Task 4.2**: Export createDashboardGptTools
+  - Description: Export `createDashboardGptTools(options)` from `admin-backend/src/dashboard/index.ts` and `admin-backend/src/index.ts`. Returns `Record<string, Tool>` for use with `addGptRoutes`.
+  - Files: `admin-backend/src/dashboard/index.ts` (new), `admin-backend/src/index.ts` (modify)
+  - Depends on: 4.1
+  - Acceptance: Tools integrate with `addGptRoutes` via `tools` option.
+
+- [x] **Task 4.3**: Frontend: render charts from GPT tool results
+  - Description: Create `admin-frontend/src/DashboardToolResult.tsx`. Detects `toolResult.result.chartConfig` → renders inline `ChartWidget` with `toolResult.result.data`. Detects `toolResult.result.dashboardId` → renders "View Dashboard →" link.
+  - Files: `admin-frontend/src/DashboardToolResult.tsx` (new), `admin-frontend/src/index.tsx` (modify)
+  - Depends on: 4.2, 2.2
+  - Acceptance: Inline chart renders from GPT tool result. "View Dashboard" link appears for createDashboard result.
+
+- [ ] **Task 4.4**: AI tool tests
+  - Description: Write `admin-backend/src/dashboard/dashboardTools.test.ts`. Zod rejection tests. `generateChart` calls query engine. `createDashboard` creates DB record.
+  - Files: `admin-backend/src/dashboard/dashboardTools.test.ts` (new)
+  - Depends on: 4.1
+  - Acceptance: `bun run admin-backend:test` passes. Invalid input rejection and DB write both covered.

--- a/research.md
+++ b/research.md
@@ -1,176 +1,280 @@
-# Research: Consent Forms System for Terreno
+# Research: Graphing & Dashboard Capabilities for GPT and Admin Tools
 
 ## Summary
-Terreno has all the building blocks to support a consent forms system: `modelRouter` for CRUD APIs, `AdminApp` for admin UI, `MarkdownView`/`SignatureField`/`CheckBox` in ui, and RTK Query for client hooks. The main work is defining the models (ConsentForm + ConsentResponse), creating a `ConsentApp` plugin for api, adding admin support, and building a `ConsentNavigator` component in ui that client apps import. The Flourish implementation provides a proven UX pattern to follow.
+
+Tableau's conceptual model maps cleanly onto MongoDB: Dimensions → `$group._id` fields, Measures → aggregation expressions, LOD expressions → `$lookup` sub-pipelines, Calculated fields → `$addFields`, and Date hierarchies → `$dateTrunc`. The key insight from Tableau is that **data source** is a first-class concept separate from the chart — supporting "enriched models" (pre-defined aggregation pipelines that join multiple models and add computed fields) is the right way to handle higher-order data, following Tableau's Custom SQL / Relationships pattern. Recharts is the charting library (web-only per PRD). Dashboards are admin-only.
+
+## Context
+
+- **Problem:** Admins can't visualize data from the admin panel or GPT chat — everything is raw tables.
+- **Why:** Dashboards + inline charts dramatically increase the value of AI-assisted data exploration.
+- **Current state:** No charting anywhere. `react-native-svg` 15.12.1 is in the catalog. AI tool system handles structured SSE responses. Admin panel exposes full typed model metadata via `GET /admin/config`.
 
 ## Decisions Made
 
-1. **Option A** — Full plugin across api+ui+rtk (not a separate package)
-2. **Server-side form-to-user mapping** — Backend filters forms before sending to client
-3. **Explicit versioning** — "Publish new version" action, not auto-version on edit
-4. **No default forms** — Admin editor will have an AI-generate button using Terreno AI tooling
-5. **Markdown editor** — New UI component (may be broken off into its own task first)
-
-## Context
-- **Problem:** Apps need consent workflows (legal agreements, HIPAA, privacy policies) but there's no reusable system in Terreno.
-- **Current state:** Flourish has a working but hardcoded consent system — forms defined in constants, types enumerated, completion tracked on the User model. It works but isn't portable.
-- **Goal:** A first-class, configurable consent system spanning all Terreno packages.
+1. **Admin-only dashboards** — only admins can create and view dashboards; only in the admin screen.
+2. **EnrichedSource is admin-only** — only pre-registered pipelines (no user-defined raw pipelines).
+3. **Linear widget layout** — list of charts stacked vertically; no drag-and-drop grid for v1.
+4. **Running totals supported** — use MongoDB 5+ `$setWindowFields`; detect version and offer conditionally.
+5. **Strict Zod schema for AI tools** — AI must produce valid `ChartConfig` or explain failure; no loose fallbacks.
+6. **No per-user chart access** — only admins chart data.
 
 ## Findings
 
-### Finding 1 — API Patterns (modelRouter + TerrenoPlugin)
+### 1. GPT Chat Streaming System
 
-**modelRouter** (`api/src/api.ts:423-453`) generates full CRUD endpoints for any Mongoose model with permissions, hooks, validation, pagination, sorting, and OpenAPI spec generation.
+`POST /gpt/prompt` in `ai/src/routes/gpt.ts:82` streams SSE events: `{text}`, `{toolCall}`, `{toolResult}`, `{image}`, `{file}`, `{done}`. A new `{chart: ChartConfig}` SSE event type follows the exact same pattern as `{image}`. The `tools` option in `addGptRoutes` means adding a `generateChart` or `createDashboard` AI tool requires zero changes to the core route handler.
 
-**TerrenoPlugin** (`api/src/terrenoPlugin.ts`) is the extension point — `AdminApp`, `HealthApp`, and `BetterAuthApp` all implement it. A plugin gets `register(app)` and can mount arbitrary Express routes.
+### 2. Admin Backend
 
-**Registration pattern** (example-backend):
+`AdminApp` in `admin-backend/src/adminApp.ts:164` accepts `models: AdminModelConfig[]` and has full field metadata from `getOpenApiSpecForModel`. The `customScreens` array in `AdminConfigResponse` is the hook for adding a "Dashboards" screen to the admin panel. The dashboard query engine can receive the same `models` array.
+
+### 3. No Existing Charting
+
+No charting libraries anywhere. `react-native-svg` 15.12.1 is in the catalog, but since PRD says web-only, Recharts is the right choice — no RN-SVG dependency needed, simpler API, more powerful for web.
+
+### 4. MongoDB → Tableau Feature Mapping
+
+| Tableau Concept | MongoDB Equivalent |
+|---|---|
+| Dimension (GROUP BY) | `$group: {_id: "$field"}` |
+| Date hierarchy (truncate to month) | `$dateTrunc: {date: "$created", unit: "month"}` |
+| Measure: SUM/AVG/MIN/MAX | `$group: {total: {$sum: "$amount"}}` |
+| Measure: COUNT | `$group: {count: {$sum: 1}}` |
+| Measure: COUNT DISTINCT | `$addToSet` + `$size` |
+| Calculated field (row-level) | `$addFields: {margin: {$divide: ["$profit", "$sales"]}}` |
+| Filter (dimension) | `$match: {status: "active"}` |
+| Filter (measure / HAVING) | `$match` after `$group` |
+| Top N | `$sort` + `$limit` after `$group` |
+| LOD FIXED (per-entity total) | `$lookup` with sub-pipeline aggregation |
+| Table calc: Running total | `$setWindowFields` with `$sum` (MongoDB 5+) |
+| Table calc: Rank | `$setWindowFields` with `$rank` (MongoDB 5+) |
+| Percent of total | Two-pass: main agg + facet for total, then `$divide` |
+| Calculated field | `$addFields` expression |
+| Custom SQL / enriched source | Pre-defined `PipelineStage[]` registered by consuming app |
+| Data blending / JOIN | `$lookup` stages |
+
+### 5. Dimensions vs. Measures
+
+Tableau's core conceptual split, applied here:
+
+- **Dimensions** = fields you GROUP BY (categorical strings, booleans, date-truncated timestamps). Go on X axis, Color channel, or filters. Every field in a data source declares its role.
+- **Measures** = numeric fields you aggregate (SUM, AVG, COUNT, etc.). Go on the Y axis or Size channel.
+- **Date fields** are special dimensions — they can be bucketed at different granularities (year, month, day, hour).
+
+### 6. The "Enriched Model" Concept (Higher-Order Data Sources)
+
+An **EnrichedSource** is a pre-defined MongoDB aggregation pipeline registered by the consuming app. It is the equivalent of Tableau's Custom SQL or Relationships — it can join multiple models, add computed fields, and produce a declared output schema that the dashboard builder treats identically to a simple model.
+
+**Example — "Users with Conversation Counts":**
 ```typescript
-const terraApp = new TerrenoApp({userModel: User, ...})
-  .register(todoRouter)            // modelRouter
-  .register(new AdminApp({...}))   // plugin
-  .start();
+{
+  type: "enriched",
+  name: "UsersWithActivity",
+  displayName: "Users (with Activity)",
+  baseModel: "User",
+  pipeline: [
+    {$lookup: {
+      from: "gpthistories",
+      localField: "_id",
+      foreignField: "userId",
+      as: "histories"
+    }},
+    {$addFields: {
+      conversationCount: {$size: "$histories"},
+      lastActiveAt: {$max: "$histories.updated"},
+    }},
+    {$project: {histories: 0}},
+  ],
+  outputFields: {
+    email: {type: "string", description: "User email", role: "dimension"},
+    created: {type: "date", description: "Account created date", role: "dimension"},
+    conversationCount: {type: "number", description: "Total conversations", role: "measure"},
+    lastActiveAt: {type: "date", description: "Last activity date", role: "dimension"},
+  }
+}
 ```
 
-**Key hooks available on modelRouter:** `preCreate`, `postCreate`, `preUpdate`, `postUpdate`, `preDelete`, `postDelete`, `queryFilter`, `responseHandler`.
+### 7. Chart Types Supported (v1)
 
-### Finding 2 — Admin Backend + Frontend
+| Chart Type | X (dimension) | Y (measure) | Color (optional) | Notes |
+|---|---|---|---|---|
+| `bar` | Categorical / date | 1 measure | — | Vertical bars |
+| `bar-horizontal` | 1 measure | Categorical | — | Horizontal bars |
+| `bar-stacked` | Categorical / date | 1 measure | Dimension | Stacked segments |
+| `bar-grouped` | Categorical / date | 1 measure | Dimension | Side-by-side |
+| `line` | Date / ordered | 1+ measures | — | Time series |
+| `line-multi` | Date / ordered | 1 measure | Dimension | Multi-series lines |
+| `area` | Date / ordered | 1+ measures | — | Filled area |
+| `area-stacked` | Date / ordered | 1 measure | Dimension | Stacked area |
+| `pie` | — | 1 measure | Dimension | Part-to-whole |
+| `donut` | — | 1 measure | Dimension | Pie with hole |
+| `scatter` | 1 measure | 1 measure | Dimension (opt) | Correlation |
+| `bubble` | 1 measure | 1 measure | Dimension (opt) | Scatter + size encoding |
+| `heatmap` | Dimension | Dimension | Measure | Cross-tab with color |
+| `combo` | Date | 2 measures | — | Bar + line dual axis |
 
-**AdminApp** (`admin-backend/src/adminApp.ts:121-206`) takes a `models` array and auto-generates:
-- `GET /admin/config` — field metadata extracted from Mongoose schemas
-- CRUD routes per model via `modelRouter` with `Permissions.IsAdmin`
+### 8. The ChartConfig Data Model
 
-**Admin frontend** auto-generates list/table/form views from the config response:
-- `AdminModelList` — card grid of all models
-- `AdminModelTable` — DataTable with pagination, sorting, actions
-- `AdminModelForm` — auto-generated form from field metadata
-- `AdminFieldRenderer` — renders fields by type (string->TextField, boolean->BooleanField, enum->SelectField, etc.)
-
-**Gap:** No markdown editor field type exists. `AdminFieldRenderer` handles string/number/boolean/date/enum/objectid. For consent form markdown content, we need a new markdown editor component in UI.
-
-### Finding 3 — UI Components Available
-
-All needed UI primitives exist in `@terreno/ui`:
-
-| Component | Use in Consents |
-|-----------|----------------|
-| `Page` | Consent form screen container |
-| `MarkdownView` | Render consent form markdown content |
-| `SignatureField` | Capture signatures |
-| `CheckBox` | Optional toggles/checkboxes |
-| `Button` | Agree/Disagree actions |
-| `ScrollView` (via Page scroll) | Scroll-to-bottom tracking |
-| `Box` | Layout |
-| `Heading`/`Text` | Form title and instructions |
-
-No existing navigator pattern for multi-step flows. `ConsentNavigator` would be new.
-
-### Finding 4 — RTK Patterns for Client Hooks
-
-**emptySplitApi** (`rtk/src/emptyApi.ts`) is the base API with auth token management. Client apps run `bun run sdk` to generate typed hooks from the backend's `/openapi.json`.
-
-**generateTags** (`rtk/src/tagGenerator.ts`) auto-creates cache invalidation rules.
-
-For the consent system, we'd export a custom hook like `useConsentForms(api)` from `@terreno/ui` that:
-1. Fetches pending consent forms for the current user
-2. Returns forms, loading state, and a submit function
-3. Runs on every app launch
-
-### Finding 5 — Flourish System Architecture (Reference)
-
-**Models:** Consent stored as subdocuments on User (`consentFormAgreements[]` with consentFormId, type, isAgreed, agreedDate, signature, signedDate).
-
-**Form definition:** Interface with `consentFormId`, `title`, `text` (function returning markdown), `consentFormType`, `captureSignature`, `requireScrollToBottom`.
-
-**Types:** 8 types (patientAgreement, familyMemberAgreement, consent, transportation, research, privacy, hipaa, virginiaRights).
-
-**Navigation flow:** App layout checks `useConsentForms()` -> if pending forms exist, redirects to `/(consent)` screen -> user completes one at a time -> PATCH user with agreement -> when all done, redirect to main app.
-
-**Key patterns to keep:**
-- Versioned forms (consentFormId as version number)
-- Ordered display (show form A first, then B)
-- Per-form type configuration (signature, scroll-to-bottom, checkboxes)
-- Run-on-every-launch check
-
-**Key patterns to change:**
-- Forms in database (not hardcoded constants)
-- Separate ConsentForm and ConsentResponse models (not subdocuments on User)
-- Admin-editable markdown content
-- Hook-based server-side mapping (user data -> which forms to show)
-
-### Finding 6 — Proposed Data Model
-
-**ConsentForm** (admin-managed):
-- `title` (string, required)
-- `slug` (string, unique identifier for form lineage)
-- `content` (string/markdown, required)
-- `type` (enum: agreement, privacy, hipaa, research, custom)
-- `version` (number, explicit versioning)
-- `order` (number, display ordering)
-- `captureSignature` (boolean)
-- `requireScrollToBottom` (boolean)
-- `checkboxes` (array of {label, required})
-- `buttons` (object: {agreeText, disagreeText, showDisagree})
-- `active` (boolean)
-
-**ConsentResponse** (user completions):
-- `userId` (ObjectId, ref User)
-- `consentFormId` (ObjectId, ref ConsentForm)
-- `agreed` (boolean)
-- `agreedAt` (Date)
-- `signature` (string, base64)
-- `signedAt` (Date)
-- `checkboxValues` (Map of label->boolean)
-- `metadata` (Mixed, for custom data from hooks)
-
-### Finding 7 — Integration Points
-
-**Backend (`@terreno/api`):**
-- `ConsentApp` plugin implementing `TerrenoPlugin`
-- Registers ConsentForm and ConsentResponse models + routes
-- `GET /consents/pending` — returns pending forms for authenticated user (checks version, previous responses)
-- `POST /consents/respond` — records a consent response
-- Hook: `resolveConsentForms(user, allForms)` — server-side filtering of which forms to show based on user data
-
-**Admin:**
-- Register ConsentForm in AdminApp models array
-- Custom markdown field renderer for content editing (new component, may be separate task)
-- AI-generate button for creating consent form content
-
-**Frontend (`@terreno/ui`):**
-- `ConsentNavigator` — drop-in navigator component
-- `ConsentFormScreen` — renders a single consent form (markdown + signature + checkboxes + buttons)
-- `useConsentForms(api)` — hook that fetches pending forms, returns state + submit
-
-**Client app integration:**
 ```typescript
-import {ConsentNavigator} from "@terreno/ui";
+interface ChartConfig {
+  type: ChartType;
+  title: string;
+  dataSource: DataSourceRef;     // name of registered SimpleSource or EnrichedSource
 
-<ConsentNavigator api={terrenoApi} onComplete={() => router.replace("/(tabs)")} />
+  // Visual encodings
+  x: AxisConfig;                 // X axis: dimension or date with optional truncation
+  y: AxisConfig | AxisConfig[];  // Y axis: one or more measures
+  color?: SeriesConfig;          // Color channel: dimension for multi-series/stacked
+  size?: AxisConfig;             // Size channel for bubble charts
+
+  // Filters
+  filters?: FilterConfig[];
+
+  // Sort
+  sort?: {field: string; direction: "asc" | "desc"};
+
+  // Performance cap
+  limit?: number;                // Max data points (default 1000, max 5000)
+}
+
+interface AxisConfig {
+  field: string;
+  label?: string;
+  aggregation?: "count" | "sum" | "avg" | "min" | "max" | "countDistinct" | "runningTotal" | "rank";
+  dateTrunc?: "year" | "quarter" | "month" | "week" | "day" | "hour";
+}
+
+type FilterConfig =
+  | {type: "eq" | "ne" | "gt" | "gte" | "lt" | "lte"; field: string; value: any}
+  | {type: "in" | "nin"; field: string; values: any[]}
+  | {type: "dateRange"; field: string; from?: string; to?: string}
+  | {type: "relative"; field: string; unit: "year" | "month" | "week" | "day" | "hour"; amount: number};
 ```
 
-## Key File Paths
+### 9. Data Source Registration
 
-| Feature | File |
-|---------|------|
-| modelRouter | `api/src/api.ts:423-453` |
-| TerrenoPlugin interface | `api/src/terrenoPlugin.ts` |
-| TerrenoApp class | `api/src/terrenoApp.ts:41-190` |
-| Permissions | `api/src/permissions.ts` |
-| OpenAPI generation | `api/src/openApi.ts` |
-| AdminApp | `admin-backend/src/adminApp.ts:121-206` |
-| AdminFieldRenderer | `admin-frontend/src/AdminFieldRenderer.tsx` |
-| AdminModelForm | `admin-frontend/src/AdminModelForm.tsx` |
-| useAdminApi | `admin-frontend/src/useAdminApi.ts` |
-| MarkdownView | `ui/src/MarkdownView.tsx` |
-| SignatureField | `ui/src/SignatureField.tsx` |
-| CheckBox | `ui/src/CheckBox.tsx` |
-| Page | `ui/src/Page.tsx` |
-| emptySplitApi | `rtk/src/emptyApi.ts` |
-| generateAuthSlice | `rtk/src/authSlice.ts` |
-| generateTags | `rtk/src/tagGenerator.ts` |
-| Example backend | `example-backend/src/server.ts` |
-| Example frontend store | `example-frontend/store/sdk.ts` |
-| Flourish consent forms | `~/src/flourish/backend/src/constants/consentForms.ts` |
-| Flourish consent screen | `~/src/flourish/app/app/(consent)/index.tsx` |
-| Flourish consent hook | `~/src/flourish/app/hooks/useConsentForms.ts` |
+```typescript
+type DataSourceConfig = SimpleSource | EnrichedSource;
+
+interface SimpleSource {
+  type: "model";
+  modelName: string;    // Mongoose model name, must be in AdminApp's models list
+  displayName: string;
+}
+
+interface EnrichedSource {
+  type: "enriched";
+  name: string;
+  displayName: string;
+  baseModel: string;    // Root model name (for permissions — must be admin-accessible)
+  pipeline: PipelineStage[];
+  outputFields: Record<string, {
+    type: "string" | "number" | "date" | "boolean";
+    description: string;
+    role: "dimension" | "measure";
+  }>;
+}
+```
+
+### 10. Dashboard Persistence Model (new in @terreno/ai)
+
+```typescript
+interface Dashboard {
+  title: string;
+  userId: ObjectId;      // Admin user who created it
+  description?: string;
+  widgets: DashboardWidget[];
+  created: Date;
+  updated: Date;
+  deleted: boolean;
+}
+
+interface DashboardWidget {
+  widgetId: string;      // Local widget ID (uuid v4)
+  chart: ChartConfig;    // Full chart config
+}
+```
+
+### 11. Backend Query Execution
+
+`POST /dashboards/query` (admin-only, `IsAdmin` permission):
+```
+Body: ChartConfig
+Returns: {data: ChartDataPoint[], meta: {total: number, truncated: boolean, mongodbVersion: string}}
+```
+
+Pipeline construction order:
+1. Start with enriched source base pipeline (if applicable)
+2. `$match` — apply filters
+3. `$addFields` — apply `$dateTrunc` to date dimension fields
+4. `$group` — group by X (and color if present), aggregate Y measures
+5. `$setWindowFields` — for `runningTotal` or `rank` aggregations (MongoDB 5+ only; version detected at startup)
+6. `$sort` — by X field or measure
+7. `$limit` — cap at configured limit (default 1000)
+
+Auto-bucketing: if a date dimension would produce > limit unique values, automatically coarsen (days → months, months → quarters).
+
+### 12. AI Tools
+
+**`generateChart` tool** (inline GPT chart, not persisted, admin-only):
+```typescript
+{
+  name: "generateChart",
+  description: "Generate a chart from model data and display it inline in the chat",
+  parameters: z.object({chartConfig: ChartConfigSchema}),
+  execute: async ({chartConfig}) => ({chartConfig})
+  // Returns {chartConfig} as tool result → frontend renders ChartWidget inline
+}
+```
+
+**`createDashboard` tool** (persists to DB, admin-only):
+```typescript
+{
+  name: "createDashboard",
+  description: "Create a persistent admin dashboard with one or more charts",
+  parameters: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+    widgets: z.array(z.object({chart: ChartConfigSchema})),
+  }),
+  execute: async ({title, description, widgets}, {userId}) => {
+    const dashboard = await Dashboard.create({title, description, widgets: widgets.map(...), userId});
+    return {dashboardId: dashboard._id.toString(), title, widgetCount: widgets.length}
+  }
+}
+```
+
+Both are registered via `addGptRoutes` `tools` option — no core route changes needed. The `createRequestTools` pattern from `GptRouteOptions` is used to inject the admin user's ID into the tool executor.
+
+### 13. Performance Strategy
+
+1. **Server-side aggregation only** — never stream raw documents to charts
+2. **Point cap** — 1000 default, 5000 absolute max
+3. **Auto-bucketing** — coarsen date granularity if row count would exceed limit
+4. **RTK Query cache** — 60s TTL for `/dashboards/query`
+5. **Parallel widget fetching** — each Dashboard widget fires its own RTK Query independently
+6. **React.memo on ChartWidget** — memoized on `chartConfig` deep equality
+7. **Index awareness** — query endpoint can warn if querying fields not in `Model.collection.indexes()`
+
+## Package Changes
+
+| Package | Changes |
+|---|---|
+| `@terreno/ai` | New: `Dashboard` model, `addDashboardRoutes()`, `DashboardApp` plugin, `ChartConfig` types, AI tools |
+| `@terreno/admin-backend` | Minor: expose data source registry to dashboard query engine |
+| `@terreno/admin-frontend` | New: `ChartWidget`, `Dashboard` screen, `DashboardBuilder`, `DashboardList`; add `recharts` dep |
+| `@terreno/ui` | No changes |
+| `@terreno/rtk` | No changes |
+
+## References
+
+- `ai/src/routes/gpt.ts:82` — SSE streaming, tool call/result pattern
+- `ai/src/types/index.ts` — `GptHistoryPrompt`, `GptRouteOptions.tools`
+- `admin-backend/src/adminApp.ts:164` — `AdminApp`, model registration, `customScreens`
+- `admin-frontend/src/AdminModelTable.tsx` — DataTable + model config integration
+- `admin-frontend/src/types.ts` — `AdminConfigResponse` with `customScreens`
+- Root `package.json:54` — `react-native-svg: 15.12.1` in catalog
+- Recharts: https://recharts.org
+- MongoDB `$setWindowFields`: https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/
+- MongoDB `$dateTrunc`: https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateTrunc/


### PR DESCRIPTION
## Summary

- Adds a complete dashboard and graphing system to `@terreno/admin-backend` and `@terreno/admin-frontend`
- Backend: `DashboardApp` TerrenoPlugin with MongoDB aggregation pipeline engine, 7 REST routes, Zod validation, and Vercel AI SDK tool factories
- Frontend: RTK Query hooks (60s cache), 14-type `ChartWidget` via Recharts, `DashboardList`/`DashboardViewer`/`DashboardBuilder` screens, and `DashboardToolResult` for inline GPT chart rendering

## Architecture

**Backend (`@terreno/admin-backend`)**
- `DashboardApp` — TerrenoPlugin; detects MongoDB version at startup for `$setWindowFields` gating
- `dashboardQueryEngine` — Pipeline builder: `$match` → `$addFields($dateTrunc)` → `$group` → `$setWindowFields` → `$sort` → `$limit`; `allowDiskUse: true`, `maxTimeMS: 30000`; `allowedFields` enforcement on `SimpleSource`; auto-bucketing for date cardinality; `countDistinct` via `$addToSet`+`$size`
- 7 routes: dashboard CRUD + `POST /query` + `GET /sources`; Zod validates `ChartConfig` at save time
- `createDashboardGptTools` factory for Vercel AI SDK integration

**Frontend (`@terreno/admin-frontend`)**
- `useDashboardApi` — RTK hooks using `build.query` (not mutation) for widget data to enable 60s caching + deduplication across widgets
- `ChartWidget` — 14 chart types (bar variants, line, area, pie, donut, scatter, bubble, heatmap, radar, funnel, treemap, composed), `React.memo`
- Builder: `DataSourcePicker`, `FieldList` (Dimensions/Measures Tableau-style), `ChartTypeSelector`, `AxisConfigForm`, `FilterBuilder`, `SortConfig`
- `DashboardToolResult` — renders inline charts or "View Dashboard →" links from GPT tool results

## Security

- `allowedFields` whitelist on `SimpleSource` — fields not in the list return 400, preventing accidental sensitive data exposure
- `FilterConfig` values constrained to `string | number | boolean | null` — no operator injection
- All dashboard routes require `IsAdmin`

## Test plan

- [ ] `bun run admin-backend:test` — 49 pass (2 pre-existing failures in `adminApp.test.ts` unrelated to this PR)
- [ ] `bun run admin-backend:compile` — exits 0
- [ ] `bun run admin-frontend:compile` — exits 0
- [ ] `bun run lint` — exits 0
- [ ] Register `DashboardApp` in an example backend with a `SimpleSource`, hit `GET /admin/dashboards/sources` and confirm fields are returned
- [ ] `POST /admin/dashboards/query` with a valid `ChartConfig` returns `{data, meta}`
- [ ] `POST /admin/dashboards/query` with a field not in `allowedFields` returns 400
- [ ] Open admin frontend, navigate to Dashboards, create a dashboard with a widget, confirm live preview renders
- [ ] Save dashboard, view it, confirm all widgets load in parallel
- [ ] Edit dashboard — confirm form pre-populates from existing data