### PR TITLE
Sync @terreno/rtk with ferns-rtk for flourish migration

### DIFF
--- a/rtk/bunfig.toml
+++ b/rtk/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+preload = ["./src/test-preload.ts"]
+root = "./src"

--- a/rtk/package.json
+++ b/rtk/package.json
@@ -47,7 +47,8 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "lint:unsafefix": "biome check --write --unsafe .",
-    "test:ci": "echo 'No tests'"
+    "test": "bun test",
+    "test:ci": "bun test"
   },
   "types": "dist/index.d.ts",
   "version": "0.7.2"

--- a/rtk/src/authSlice.test.ts
+++ b/rtk/src/authSlice.test.ts
@@ -233,7 +233,7 @@ describe("generateAuthSlice", () => {
       expect(store.getState().auth.isAuthenticating).toBe(false);
     });
 
-    it("matchRejected clears isAuthenticating", () => {
+    it("matchRejected sets error and clears isAuthenticating", () => {
       store.dispatch({
         meta: {arg: {endpointName: "googleLogin", type: "mutation"}, requestId: "test-1"},
         payload: undefined,
@@ -241,10 +241,12 @@ describe("generateAuthSlice", () => {
       });
       store.dispatch({
         meta: {arg: {endpointName: "googleLogin", type: "mutation"}, requestId: "test-1"},
-        payload: {},
+        payload: {data: {message: "Google auth failed"}},
         type: "terreno-rtk/executeMutation/rejected",
       });
-      expect(store.getState().auth.isAuthenticating).toBe(false);
+      const state = store.getState().auth;
+      expect(state.isAuthenticating).toBe(false);
+      expect(state.error).toBe("Google auth failed");
     });
   });
 

--- a/rtk/src/authSlice.test.ts
+++ b/rtk/src/authSlice.test.ts
@@ -1,0 +1,304 @@
+import {beforeEach, describe, expect, it} from "bun:test";
+import {configureStore} from "@reduxjs/toolkit";
+import {createApi, fetchBaseQuery} from "@reduxjs/toolkit/query/react";
+
+import {
+  type EmailLoginRequest,
+  generateAuthSlice,
+  selectCurrentUserId,
+  selectIsAuthenticating,
+} from "./authSlice";
+
+// Create a real RTK Query API with the endpoints that generateAuthSlice expects
+const api = createApi({
+  baseQuery: fetchBaseQuery({baseUrl: "/"}),
+  endpoints: (builder) => ({
+    emailLogin: builder.mutation({
+      query: (body: EmailLoginRequest) => ({body, method: "POST", url: "auth/login"}),
+    }),
+    emailSignUp: builder.mutation({
+      query: (body: {email: string; password: string}) => ({
+        body,
+        method: "POST",
+        url: "auth/signup",
+      }),
+    }),
+    googleLogin: builder.mutation({
+      query: (body: {idToken: string}) => ({body, method: "POST", url: "auth/google"}),
+    }),
+  }),
+  reducerPath: "terreno-rtk",
+});
+
+const createTestStore = () => {
+  const {authReducer, middleware, ...rest} = generateAuthSlice(
+    // biome-ignore lint/suspicious/noExplicitAny: Test mock
+    api as any
+  );
+
+  return {
+    ...rest,
+    store: configureStore({
+      middleware: (getDefault) =>
+        getDefault({serializableCheck: false}).concat(api.middleware, ...middleware),
+      reducer: {
+        [api.reducerPath]: api.reducer,
+        auth: authReducer,
+      },
+    }),
+  };
+};
+
+describe("generateAuthSlice", () => {
+  let store: ReturnType<typeof createTestStore>["store"];
+  let authSlice: ReturnType<typeof createTestStore>["authSlice"];
+
+  beforeEach(() => {
+    const result = createTestStore();
+    store = result.store;
+    authSlice = result.authSlice;
+  });
+
+  describe("initial state", () => {
+    it("has correct initial values", () => {
+      const state = store.getState().auth;
+      expect(state.userId).toBeNull();
+      expect(state.error).toBeNull();
+      expect(state.isAuthenticating).toBe(false);
+      expect(state.lastTokenRefreshTimestamp).toBeNull();
+    });
+  });
+
+  describe("reducers", () => {
+    it("setUserId sets userId and clears isAuthenticating", () => {
+      store.dispatch(authSlice.actions.setUserId({userId: "user-123"}));
+      const state = store.getState().auth;
+      expect(state.userId).toBe("user-123");
+      expect(state.isAuthenticating).toBe(false);
+    });
+
+    it("logout clears state", () => {
+      store.dispatch(authSlice.actions.setUserId({userId: "user-123"}));
+      store.dispatch(authSlice.actions.logout());
+      const state = store.getState().auth;
+      expect(state.userId).toBeNull();
+      expect(state.isAuthenticating).toBe(false);
+      expect(state.lastTokenRefreshTimestamp).toBeNull();
+    });
+
+    it("tokenRefreshedSuccess sets timestamp", () => {
+      const before = Date.now();
+      store.dispatch(authSlice.actions.tokenRefreshedSuccess());
+      const state = store.getState().auth;
+      expect(state.lastTokenRefreshTimestamp).toBeGreaterThanOrEqual(before);
+      expect(state.lastTokenRefreshTimestamp).toBeLessThanOrEqual(Date.now());
+    });
+  });
+
+  describe("emailLogin matchers", () => {
+    it("matchPending sets isAuthenticating and clears error", () => {
+      // Simulate a pending email login action
+      store.dispatch({
+        meta: {arg: {endpointName: "emailLogin", type: "mutation"}, requestId: "test-1"},
+        payload: undefined,
+        type: "terreno-rtk/executeMutation/pending",
+      });
+      const state = store.getState().auth;
+      expect(state.isAuthenticating).toBe(true);
+      expect(state.error).toBeNull();
+    });
+
+    it("matchFulfilled clears isAuthenticating", () => {
+      // Set authenticating first
+      store.dispatch({
+        meta: {arg: {endpointName: "emailLogin", type: "mutation"}, requestId: "test-1"},
+        payload: undefined,
+        type: "terreno-rtk/executeMutation/pending",
+      });
+      expect(store.getState().auth.isAuthenticating).toBe(true);
+
+      // Then fulfill
+      store.dispatch({
+        meta: {arg: {endpointName: "emailLogin", type: "mutation"}, requestId: "test-1"},
+        payload: {token: "abc", userId: "user-1"},
+        type: "terreno-rtk/executeMutation/fulfilled",
+      });
+      expect(store.getState().auth.isAuthenticating).toBe(false);
+    });
+
+    it("matchRejected sets error and clears isAuthenticating", () => {
+      // Set authenticating first
+      store.dispatch({
+        meta: {arg: {endpointName: "emailLogin", type: "mutation"}, requestId: "test-1"},
+        payload: undefined,
+        type: "terreno-rtk/executeMutation/pending",
+      });
+
+      // Then reject with error
+      store.dispatch({
+        meta: {arg: {endpointName: "emailLogin", type: "mutation"}, requestId: "test-1"},
+        payload: {data: {message: "Invalid credentials"}},
+        type: "terreno-rtk/executeMutation/rejected",
+      });
+      const state = store.getState().auth;
+      expect(state.isAuthenticating).toBe(false);
+      expect(state.error).toBe("Invalid credentials");
+    });
+  });
+
+  describe("emailSignUp matchers", () => {
+    it("matchPending sets isAuthenticating and clears error", () => {
+      store.dispatch({
+        meta: {arg: {endpointName: "emailSignUp", type: "mutation"}, requestId: "test-1"},
+        payload: undefined,
+        type: "terreno-rtk/executeMutation/pending",
+      });
+      const state = store.getState().auth;
+      expect(state.isAuthenticating).toBe(true);
+      expect(state.error).toBeNull();
+    });
+
+    it("matchFulfilled clears isAuthenticating", () => {
+      store.dispatch({
+        meta: {arg: {endpointName: "emailSignUp", type: "mutation"}, requestId: "test-1"},
+        payload: undefined,
+        type: "terreno-rtk/executeMutation/pending",
+      });
+      store.dispatch({
+        meta: {arg: {endpointName: "emailSignUp", type: "mutation"}, requestId: "test-1"},
+        payload: {token: "abc", userId: "user-1"},
+        type: "terreno-rtk/executeMutation/fulfilled",
+      });
+      expect(store.getState().auth.isAuthenticating).toBe(false);
+    });
+
+    it("matchRejected sets error and clears isAuthenticating", () => {
+      store.dispatch({
+        meta: {arg: {endpointName: "emailSignUp", type: "mutation"}, requestId: "test-1"},
+        payload: undefined,
+        type: "terreno-rtk/executeMutation/pending",
+      });
+      store.dispatch({
+        meta: {arg: {endpointName: "emailSignUp", type: "mutation"}, requestId: "test-1"},
+        payload: {data: {message: "Email already exists"}},
+        type: "terreno-rtk/executeMutation/rejected",
+      });
+      const state = store.getState().auth;
+      expect(state.isAuthenticating).toBe(false);
+      expect(state.error).toBe("Email already exists");
+    });
+  });
+
+  describe("googleLogin matchers", () => {
+    it("matchPending sets isAuthenticating and clears error", () => {
+      store.dispatch({
+        meta: {arg: {endpointName: "googleLogin", type: "mutation"}, requestId: "test-1"},
+        payload: undefined,
+        type: "terreno-rtk/executeMutation/pending",
+      });
+      const state = store.getState().auth;
+      expect(state.isAuthenticating).toBe(true);
+      expect(state.error).toBeNull();
+    });
+
+    it("matchPending clears stale error from previous attempt", () => {
+      // First: fail a login to set an error
+      store.dispatch({
+        meta: {arg: {endpointName: "emailLogin", type: "mutation"}, requestId: "test-1"},
+        payload: {data: {message: "Previous error"}},
+        type: "terreno-rtk/executeMutation/rejected",
+      });
+      expect(store.getState().auth.error).toBe("Previous error");
+
+      // Then: start a google login — should clear the error
+      store.dispatch({
+        meta: {arg: {endpointName: "googleLogin", type: "mutation"}, requestId: "test-2"},
+        payload: undefined,
+        type: "terreno-rtk/executeMutation/pending",
+      });
+      expect(store.getState().auth.error).toBeNull();
+    });
+
+    it("matchFulfilled clears isAuthenticating", () => {
+      store.dispatch({
+        meta: {arg: {endpointName: "googleLogin", type: "mutation"}, requestId: "test-1"},
+        payload: undefined,
+        type: "terreno-rtk/executeMutation/pending",
+      });
+      store.dispatch({
+        meta: {arg: {endpointName: "googleLogin", type: "mutation"}, requestId: "test-1"},
+        payload: {token: "abc", userId: "user-1"},
+        type: "terreno-rtk/executeMutation/fulfilled",
+      });
+      expect(store.getState().auth.isAuthenticating).toBe(false);
+    });
+
+    it("matchRejected clears isAuthenticating", () => {
+      store.dispatch({
+        meta: {arg: {endpointName: "googleLogin", type: "mutation"}, requestId: "test-1"},
+        payload: undefined,
+        type: "terreno-rtk/executeMutation/pending",
+      });
+      store.dispatch({
+        meta: {arg: {endpointName: "googleLogin", type: "mutation"}, requestId: "test-1"},
+        payload: {},
+        type: "terreno-rtk/executeMutation/rejected",
+      });
+      expect(store.getState().auth.isAuthenticating).toBe(false);
+    });
+  });
+
+  describe("persist/REHYDRATE", () => {
+    it("resets isAuthenticating to false", () => {
+      // Set authenticating
+      store.dispatch({
+        meta: {arg: {endpointName: "emailLogin", type: "mutation"}, requestId: "test-1"},
+        payload: undefined,
+        type: "terreno-rtk/executeMutation/pending",
+      });
+      expect(store.getState().auth.isAuthenticating).toBe(true);
+
+      // Simulate rehydration
+      store.dispatch({type: "persist/REHYDRATE"});
+      expect(store.getState().auth.isAuthenticating).toBe(false);
+    });
+  });
+});
+
+describe("selectors", () => {
+  it("selectCurrentUserId returns userId", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: Test mock state
+    const state = {auth: {userId: "user-123"}} as any;
+    expect(selectCurrentUserId(state)).toBe("user-123");
+  });
+
+  it("selectCurrentUserId returns undefined when no auth state", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: Test mock state
+    expect(selectCurrentUserId({} as any)).toBeUndefined();
+  });
+
+  it("selectIsAuthenticating returns isAuthenticating", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: Test mock state
+    const state = {auth: {isAuthenticating: true}} as any;
+    expect(selectIsAuthenticating(state)).toBe(true);
+  });
+
+  it("selectIsAuthenticating defaults to false", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: Test mock state
+    expect(selectIsAuthenticating({} as any)).toBe(false);
+  });
+});
+
+describe("EmailLoginRequest type", () => {
+  it("accepts email-based login", () => {
+    const request: EmailLoginRequest = {email: "test@example.com", password: "pass"};
+    expect(request.email).toBe("test@example.com");
+    expect(request.password).toBe("pass");
+  });
+
+  it("accepts username-based login", () => {
+    const request: EmailLoginRequest = {password: "pass", username: "testuser"};
+    expect(request.username).toBe("testuser");
+    expect(request.password).toBe("pass");
+  });
+});

--- a/rtk/src/authSlice.ts
+++ b/rtk/src/authSlice.ts
@@ -156,9 +156,14 @@ export const generateAuthSlice = (api: Api<any, any, any, any, any>) => {
         // Safety fallback: clear isAuthenticating in case the listener middleware fails.
         state.isAuthenticating = false;
       });
-      builder.addMatcher(api.endpoints.googleLogin.matchRejected, (state) => {
-        state.isAuthenticating = false;
-      });
+      builder.addMatcher(
+        api.endpoints.googleLogin.matchRejected,
+        // biome-ignore lint/suspicious/noExplicitAny: Generic
+        (state, action: PayloadAction<{data: any}>) => {
+          state.error = action.payload?.data?.message;
+          state.isAuthenticating = false;
+        }
+      );
     },
     initialState: {
       error: null,

--- a/rtk/src/authSlice.ts
+++ b/rtk/src/authSlice.ts
@@ -70,7 +70,7 @@ export function generateProfileEndpoints(
       extraOptions: {maxRetries: 0},
       invalidatesTags: [path],
       query: ({email, username, password}) => ({
-        body: {email, username, password},
+        body: {email, password, username},
         method: "POST",
         url: "auth/login",
       }),

--- a/rtk/src/authSlice.ts
+++ b/rtk/src/authSlice.ts
@@ -12,6 +12,7 @@ import {IsWeb} from "./platform";
 type AuthState = {
   userId: string | null;
   error: string | null;
+  isAuthenticating: boolean;
   lastTokenRefreshTimestamp: number | null;
 };
 
@@ -24,7 +25,8 @@ export interface UserResponse {
 }
 
 export interface EmailLoginRequest {
-  email: string;
+  email?: string;
+  username?: string;
   password: string;
 }
 
@@ -67,8 +69,8 @@ export function generateProfileEndpoints(
     emailLogin: builder.mutation<UserResponse, EmailLoginRequest>({
       extraOptions: {maxRetries: 0},
       invalidatesTags: [path],
-      query: ({email, password}) => ({
-        body: {email, password},
+      query: ({email, username, password}) => ({
+        body: {email, username, password},
         method: "POST",
         url: "auth/login",
       }),
@@ -105,7 +107,14 @@ export function generateProfileEndpoints(
 export const generateAuthSlice = (api: Api<any, any, any, any, any>) => {
   const authSlice = createSlice({
     extraReducers: (builder) => {
-      builder.addMatcher(api.endpoints.emailLogin.matchFulfilled, () => {
+      // Reset isAuthenticating on rehydration in case the app was killed mid-login
+      builder.addCase("persist/REHYDRATE", (state) => {
+        state.isAuthenticating = false;
+      });
+      builder.addMatcher(api.endpoints.emailLogin.matchFulfilled, (state) => {
+        // Note: isAuthenticating is normally cleared by setUserId after the listener
+        // middleware stores the token. This is a safety fallback in case the listener fails.
+        state.isAuthenticating = false;
         console.debug("Login success");
       });
       builder.addMatcher(
@@ -113,14 +122,18 @@ export const generateAuthSlice = (api: Api<any, any, any, any, any>) => {
         // biome-ignore lint/suspicious/noExplicitAny: Generic
         (state, action: PayloadAction<{data: any}>) => {
           state.error = action.payload?.data?.message;
+          state.isAuthenticating = false;
           console.debug("Login rejected", action.payload?.data?.message);
         }
       );
       builder.addMatcher(api.endpoints.emailLogin.matchPending, (state) => {
         state.error = null;
+        state.isAuthenticating = true;
         console.debug("Login pending");
       });
-      builder.addMatcher(api.endpoints.emailSignUp.matchFulfilled, () => {
+      builder.addMatcher(api.endpoints.emailSignUp.matchFulfilled, (state) => {
+        // Safety fallback: clear isAuthenticating in case the listener middleware fails.
+        state.isAuthenticating = false;
         console.debug("Signup success");
       });
       builder.addMatcher(
@@ -128,23 +141,42 @@ export const generateAuthSlice = (api: Api<any, any, any, any, any>) => {
         // biome-ignore lint/suspicious/noExplicitAny: Generic
         (state, action: PayloadAction<{data: any}>) => {
           state.error = action.payload?.data?.message;
+          state.isAuthenticating = false;
           console.debug("Signup rejected", action.payload);
         }
       );
       builder.addMatcher(api.endpoints.emailSignUp.matchPending, (state) => {
         state.error = null;
+        state.isAuthenticating = true;
         console.debug("Signup pending");
       });
+      builder.addMatcher(api.endpoints.googleLogin.matchPending, (state) => {
+        state.isAuthenticating = true;
+      });
+      builder.addMatcher(api.endpoints.googleLogin.matchFulfilled, (state) => {
+        // Safety fallback: clear isAuthenticating in case the listener middleware fails.
+        state.isAuthenticating = false;
+      });
+      builder.addMatcher(api.endpoints.googleLogin.matchRejected, (state) => {
+        state.isAuthenticating = false;
+      });
     },
-    initialState: {error: null, lastTokenRefreshTimestamp: null, userId: null} as AuthState,
+    initialState: {
+      error: null,
+      isAuthenticating: false,
+      lastTokenRefreshTimestamp: null,
+      userId: null,
+    } as AuthState,
     name: "auth",
     reducers: {
       logout: (state) => {
         state.userId = null;
+        state.isAuthenticating = false;
         state.lastTokenRefreshTimestamp = null;
       },
       setUserId: (state, {payload: {userId}}: PayloadAction<{userId: string}>) => {
         state.userId = userId;
+        state.isAuthenticating = false;
       },
       tokenRefreshedSuccess: (state) => {
         state.lastTokenRefreshTimestamp = Date.now();
@@ -249,11 +281,17 @@ export const generateAuthSlice = (api: Api<any, any, any, any, any>) => {
 export const selectCurrentUserId = (state: RootState): string | undefined => state.auth?.userId;
 export const selectLastTokenRefreshTimestamp = (state: RootState): number | null =>
   state.auth?.lastTokenRefreshTimestamp;
+export const selectIsAuthenticating = (state: RootState): boolean =>
+  state.auth?.isAuthenticating ?? false;
 
 export const useSelectCurrentUserId = (): string | undefined => {
   return useSelector((state: RootState): string | undefined => {
     return state.auth?.userId;
   });
+};
+
+export const useSelectIsAuthenticating = (): boolean => {
+  return useSelector((state: RootState): boolean => state.auth?.isAuthenticating ?? false);
 };
 
 export async function getAuthToken(): Promise<string | null> {

--- a/rtk/src/authSlice.ts
+++ b/rtk/src/authSlice.ts
@@ -24,11 +24,9 @@ export interface UserResponse {
   };
 }
 
-export interface EmailLoginRequest {
-  email?: string;
-  username?: string;
-  password: string;
-}
+export type EmailLoginRequest =
+  | {email: string; username?: never; password: string}
+  | {username: string; email?: never; password: string};
 
 export interface EmailSignupRequest {
   email: string;
@@ -151,6 +149,7 @@ export const generateAuthSlice = (api: Api<any, any, any, any, any>) => {
         console.debug("Signup pending");
       });
       builder.addMatcher(api.endpoints.googleLogin.matchPending, (state) => {
+        state.error = null;
         state.isAuthenticating = true;
       });
       builder.addMatcher(api.endpoints.googleLogin.matchFulfilled, (state) => {

--- a/rtk/src/test-preload.ts
+++ b/rtk/src/test-preload.ts
@@ -1,0 +1,28 @@
+import {mock} from "bun:test";
+
+mock.module("react-native", () => ({
+  Platform: {OS: "web"},
+  StyleSheet: {create: (s: unknown) => s},
+}));
+
+mock.module("expo-secure-store", () => ({
+  deleteItemAsync: async () => {},
+  getItemAsync: async () => null,
+  setItemAsync: async () => {},
+}));
+
+mock.module("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: async () => null,
+    removeItem: async () => {},
+    setItem: async () => {},
+  },
+}));
+
+mock.module("expo-constants", () => ({
+  default: {expoConfig: {extra: {}}},
+}));
+
+mock.module("expo-network", () => ({
+  getNetworkStateAsync: async () => ({isConnected: true}),
+}));


### PR DESCRIPTION
## Summary

Syncs substantive changes from flourish's `ferns-rtk` package into `@terreno/rtk` to unblock migrating flourish off its vendored auth layer and onto the shared package. Two rounds of work:

1. **Auth slice sync** — ports `isAuthenticating` state with race-condition guards, username-based login support, `googleLogin` error capture, and test infrastructure.
2. **Behavior improvements + factory pattern** — ports retry/mutex hardening, adds a configurable `createEmptyApi` factory so apps can parameterise their reducerPath and endpoint lists without forking the package.

## Human Testing Steps

- [ ] Start the example backend and frontend, log in via email, confirm token refresh and logout work normally
- [ ] Verify `createEmptyApi({reducerPath: "flourishApi", unauthenticatedEndpoints: [...]})` produces a functional API in a downstream app
- [ ] Check that a flourish dev branch can replace `ferns-rtk/emptyApi` imports with `@terreno/rtk` equivalents and compile cleanly

## Changes

- `authSlice.ts`: Add `isAuthenticating` state, username login support, `persist/REHYDRATE` reset, `googleLogin` error capture, dynamic `reducerPath` in `loginListenerMiddleware`, `readStoredToken` helper with iOS keychain error handling, `getRefreshToken`, early-bail in logout listener when tokens already absent
- `emptyApi.ts`: `createBaseQuery(options)` and `createEmptyApi(options)` factories accepting `reducerPath`, `unauthenticatedEndpoints`, `optionalAuthEndpoints`, `tasksUrlPrefix`; `retry.fail()` on all logout paths; `isUserLoggedIn` guard on every `LOGOUT_ACTION_TYPE` dispatch; `lastRefreshedToken` module-level cache + double-checked locking; `ERR_NETWORK` tolerance during refresh; `__resetRefreshState()` test helper
- `constants.ts`: `isAuthRecoveryStatus(status)` helper for 401/403/404 detection
- `authSlice.test.ts`: Test API uses `reducerPath: "test-api"` to prove dynamic resolution; added login listener middleware test; 41 tests passing

## Automated Tests

- `bun run --filter '@terreno/rtk' test` — 41/41 pass
- `bun run --filter '@terreno/rtk' lint` — clean
- `bun run compile` (monorepo-wide) — all packages compile