### PR TITLE
Add extra screens and template variables to ConsentNavigator

### DIFF
--- a/ui/src/ConsentFormScreen.tsx
+++ b/ui/src/ConsentFormScreen.tsx
@@ -17,6 +17,7 @@ interface ConsentFormScreenProps {
   locale: string;
   onAgree: (data: {checkboxValues: Record<string, boolean>; signature?: string}) => void;
   onDecline?: () => void;
+  variables?: Record<string, string>;
 }
 
 export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
@@ -25,6 +26,7 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
   locale,
   onAgree,
   onDecline,
+  variables,
 }) => {
   const [checkboxValues, setCheckboxValues] = useState<Record<string, boolean>>({});
   const [hasScrolledToBottom, setHasScrolledToBottom] = useState(!form.requireScrollToBottom);
@@ -35,7 +37,10 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
   const [contentHeight, setContentHeight] = useState(0);
   const [layoutHeight, setLayoutHeight] = useState(0);
 
-  const content = form.content[locale] ?? form.content[form.defaultLocale] ?? "";
+  const rawContent = form.content[locale] ?? form.content[form.defaultLocale] ?? "";
+  const content = variables
+    ? rawContent.replace(/\{\{(\w+)\}\}/g, (match, key) => variables[key] ?? match)
+    : rawContent;
 
   const allRequiredCheckboxesChecked = form.checkboxes.every((checkbox, index) => {
     if (!checkbox.required) {

--- a/ui/src/ConsentNavigator.test.tsx
+++ b/ui/src/ConsentNavigator.test.tsx
@@ -1,5 +1,7 @@
 import {describe, expect, it, mock} from "bun:test";
 import React from "react";
+import {Pressable} from "react-native";
+import {Box} from "./Box";
 import {ConsentNavigator} from "./ConsentNavigator";
 import {Text} from "./Text";
 import {renderWithTheme} from "./test-utils";
@@ -71,6 +73,15 @@ const createLoadingMockApi = () => {
   };
 };
 
+const ExtraScreen: React.FC<{onNext?: () => void}> = ({onNext}) => (
+  <Box testID="extra-screen">
+    <Text>Extra Screen Content</Text>
+    <Pressable onPress={onNext} testID="extra-screen-next">
+      <Text>Next</Text>
+    </Pressable>
+  </Box>
+);
+
 describe("ConsentNavigator", () => {
   it("renders children when there are no pending consent forms", async () => {
     const api = createMockApi([]);
@@ -107,5 +118,50 @@ describe("ConsentNavigator", () => {
     );
 
     expect(getByTestId("consent-navigator-loading")).toBeTruthy();
+  });
+
+  it("shows extra screens after consent forms are completed", async () => {
+    const api = createMockApi([]);
+
+    const {getByTestId, queryByText} = renderWithTheme(
+      <ConsentNavigator api={api} extraScreens={[<ExtraScreen key="extra" />]}>
+        <Text>App Content</Text>
+      </ConsentNavigator>
+    );
+
+    expect(getByTestId("extra-screen")).toBeTruthy();
+    expect(queryByText("App Content")).toBeNull();
+  });
+
+  it("shows children after all extra screens are dismissed", async () => {
+    const api = createMockApi([]);
+    const {act, fireEvent, waitFor} = await import("@testing-library/react-native");
+
+    const {getByTestId, getByText} = renderWithTheme(
+      <ConsentNavigator api={api} extraScreens={[<ExtraScreen key="extra" />]}>
+        <Text>App Content</Text>
+      </ConsentNavigator>
+    );
+
+    expect(getByTestId("extra-screen")).toBeTruthy();
+    await act(async () => {
+      fireEvent.press(getByTestId("extra-screen-next"));
+    });
+    await waitFor(() => {
+      expect(getByText("App Content")).toBeTruthy();
+    });
+  });
+
+  it("injects onNext prop into extra screen elements", async () => {
+    const api = createMockApi([]);
+
+    const {getByTestId} = renderWithTheme(
+      <ConsentNavigator api={api} extraScreens={[<ExtraScreen key="extra" />]}>
+        <Text>App Content</Text>
+      </ConsentNavigator>
+    );
+
+    // The extra screen should have a working next button (onNext was injected)
+    expect(getByTestId("extra-screen-next")).toBeTruthy();
   });
 });

--- a/ui/src/ConsentNavigator.tsx
+++ b/ui/src/ConsentNavigator.tsx
@@ -13,19 +13,25 @@ interface ConsentNavigatorProps {
   api: any;
   baseUrl?: string;
   children: React.ReactNode;
+  extraScreens?: React.ReactNode[];
   onError?: (error: any) => void;
+  variables?: Record<string, string>;
 }
 
 export const ConsentNavigator: React.FC<ConsentNavigatorProps> = ({
   api,
   baseUrl,
   children,
+  extraScreens,
   onError,
+  variables,
 }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [extraScreenIndex, setExtraScreenIndex] = useState(0);
   const {forms, isLoading, error, refetch} = useConsentForms(api, baseUrl);
   const {submit, isSubmitting} = useSubmitConsent(api, baseUrl);
   const locale = detectLocale();
+  const validExtraScreens = extraScreens ?? [];
 
   if (isLoading) {
     console.debug("[ConsentNavigator] Loading pending consents...");
@@ -68,6 +74,18 @@ export const ConsentNavigator: React.FC<ConsentNavigatorProps> = ({
   }
 
   if (forms.length === 0 || currentIndex >= forms.length) {
+    if (extraScreenIndex < validExtraScreens.length) {
+      const currentScreen = validExtraScreens[extraScreenIndex];
+      console.debug(
+        `[ConsentNavigator] Showing extra screen ${extraScreenIndex + 1}/${validExtraScreens.length}`
+      );
+      if (React.isValidElement(currentScreen)) {
+        return React.cloneElement(currentScreen as React.ReactElement<any>, {
+          onNext: () => setExtraScreenIndex((i) => i + 1),
+        });
+      }
+      return <>{currentScreen}</>;
+    }
     console.debug("[ConsentNavigator] No pending consents, showing app");
     return <>{children}</>;
   }
@@ -123,6 +141,7 @@ export const ConsentNavigator: React.FC<ConsentNavigatorProps> = ({
       locale={locale}
       onAgree={handleAgree}
       onDecline={currentForm.required ? undefined : handleDecline}
+      variables={variables}
     />
   );
 };


### PR DESCRIPTION
- Add extraScreens prop: screens displayed after all consent forms are completed, before the main children. Each screen receives an injected onNext prop to advance.
- Add variables prop: Record<string, string> that replaces {{key}} patterns in consent form markdown content with the supplied values. Unmatched variables are left as-is.
- Pass variables through from ConsentNavigator to ConsentFormScreen, which also accepts variables directly for standalone use.
- Add tests for extra screen rendering, onNext advancement, and prop injection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the end-of-consent navigation flow and introduces runtime string templating into rendered markdown, which could affect user progression and displayed legal text if misconfigured.
> 
> **Overview**
> Adds support for an `extraScreens` sequence that renders *after* all required consent forms are completed and *before* the app `children`, automatically injecting an `onNext` handler into extra screen React elements to advance.
> 
> Adds a `variables` prop passed through `ConsentNavigator` to `ConsentFormScreen` to replace `{{key}}` placeholders in consent markdown with provided values (leaving unknown placeholders unchanged), and expands navigator tests to cover extra-screen rendering and advancement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb37fc443476bcb2ff5361cdcda045acc4fbb64e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->