### PR TITLE
Lower APIError log level to warn when disableExternalErrorTracking is true

### DIFF
--- a/api/src/errors.ts
+++ b/api/src/errors.ts
@@ -120,11 +120,14 @@ export class APIError extends Error {
       this.meta.fields = fields;
     }
     this.error = error;
-    logger.error(
-      `APIError(${status}): ${title} ${detail ? detail : ""}${
-        data.error?.stack ? `\n${data.error?.stack}` : ""
-      }`
-    );
+    const logMessage = `APIError(${status}): ${title} ${detail ? detail : ""}${
+      data.error?.stack ? `\n${data.error?.stack}` : ""
+    }`;
+    if (data.disableExternalErrorTracking) {
+      logger.warn(logMessage);
+    } else {
+      logger.error(logMessage);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- When `disableExternalErrorTracking` is set on an `APIError`, the constructor now logs at `warn` level instead of `error`
- This is consistent with the intent of the flag: errors that shouldn't be sent to external tracking tools (e.g. expected 404s, validation errors) also shouldn't pollute the error log

## Test plan

- [ ] Throw an `APIError` with `disableExternalErrorTracking: true` and verify the log output is at `warn` level
- [ ] Throw an `APIError` without `disableExternalErrorTracking` and verify the log output is at `error` level

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts logging severity in the `APIError` constructor based on an existing flag, without changing API responses or Sentry capture behavior.
> 
> **Overview**
> **Changes `APIError` logging behavior** so that when `disableExternalErrorTracking` is set, the constructor logs the same message at `logger.warn` instead of `logger.error`.
> 
> Errors without `disableExternalErrorTracking` continue to log at `error` level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a8f81c2eaa4c5eae3d2d19701431d872efd89d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->