### PR TITLE
Set up npm trusted publishing with OIDC

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -24,6 +24,9 @@ jobs:
   publish-api:
     needs: check-changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: api
@@ -128,9 +131,7 @@ jobs:
         run: bun run test
 
       - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: npm publish --provenance --access public
 
       - name: Summary
         run: echo "Published @terreno/api@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
@@ -138,6 +139,9 @@ jobs:
   publish-ui:
     needs: check-changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: ui
@@ -272,9 +276,7 @@ jobs:
         run: bun run test:ci
 
       - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: npm publish --provenance --access public
 
       - name: Summary
         run: echo "Published @terreno/ui@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
@@ -282,6 +284,9 @@ jobs:
   publish-rtk:
     needs: [check-changes, publish-ui]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: rtk
@@ -419,9 +424,7 @@ jobs:
         run: bun run compile
 
       - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: npm publish --provenance --access public
 
       - name: Summary
         run: echo "Published @terreno/rtk@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
@@ -429,6 +432,9 @@ jobs:
   publish-admin-backend:
     needs: [check-changes, publish-api]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: admin-backend
@@ -499,9 +505,7 @@ jobs:
         run: bun run compile
 
       - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: npm publish --provenance --access public
 
       - name: Summary
         run: echo "Published @terreno/admin-backend@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
@@ -509,6 +513,9 @@ jobs:
   publish-admin-frontend:
     needs: [check-changes, publish-ui]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: admin-frontend
@@ -593,9 +600,7 @@ jobs:
         run: bun run compile
 
       - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: npm publish --provenance --access public
 
       - name: Summary
         run: echo "Published @terreno/admin-frontend@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
@@ -603,6 +608,9 @@ jobs:
   publish-ai:
     needs: [check-changes, publish-api]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: ai
@@ -682,9 +690,7 @@ jobs:
         run: bun run test
 
       - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: npm publish --provenance --access public
 
       - name: Summary
         run: echo "Published @terreno/ai@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
@@ -692,6 +698,9 @@ jobs:
   publish-api-health:
     needs: [check-changes, publish-api]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: api-health
@@ -765,9 +774,7 @@ jobs:
         run: bun run test
 
       - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: npm publish --provenance --access public
 
       - name: Summary
         run: echo "Published @terreno/api-health@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
@@ -779,6 +786,9 @@ jobs:
       always() &&
       (needs.publish-api.result == 'success' || needs.publish-ui.result == 'success' || needs.publish-rtk.result == 'success' || needs.publish-admin-backend.result == 'success' || needs.publish-admin-frontend.result == 'success' || needs.publish-ai.result == 'success' || needs.publish-api-health.result == 'success')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## What changed

Replaces the `NPM_PUBLISH_TOKEN` secret with npm's OIDC-based trusted publishing across all 7 publish jobs.

**Per publish job (`publish-api`, `publish-ui`, `publish-rtk`, `publish-admin-backend`, `publish-admin-frontend`, `publish-ai`, `publish-api-health`):**
- Added `permissions: contents: read, id-token: write` — required for OIDC token generation
- Replaced `npm publish --access public` + `NODE_AUTH_TOKEN` env var with `npm publish --provenance --access public`

**`create-version-pr` job:**
- Added explicit `permissions: contents: write, pull-requests: write`

## Why

npm trusted publishing uses GitHub's OIDC provider to authenticate without a long-lived API token. Benefits:
- No token to rotate, leak, or expire
- Each published package gets a verified provenance badge on npmjs.com linking back to the exact commit and workflow run
- Scoped to this specific repo and workflow — can't be misused outside of a tag push

## Required follow-up (manual)

For each of the 7 packages on npmjs.com, configure a trusted publisher:
1. Go to `https://www.npmjs.com/package/@terreno/<name>/access`
2. Under **Trusted Publishers** → **Add trusted publisher**
3. Set: repo owner, repo name (`terreno`), workflow filename (`publish-on-tag.yml`), no environment
4. Repeat for: `api`, `ui`, `rtk`, `admin-backend`, `admin-frontend`, `ai`, `api-health`

Once configured, the `NPM_PUBLISH_TOKEN` secret can be deleted from the repo.

## Testing

- Workflow YAML syntax is valid (no type changes, no logic changes)
- The `example-frontend` lint failure in CI is pre-existing and unrelated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release workflow authentication path for all npm publishes, which could block or alter package releases if OIDC/trusted publisher settings are misconfigured. No runtime application code is changed.
> 
> **Overview**
> Switches `publish-on-tag.yml` from secret-based npm auth (`NODE_AUTH_TOKEN`/`NPM_PUBLISH_TOKEN`) to **OIDC trusted publishing** by granting per-job `id-token: write` and publishing with `npm publish --provenance --access public` across all package publish jobs.
> 
> Adds explicit GitHub `permissions` for the `create-version-pr` job (`contents: write`, `pull-requests: write`) and constrains publish jobs to `contents: read` + OIDC token issuance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 551571517acc64ea7fd59c7110d82b417dc9c006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->