### PR TITLE
Add EAS dev build workflow and fix package.json dependency ordering

### DIFF
--- a/.github/workflows/eas-dev-build.yml
+++ b/.github/workflows/eas-dev-build.yml
@@ -1,0 +1,57 @@
+name: EAS Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Select the environment"
+        required: true
+        type: choice
+        options:
+          - development
+          - preview
+          - production
+      platform:
+        description: "Select the platform"
+        required: true
+        type: choice
+        options:
+          - iOS
+          - Android
+
+defaults:
+  run:
+    working-directory: example-frontend
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          expo-version: latest
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run EAS Build
+        run: |
+          PROFILE="${{ github.event.inputs.environment }}"
+          PLATFORM="${{ github.event.inputs.platform }}"
+
+          if [ "$PLATFORM" == "iOS" ]; then
+            eas build --profile "$PROFILE" --platform ios --non-interactive
+          elif [ "$PLATFORM" == "Android" ]; then
+            eas build --profile "$PROFILE" --platform android --non-interactive
+          fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a new manually triggered CI workflow that runs EAS builds; primary risk is misconfiguration/secret usage (`EXPO_TOKEN`) affecting build automation only.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/eas-dev-build.yml`) to manually trigger Expo EAS builds.
> 
> The workflow accepts `environment` (development/preview/production) and `platform` (iOS/Android) inputs, installs dependencies in `example-frontend` using Bun, authenticates via `EXPO_TOKEN`, and runs `eas build` for the selected profile/platform in non-interactive mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e06c9815d37372ead060799cea9fec46c0ce9d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->