### PR TITLE
Fix EAS build workflow: compile workspace packages and support both apps

### DIFF
--- a/.github/workflows/eas-dev-build.yml
+++ b/.github/workflows/eas-dev-build.yml
@@ -3,6 +3,13 @@ name: EAS Build
 on:
   workflow_dispatch:
     inputs:
+      app:
+        description: "Select the app to build"
+        required: true
+        type: choice
+        options:
+          - demo
+          - example-frontend
       environment:
         description: "Select the environment"
         required: true
@@ -18,10 +25,6 @@ on:
         options:
           - iOS
           - Android
-
-defaults:
-  run:
-    working-directory: example-frontend
 
 jobs:
   build:
@@ -45,7 +48,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Compile workspace packages
+        run: bun run compile
+
       - name: Run EAS Build
+        working-directory: ${{ github.event.inputs.app }}
         run: |
           PROFILE="${{ github.event.inputs.environment }}"
           PLATFORM="${{ github.event.inputs.platform }}"


### PR DESCRIPTION
## Summary
The EAS build workflow was failing because workspace packages weren't compiled before `eas build` ran. Since `dist/` is gitignored, `@terreno/rtk/buildNumber` (which `app.config.ts` imports) didn't exist in CI, causing EAS CLI to fail with "Unexpected token '{'". The workflow was also hardcoded to only build `example-frontend`.

## Human Testing Steps
- [ ] Trigger the workflow from GitHub Actions → EAS Build
- [ ] Verify the new `app` input appears with `demo` and `example-frontend` options
- [ ] Run a development build for `example-frontend` on iOS and confirm it succeeds
- [ ] Run a development build for `demo` on iOS and confirm it succeeds

## Changes
- Added `app` input (choice: `demo`, `example-frontend`) to the workflow dispatch
- Removed the hardcoded `working-directory: example-frontend` default
- Added `bun install` at repo root so workspace packages resolve correctly
- Added `bun run compile` step to build all workspace packages before EAS reads `app.config.ts`
- Made the `eas build` step use `working-directory: ${{ github.event.inputs.app }}`

## Automated Tests
- None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the GitHub Actions EAS build workflow behavior (working directory and pre-build steps), which could affect CI build success across apps/environments.
> 
> **Overview**
> Fixes the `EAS Build` GitHub Actions workflow to support building either `demo` or `example-frontend` via a new `app` input, instead of being hardcoded to `example-frontend`.
> 
> The workflow now installs dependencies at the repo root and runs `bun run compile` to build workspace packages before invoking `eas build`, and it runs `eas build` from the selected app’s directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78dd6290d5af3f87828e05d0b0cd78bca5258773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->