### PR TITLE
Compile workspace packages on EAS Build via post-install hook

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -92,6 +92,7 @@
   },
   "scripts": {
     "android": "NODE_OPTIONS=--openssl-legacy-provider expo start --android --port 8085",
+    "eas-build-post-install": "cd .. && bun run compile",
     "build-preview": "NODE_OPTIONS=--openssl-legacy-provider bun run build-web",
     "build-web": "NODE_OPTIONS=--openssl-legacy-provider bunx expo export",
     "compile": "tsc",

--- a/demo/package.json
+++ b/demo/package.json
@@ -92,12 +92,12 @@
   },
   "scripts": {
     "android": "NODE_OPTIONS=--openssl-legacy-provider expo start --android --port 8085",
-    "eas-build-post-install": "cd .. && bun run compile",
     "build-preview": "NODE_OPTIONS=--openssl-legacy-provider bun run build-web",
     "build-web": "NODE_OPTIONS=--openssl-legacy-provider bunx expo export",
     "compile": "tsc",
     "compile:watch": "tsc -w",
     "doctor": "bunx expo-doctor",
+    "eas-build-post-install": "cd .. && bun run compile",
     "export": "expo export -p web",
     "ios": "NODE_OPTIONS=--openssl-legacy-provider expo start --ios --port 8085",
     "lint": "biome check .",

--- a/example-frontend/package.json
+++ b/example-frontend/package.json
@@ -42,6 +42,7 @@
   "private": true,
   "scripts": {
     "android": "bun expo start --android --port 8082",
+    "eas-build-post-install": "cd .. && bun run compile",
     "export": "bun expo export --platform web",
     "ios": "bun expo start --ios --port 8082",
     "lint": "bun biome check .",


### PR DESCRIPTION
## Summary
EAS builds were failing with "Unexpected token '{'" because `app.config.ts` imports `resolveBuildNumber` from `@terreno/rtk/buildNumber`, which resolves to `dist/buildNumber.js`. On Expo's remote build servers, workspace packages aren't compiled, so `dist/` doesn't exist when `expo config` tries to evaluate the app config.

Adds an `eas-build-post-install` hook to both `example-frontend` and `demo` that runs `bun run compile` from the monorepo root after dependency installation, building all workspace packages before Expo reads the config.

## Human Testing Steps
- [ ] Trigger an EAS build for `example-frontend` via the GitHub Actions workflow
- [ ] Confirm build proceeds past the `expo config` step without "Unexpected token" errors

## Changes
- `example-frontend/package.json`: Add `eas-build-post-install` script
- `demo/package.json`: Add `eas-build-post-install` script

## Automated Tests
- None (EAS build lifecycle hook, requires manual trigger)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds an EAS build lifecycle script to run existing TypeScript compilation, with no runtime logic changes. Risk is limited to potential build-time failures if `bun run compile` or monorepo paths differ in EAS environments.
> 
> **Overview**
> Adds `eas-build-post-install` scripts to `demo` and `example-frontend` that `cd ..` and run `bun run compile` after dependency install, ensuring workspace packages are built before Expo evaluates app config during EAS builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a9b26c97fbfe512c156efdface9132a6c2f07c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->