### PR TITLE
Fix OIDC trusted publishing: remove registry-url from setup-node

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -42,7 +42,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org/
 
       - name: Cache Bun dependencies
         uses: actions/cache@v5
@@ -157,7 +156,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org/
 
       - name: Cache Bun dependencies
         uses: actions/cache@v5
@@ -302,7 +300,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org/
 
       - name: Cache Bun dependencies
         uses: actions/cache@v5
@@ -450,7 +447,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org/
 
       - name: Cache Bun dependencies
         uses: actions/cache@v5
@@ -531,7 +527,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org/
 
       - name: Cache Bun dependencies
         uses: actions/cache@v5
@@ -626,7 +621,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org/
 
       - name: Cache Bun dependencies
         uses: actions/cache@v5
@@ -716,7 +710,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org/
 
       - name: Cache Bun dependencies
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary
The publish-on-tag workflow was failing because \`actions/setup-node\` with \`registry-url\` creates an \`.npmrc\` that sets \`_authToken=\${NODE_AUTH_TOKEN}\`. With npm OIDC trusted publishing there is no \`NODE_AUTH_TOKEN\`, so npm sees an empty auth token and rejects the publish before the OIDC token exchange can happen.

## Human Testing Steps
- [ ] Push a semver tag and verify all publish jobs succeed

## Changes
- Remove \`registry-url: https://registry.npmjs.org/\` from all 7 \`setup-node\` steps in \`publish-on-tag.yml\` — npm defaults to the public registry and OIDC handles auth

## Automated Tests
- None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adjusts npm publish authentication behavior; main risk is misconfiguration causing release publishes to fail on tag pushes.
> 
> **Overview**
> Fixes npm OIDC trusted publishing in `publish-on-tag.yml` by removing the `registry-url` setting from all `actions/setup-node@v6` steps so the workflow no longer writes an `.npmrc` expecting `NODE_AUTH_TOKEN`, allowing `npm publish --provenance` to complete via OIDC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e276096f6c7bf2cb79d37f27cd46bd437d0ba47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->