### PR TITLE
Fix npm trusted publishing configuration

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -130,7 +130,7 @@ jobs:
         run: bun run test
 
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --provenance
 
       - name: Summary
         run: echo "Published @terreno/api@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
@@ -274,7 +274,7 @@ jobs:
         run: bun run test:ci
 
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --provenance
 
       - name: Summary
         run: echo "Published @terreno/ui@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
@@ -421,7 +421,7 @@ jobs:
         run: bun run compile
 
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --provenance
 
       - name: Summary
         run: echo "Published @terreno/rtk@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
@@ -501,7 +501,7 @@ jobs:
         run: bun run compile
 
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --provenance
 
       - name: Summary
         run: echo "Published @terreno/admin-backend@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
@@ -595,7 +595,7 @@ jobs:
         run: bun run compile
 
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --provenance
 
       - name: Summary
         run: echo "Published @terreno/admin-frontend@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
@@ -684,7 +684,7 @@ jobs:
         run: bun run test
 
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --provenance
 
       - name: Summary
         run: echo "Published @terreno/ai@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
@@ -767,7 +767,7 @@ jobs:
         run: bun run test
 
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --provenance
 
       - name: Summary
         run: echo "Published @terreno/api-health@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY

--- a/admin-backend/package.json
+++ b/admin-backend/package.json
@@ -35,6 +35,9 @@
   },
   "main": "dist/index.js",
   "name": "@terreno/admin-backend",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/FlourishHealth/terreno.git"

--- a/admin-frontend/package.json
+++ b/admin-frontend/package.json
@@ -36,6 +36,9 @@
       "optional": true
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "compile": "tsc",
     "compile:watch": "tsc -w",

--- a/ai/package.json
+++ b/ai/package.json
@@ -44,6 +44,9 @@
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "name": "@terreno/ai",
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "@terreno/api": "workspace:*",
     "mongoose": "^8.0.0"

--- a/api-health/package.json
+++ b/api-health/package.json
@@ -26,6 +26,9 @@
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "name": "@terreno/api-health",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/FlourishHealth/terreno.git"

--- a/api/package.json
+++ b/api/package.json
@@ -77,6 +77,9 @@
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "name": "@terreno/api",
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "mongoose": "^8.0.0"
   },

--- a/feature-flags/package.json
+++ b/feature-flags/package.json
@@ -30,6 +30,9 @@
   },
   "main": "dist/index.js",
   "name": "@terreno/feature-flags",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/FlourishHealth/terreno.git"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -41,5 +41,8 @@
     "ai",
     "code-generation"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/rtk/package.json
+++ b/rtk/package.json
@@ -50,6 +50,9 @@
   "peerDependencies": {
     "react": "catalog:"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "compile": "tsc",
     "compile:watch": "tsc -w",

--- a/ui/package.json
+++ b/ui/package.json
@@ -121,6 +121,9 @@
     "trailingComma": "es5",
     "useTabs": false
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "compile": "tsc",
     "compile:watch": "tsc -w",


### PR DESCRIPTION
Add explicit public publishConfig entries for publishable @terreno packages and use npm provenance in the release workflow so GitHub Actions can use OIDC trusted publishing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect the release pipeline and npm publishing behavior; misconfiguration could block releases or publish with incorrect access settings, but no runtime/business logic is touched.
> 
> **Overview**
> **Release/publishing config update.** The GitHub Actions tag workflow now runs `npm publish --provenance` for all publish jobs to support OIDC trusted publishing.
> 
> **Package metadata update.** Adds `publishConfig.access=public` to the publishable `@terreno/*` package manifests (e.g., `api`, `ui`, `rtk`, admin packages, `ai`, `api-health`, `feature-flags`, `mcp-server`) to avoid default/private publish behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4925d5605e853b1b1a7e726667fc4cf1cc8dfb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->