### PR TITLE
Enable automerge for version bumps

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -912,11 +912,11 @@ jobs:
           assignees: joshgachnang
           reviewers: joshgachnang
 
-      - name: Auto-merge version bump PR
+      - name: Enable auto-merge for version bump PR
         if: steps.create-pr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --squash --delete-branch
+        run: gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --squash --delete-branch --auto
 
   notify:
     needs: [check-changes, publish-api, publish-ui, publish-rtk, publish-admin-backend, publish-admin-frontend, publish-ai, publish-api-health]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CD automation to rely on GitHub auto-merge for version bump PRs, which could alter merge timing/behavior if required checks or branch protections are misconfigured. Limited to workflow logic; no runtime code changes.
> 
> **Overview**
> **Release workflow behavior change:** the `publish-on-tag.yml` step that merges the generated version-bump PR now uses `gh pr merge --auto` (and is renamed accordingly), enabling GitHub auto-merge rather than performing an immediate squash merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06526d7d3eb5abed51da053233e07b69f4c053ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->