### PR TITLE
Add 'Street Address' title to WebAddressAutocomplete TextField

### DIFF
--- a/ui/src/WebAddressAutocomplete.tsx
+++ b/ui/src/WebAddressAutocomplete.tsx
@@ -77,6 +77,7 @@ export const WebAddressAutocomplete = ({
         handleAddressChange(value);
       }}
       placeholder="Enter an address"
+      title="Street Address"
       type="text"
       value={inputValue}
     />

--- a/ui/src/__snapshots__/WebAddressAutocomplete.test.tsx.snap
+++ b/ui/src/__snapshots__/WebAddressAutocomplete.test.tsx.snap
@@ -7,6 +7,21 @@ exports[`WebAddressAutocomplete renders correctly without Google API key 1`] = `
     {
       "$$typeof": Symbol(react.test.json),
       "children": [
+        "Street Address",
+      ],
+      "props": {
+        "style": {
+          "color": "#1C1C1C",
+          "fontSize": 14,
+          "fontWeight": 600,
+          "lineHeight": 22.4,
+        },
+      },
+      "type": "Text",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
         {
           "$$typeof": Symbol(react.test.json),
           "children": [
@@ -100,6 +115,21 @@ exports[`WebAddressAutocomplete renders with input value 1`] = `
     {
       "$$typeof": Symbol(react.test.json),
       "children": [
+        "Street Address",
+      ],
+      "props": {
+        "style": {
+          "color": "#1C1C1C",
+          "fontSize": 14,
+          "fontWeight": 600,
+          "lineHeight": 22.4,
+        },
+      },
+      "type": "Text",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
         {
           "$$typeof": Symbol(react.test.json),
           "children": [
@@ -190,6 +220,21 @@ exports[`WebAddressAutocomplete renders disabled state 1`] = `
 {
   "$$typeof": Symbol(react.test.json),
   "children": [
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        "Street Address",
+      ],
+      "props": {
+        "style": {
+          "color": "#1C1C1C",
+          "fontSize": 14,
+          "fontWeight": 600,
+          "lineHeight": 22.4,
+        },
+      },
+      "type": "Text",
+    },
     {
       "$$typeof": Symbol(react.test.json),
       "children": [


### PR DESCRIPTION
## Summary

Adds the missing `title="Street Address"` prop to the `TextField` inside `WebAddressAutocomplete`.

When a valid `googleMapsApiKey` is provided on web, `UnifiedAddressAutoCompleteField` renders `WebAddressAutocomplete` instead of the fallback `TextField`. The fallback path includes `title="Street Address"`, but `WebAddressAutocomplete` was missing it — causing the field label to disappear when autocomplete was enabled.

This is a companion fix to [FlourishHealth/flourish#5411](https://github.com/FlourishHealth/flourish/pull/5411), which adds autocomplete to the Contact page and surfaced this bug.

## Review & Testing Checklist for Human
- [ ] Verify the "Street Address" label appears on web when a valid `googleMapsApiKey` is provided (e.g. on the Flourish Create User page and Contact page)
- [ ] Confirm the label matches the appearance of the fallback (no API key) path
- [ ] Verify snapshot updates are correct — they were manually updated to match the expected `Text` node for the title (the same structure used in `UnifiedAddressAutoComplete.test.tsx.snap`). Confirm by running `bun ui:test` locally.

### Notes
- The `MobileAddressAutocomplete` component already includes `placeholder="Street Address"`, so this was only missing on the web path.
- All existing consumers that pass a valid API key will now see the "Street Address" title where it was previously absent.

Link to Devin session: https://app.devin.ai/sessions/b6003c170f834659bc639048ee0b2bbc
Requested by: @katcrossman