### PR TITLE
Add bootstrap and bootstrap:update scripts

### DIFF
--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -17,6 +17,20 @@ A monorepo containing shared packages for building full-stack applications with 
 
 Uses [Bun](https://bun.sh/) as the package manager.
 
+### Bootstrap
+
+Run these commands when setting up or updating the project:
+
+```bash
+bun run bootstrap        # Initial setup: install deps + compile all packages
+bun run bootstrap:update # Update after changes: install deps + recompile all packages
+```
+
+- **`bootstrap`**: Run when first cloning the repo or creating a new dev environment (e.g. a container image). Installs all dependencies and compiles every package.
+- **`bootstrap:update`**: Run when resuming work after pulling changes, switching branches, or when dependencies have changed. Reinstalls dependencies and recompiles to pick up any changes.
+
+### Common Commands
+
 ```bash
 bun install              # Install dependencies
 bun run compile          # Compile all packages

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
   },
   "private": true,
   "scripts": {
+    "bootstrap": "bun install && bun run compile",
+    "bootstrap:update": "bun install && bun run compile",
     "admin-backend:compile": "bun run --filter '@terreno/admin-backend' compile",
     "admin-backend:lint": "bun run --filter '@terreno/admin-backend' lint",
     "admin-backend:test": "bun run --filter '@terreno/admin-backend' test",


### PR DESCRIPTION
## Summary
Adds `bootstrap` and `bootstrap:update` scripts to the root `package.json` for AI agents and developers setting up or resuming work on the project. Both run `bun install && bun run compile` — having separate commands allows them to diverge later (e.g. bootstrap could seed data or generate SDKs on first run). Also updates CLAUDE.local.md with documentation on when to use each.

## Human Testing Steps
- [ ] Run `bun run bootstrap` from the repo root and verify it installs deps and compiles all packages

## Changes
- `package.json`: Added `bootstrap` and `bootstrap:update` scripts
- `CLAUDE.local.md`: Documented bootstrap commands and when to use them

## Automated Tests
- None (script-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds two repo-level convenience scripts and documentation only; no runtime or production code paths change.
> 
> **Overview**
> Adds root `bun run bootstrap` and `bun run bootstrap:update` scripts (currently identical: `bun install && bun run compile`) to standardize initial setup vs. post-update workflows.
> 
> Updates `CLAUDE.local.md` to document when to use each bootstrap command and lists them alongside other common development commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1de4c7a95df630560b9d460b929e6b0ddb8ee72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->