### PR TITLE
[alignRules] utils.ts, tests.ts, plugins.ts

### DIFF
--- a/api/src/plugins.ts
+++ b/api/src/plugins.ts
@@ -15,10 +15,12 @@ export interface BaseUser {
   email: string;
 }
 
-export function baseUserPlugin(schema: Schema<any, any, any, any>) {
-  schema.add({admin: {default: false, type: Boolean}});
-  schema.add({email: {index: true, type: String}});
-}
+export const baseUserPlugin = (schema: Schema<any, any, any, any>): void => {
+  schema.add({
+    admin: {default: false, description: "Whether the user has admin privileges", type: Boolean},
+  });
+  schema.add({email: {description: "The user's email address", index: true, type: String}});
+};
 
 /** For models with the isDeletedPlugin, extend this interface to add the appropriate fields. */
 export interface IsDeleted {
@@ -26,7 +28,7 @@ export interface IsDeleted {
   deleted: boolean;
 }
 
-export function isDeletedPlugin(schema: Schema<any, any, any, any>, defaultValue = false) {
+export const isDeletedPlugin = (schema: Schema<any, any, any, any>, defaultValue = false): void => {
   schema.add({
     deleted: {
       default: defaultValue,
@@ -37,21 +39,24 @@ export function isDeletedPlugin(schema: Schema<any, any, any, any>, defaultValue
       type: Boolean,
     },
   });
-  function applyDeleteFilter(q: Query<any, any>) {
+  const applyDeleteFilter = (q: Query<any, any>): void => {
     const query = q.getQuery();
     if (query && query.deleted === undefined) {
       void q.where({deleted: {$ne: true}});
     }
-  }
+  };
   schema.pre("find", function () {
     applyDeleteFilter(this);
   });
   schema.pre("findOne", function () {
     applyDeleteFilter(this);
   });
-}
+};
 
-export function isDisabledPlugin(schema: Schema<any, any, any, any>, defaultValue = false) {
+export const isDisabledPlugin = (
+  schema: Schema<any, any, any, any>,
+  defaultValue = false
+): void => {
   schema.add({
     disabled: {
       default: defaultValue,
@@ -60,16 +65,18 @@ export function isDisabledPlugin(schema: Schema<any, any, any, any>, defaultValu
       type: Boolean,
     },
   });
-}
+};
 
 export interface CreatedDeleted {
   updated: {type: Date; required: true};
   created: {type: Date; required: true};
 }
 
-export function createdUpdatedPlugin(schema: Schema<any, any, any, any>) {
-  schema.add({updated: {index: true, type: Date}});
-  schema.add({created: {index: true, type: Date}});
+export const createdUpdatedPlugin = (schema: Schema<any, any, any, any>): void => {
+  schema.add({
+    updated: {description: "When this document was last updated", index: true, type: Date},
+  });
+  schema.add({created: {description: "When this document was created", index: true, type: Date}});
 
   schema.pre("save", function () {
     if (this.disableCreatedUpdatedPlugin === true) {
@@ -86,11 +93,13 @@ export function createdUpdatedPlugin(schema: Schema<any, any, any, any>) {
   schema.pre(/save|updateOne|insertMany/, function () {
     void this.updateOne({}, {$set: {updated: new Date()}});
   });
-}
+};
 
-export function firebaseJWTPlugin(schema: Schema) {
-  schema.add({firebaseId: {index: true, type: String}});
-}
+export const firebaseJWTPlugin = (schema: Schema): void => {
+  schema.add({
+    firebaseId: {description: "The user's Firebase authentication ID", index: true, type: String},
+  });
+};
 
 /**
  * This adds a static method `Model.findOneOrNone` to the schema. This should replace `Model.findOne` in most instances.
@@ -99,7 +108,7 @@ export function firebaseJWTPlugin(schema: Schema) {
  * document, or throws an exception if multiple are found.
  * @param schema Mongoose Schema
  */
-export function findOneOrNone<T>(schema: Schema<T>) {
+export const findOneOrNone = <T>(schema: Schema<T>): void => {
   schema.statics.findOneOrNone = async function (
     query: Record<string, any>,
     errorArgs?: Partial<APIErrorConstructor>
@@ -118,7 +127,7 @@ export function findOneOrNone<T>(schema: Schema<T>) {
     }
     return results[0];
   };
-}
+};
 
 /**
  * This adds a static method `Model.findExactlyOne` to the schema. This or findOneOrNone should replace `Model.findOne`
@@ -128,7 +137,7 @@ export function findOneOrNone<T>(schema: Schema<T>) {
  * multiple or none are found.
  * @param schema Mongoose Schema
  */
-export function findExactlyOne<T>(schema: Schema<T>) {
+export const findExactlyOne = <T>(schema: Schema<T>): void => {
   schema.statics.findExactlyOne = async function (
     query: Record<string, any>,
     errorArgs?: Partial<APIErrorConstructor>
@@ -152,7 +161,7 @@ export function findExactlyOne<T>(schema: Schema<T>) {
     }
     return results[0];
   };
-}
+};
 
 /**
  * This adds a static method `Model.upsert` to the schema. This method will either update an existing document
@@ -160,7 +169,7 @@ export function findExactlyOne<T>(schema: Schema<T>) {
  * match the conditions to prevent ambiguous updates.
  * @param schema Mongoose Schema
  */
-export function upsertPlugin<T>(schema: Schema<any, any, any, any>) {
+export const upsertPlugin = <T>(schema: Schema<any, any, any, any>): void => {
   schema.statics.upsert = async function (
     conditions: Record<string, any>,
     update: Record<string, any>
@@ -187,7 +196,7 @@ export function upsertPlugin<T>(schema: Schema<any, any, any, any>) {
     const newDoc = new this(combinedData);
     return newDoc.save();
   };
-}
+};
 
 /** For models with the upsertPlugin, extend this interface to add the upsert static method. */
 export interface HasUpsert<T> {

--- a/api/src/tests.ts
+++ b/api/src/tests.ts
@@ -162,7 +162,7 @@ const requiredSchema = new Schema<RequiredField>({
 });
 export const RequiredModel = model<RequiredField>("Required", requiredSchema);
 
-export function getBaseServer(): Express {
+export const getBaseServer = (): Express => {
   const app = express();
   app.set("query parser", (str: string) => qs.parse(str, {arrayLimit: 200}));
 
@@ -186,12 +186,12 @@ export function getBaseServer(): Express {
   });
   app.use(express.json());
   return app;
-}
+};
 
-export async function authAsUser(
+export const authAsUser = async (
   app: express.Application,
   type: "admin" | "notAdmin"
-): Promise<TestAgent> {
+): Promise<TestAgent> => {
   const email = type === "admin" ? "admin@example.com" : "notAdmin@example.com";
   const password = type === "admin" ? "securePassword" : "password";
 
@@ -199,9 +199,9 @@ export async function authAsUser(
   const res = await agent.post("/auth/login").send({email, password}).expect(200);
   await agent.set("authorization", `Bearer ${res.body.data.token}`);
   return agent;
-}
+};
 
-export async function setupDb() {
+export const setupDb = async () => {
   await mongoose
     .connect("mongodb://127.0.0.1/terreno?&connectTimeoutMS=360000")
     .catch(logger.catch);
@@ -233,7 +233,7 @@ export async function setupDb() {
 
     return [admin, notAdmin, adminOther];
   } catch (error) {
-    console.error("Error setting up DB", error);
+    logger.error("Error setting up DB", error);
     throw error;
   }
-}
+};

--- a/api/src/utils.ts
+++ b/api/src/utils.ts
@@ -4,14 +4,14 @@ import {logger} from "./logger";
 
 // A better version of mongoose's ObjectId.isValid,
 // which falsely will say any 12 character string is valid.
-export function isValidObjectId(id: string): boolean {
+export const isValidObjectId = (id: string): boolean => {
   try {
     return new Types.ObjectId(id).toString() === id;
   } catch (error) {
     logger.error(`Error validating object id ${id}: ${error}`);
     return false;
   }
-}
+};
 
 export const timeout = async (ms: number): Promise<NodeJS.Timeout> => {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -25,7 +25,7 @@ export const timeout = async (ms: number): Promise<NodeJS.Timeout> => {
  * @param ignoredModels - Array of model names to skip validation for
  * @throws Error if any model is not set to strict mode or missing virtual settings
  */
-export function checkModelsStrict(ignoredModels: string[] = []): void {
+export const checkModelsStrict = (ignoredModels: string[] = []): void => {
   const models = mongoose.modelNames();
   for (const model of models) {
     const schema = mongoose.model(model).schema;
@@ -44,4 +44,4 @@ export function checkModelsStrict(ignoredModels: string[] = []): void {
       throw new Error(`Model ${model} is not set to strict mode.`);
     }
   }
-}
+};


### PR DESCRIPTION
## Summary

Brings three `api/src/` files into compliance with the repo's code style rules (from `.rulesync/` and `AGENTS.md`):

- **`utils.ts`**: Converted `isValidObjectId` and `checkModelsStrict` from `function` declarations to `const` arrow functions.
- **`tests.ts`**: Converted `getBaseServer`, `authAsUser`, and `setupDb` to `const` arrow functions. Replaced `console.error` with `logger.error` in `setupDb` (per backend logging rule).
- **`plugins.ts`**: Converted all 8 plugin `function` declarations (plus inner `applyDeleteFilter`) to `const` arrow functions. Added missing `description` properties to schema fields in `baseUserPlugin`, `createdUpdatedPlugin`, and `firebaseJWTPlugin` (per model field descriptions rule).

No logic, behavior, or variable naming changes beyond the above.

## Review & Testing Checklist for Human

- [ ] **Verify `this` binding is preserved in Mongoose hooks**: The `schema.pre(...)` callbacks in `plugins.ts` still use `function()` (not arrow), so `this` should correctly reference the Mongoose document/query. Confirm no subtle breakage in delete filtering or created/updated timestamps.
- [ ] **Check that no callers rely on function hoisting**: `const` arrow functions are not hoisted. All three files export their functions, so consumers import them — but worth a quick sanity check.
- [ ] **Review added `description` strings for accuracy**: New descriptions on `admin`, `email`, `updated`, `created`, and `firebaseId` fields will flow into the OpenAPI spec via mongoose-to-swagger.

Recommended test: run `bun api:test` to confirm plugin behavior (especially delete filtering, created/updated timestamps, and findOneOrNone/findExactlyOne) is unchanged.

### Notes
- The `console.error` → `logger.error` change in `tests.ts:setupDb` is a minor logging behavior change (Winston vs stdout) but aligns with the repo's backend logging rule.
- The `isDeletedPlugin`, `isDisabledPlugin`, and `deleted` field already had `description` properties before this PR — only fields that were missing descriptions were updated.

Link to Devin session: https://app.devin.ai/sessions/3c529df141a24b5b864eb7be8b740e3c
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily stylistic refactors and schema metadata additions; behavior should be unchanged aside from logging output, with minor risk if any callers depended on function hoisting.
> 
> **Overview**
> Refactors several `api/src` helpers/plugins from `function` declarations to exported `const` arrow functions (including the `applyDeleteFilter` helper in `isDeletedPlugin`) to match repository style.
> 
> Adds missing Mongoose schema field `description` metadata for `baseUserPlugin`, `createdUpdatedPlugin`, and `firebaseJWTPlugin`, and switches test DB setup error logging from `console.error` to `logger.error`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70b6be1c9beb037dc28ba2aaf4d9921e0c6c7d2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->