### PR TITLE
[alignRules] adminApp.test.ts, adminApp.ts, documentStorageApp.ts

### DIFF
--- a/admin-backend/src/adminApp.test.ts
+++ b/admin-backend/src/adminApp.test.ts
@@ -4,7 +4,9 @@ import {
   apiErrorMiddleware,
   apiUnauthorizedMiddleware,
   BackgroundTask,
+  type ScriptRunner,
   setupAuth,
+  type UserModel as UserModelType,
 } from "@terreno/api";
 import {authAsUser, getBaseServer, setupDb, UserModel} from "@terreno/api/src/tests";
 import type express from "express";
@@ -13,7 +15,7 @@ import type TestAgent from "supertest/lib/agent";
 
 import {AdminApp} from "./adminApp";
 
-const createTestScript = (overrides?: {runner?: any; name?: string; description?: string}) => ({
+const createTestScript = (overrides?: {runner?: ScriptRunner; name?: string; description?: string}) => ({
   description: overrides?.description ?? "A test script",
   name: overrides?.name ?? "test-script",
   runner:
@@ -43,8 +45,8 @@ const createFailingScript = () => ({
 
 const buildApp = (scripts = [createTestScript()]): express.Application => {
   const app = getBaseServer();
-  setupAuth(app, UserModel as any);
-  addAuthRoutes(app, UserModel as any);
+  setupAuth(app, UserModel as unknown as UserModelType);
+  addAuthRoutes(app, UserModel as unknown as UserModelType);
 
   const admin = new AdminApp({
     basePath: "/admin",
@@ -241,7 +243,7 @@ describe("AdminApp script routes", () => {
       const res = await adminAgent.delete(`/admin/scripts/tasks/${res1.body.taskId}`).expect(200);
 
       const logs = res.body.task.logs;
-      const cancelLog = logs.find((l: any) => l.message.includes("cancelled"));
+      const cancelLog = logs.find((l: {message: string; level: string}) => l.message.includes("cancelled"));
       expect(cancelLog).toBeDefined();
       expect(cancelLog.level).toBe("info");
     });

--- a/admin-backend/src/adminApp.ts
+++ b/admin-backend/src/adminApp.ts
@@ -6,6 +6,7 @@ import {
   type BackgroundTaskDocument,
   checkPermissions,
   getOpenApiSpecForModel,
+  type JSONValue,
   logger,
   type ModelRouterOptions,
   modelRouter,
@@ -15,6 +16,7 @@ import {
   type ScriptResult,
   type ScriptRunner,
   TaskCancelledError,
+  type User,
   VersionConfig,
 } from "@terreno/api";
 import express from "express";
@@ -31,6 +33,8 @@ export interface AdminFieldOverride {
 }
 
 export interface AdminModelConfig {
+  // noExplicitAny: Model must accept any document type for the generic admin panel;
+  // Model<unknown> breaks callers since Model<T> is invariant in T.
   /** The Mongoose model to expose in the admin panel */
   model: Model<any>;
   /** Route path for this model's endpoints, relative to basePath (e.g., "/users") */
@@ -78,7 +82,7 @@ interface AdminFieldMeta {
   required: boolean;
   description?: string;
   enum?: string[];
-  default?: any;
+  default?: unknown;
   ref?: string;
   widget?: string;
   /** For array fields: metadata about each item's sub-fields */
@@ -106,11 +110,16 @@ interface AdminConfigResponse {
   scripts: AdminScriptMeta[];
 }
 
-const toPlainObject = (value: any): any => {
-  if (value && typeof value === "object" && typeof value.toObject === "function") {
-    return value.toObject();
+const toPlainObject = (value: unknown): Record<string, unknown> => {
+  if (
+    value &&
+    typeof value === "object" &&
+    "toObject" in value &&
+    typeof value.toObject === "function"
+  ) {
+    return (value as {toObject: () => Record<string, unknown>}).toObject();
   }
-  return value;
+  return value as Record<string, unknown>;
 };
 
 const removeHiddenFields = (value: unknown, hiddenFieldSet: Set<string>): unknown => {
@@ -120,7 +129,7 @@ const removeHiddenFields = (value: unknown, hiddenFieldSet: Set<string>): unknow
   if (!value || typeof value !== "object") {
     return value;
   }
-  const plainValue = toPlainObject(value as any);
+  const plainValue = toPlainObject(value);
   const nextValue: Record<string, unknown> = {};
   for (const [key, fieldValue] of Object.entries(plainValue)) {
     if (!hiddenFieldSet.has(key)) {
@@ -130,8 +139,21 @@ const removeHiddenFields = (value: unknown, hiddenFieldSet: Set<string>): unknow
   return nextValue;
 };
 
+interface OpenApiProperty {
+  default?: unknown;
+  description?: string;
+  enum?: string[];
+  $ref?: string;
+  type?: string;
+  format?: string;
+  items?: {
+    properties?: Record<string, OpenApiProperty>;
+    required?: string[];
+  };
+}
+
 const extractFieldMeta = (
-  properties: Record<string, any>,
+  properties: Record<string, OpenApiProperty>,
   required: string[]
 ): Record<string, AdminFieldMeta> => {
   const fields: Record<string, AdminFieldMeta> = {};
@@ -148,7 +170,10 @@ const extractFieldMeta = (
     // For array fields, extract item sub-field metadata
     if (prop.type === "array" && prop.items?.properties) {
       const itemRequired: string[] = prop.items.required ?? [];
-      fields[key].items = extractFieldMeta(prop.items.properties, itemRequired);
+      fields[key].items = extractFieldMeta(
+        prop.items.properties as Record<string, OpenApiProperty>,
+        itemRequired
+      );
     }
 
     // Check for ObjectId references in the raw property
@@ -233,7 +258,10 @@ export class AdminApp {
 
     // Build config response with field metadata from Mongoose schemas
     const configModels: AdminModelMeta[] = modelConfigs.map((config) => {
-      const {properties, required} = getOpenApiSpecForModel(config.model);
+      const {properties, required} = getOpenApiSpecForModel(config.model) as {
+        properties: Record<string, OpenApiProperty>;
+        required: string[];
+      };
       const hiddenFieldSet = new Set(config.hiddenFields ?? []);
       const filteredProperties = Object.fromEntries(
         Object.entries(properties).filter(([key]) => !hiddenFieldSet.has(key))
@@ -299,7 +327,7 @@ export class AdminApp {
       `${basePath}/config`,
       authenticateMiddleware(),
       asyncHandler(async (req, res) => {
-        if (!(await checkPermissions("read", [Permissions.IsAdmin], req.user as any))) {
+        if (!(await checkPermissions("read", [Permissions.IsAdmin], req.user as User | undefined))) {
           throw new APIError({status: 403, title: "Admin access required"});
         }
         return res.json(configResponse);
@@ -312,7 +340,7 @@ export class AdminApp {
       versionConfigPath,
       authenticateMiddleware(),
       asyncHandler(async (req, res) => {
-        if (!(await checkPermissions("read", [Permissions.IsAdmin], req.user as any))) {
+        if (!(await checkPermissions("read", [Permissions.IsAdmin], req.user as User | undefined))) {
           throw new APIError({status: 403, title: "Admin access required"});
         }
         const config = await VersionConfig.findOneOrNone({_singleton: "config"});
@@ -332,7 +360,7 @@ export class AdminApp {
       versionConfigPath,
       authenticateMiddleware(),
       asyncHandler(async (req, res) => {
-        if (!(await checkPermissions("update", [Permissions.IsAdmin], req.user as any))) {
+        if (!(await checkPermissions("update", [Permissions.IsAdmin], req.user as User | undefined))) {
           throw new APIError({status: 403, title: "Admin access required"});
         }
         const raw = req.body as Record<string, unknown>;
@@ -374,6 +402,7 @@ export class AdminApp {
     // Mount modelRouter for each model with IsAdmin permissions
     for (const config of modelConfigs) {
       const hiddenFieldSet = new Set(config.hiddenFields ?? []);
+      // noExplicitAny: ModelRouterOptions<any> matches the Model<any> from AdminModelConfig.
       const routerOptions: ModelRouterOptions<any> = {
         ...(openApi ? {openApi: openApi as OpenApiMiddleware} : {}),
         permissions: {
@@ -385,8 +414,8 @@ export class AdminApp {
         },
         responseHandler:
           hiddenFieldSet.size > 0
-            ? async (value, _method, _request, _options): Promise<any> =>
-                removeHiddenFields(value, hiddenFieldSet) as any
+            ? async (value, _method, _request, _options): Promise<JSONValue> =>
+                removeHiddenFields(value, hiddenFieldSet) as JSONValue
             : undefined,
         sort: config.defaultSort ?? "-created",
       };

--- a/admin-backend/src/documentStorageApp.ts
+++ b/admin-backend/src/documentStorageApp.ts
@@ -48,7 +48,7 @@ const DEFAULT_ALLOWED_MIME_TYPES = new Set([
 const DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
 const isAdmin = (req: express.Request): boolean => {
-  const user = (req as any).user;
+  const user = req.user as {admin?: boolean} | undefined;
   return user?.admin === true;
 };
 
@@ -144,7 +144,8 @@ export class DocumentStorageApp {
             updated: file.metadata.updated as string,
           }));
 
-        const prefixes = ((apiResponse as any)?.prefixes as string[] | undefined) ?? [];
+        const prefixes =
+          ((apiResponse as {prefixes?: string[]})?.prefixes as string[] | undefined) ?? [];
         const folders = prefixes.map((p) => {
           const relative = p.slice(this.prefix.length);
           return relative;
@@ -164,9 +165,10 @@ export class DocumentStorageApp {
     app.post(
       `${basePath}/`,
       ...adminGuard,
+      // noExplicitAny: multer's RequestHandler type is incompatible with Express 5's middleware signature.
       upload.single("file") as any,
       asyncHandler(async (req: express.Request, res: express.Response) => {
-        const file = (req as any).file as Express.Multer.File | undefined;
+        const file = (req as unknown as {file?: Express.Multer.File}).file;
         if (!file) {
           throw new APIError({status: 400, title: "No file provided"});
         }
@@ -213,12 +215,20 @@ export class DocumentStorageApp {
           const [meta] = await gcsFile.getMetadata();
           metadata = meta as Record<string, unknown>;
           console.info("[documentStorage] getMetadata success", {
-            contentType: (meta as any)?.contentType,
-            etag: (meta as any)?.etag,
-            size: (meta as any)?.size,
+            contentType: metadata.contentType,
+            etag: metadata.etag,
+            size: metadata.size,
           });
-        } catch (err: any) {
-          if (err?.code === 404) {
+        } catch (err: unknown) {
+          const storageErr = err as {
+            code?: number;
+            message?: string;
+            stack?: string;
+            errors?: unknown[];
+            response?: unknown;
+            status?: number;
+          };
+          if (storageErr?.code === 404) {
             throw new APIError({
               detail: filePath,
               disableExternalErrorTracking: true,
@@ -227,21 +237,21 @@ export class DocumentStorageApp {
             });
           }
           console.error("[documentStorage] getMetadata error", {
-            code: err?.code,
-            errors: err?.errors,
-            message: err?.message,
-            response: err?.response,
-            stack: err?.stack,
-            status: err?.status,
+            code: storageErr?.code,
+            errors: storageErr?.errors,
+            message: storageErr?.message,
+            response: storageErr?.response,
+            stack: storageErr?.stack,
+            status: storageErr?.status,
           });
           logger.error("[documentStorage] getMetadata error", {
-            code: err?.code,
-            errors: err?.errors,
-            message: err?.message,
-            status: err?.status,
+            code: storageErr?.code,
+            errors: storageErr?.errors,
+            message: storageErr?.message,
+            status: storageErr?.status,
           });
           throw new APIError({
-            detail: err?.message ?? String(err),
+            detail: storageErr?.message ?? String(err),
             status: 500,
             title: "Failed to access file",
           });
@@ -259,20 +269,21 @@ export class DocumentStorageApp {
 
         try {
           await pipeline(gcsFile.createReadStream(), res);
-        } catch (err: any) {
+        } catch (err: unknown) {
+          const pipelineErr = err as {code?: number; message?: string; stack?: string};
           console.error("[documentStorage] pipeline error", {
-            code: err?.code,
-            message: err?.message,
-            stack: err?.stack,
+            code: pipelineErr?.code,
+            message: pipelineErr?.message,
+            stack: pipelineErr?.stack,
           });
           logger.error("[documentStorage] pipeline error", {
-            code: err?.code,
-            message: err?.message,
-            stack: err?.stack,
+            code: pipelineErr?.code,
+            message: pipelineErr?.message,
+            stack: pipelineErr?.stack,
           });
           if (!res.headersSent) {
             throw new APIError({
-              detail: err?.message ?? String(err),
+              detail: pipelineErr?.message ?? String(err),
               status: 500,
               title: "Failed to stream file",
             });


### PR DESCRIPTION
## Summary

Replaces explicit `any` types with precise types across three `admin-backend` files. No logic, behavior, or runtime changes — only type annotations.

**Key changes per file:**

- **adminApp.test.ts** — `runner?: any` → `ScriptRunner`, `UserModel as any` → double-cast through `unknown` to `UserModelType`, inline `(l: any)` → `{message: string; level: string}`
- **adminApp.ts** — New `OpenApiProperty` interface to replace `Record<string, any>` in `extractFieldMeta`; `toPlainObject` narrowed from `any`→`any` to `unknown`→`Record<string, unknown>` with proper `"toObject" in value` guard; `req.user as any` → `req.user as User | undefined` (×3); response handler typed as `JSONValue`
- **documentStorageApp.ts** — `(req as any).user` / `(req as any).file` → typed assertions; `catch (err: any)` → `catch (err: unknown)` with named error shape casts (×2); `(meta as any)?.contentType` → access via already-typed `metadata` variable

Three `any` usages are intentionally retained with `noExplicitAny:` comments:
- `Model<any>` in `AdminModelConfig` — `Model<T>` is invariant; `Model<unknown>` breaks callers
- `ModelRouterOptions<any>` — matches the `Model<any>` above
- `upload.single("file") as any` — multer's `RequestHandler` is incompatible with Express 5

## Review & Testing Checklist for Human

- [ ] **`toPlainObject` return type change**: Now returns `Record<string, unknown>` instead of `any`. Verify downstream consumers (only `removeHiddenFields`) still work correctly — the `Object.entries()` iteration should be fine, but confirm no caller expects specific typed properties.
- [ ] **`UserModel as unknown as UserModelType` double-cast in tests**: This masks potential type mismatches between the test `UserModel` and the production `UserModelType`. Confirm these are genuinely the same shape.
- [ ] **Error shape assertions in `documentStorageApp.ts`**: `err as {code?: number; ...}` — verify the GCS SDK errors actually carry these properties (they do today, but a major version bump could change this).

### Notes
- TypeScript compilation (`bun compile`) passes for `admin-backend`.
- The 2 lint errors reported are **pre-existing** `noNonNullAssertion` warnings in `adminApp.test.ts` (unrelated to these changes).

Link to Devin session: https://app.devin.ai/sessions/b9062c6ff64b44e3be6116e2186a7170
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refinements (replacing `any` with `unknown`/explicit shapes) with no intended runtime behavior changes; main risk is subtle compile-time casting assumptions around `req.user`/OpenAPI shapes.
> 
> **Overview**
> Tightens TypeScript typing across the admin backend by replacing several `any` usages with explicit types (`ScriptRunner`, `User`, `JSONValue`, and structured OpenAPI property types) and adding safer `unknown`-based narrowing.
> 
> `AdminApp` and `DocumentStorageApp` update request/user/file casting and error handling to use `unknown` plus explicit error-shape assertions, and the admin config metadata extraction now uses a typed `OpenApiProperty` interface instead of `Record<string, any>`. Tests were updated accordingly to use the new types and narrower log entry typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79426fbab9f7b1ec39eccbb83b5d1610f4ca272d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->