### PR TITLE
[alignRules] googleChatNotifier.test.ts, EmailField.test.tsx, aiRequest.test.ts, buildNumber.test.ts

### DIFF
--- a/ai/src/models/aiRequest.test.ts
+++ b/ai/src/models/aiRequest.test.ts
@@ -79,6 +79,87 @@ describe("AIRequest Model", () => {
     });
   });
 
+  describe("logMultiAgentRequest static", () => {
+    it("should create a parent request with sub-request references", async () => {
+      const sub1 = await AIRequest.create({
+        aiModel: "gpt-4",
+        prompt: "sub task 1",
+        requestType: "general",
+        response: "result 1",
+        responseTime: 100,
+        tokensUsed: 10,
+      });
+      const sub2 = await AIRequest.create({
+        aiModel: "gpt-4",
+        prompt: "sub task 2",
+        requestType: "general",
+        response: "result 2",
+        responseTime: 200,
+        tokensUsed: 20,
+      });
+
+      const parent = await AIRequest.logMultiAgentRequest({
+        aiModel: "gpt-4",
+        requestType: "multi-agent",
+        subRequestIds: [sub1._id, sub2._id],
+        totalResponseTime: 300,
+        totalTokensUsed: 30,
+      });
+
+      expect(parent._id).toBeDefined();
+      expect(parent.prompt).toBe("[multi-agent parent request]");
+      expect(parent.requestType).toBe("multi-agent");
+      expect(parent.totalResponseTime).toBe(300);
+      expect(parent.totalTokensUsed).toBe(30);
+      expect(parent.subRequestIds).toHaveLength(2);
+
+      // Verify sub-requests were updated with parentRequestId
+      const updatedSub1 = await AIRequest.findById(sub1._id);
+      const updatedSub2 = await AIRequest.findById(sub2._id);
+      expect(updatedSub1?.parentRequestId?.toString()).toBe(parent._id.toString());
+      expect(updatedSub2?.parentRequestId?.toString()).toBe(parent._id.toString());
+    });
+
+    it("should create a parent request with metadata", async () => {
+      const sub = await AIRequest.create({
+        aiModel: "gpt-4",
+        prompt: "sub",
+        requestType: "general",
+      });
+
+      const parent = await AIRequest.logMultiAgentRequest({
+        aiModel: "gpt-4",
+        metadata: {workflow: "test"},
+        requestType: "multi-agent",
+        subRequestIds: [sub._id],
+        totalResponseTime: 100,
+        totalTokensUsed: 10,
+      });
+
+      expect(parent.metadata).toEqual({workflow: "test"});
+    });
+
+    it("should create a parent request with userId", async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const sub = await AIRequest.create({
+        aiModel: "gpt-4",
+        prompt: "sub",
+        requestType: "general",
+      });
+
+      const parent = await AIRequest.logMultiAgentRequest({
+        aiModel: "gpt-4",
+        requestType: "multi-agent",
+        subRequestIds: [sub._id],
+        totalResponseTime: 50,
+        totalTokensUsed: 5,
+        userId,
+      });
+
+      expect(parent.userId?.toString()).toBe(userId.toString());
+    });
+  });
+
   describe("soft delete", () => {
     it("should filter out deleted records by default", async () => {
       await AIRequest.create({

--- a/api/src/notifiers/googleChatNotifier.test.ts
+++ b/api/src/notifiers/googleChatNotifier.test.ts
@@ -111,4 +111,14 @@ describe("sendToGoogleChat", () => {
     await sendToGoogleChat("err", {shouldThrow: false});
     expect(mockAxiosPost.mock.calls.length).toBe(1);
   });
+
+  it("returns early when webhook url is missing for channel and no default exists", async () => {
+    process.env.GOOGLE_CHAT_WEBHOOKS = JSON.stringify({
+      ops: "https://chat.example/ops",
+    });
+
+    await sendToGoogleChat("no default", {channel: "missing"});
+    expect(mockAxiosPost.mock.calls.length).toBe(0);
+    expect(Sentry.captureException).toHaveBeenCalled();
+  });
 });

--- a/rtk/src/buildNumber.test.ts
+++ b/rtk/src/buildNumber.test.ts
@@ -1,0 +1,120 @@
+import {afterAll, beforeEach, describe, expect, it} from "bun:test";
+
+import {coerceBuildNumber, resolveBuildNumber} from "./buildNumber";
+
+describe("coerceBuildNumber", () => {
+  it("returns undefined for undefined", () => {
+    expect(coerceBuildNumber(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for null", () => {
+    expect(coerceBuildNumber(null)).toBeUndefined();
+  });
+
+  it("returns the number for a valid positive integer", () => {
+    expect(coerceBuildNumber(42)).toBe(42);
+  });
+
+  it("returns the number for zero", () => {
+    expect(coerceBuildNumber(0)).toBe(0);
+  });
+
+  it("returns undefined for NaN", () => {
+    expect(coerceBuildNumber(Number.NaN)).toBeUndefined();
+  });
+
+  it("returns undefined for Infinity", () => {
+    expect(coerceBuildNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
+  });
+
+  it("parses a valid numeric string", () => {
+    expect(coerceBuildNumber("123")).toBe(123);
+  });
+
+  it("returns undefined for a non-numeric string", () => {
+    expect(coerceBuildNumber("abc")).toBeUndefined();
+  });
+
+  it("returns the number for a negative integer", () => {
+    expect(coerceBuildNumber(-5)).toBe(-5);
+  });
+
+  it("parses a string with leading zeros", () => {
+    expect(coerceBuildNumber("007")).toBe(7);
+  });
+});
+
+describe("resolveBuildNumber", () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = {...ORIGINAL_ENV};
+    delete process.env.EXPO_PUBLIC_BUILD_NUMBER;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("returns override when provided", () => {
+    expect(resolveBuildNumber({override: 99})).toBe(99);
+  });
+
+  it("returns configValue when override is not provided", () => {
+    expect(resolveBuildNumber({configValue: 50})).toBe(50);
+  });
+
+  it("returns env var when override and configValue are not provided", () => {
+    process.env.EXPO_PUBLIC_BUILD_NUMBER = "200";
+    expect(resolveBuildNumber()).toBe(200);
+  });
+
+  it("uses custom envVar name", () => {
+    process.env.CUSTOM_BUILD = "77";
+    expect(resolveBuildNumber({envVar: "CUSTOM_BUILD"})).toBe(77);
+  });
+
+  it("prefers override over configValue", () => {
+    expect(resolveBuildNumber({configValue: 10, override: 20})).toBe(20);
+  });
+
+  it("prefers configValue over env var", () => {
+    process.env.EXPO_PUBLIC_BUILD_NUMBER = "300";
+    expect(resolveBuildNumber({configValue: 15})).toBe(15);
+  });
+
+  it("falls back to git rev-list count when nothing else is set", () => {
+    const result = resolveBuildNumber();
+    // In a git repo, this should return a positive integer
+    expect(typeof result).toBe("number");
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it("skips invalid env var values and falls through to git", () => {
+    process.env.EXPO_PUBLIC_BUILD_NUMBER = "not-a-number";
+    // Should fall through past the env var to git
+    const result = resolveBuildNumber();
+    expect(typeof result).toBe("number");
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it("skips undefined override and uses configValue", () => {
+    expect(resolveBuildNumber({configValue: 42, override: undefined})).toBe(42);
+  });
+
+  it("skips invalid configValue and uses env var", () => {
+    process.env.EXPO_PUBLIC_BUILD_NUMBER = "88";
+    expect(resolveBuildNumber({configValue: "bad"})).toBe(88);
+  });
+
+  it("returns a number with default options", () => {
+    const result = resolveBuildNumber();
+    expect(result).toBeDefined();
+    expect(typeof result).toBe("number");
+  });
+
+  it("prefers override over env var", () => {
+    process.env.EXPO_PUBLIC_BUILD_NUMBER = "999";
+    expect(resolveBuildNumber({override: 1})).toBe(1);
+  });
+});

--- a/ui/src/EmailField.test.tsx
+++ b/ui/src/EmailField.test.tsx
@@ -103,4 +103,85 @@ describe("EmailField", () => {
     );
     expect(toJSON()).toMatchSnapshot();
   });
+
+  it("calls onBlur with valid email", async () => {
+    const handleBlur = mock((_value: string) => {});
+    const {getByDisplayValue} = renderWithTheme(
+      <EmailField label="Email" onBlur={handleBlur} onChange={() => {}} value="valid@email.com" />
+    );
+
+    const input = getByDisplayValue("valid@email.com");
+    await act(async () => {
+      fireEvent(input, "blur", {nativeEvent: {text: "valid@email.com"}});
+    });
+
+    await waitFor(() => {
+      expect(handleBlur).toHaveBeenCalledWith("valid@email.com");
+    });
+  });
+
+  it("does not call onBlur with invalid email", async () => {
+    const handleBlur = mock((_value: string) => {});
+    const {getByDisplayValue} = renderWithTheme(
+      <EmailField label="Email" onBlur={handleBlur} onChange={() => {}} value="" />
+    );
+
+    const input = getByDisplayValue("");
+    await act(async () => {
+      fireEvent.changeText(input, "invalid-email");
+    });
+    await act(async () => {
+      fireEvent(input, "blur", {nativeEvent: {text: "invalid-email"}});
+    });
+
+    expect(handleBlur).not.toHaveBeenCalled();
+  });
+
+  it("clears local error when typing a valid email after invalid", async () => {
+    const handleChange = mock((_value: string) => {});
+    const {getByDisplayValue, queryByText} = renderWithTheme(
+      <EmailField label="Email" onChange={handleChange} value="" />
+    );
+
+    const input = getByDisplayValue("");
+
+    // Type invalid email first
+    await act(async () => {
+      fireEvent.changeText(input, "bad");
+    });
+    // Trigger blur to set the error
+    await act(async () => {
+      fireEvent(input, "blur", {nativeEvent: {text: "bad"}});
+    });
+
+    await waitFor(() => {
+      expect(queryByText("Invalid email address format")).toBeTruthy();
+    });
+
+    // Now type a valid email to clear the error
+    await act(async () => {
+      fireEvent.changeText(input, "good@email.com");
+    });
+
+    await waitFor(() => {
+      expect(queryByText("Invalid email address format")).toBeFalsy();
+      expect(handleChange).toHaveBeenCalledWith("good@email.com");
+    });
+  });
+
+  it("validates empty string as valid on blur", async () => {
+    const handleBlur = mock((_value: string) => {});
+    const {getByDisplayValue} = renderWithTheme(
+      <EmailField label="Email" onBlur={handleBlur} onChange={() => {}} value="" />
+    );
+
+    const input = getByDisplayValue("");
+    await act(async () => {
+      fireEvent(input, "blur", {nativeEvent: {text: ""}});
+    });
+
+    await waitFor(() => {
+      expect(handleBlur).toHaveBeenCalledWith("");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Test coverage improvements across all four packages (`api`, `ui`, `ai`, `rtk`). No production code changes.

| Package | File | Coverage before | Coverage after |
|---------|------|----------------|----------------|
| api | `googleChatNotifier.ts` | 89.74% | 100% |
| ui | `EmailField.tsx` | 86.44% | 100% |
| ai | `aiRequest.ts` | 79.31% | 100% |
| rtk | `buildNumber.ts` | 0% (no tests) | 96.43% |

**api** — Added 1 test for the missing-webhook-URL-with-no-default early-return path (lines 23-28 of source).

**ui** — Added 4 tests covering the `onBlur` validation callback and the error-clearing path in `onChange` (previously untested `localOnBlur` and the `localError` clearing branch).

**ai** — Added 3 tests for the `logMultiAgentRequest` static method, covering parent/sub-request linking, metadata pass-through, and userId propagation.

**rtk** — New test file with 22 tests for `coerceBuildNumber` (10 edge cases) and `resolveBuildNumber` (12 tests covering the priority chain: override → configValue → env var → git fallback).

## Review & Testing Checklist for Human

- [ ] Verify the `aiRequest` tests correctly exercise the `logMultiAgentRequest` static — specifically that `updateMany` linking sub-requests to the parent is validated (lines 117-120 of the test)
- [ ] Confirm `buildNumber.test.ts` `resolveBuildNumber` tests will pass in CI (they rely on running inside a git repo for the git-fallback tests; the `catch` branch for git failure is **not** covered since `execSync` can't be easily mocked with static imports — 96.43% vs 100%)

### Notes
- The `bun.lock` diff was intentionally excluded from the commit since no dependencies were changed.
- RTK `buildNumber.ts` coverage gap: the `catch` block (git unavailable fallback, lines 65-68) is not exercised because Bun's module system doesn't support runtime replacement of statically imported `execSync`. This is a known limitation, not a test oversight.

Link to Devin session: https://app.devin.ai/sessions/0d530893b7e142dcb052d48553e65d90
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes; main risk is potential CI flakiness from `resolveBuildNumber` tests that depend on running inside a git repo / environment variables.
> 
> **Overview**
> Improves test coverage across `ai`, `api`, and `ui` by adding new assertions for previously untested branches: `AIRequest.logMultiAgentRequest` parent/child linking (including `parentRequestId` updates), `sendToGoogleChat` early-return when a channel has no webhook and no default, and `EmailField` `onBlur` validation plus clearing of local error state on valid input.
> 
> Adds a new `rtk` test suite for `buildNumber` covering `coerceBuildNumber` edge cases and the `resolveBuildNumber` precedence chain (override/config/env/git fallback).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc77c11bad92a4868c1cca615e37c7433d044c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->