### PR TITLE
[alignRules] consentApp.test.ts

### DIFF
--- a/api/src/consentApp.test.ts
+++ b/api/src/consentApp.test.ts
@@ -707,6 +707,168 @@ describe("ConsentApp", () => {
     });
   });
 
+  describe("POST /consent-forms/generate (aiConfig)", () => {
+    const aiConfig = {
+      generateContent: async ({
+        type,
+        description,
+        locale,
+      }: {
+        type: string;
+        description: string;
+        locale: string;
+      }) => `Generated ${type} content (${locale}) for: ${description}`,
+      translateContent: async ({
+        content,
+        fromLocale,
+        toLocale,
+      }: {
+        content: string;
+        fromLocale: string;
+        toLocale: string;
+      }) => `[${fromLocale}->${toLocale}] ${content}`,
+    };
+
+    it("generates consent form content for admins", async () => {
+      const aiApp = buildApp({aiConfig});
+      const aiAdmin = await authAsUser(aiApp, "admin");
+
+      const res = await aiAdmin
+        .post("/consent-forms/generate")
+        .send({description: "Privacy policy for a health app", locale: "es", type: "privacy"})
+        .expect(200);
+
+      expect(res.body.data.content).toBe(
+        "Generated privacy content (es) for: Privacy policy for a health app"
+      );
+    });
+
+    it("defaults locale to en when not provided", async () => {
+      const aiApp = buildApp({aiConfig});
+      const aiAdmin = await authAsUser(aiApp, "admin");
+
+      const res = await aiAdmin
+        .post("/consent-forms/generate")
+        .send({description: "Terms", type: "terms"})
+        .expect(200);
+
+      expect(res.body.data.content).toContain("(en)");
+    });
+
+    it("returns 403 for non-admin users", async () => {
+      const aiApp = buildApp({aiConfig});
+      const aiUser = await authAsUser(aiApp, "notAdmin");
+
+      await aiUser
+        .post("/consent-forms/generate")
+        .send({description: "Privacy", type: "privacy"})
+        .expect(403);
+    });
+
+    it("returns 400 when type is missing", async () => {
+      const aiApp = buildApp({aiConfig});
+      const aiAdmin = await authAsUser(aiApp, "admin");
+
+      await aiAdmin.post("/consent-forms/generate").send({description: "Privacy"}).expect(400);
+    });
+
+    it("returns 400 when description is missing", async () => {
+      const aiApp = buildApp({aiConfig});
+      const aiAdmin = await authAsUser(aiApp, "admin");
+
+      await aiAdmin.post("/consent-forms/generate").send({type: "privacy"}).expect(400);
+    });
+
+    it("returns 404 when aiConfig is not provided", async () => {
+      await adminAgent
+        .post("/consent-forms/generate")
+        .send({description: "Privacy", type: "privacy"})
+        .expect(404);
+    });
+  });
+
+  describe("POST /consent-forms/translate (aiConfig)", () => {
+    const aiConfig = {
+      generateContent: async ({
+        type,
+        description,
+        locale,
+      }: {
+        type: string;
+        description: string;
+        locale: string;
+      }) => `Generated ${type} content (${locale}) for: ${description}`,
+      translateContent: async ({
+        content,
+        fromLocale,
+        toLocale,
+      }: {
+        content: string;
+        fromLocale: string;
+        toLocale: string;
+      }) => `[${fromLocale}->${toLocale}] ${content}`,
+    };
+
+    it("translates consent form content for admins", async () => {
+      const aiApp = buildApp({aiConfig});
+      const aiAdmin = await authAsUser(aiApp, "admin");
+
+      const res = await aiAdmin
+        .post("/consent-forms/translate")
+        .send({content: "Hello world", fromLocale: "en", toLocale: "es"})
+        .expect(200);
+
+      expect(res.body.data.content).toBe("[en->es] Hello world");
+    });
+
+    it("returns 403 for non-admin users", async () => {
+      const aiApp = buildApp({aiConfig});
+      const aiUser = await authAsUser(aiApp, "notAdmin");
+
+      await aiUser
+        .post("/consent-forms/translate")
+        .send({content: "Hello", fromLocale: "en", toLocale: "es"})
+        .expect(403);
+    });
+
+    it("returns 400 when content is missing", async () => {
+      const aiApp = buildApp({aiConfig});
+      const aiAdmin = await authAsUser(aiApp, "admin");
+
+      await aiAdmin
+        .post("/consent-forms/translate")
+        .send({fromLocale: "en", toLocale: "es"})
+        .expect(400);
+    });
+
+    it("returns 400 when fromLocale is missing", async () => {
+      const aiApp = buildApp({aiConfig});
+      const aiAdmin = await authAsUser(aiApp, "admin");
+
+      await aiAdmin
+        .post("/consent-forms/translate")
+        .send({content: "Hello", toLocale: "es"})
+        .expect(400);
+    });
+
+    it("returns 400 when toLocale is missing", async () => {
+      const aiApp = buildApp({aiConfig});
+      const aiAdmin = await authAsUser(aiApp, "admin");
+
+      await aiAdmin
+        .post("/consent-forms/translate")
+        .send({content: "Hello", fromLocale: "en"})
+        .expect(400);
+    });
+
+    it("returns 404 when aiConfig is not provided", async () => {
+      await adminAgent
+        .post("/consent-forms/translate")
+        .send({content: "Hello", fromLocale: "en", toLocale: "es"})
+        .expect(404);
+    });
+  });
+
   describe("GET /consents/audit/:userId", () => {
     it("returns audit history for a user when auditTrail is enabled", async () => {
       const form = await ConsentForm.create({


### PR DESCRIPTION
## Summary
Adds test coverage for the AI-powered endpoints in `api/src/consentApp.ts` that were previously uncovered:
- `POST /consent-forms/generate` (aiConfig path)
- `POST /consent-forms/translate` (aiConfig path)

Tests cover: happy-path admin usage, admin-only access (403 for non-admin), required-field validation (400 responses), default locale fallback, and 404 behavior when `aiConfig` is not provided on the plugin.

This brings `consentApp.ts` line & function coverage to 100% per `bun test --coverage`. No production code was changed — only additions to `api/src/consentApp.test.ts`.

## Review & Testing Checklist for Human
- [ ] Confirm the mocked `aiConfig` in the new describe blocks matches the real-world shape used in downstream consumers (e.g. flourish)
- [ ] Verify CI `api:test` passes and coverage numbers look reasonable

### Notes
- No changes to `consentApp.ts` itself — the endpoints already existed but had no tests exercising the `aiConfig` branch.
- Linter (biome) and TypeScript compile were run locally on the changed file before pushing.

Link to Devin session: https://app.devin.ai/sessions/34e0d8faa2344c15bbcf3bc1e7490904
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to new test cases covering existing routes and validation paths, with no production code modifications.
> 
> **Overview**
> Adds new tests for the `aiConfig`-gated admin endpoints `POST /consent-forms/generate` and `POST /consent-forms/translate`.
> 
> Coverage includes admin happy paths, **admin-only enforcement (403)**, required-field validation (400), locale defaulting to `en`, and **404 behavior when `aiConfig` is not configured**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64dbb76ca73c69b7667ad6d3efb87269188ad5db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->