### PR TITLE
[alignRules] Banner.tsx, TextFieldNumberActionSheet.tsx, Toast.tsx

### DIFF
--- a/ui/src/Banner.tsx
+++ b/ui/src/Banner.tsx
@@ -86,9 +86,9 @@ const BannerButton = ({
   );
 };
 
-function getKey(id: string): string {
+const getKey = (id: string): string => {
   return `@TerrenoUI:${id}`;
-}
+};
 
 export const hideBanner = (id: string): Promise<void> => {
   console.debug(`[banner] Hiding ${getKey(id)} `);

--- a/ui/src/TextFieldNumberActionSheet.tsx
+++ b/ui/src/TextFieldNumberActionSheet.tsx
@@ -12,7 +12,7 @@ export class NumberPickerActionSheet extends React.Component<
   TextFieldPickerActionSheetProps,
   NumberPickerActionSheetState
 > {
-  render() {
+  render(): React.ReactElement {
     return (
       <ActionSheet bounceOnOpen gestureEnabled ref={this.props.actionSheetRef}>
         <Box marginBottom={8} paddingX={4} width="100%">

--- a/ui/src/Toast.tsx
+++ b/ui/src/Toast.tsx
@@ -21,7 +21,7 @@ type UseToastVariantOptions = {
 
 type UseToastOptions = {variant?: ToastProps["variant"]} & UseToastVariantOptions;
 
-export function useToast(): {
+export const useToast = (): {
   hide: (id: string) => void;
   success: (title: string, options?: UseToastVariantOptions) => string;
   info: (title: string, options?: UseToastVariantOptions) => string;
@@ -29,7 +29,7 @@ export function useToast(): {
   error: (title: string, options?: UseToastVariantOptions) => string;
   show: (title: string, options?: UseToastOptions) => string;
   catch: (error: any, message?: string, options?: UseToastVariantOptions) => void;
-} {
+} => {
   const toast = useToastNotifications();
   const show = (title: string, options?: UseToastOptions): string => {
     if (!toast?.show) {
@@ -78,7 +78,7 @@ export function useToast(): {
       return show(title, {...options, variant: "warning"});
     },
   };
-}
+};
 
 // TODO: Support secondary version of Toast.
 // TODO: Support dismissible version of Toast. Currently only persistent are dismissible.


### PR DESCRIPTION
## Summary

Minimal style-only alignment with the Terreno code style rules (see `.rulesync/rules/00-root.md` — "Prefer const arrow functions over `function` keyword", "Always provide return types for functions"). No logic or behavior changes.

- `ui/src/Banner.tsx`: convert `function getKey(...)` to `const getKey = (...) =>`.
- `ui/src/Toast.tsx`: convert `export function useToast(): {...} {` to `export const useToast = (): {...} => {`.
- `ui/src/TextFieldNumberActionSheet.tsx`: add explicit `React.ReactElement` return type on the class `render()` method.

Verified locally:
- `bun ui:lint` ✓
- `bun compile` ✓ for `@terreno/ui` and `@terreno/api` (unrelated pre-existing errors remain in `@terreno/example-backend` about missing module type declarations — not touched here).

## Review & Testing Checklist for Human

- [ ] Confirm no consumers rely on function-declaration hoisting for `useToast` or `getKey` (they're both declared before any usage in-file / imported normally, so this should be a no-op).
- [ ] Sanity-check `Toast`, `Banner`, and `NumberPickerActionSheet` still render in the demo app.

### Notes

I considered also converting the `interface NumberPickerActionSheetState {}` form for the `type`→`interface` rule, but biome's `noEmptyInterface` lint rule forbids empty interfaces and requires a type alias, so the original `type … = {}` form was kept to satisfy the lint rule that's actually enforced in CI.

Link to Devin session: https://app.devin.ai/sessions/9d375350f098487ebed82a280c64702e
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, style/typing-only refactors; the only potential footgun is loss of function-declaration hoisting for `useToast`/`getKey`, but usage remains after definition and imports are unchanged.
> 
> **Overview**
> Aligns UI components to style rules by converting `function` declarations to `const` arrow functions in `Banner.tsx` (`getKey`) and `Toast.tsx` (`useToast`).
> 
> Adds an explicit `React.ReactElement` return type to `NumberPickerActionSheet.render()` in `TextFieldNumberActionSheet.tsx`, with no intended runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a500de7e23baf20ea6655c01763eec64ce6fa9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->