### PR TITLE
[alignRules] Signature.test.tsx

### DIFF
--- a/ui/src/Signature.test.tsx
+++ b/ui/src/Signature.test.tsx
@@ -1,15 +1,26 @@
 import {describe, expect, it, mock} from "bun:test";
-import {forwardRef} from "react";
+import {fireEvent} from "@testing-library/react-native";
+import {forwardRef, useImperativeHandle} from "react";
 import {View} from "react-native";
 
 import {Signature} from "./Signature";
 import {renderWithTheme} from "./test-utils";
 
-// Mock react-signature-canvas
+const clearMock = mock(() => {});
+let toDataURLReturn: string = "";
+const toDataURLMock = mock(() => toDataURLReturn);
+let lastOnEnd: (() => void) | undefined;
+
+// Mock react-signature-canvas so we can exercise the ref methods and onEnd callback.
 mock.module("react-signature-canvas", () => ({
-  default: forwardRef(({backgroundColor}: any, ref) => (
-    <View ref={ref as any} style={{backgroundColor}} testID="signature-canvas" />
-  )),
+  default: forwardRef(({backgroundColor, onEnd}: any, ref) => {
+    lastOnEnd = onEnd;
+    useImperativeHandle(ref, () => ({
+      clear: clearMock,
+      toDataURL: toDataURLMock,
+    }));
+    return <View style={{backgroundColor}} testID="signature-canvas" />;
+  }),
 }));
 
 describe("Signature", () => {
@@ -28,5 +39,31 @@ describe("Signature", () => {
     const mockOnChange = mock(() => {});
     const {getByText} = renderWithTheme(<Signature onChange={mockOnChange} />);
     expect(getByText("Clear")).toBeTruthy();
+  });
+
+  it("calls clear on the signature canvas when Clear is pressed", () => {
+    clearMock.mockClear();
+    const mockOnChange = mock(() => {});
+    const {getByText} = renderWithTheme(<Signature onChange={mockOnChange} />);
+    fireEvent.press(getByText("Clear"));
+    expect(clearMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onChange with the data URL when a stroke ends", () => {
+    toDataURLReturn = "data:image/png;base64,abc";
+    const mockOnChange = mock(() => {});
+    renderWithTheme(<Signature onChange={mockOnChange} />);
+    expect(lastOnEnd).toBeDefined();
+    lastOnEnd?.();
+    expect(mockOnChange).toHaveBeenCalledWith("data:image/png;base64,abc");
+  });
+
+  it("does not call onChange when toDataURL returns an empty value", () => {
+    toDataURLReturn = "";
+    const mockOnChange = mock(() => {});
+    renderWithTheme(<Signature onChange={mockOnChange} />);
+    expect(lastOnEnd).toBeDefined();
+    lastOnEnd?.();
+    expect(mockOnChange).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/__snapshots__/Signature.test.tsx.snap
+++ b/ui/src/__snapshots__/Signature.test.tsx.snap
@@ -11,9 +11,6 @@ exports[`Signature renders correctly 1`] = `
           "$$typeof": Symbol(react.test.json),
           "children": null,
           "props": {
-            "ref": {
-              "current": null,
-            },
             "style": {
               "backgroundColor": "#FFFFFF",
             },


### PR DESCRIPTION
## Summary
Adds test coverage for `ui/src/Signature.tsx`, exercising branches that were previously uncovered (the `onClear` handler and the `onUpdatedSignature` / onEnd handler).

Changes are test-only — no production code was modified:
- Updates the `react-signature-canvas` module mock in `Signature.test.tsx` to expose `clear` and `toDataURL` via `useImperativeHandle` and to capture the `onEnd` prop, so the ref-driven code paths can be triggered from tests.
- Adds three new tests:
  - Pressing the "Clear" link calls `clear()` on the canvas ref.
  - On stroke end, `onChange` is called with the data URL returned by `toDataURL()`.
  - On stroke end, `onChange` is NOT called when `toDataURL()` returns an empty value.
- Regenerates the `Signature.test.tsx.snap` snapshot (the `ref` entry is no longer serialized into the snapshot because the mock now passes the ref through `useImperativeHandle` instead of attaching it directly to the underlying `View`).

Brings `Signature.tsx` to 100% function / 100% line coverage locally per `bun test --coverage` (target was 90%).

Lint (`biome`) and TypeScript compile (`tsc`) were run locally on the package before pushing.

## Review & Testing Checklist for Human
- [ ] Review the mock strategy — the mock file uses module-level mutable state (`lastOnEnd`, `toDataURLReturn`, `clearMock`, `toDataURLMock`) which is scoped to this test file but could be surprising; confirm there's no cross-test leakage.
- [ ] Confirm the updated snapshot is acceptable (only change is the removal of the `"ref": { "current": null }` entry that was previously serialized by the mock).
- [ ] Spot-check the new `onChange` / `clear` assertions match the actual component contract.

### Notes
- No changes to `Signature.tsx` itself.
- `Signature.native.tsx` is not touched by this PR.

Link to Devin session: https://app.devin.ai/sessions/34e0d8faa2344c15bbcf3bc1e7490904
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are test-only and limited to the `Signature` unit test/mocks plus an updated snapshot.
> 
> **Overview**
> Improves `Signature` test coverage by enhancing the `react-signature-canvas` mock to expose `clear()`/`toDataURL()` via `useImperativeHandle` and to capture the `onEnd` callback.
> 
> Adds assertions that pressing **Clear** calls `clear()`, that `onEnd` triggers `onChange` with the canvas `toDataURL()` result, and that empty `toDataURL()` output does not call `onChange`. Updates the snapshot to reflect the new mock behavior (no serialized `ref`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5976763298bddfde9ebc0269b13799d0284f7d24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->