### PR TITLE
[alignRules] aiRequestsExplorer.ts

### DIFF
--- a/ai/src/routes/routes.test.ts
+++ b/ai/src/routes/routes.test.ts
@@ -172,5 +172,122 @@ describe("AI Routes", () => {
       expect(res.body.total).toBeGreaterThanOrEqual(1);
       expect(res.body.page).toBe(1);
     });
+
+    it("filters by requestType query parameter", async () => {
+      await AIRequest.create({
+        aiModel: "gpt-4",
+        prompt: "remix prompt",
+        requestType: "remix",
+        response: "remix response",
+      });
+      await AIRequest.create({
+        aiModel: "gpt-4",
+        prompt: "general prompt",
+        requestType: "general",
+        response: "general response",
+      });
+
+      const agent = await authAsUser(app, "admin");
+      const res = await agent.get("/aiRequestsExplorer?requestType=remix");
+
+      expect(res.status).toBe(200);
+      expect(res.body.total).toBe(1);
+      expect(res.body.data[0].requestType).toBe("remix");
+    });
+
+    it("filters by model query parameter", async () => {
+      await AIRequest.create({
+        aiModel: "gpt-4",
+        prompt: "p1",
+        requestType: "general",
+        response: "r1",
+      });
+      await AIRequest.create({
+        aiModel: "claude-3",
+        prompt: "p2",
+        requestType: "general",
+        response: "r2",
+      });
+
+      const agent = await authAsUser(app, "admin");
+      const res = await agent.get("/aiRequestsExplorer?model=claude-3");
+
+      expect(res.status).toBe(200);
+      expect(res.body.total).toBe(1);
+      expect(res.body.data[0].aiModel).toBe("claude-3");
+    });
+
+    it("filters by startDate query parameter", async () => {
+      const old = await AIRequest.create({
+        aiModel: "gpt-4",
+        prompt: "old",
+        requestType: "general",
+        response: "r",
+      });
+      await AIRequest.updateOne({_id: old._id}, {created: new Date("2020-01-01T00:00:00Z")});
+
+      await AIRequest.create({
+        aiModel: "gpt-4",
+        prompt: "new",
+        requestType: "general",
+        response: "r",
+      });
+
+      const agent = await authAsUser(app, "admin");
+      const res = await agent.get("/aiRequestsExplorer?startDate=2024-01-01T00:00:00Z");
+
+      expect(res.status).toBe(200);
+      // Only the recently-created record should be returned
+      expect(res.body.total).toBe(1);
+    });
+
+    it("filters by endDate query parameter", async () => {
+      const old = await AIRequest.create({
+        aiModel: "gpt-4",
+        prompt: "old",
+        requestType: "general",
+        response: "r",
+      });
+      await AIRequest.updateOne({_id: old._id}, {created: new Date("2020-01-01T00:00:00Z")});
+
+      await AIRequest.create({
+        aiModel: "gpt-4",
+        prompt: "new",
+        requestType: "general",
+        response: "r",
+      });
+
+      const agent = await authAsUser(app, "admin");
+      const res = await agent.get("/aiRequestsExplorer?endDate=2021-01-01T00:00:00Z");
+
+      expect(res.status).toBe(200);
+      expect(res.body.total).toBe(1);
+    });
+
+    it("filters by startDate and endDate range", async () => {
+      const a = await AIRequest.create({
+        aiModel: "gpt-4",
+        prompt: "a",
+        requestType: "general",
+        response: "r",
+      });
+      await AIRequest.updateOne({_id: a._id}, {created: new Date("2022-06-01T00:00:00Z")});
+
+      const b = await AIRequest.create({
+        aiModel: "gpt-4",
+        prompt: "b",
+        requestType: "general",
+        response: "r",
+      });
+      await AIRequest.updateOne({_id: b._id}, {created: new Date("2020-01-01T00:00:00Z")});
+
+      const agent = await authAsUser(app, "admin");
+      const res = await agent.get(
+        "/aiRequestsExplorer?startDate=2022-01-01T00:00:00Z&endDate=2023-01-01T00:00:00Z"
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.total).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary
Adds test coverage for the query-parameter filter branches in `ai/src/routes/aiRequestsExplorer.ts` that were previously uncovered (lines 48–62). Test-only — no production code changed.

New tests added to `ai/src/routes/routes.test.ts` under `AI Requests Explorer route`:
- Filters by `requestType`
- Filters by `model` (maps to `aiModel`)
- Filters by `startDate` (lower bound on `created`)
- Filters by `endDate` (upper bound on `created`)
- Combined `startDate` + `endDate` range

Brings `aiRequestsExplorer.ts` to 100% function / 100% line coverage locally per `bun test --coverage` (target was 90%).

Lint (`biome`) and TypeScript compile (`tsc`) were run locally on the package before pushing.

## Review & Testing Checklist for Human
- [ ] The date-range tests set `created` via a direct `AIRequest.updateOne(...)` after create. Confirm this is a reliable way to override the auto-managed `created` timestamp for these docs given the `createdUpdatedPlugin` in use.
- [ ] Spot-check that the new filters exercise the intended code branches (lines 48–62 in `aiRequestsExplorer.ts`) and not just the happy path.

### Notes
- No changes to `aiRequestsExplorer.ts` itself.
- Test isolation is handled by the existing `afterEach` in the file, which clears `AIRequest` and `GptHistory`.

Link to Devin session: https://app.devin.ai/sessions/34e0d8faa2344c15bbcf3bc1e7490904
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds route-level tests and does not modify production code or request-handling logic.
> 
> **Overview**
> Adds new tests for `GET /aiRequestsExplorer` to exercise previously-uncovered query-parameter filtering branches.
> 
> Coverage now includes filtering by `requestType`, `model` (mapped to `aiModel`), `startDate`/`endDate` bounds on `created`, and a combined date-range filter; tests set up records and assert the filtered result counts/fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be9ac41aa9a4caa24a119a08f5369cbaa10f6411. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->