### PR TITLE
[alignRules] tagGenerator.ts

### DIFF
--- a/rtk/src/tagGenerator.test.ts
+++ b/rtk/src/tagGenerator.test.ts
@@ -1,0 +1,109 @@
+import {describe, expect, it} from "bun:test";
+
+import {generateTags} from "./tagGenerator";
+
+describe("generateTags", () => {
+  const tagTypes = ["users", "posts", "conversations", "messages"];
+
+  it("assigns invalidatesTags for getConversations endpoint", () => {
+    const api = {
+      endpoints: {
+        getConversations: {},
+      },
+    };
+    const tags = generateTags(api, tagTypes);
+    // getConversations matches both the special case AND the list-endpoint branch,
+    // so the list-endpoint branch wins as the final assignment. The special case
+    // still executes for coverage, but the final value is the list providesTags.
+    expect(tags.getConversations).toBeDefined();
+    expect(typeof tags.getConversations.providesTags).toBe("function");
+  });
+
+  it("assigns providesTags on list get endpoints", () => {
+    const api = {
+      endpoints: {
+        getUsers: {},
+      },
+    };
+    const tags = generateTags(api, tagTypes);
+    expect(typeof tags.getUsers.providesTags).toBe("function");
+
+    // Exercise the returned provides function with and without data
+    const providesFn = tags.getUsers.providesTags;
+    expect(providesFn(null)).toEqual(["users"]);
+    expect(providesFn({data: [{_id: "1"}, {_id: "2"}]})).toEqual([
+      {id: "1", type: "users"},
+      {id: "2", type: "users"},
+      "users",
+    ]);
+    expect(providesFn({})).toEqual(["users"]);
+  });
+
+  it("assigns providesTags on read (ById) get endpoints", () => {
+    const api = {
+      endpoints: {
+        getUserById: {},
+      },
+    };
+    const tags = generateTags(api, tagTypes);
+    expect(typeof tags.getUserById.providesTags).toBe("function");
+
+    const providesFn = tags.getUserById.providesTags;
+    expect(providesFn(null)).toEqual(["users"]);
+    expect(providesFn({_id: "abc"})).toEqual([{id: "abc", type: "users"}]);
+  });
+
+  it("assigns invalidatesTags on patch endpoints", () => {
+    const api = {
+      endpoints: {
+        patchUserById: {},
+      },
+    };
+    const tags = generateTags(api, tagTypes);
+    expect(typeof tags.patchUserById.invalidatesTags).toBe("function");
+
+    const invalidateFn = tags.patchUserById.invalidatesTags;
+    expect(invalidateFn(null)).toEqual(["users"]);
+    expect(invalidateFn({data: [{_id: "x"}]})).toEqual([{id: "x", type: "users"}, "users"]);
+  });
+
+  it("assigns invalidatesTags on delete endpoints", () => {
+    const api = {
+      endpoints: {
+        deletePostById: {},
+      },
+    };
+    const tags = generateTags(api, tagTypes);
+    expect(typeof tags.deletePostById.invalidatesTags).toBe("function");
+
+    const invalidateFn = tags.deletePostById.invalidatesTags;
+    expect(invalidateFn(null)).toEqual(["posts"]);
+  });
+
+  it("skips endpoints with no matching tag", () => {
+    const api = {
+      endpoints: {
+        getUnknownThing: {},
+        patchOrphan: {},
+      },
+    };
+    const tags = generateTags(api, tagTypes);
+    expect(tags.getUnknownThing).toBeUndefined();
+    expect(tags.patchOrphan).toBeUndefined();
+  });
+
+  it("returns an empty object for an empty endpoint list", () => {
+    const tags = generateTags({endpoints: {}}, tagTypes);
+    expect(tags).toEqual({});
+  });
+
+  it("ignores endpoints that are not get/patch/delete", () => {
+    const api = {
+      endpoints: {
+        postUser: {},
+      },
+    };
+    const tags = generateTags(api, tagTypes);
+    expect(tags.postUser).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Adds a new unit test file `rtk/src/tagGenerator.test.ts` covering the previously untested `generateTags` helper in `rtk/src/tagGenerator.ts`. Test-only — no production code changed.

Coverage of `tagGenerator.ts` goes from 0% (not imported by any test) to 100% function / 100% line per `bun test --coverage` locally (target was 90%).

The tests cover:
- The special-case `getConversations` branch.
- List-style `get*` endpoints → `providesTags` (exercises the returned function with `null`, populated `data`, and empty result).
- Read-style `get*ById` endpoints → `providesTags` (single-doc shape).
- `patch*` endpoints → `invalidatesTags`.
- `delete*` endpoints → `invalidatesTags`.
- Endpoints whose cleaned name does not match any tag type are skipped.
- Empty endpoint map returns `{}`.
- Non-get/patch/delete endpoints (e.g. `postUser`) are ignored.

Lint (`biome`) and TypeScript compile (`tsc`) were run locally on the package before pushing.

## Review & Testing Checklist for Human
- [ ] The `getConversations` test only asserts that `providesTags` is defined. In the current implementation, the special-case assignment `{invalidatesTags: [...]}` is overwritten by the subsequent list-endpoint branch because `getConversations` also matches the "get list endpoint" path. Confirm this is intended behavior (and whether the special case is effectively dead code).
- [ ] Spot-check that the `providesTags` / `invalidatesTags` shapes asserted in the tests match what RTK Query actually expects in this codebase.

### Notes
- No changes to `tagGenerator.ts` itself.
- Part of a batch of per-package coverage PRs (`api`, `ui`, `ai`, `rtk`); this is the `rtk` one.

Link to Devin session: https://app.devin.ai/sessions/34e0d8faa2344c15bbcf3bc1e7490904
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds a new test file and does not change production logic; the main risk is asserting current (possibly unintended) `getConversations` behavior.
> 
> **Overview**
> Adds a new `rtk/src/tagGenerator.test.ts` suite that exercises `generateTags` across list/read `get*` endpoints and `patch*`/`delete*` mutations, including null/empty/populated result shapes.
> 
> Also covers edge cases: the `getConversations` special-case path, skipping endpoints with no matching tag type, ignoring non-`get`/`patch`/`delete` endpoints, and returning `{}` for an empty endpoint map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeb49561eb20786a83231a1ca7fb3eb5b54d9b39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->