### PR TITLE
Add context to OpenAPI middleware skip debug logs

### DIFF
--- a/admin-frontend/src/AdminObjectPicker.tsx
+++ b/admin-frontend/src/AdminObjectPicker.tsx
@@ -177,7 +177,6 @@ export const AdminObjectPicker: React.FC<AdminObjectPickerProps> = ({
             accessibilityLabel="Change selection"
             iconName="pencil"
             onClick={handleChange}
-
             testID={`admin-picker-${refModelName}-change`}
           />
           <IconButton
@@ -185,7 +184,6 @@ export const AdminObjectPicker: React.FC<AdminObjectPickerProps> = ({
             accessibilityLabel="Clear selection"
             iconName="xmark"
             onClick={handleClear}
-
             testID={`admin-picker-${refModelName}-clear`}
           />
         </Box>

--- a/api/src/openApi.ts
+++ b/api/src/openApi.ts
@@ -120,7 +120,9 @@ export function getOpenApiMiddleware<T>(
   createAPIErrorComponent(options.openApi);
   if (!options.openApi?.path) {
     // Just log this once rather than for each middleware.
-    logger.debug("No options.openApi provided, skipping *OpenApiMiddleware");
+    logger.debug(
+      `No options.openApi provided for model "${model.modelName}" in getOpenApiMiddleware, skipping *OpenApiMiddleware`
+    );
     return noop;
   }
 
@@ -466,7 +468,9 @@ export function readOpenApiMiddleware<T>(
 ): any {
   if (!options.openApi?.path) {
     // Just log this once rather than for each middleware.
-    logger.debug("No options.openApi provided, skipping *OpenApiMiddleware");
+    logger.debug(
+      "No options.openApi provided in readOpenApiMiddleware, skipping *OpenApiMiddleware"
+    );
     return noop;
   }
 

--- a/api/src/openApiBuilder.ts
+++ b/api/src/openApiBuilder.ts
@@ -310,6 +310,17 @@ export class OpenApiMiddlewareBuilder {
     this.validationConfig = {};
   }
 
+  private describeRoute(): string {
+    const parts: string[] = [];
+    if (this.config.summary) {
+      parts.push(`"${this.config.summary}"`);
+    }
+    if (this.config.tags?.length) {
+      parts.push(`tags=[${this.config.tags.join(", ")}]`);
+    }
+    return parts.length > 0 ? parts.join(" ") : "unnamed route";
+  }
+
   /**
    * Sets the tags for the OpenAPI operation.
    *
@@ -678,7 +689,9 @@ export class OpenApiMiddlewareBuilder {
         )
       );
     } else {
-      logger.debug("No options.openApi provided, skipping OpenApiMiddleware");
+      logger.debug(
+        `No options.openApi provided in buildWithSchemas for ${this.describeRoute()}, skipping OpenApiMiddleware`
+      );
     }
 
     const globalConfig = getOpenApiValidatorConfig();
@@ -739,7 +752,9 @@ export class OpenApiMiddlewareBuilder {
         )
       );
     } else {
-      logger.debug("No options.openApi provided, skipping OpenApiMiddleware");
+      logger.debug(
+        `No options.openApi provided in build for ${this.describeRoute()}, skipping OpenApiMiddleware`
+      );
     }
 
     // Check if validation should be enabled


### PR DESCRIPTION
## Summary
The `No options.openApi provided, skipping *OpenApiMiddleware` debug log was identical across all call sites, making it impossible to tell which model or route triggered it. Each site now includes function name, model name (for model-based middleware), and route summary/tags (for the builder).

## Human Testing Steps
- [ ] Start the example backend and confirm no new log noise
- [ ] Check debug logs — each skip message now names the model or route

## Changes
- `getOpenApiMiddleware`: includes `model.modelName` and function name
- `readOpenApiMiddleware`: includes function name
- `OpenApiMiddlewareBuilder.build` / `buildWithSchemas`: includes summary and tags via new `describeRoute()` helper
- `AdminObjectPicker.tsx`: lint fix (blank line formatting)

## Automated Tests
- api unit tests: 9 passed (3 pre-existing MongoDB-not-running failures)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to debug log message wording when OpenAPI config is absent, plus a small frontend lint/format tweak.
> 
> **Overview**
> Improves debuggability when OpenAPI middleware is skipped by making the debug logs include *where* the skip occurred: `getOpenApiMiddleware` now logs the `model.modelName`, `readOpenApiMiddleware` logs its function context, and `OpenApiMiddlewareBuilder` logs the route summary/tags via a new `describeRoute()` helper.
> 
> Also applies a minor formatting/lint fix in `AdminObjectPicker.tsx` (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5e04084e75c38fb5ecbf8dc33e91b1d7af7a8e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->