### PR TITLE
[alignRules] UserInactivity.tsx, authSlice.ts

### DIFF
--- a/rtk/src/authSlice.test.ts
+++ b/rtk/src/authSlice.test.ts
@@ -449,6 +449,85 @@ describe("listener middleware side effects", () => {
     }
   });
 
+  it("re-throws and logs when AsyncStorage.setItem fails on web login", async () => {
+    const {store} = createTestStore();
+    const originalSetItem = AsyncStorage.setItem;
+    const originalConsoleError = console.error;
+    const globalWithWindow = globalThis as {window?: unknown};
+    const originalWindow = globalWithWindow.window;
+    const errorCalls: unknown[][] = [];
+
+    console.error = (...args: unknown[]): void => {
+      errorCalls.push(args);
+    };
+    AsyncStorage.setItem = async (): Promise<void> => {
+      throw new Error("storage quota exceeded");
+    };
+    globalWithWindow.window = {};
+
+    try {
+      store.dispatch({
+        meta: {
+          arg: {endpointName: "emailLogin", type: "mutation"},
+          requestId: "listener-login-error",
+        },
+        payload: {refreshToken: "refresh-token", token: "auth-token", userId: "user-err"},
+        type: "terreno-rtk/executeMutation/fulfilled",
+      });
+
+      await flushAsyncListeners();
+
+      const loggedErrorMessage = errorCalls.find((args) =>
+        args.some(
+          (value) => typeof value === "string" && value.includes("Error setting auth token")
+        )
+      );
+      expect(loggedErrorMessage).toBeDefined();
+    } finally {
+      AsyncStorage.setItem = originalSetItem;
+      console.error = originalConsoleError;
+      if (typeof originalWindow === "undefined") {
+        delete globalWithWindow.window;
+      } else {
+        globalWithWindow.window = originalWindow;
+      }
+    }
+  });
+
+  it("skips storing auth tokens when window is undefined (SSR context)", async () => {
+    const {store} = createTestStore();
+    const setItemCalls: Array<[string, string]> = [];
+    const originalSetItem = AsyncStorage.setItem;
+    const globalWithWindow = globalThis as {window?: unknown};
+    const originalWindow = globalWithWindow.window;
+
+    AsyncStorage.setItem = async (key: string, value: string): Promise<void> => {
+      setItemCalls.push([key, value]);
+    };
+    delete globalWithWindow.window;
+
+    try {
+      store.dispatch({
+        meta: {
+          arg: {endpointName: "emailSignUp", type: "mutation"},
+          requestId: "listener-ssr-1",
+        },
+        payload: {refreshToken: "r", token: "t", userId: "user-ssr"},
+        type: "terreno-rtk/executeMutation/fulfilled",
+      });
+
+      await flushAsyncListeners();
+
+      expect(setItemCalls).toEqual([]);
+      expect(store.getState().auth.userId).toBe("user-ssr");
+    } finally {
+      AsyncStorage.setItem = originalSetItem;
+      if (typeof originalWindow !== "undefined") {
+        globalWithWindow.window = originalWindow;
+      }
+    }
+  });
+
   it("removes tokens from AsyncStorage on web logout when window exists", async () => {
     const {store, authSlice} = createTestStore();
     const removeItemCalls: string[] = [];

--- a/ui/src/UserInactivity.test.tsx
+++ b/ui/src/UserInactivity.test.tsx
@@ -1,5 +1,6 @@
-import {describe, expect, it, mock} from "bun:test";
+import {describe, expect, it, mock, spyOn} from "bun:test";
 import {act} from "@testing-library/react-native";
+import {Keyboard} from "react-native";
 
 import {Text} from "./Text";
 import {renderWithTheme} from "./test-utils";
@@ -92,5 +93,76 @@ describe("UserInactivity", () => {
       </UserInactivity>
     );
     expect(toJSON()).toBeTruthy();
+  });
+
+  it("clears any pending timer when unmounted before the timeout fires", () => {
+    const onAction = mock((_active: boolean) => {});
+    const {unmount} = renderWithTheme(
+      <UserInactivity onAction={onAction} timeForInactivity={10_000}>
+        <Text>Test Content</Text>
+      </UserInactivity>
+    );
+
+    act(() => {
+      unmount();
+    });
+
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it("removes keyboard listeners on unmount", () => {
+    const onAction = mock((_active: boolean) => {});
+    const removeHide = mock(() => {});
+    const removeShow = mock(() => {});
+    const addListenerSpy = spyOn(Keyboard, "addListener")
+      .mockReturnValueOnce({remove: removeHide} as any)
+      .mockReturnValueOnce({remove: removeShow} as any);
+
+    const {unmount} = renderWithTheme(
+      <UserInactivity onAction={onAction}>
+        <Text>Test Content</Text>
+      </UserInactivity>
+    );
+
+    act(() => {
+      unmount();
+    });
+
+    expect(addListenerSpy).toHaveBeenCalled();
+    expect(removeHide).toHaveBeenCalled();
+    expect(removeShow).toHaveBeenCalled();
+    addListenerSpy.mockRestore();
+  });
+
+  it("calls onAction with true when activity occurs after inactivity", async () => {
+    const onAction = mock((_active: boolean) => {});
+    let capturedHideCallback: (() => void) | undefined;
+    const addListenerSpy = spyOn(Keyboard, "addListener").mockImplementation(
+      (event: string, callback: () => void) => {
+        if (event === "keyboardDidHide") {
+          capturedHideCallback = callback;
+        }
+        return {remove: mock(() => {})} as any;
+      }
+    );
+
+    renderWithTheme(
+      <UserInactivity onAction={onAction} timeForInactivity={30}>
+        <Text>Test Content</Text>
+      </UserInactivity>
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 80));
+    });
+
+    expect(onAction).toHaveBeenCalledWith(false);
+
+    await act(async () => {
+      capturedHideCallback?.();
+    });
+
+    expect(onAction).toHaveBeenCalledWith(true);
+    addListenerSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

Increases test coverage for two frontend files to reach the 90% line coverage target. Only test additions; no changes to production logic.

- **`ui/src/UserInactivity.tsx`** — added tests for (1) clearing the pending inactivity timer on unmount, (2) removing keyboard listeners on unmount, and (3) re-activating on `keyboardDidHide` after inactivity. Coverage: **~77% → 97.33%** lines.
- **`rtk/src/authSlice.ts`** — added two tests in the listener-middleware suite covering (1) the web `AsyncStorage.setItem` failure path (error is logged and re-thrown) and (2) the SSR path where `window` is undefined so tokens are not written. Coverage: **~90.82% → 91.79%** lines.

Ran lint (biome, with auto-formatting) and tsc locally for both packages — all passing.

## Review & Testing Checklist for Human

- [ ] Confirm the `UserInactivity` keyboard-listener cleanup test correctly exercises the effect's teardown logic.
- [ ] Sanity-check that the new `authSlice` SSR test (window undefined) reflects the intended behavior — tokens should not be persisted, and `setUserId` should still fire.
- [ ] Verify no existing tests were altered; only new `it(...)` cases were added.

### Notes

- No production code was modified. Only test files in `ui/` and `rtk/` were changed.
- Backend coverage improvements (api/, ai/) are in a separate PR to keep frontend and backend changes unmixed: #460.


Link to Devin session: https://app.devin.ai/sessions/e595ca7ee13841578cf6dde597bd61e0
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because the PR only adds/adjusts tests; no production logic changes. The main risk is test flakiness due to timers/keyboard listener mocking and global `window`/console monkeypatching.
> 
> **Overview**
> Adds targeted test coverage for edge cases in `rtk` auth listener middleware and the `UserInactivity` component.
> 
> In `authSlice.test.ts`, new cases validate **web token persistence error handling** (logs and rethrows when `AsyncStorage.setItem` fails) and the **SSR guard** (when `window` is undefined, tokens are not stored but `userId` is still set).
> 
> In `UserInactivity.test.tsx`, new tests cover **timer cleanup on unmount**, **keyboard listener teardown**, and **re-activation after inactivity** when a `keyboardDidHide` event occurs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78631fa33dd4f86a0543e50869a6ebe51c7c21e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->