### PR TITLE
Lazy-load expo-notifications on web to silence push-token listener warning

### DIFF
--- a/example-frontend/store/utils.ts
+++ b/example-frontend/store/utils.ts
@@ -1,6 +1,5 @@
 import Constants from "expo-constants";
 import type {ExpoPushToken} from "expo-notifications";
-import * as Notifications from "expo-notifications";
 import * as Updates from "expo-updates";
 import {Platform} from "react-native";
 
@@ -34,6 +33,10 @@ export const getCurrentExpoToken = async (): Promise<ExpoPushToken> => {
   if (Platform.OS === "web") {
     return {data: "", type: "expo"};
   }
+  // Lazy-load expo-notifications so importing this module on web does not
+  // evaluate expo-notifications' DevicePushTokenAutoRegistration side effect,
+  // which logs "Listening to push token changes is not yet fully supported on web".
+  const Notifications = await import("expo-notifications");
   let tokenRes: ExpoPushToken;
   if (__DEV__) {
     const appConfig = require("../app.json");


### PR DESCRIPTION
## Summary

Fixes the console warning:

> [expo-notifications] Listening to push token changes is not yet fully supported on web. Adding a listener will have no effect.

`expo-notifications` registers a push-token listener as an import-time side effect via its `DevicePushTokenAutoRegistration.fx` module (declared under `sideEffects` in its `package.json`). On web, that listener is a no-op that logs a warning. Previously, `example-frontend/store/utils.ts` imported the module at the top level, so the side effect ran on every web load even though `getCurrentExpoToken` already short-circuits on web.

This moves the runtime import into the native branch of `getCurrentExpoToken` so the side effect is never evaluated on web. The type-only `ExpoPushToken` import stays at the top (type imports are stripped at compile time and don't trigger side effects).

## Review & Testing Checklist for Human

- [ ] Run `bun frontend:web` and confirm the `[expo-notifications] Listening to push token changes…` warning no longer appears in the browser console on load.
- [ ] Sanity-check that `getCurrentExpoToken` still resolves a token on iOS/Android dev builds (the function is not currently called from anywhere in the repo, but the native path is preserved via a dynamic `await import("expo-notifications")`).

### Notes

Only `example-frontend/store/utils.ts` referenced `expo-notifications` at runtime in this repo.

Link to Devin session: https://app.devin.ai/sessions/d9745711faaf456d80d9961e97915fbd
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes when `expo-notifications` is imported to avoid a web-only side effect; native token retrieval logic remains the same aside from using a dynamic import.
> 
> **Overview**
> Prevents `expo-notifications` from being evaluated on web by replacing the top-level runtime import with an `await import("expo-notifications")` inside the native branch of `getCurrentExpoToken`.
> 
> This avoids the web console warning triggered by `expo-notifications` import-time side effects while keeping the existing web short-circuit return and native `getExpoPushTokenAsync` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e667ee92f7b7d447ba620fd1909d324d3e1784f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->