### PR TITLE
[example-frontend] Skip RTK queries when not logged in

### DIFF
--- a/.github/workflows/frontend-example-deploy.yml
+++ b/.github/workflows/frontend-example-deploy.yml
@@ -20,14 +20,18 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
+      has_backend_changes: ${{ steps.check.outputs.has_backend_changes }}
     steps:
       - uses: actions/checkout@v6
 
-      - name: Check PR diff for frontend-related changes
+      - name: Check PR diff for relevant changes
         id: check
         run: |
-          CHANGES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only | grep -cE '^(example-frontend/|ui/|rtk/|admin-frontend/)' || true)
+          FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
+          CHANGES=$(echo "$FILES" | grep -cE '^(example-frontend/|ui/|rtk/|admin-frontend/)' || true)
+          BACKEND_CHANGES=$(echo "$FILES" | grep -cE '^(example-backend/|api/|api-health/|admin-backend/|ai/)' || true)
           echo "has_changes=$( [ "$CHANGES" -gt 0 ] && echo true || echo false )" >> $GITHUB_OUTPUT
+          echo "has_backend_changes=$( [ "$BACKEND_CHANGES" -gt 0 ] && echo true || echo false )" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -35,6 +39,7 @@ jobs:
     name: Build Example Frontend
     needs: [check-changes]
     if: always() && (github.event_name == 'push' || needs.check-changes.outputs.has_changes == 'true')
+    # check-changes outputs are consumed by the "Set BASE_URL for deploy" step below
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -68,13 +73,18 @@ jobs:
         working-directory: ai
 
       - name: Set BASE_URL for deploy
+        env:
+          HAS_BACKEND_CHANGES: ${{ needs.check-changes.outputs.has_backend_changes }}
         run: |
+          PROD_URL="https://prod---terreno-backend-example-7knxlrnpqq-uc.a.run.app"
           if [ "${{ github.ref }}" = "refs/heads/master" ]; then
-            URL="https://prod---terreno-backend-example-7knxlrnpqq-uc.a.run.app"
-          elif [ -n "${{ github.event.pull_request.number }}" ]; then
+            URL="$PROD_URL"
+          elif [ -n "${{ github.event.pull_request.number }}" ] && [ "$HAS_BACKEND_CHANGES" = "true" ]; then
+            # Backend preview is only deployed when the PR touches backend files
+            # (see deploy-example-gcp.yml check-changes). Otherwise fall back to prod.
             URL="https://pr-${{ github.event.pull_request.number }}---terreno-backend-example-7knxlrnpqq-uc.a.run.app"
           else
-            URL="https://prod---terreno-backend-example-7knxlrnpqq-uc.a.run.app"
+            URL="$PROD_URL"
           fi
           jq --arg url "$URL" '.expo.extra.BASE_URL = $url' app.json > app.json.tmp && mv app.json.tmp app.json
           echo "BASE_URL set to $URL"

--- a/example-frontend/app/(tabs)/ai.tsx
+++ b/example-frontend/app/(tabs)/ai.tsx
@@ -1,4 +1,4 @@
-import {baseUrl, getAuthToken} from "@terreno/rtk";
+import {baseUrl, getAuthToken, useSelectCurrentUserId} from "@terreno/rtk";
 import {
   Box,
   GPTChat,
@@ -79,7 +79,8 @@ const AiScreen: React.FC = () => {
   const [selectedModel, setSelectedModel] = useState<string>(AVAILABLE_MODELS[0].value);
 
   const dispatch = useDispatch();
-  const {data: historiesData, isLoading} = useGetGptHistoriesQuery();
+  const userId = useSelectCurrentUserId();
+  const {data: historiesData, isLoading} = useGetGptHistoriesQuery(undefined, {skip: !userId});
   const [deleteHistory] = useDeleteGptHistoriesByIdMutation();
   const [patchHistory] = usePatchGptHistoriesByIdMutation();
 

--- a/example-frontend/app/(tabs)/index.tsx
+++ b/example-frontend/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import {useFeatureFlags} from "@terreno/rtk";
+import {useFeatureFlags, useSelectCurrentUserId} from "@terreno/rtk";
 import {
   Badge,
   Box,
@@ -85,12 +85,14 @@ const TodosScreen: React.FC = () => {
   const [newTodoTitle, setNewTodoTitle] = useState<string>("");
   const [showCompleted, setShowCompleted] = useState<boolean>(true);
 
-  const {data: todosData, isLoading, refetch, isFetching} = useGetTodosQuery({});
+  const userId = useSelectCurrentUserId();
+
+  const {data: todosData, isLoading, refetch, isFetching} = useGetTodosQuery({}, {skip: !userId});
   const [createTodo, {isLoading: isCreating}] = usePostTodosMutation();
   const [updateTodo] = usePatchTodosByIdMutation();
   const [deleteTodo] = useDeleteTodosByIdMutation();
 
-  const {getFlag} = useFeatureFlags(terrenoApi);
+  const {getFlag} = useFeatureFlags(terrenoApi, {skip: !userId});
   const showSummaryCard = getFlag("todo-summary-card");
 
   const todos = todosData?.data ?? [];

--- a/example-frontend/app/(tabs)/profile.tsx
+++ b/example-frontend/app/(tabs)/profile.tsx
@@ -1,4 +1,4 @@
-import {useFeatureFlags} from "@terreno/rtk";
+import {useFeatureFlags, useSelectCurrentUserId} from "@terreno/rtk";
 import {
   Box,
   Button,
@@ -19,7 +19,8 @@ import {logout, terrenoApi, useAppDispatch, useGetMeQuery, usePatchMeMutation} f
 const ProfileScreen: React.FC = () => {
   const router = useRouter();
   const dispatch = useAppDispatch();
-  const {data: profileResponse, isLoading, refetch} = useGetMeQuery();
+  const userId = useSelectCurrentUserId();
+  const {data: profileResponse, isLoading, refetch} = useGetMeQuery(undefined, {skip: !userId});
   const [updateProfile, {isLoading: isUpdating}] = usePatchMeMutation();
   const {setPrimitives, resetTheme} = useTheme();
 
@@ -28,7 +29,7 @@ const ProfileScreen: React.FC = () => {
     getFlag,
     isLoading: isFeatureFlagsLoading,
     error: featureFlagsError,
-  } = useFeatureFlags(terrenoApi);
+  } = useFeatureFlags(terrenoApi, {skip: !userId});
   const showDarkModeToggle = getFlag("dark-mode-toggle");
   const featureFlagEntries = useMemo(
     (): Array<{key: string; value: boolean | string | null}> =>

--- a/example-frontend/app/admin/AIAdminScreen.tsx
+++ b/example-frontend/app/admin/AIAdminScreen.tsx
@@ -1,3 +1,4 @@
+import {useSelectCurrentUserId} from "@terreno/rtk";
 import {AIRequestExplorer, type AIRequestExplorerData, Page} from "@terreno/ui";
 import React, {useCallback, useState} from "react";
 import {useGetAiRequestsExplorerQuery} from "@/store";
@@ -10,13 +11,18 @@ const AIAdminScreen: React.FC = () => {
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
 
-  const {data: explorerData, isLoading} = useGetAiRequestsExplorerQuery({
-    endDate: endDate || undefined,
-    limit: EXPLORER_LIMIT,
-    page,
-    requestType: requestTypeFilter.length === 1 ? requestTypeFilter[0] : undefined,
-    startDate: startDate || undefined,
-  });
+  const userId = useSelectCurrentUserId();
+
+  const {data: explorerData, isLoading} = useGetAiRequestsExplorerQuery(
+    {
+      endDate: endDate || undefined,
+      limit: EXPLORER_LIMIT,
+      page,
+      requestType: requestTypeFilter.length === 1 ? requestTypeFilter[0] : undefined,
+      startDate: startDate || undefined,
+    },
+    {skip: !userId}
+  );
 
   const handlePageChange = useCallback((newPage: number) => {
     setPage(newPage);

--- a/example-frontend/hooks/useReadProfile.ts
+++ b/example-frontend/hooks/useReadProfile.ts
@@ -1,3 +1,4 @@
+import {useSelectCurrentUserId} from "@terreno/rtk";
 import {useGetMeQuery} from "@/store";
 
 export interface ProfileData {
@@ -9,7 +10,8 @@ export interface ProfileData {
 }
 
 export const useReadProfile = (): ProfileData | undefined => {
-  const {data: profile} = useGetMeQuery();
+  const userId = useSelectCurrentUserId();
+  const {data: profile} = useGetMeQuery(undefined, {skip: !userId});
 
   if (!profile) {
     return undefined;

--- a/rtk/src/useFeatureFlags.test.ts
+++ b/rtk/src/useFeatureFlags.test.ts
@@ -1,0 +1,57 @@
+import {describe, expect, it} from "bun:test";
+import {resolveFeatureFlagsOptions} from "./useFeatureFlags";
+
+describe("resolveFeatureFlagsOptions", () => {
+  it("applies defaults when no argument is provided", () => {
+    expect(resolveFeatureFlagsOptions()).toEqual({
+      basePath: "/feature-flags",
+      skip: false,
+    });
+  });
+
+  it("applies defaults when an empty options object is provided", () => {
+    expect(resolveFeatureFlagsOptions({})).toEqual({
+      basePath: "/feature-flags",
+      skip: false,
+    });
+  });
+
+  it("treats a string argument as a legacy basePath with skip=false", () => {
+    expect(resolveFeatureFlagsOptions("/custom-path")).toEqual({
+      basePath: "/custom-path",
+      skip: false,
+    });
+  });
+
+  it("preserves an empty string basePath when passed as a legacy string argument", () => {
+    expect(resolveFeatureFlagsOptions("")).toEqual({
+      basePath: "",
+      skip: false,
+    });
+  });
+
+  it("uses options.basePath when provided", () => {
+    expect(resolveFeatureFlagsOptions({basePath: "/flags"})).toEqual({
+      basePath: "/flags",
+      skip: false,
+    });
+  });
+
+  it("uses options.skip when provided", () => {
+    expect(resolveFeatureFlagsOptions({skip: true})).toEqual({
+      basePath: "/feature-flags",
+      skip: true,
+    });
+  });
+
+  it("uses both options.basePath and options.skip when provided together", () => {
+    expect(resolveFeatureFlagsOptions({basePath: "/flags", skip: true})).toEqual({
+      basePath: "/flags",
+      skip: true,
+    });
+  });
+
+  it("does not let a legacy string basePath override skip to true", () => {
+    expect(resolveFeatureFlagsOptions("/custom-path").skip).toBe(false);
+  });
+});

--- a/rtk/src/useFeatureFlags.ts
+++ b/rtk/src/useFeatureFlags.ts
@@ -27,7 +27,7 @@ interface UseFeatureFlagsResult {
  * const variant = getVariant("checkout-experiment");           // "control" | "variant-a" | null
  * ```
  */
-interface UseFeatureFlagsOptions {
+export interface UseFeatureFlagsOptions {
   /**
    * Base path for the feature-flags endpoint. Defaults to "/feature-flags".
    */
@@ -39,6 +39,29 @@ interface UseFeatureFlagsOptions {
   skip?: boolean;
 }
 
+interface ResolvedFeatureFlagsOptions {
+  basePath: string;
+  skip: boolean;
+}
+
+/**
+ * Normalizes the legacy-compatible `basePathOrOptions` argument into a
+ * `{basePath, skip}` pair with defaults applied.
+ *
+ * - `undefined` -> `{basePath: "/feature-flags", skip: false}`
+ * - `string`    -> `{basePath: <string>, skip: false}` (legacy form)
+ * - `object`    -> `{basePath: opts.basePath ?? "/feature-flags", skip: opts.skip ?? false}`
+ */
+export const resolveFeatureFlagsOptions = (
+  basePathOrOptions?: string | UseFeatureFlagsOptions
+): ResolvedFeatureFlagsOptions => {
+  const {basePath = "/feature-flags", skip = false} =
+    typeof basePathOrOptions === "string"
+      ? {basePath: basePathOrOptions, skip: false}
+      : (basePathOrOptions ?? {});
+  return {basePath, skip};
+};
+
 // Overloaded signature preserves backwards compatibility with callers that
 // pass a string basePath as the second argument.
 export function useFeatureFlags(
@@ -46,10 +69,7 @@ export function useFeatureFlags(
   api: Api<any, any, any, any>,
   basePathOrOptions?: string | UseFeatureFlagsOptions
 ): UseFeatureFlagsResult {
-  const {basePath = "/feature-flags", skip = false} =
-    typeof basePathOrOptions === "string"
-      ? {basePath: basePathOrOptions, skip: false}
-      : (basePathOrOptions ?? {});
+  const {basePath, skip} = resolveFeatureFlagsOptions(basePathOrOptions);
 
   const enhancedApi = useMemo(
     () =>

--- a/rtk/src/useFeatureFlags.ts
+++ b/rtk/src/useFeatureFlags.ts
@@ -27,11 +27,30 @@ interface UseFeatureFlagsResult {
  * const variant = getVariant("checkout-experiment");           // "control" | "variant-a" | null
  * ```
  */
-export const useFeatureFlags = (
+interface UseFeatureFlagsOptions {
+  /**
+   * Base path for the feature-flags endpoint. Defaults to "/feature-flags".
+   */
+  basePath?: string;
+  /**
+   * When true, the underlying evaluate query is not fired. Use this to avoid
+   * fetching before the user is authenticated.
+   */
+  skip?: boolean;
+}
+
+// Overloaded signature preserves backwards compatibility with callers that
+// pass a string basePath as the second argument.
+export function useFeatureFlags(
   // biome-ignore lint/suspicious/noExplicitAny: RTK Query API generic typing is intentionally flexible here.
   api: Api<any, any, any, any>,
-  basePath = "/feature-flags"
-): UseFeatureFlagsResult => {
+  basePathOrOptions?: string | UseFeatureFlagsOptions
+): UseFeatureFlagsResult {
+  const {basePath = "/feature-flags", skip = false} =
+    typeof basePathOrOptions === "string"
+      ? {basePath: basePathOrOptions, skip: false}
+      : (basePathOrOptions ?? {});
+
   const enhancedApi = useMemo(
     () =>
       api.injectEndpoints({
@@ -50,7 +69,7 @@ export const useFeatureFlags = (
 
   // biome-ignore lint/suspicious/noExplicitAny: Endpoint hook is injected dynamically by RTK Query.
   const useEvaluateQuery = (enhancedApi as any).useEvaluateFeatureFlagsQuery;
-  const {data, isLoading, error, refetch} = useEvaluateQuery();
+  const {data, isLoading, error, refetch} = useEvaluateQuery(undefined, {skip});
   const evaluateStartedAtRef = useRef<number | null>(null);
 
   const flags: FlagValues = data ?? {};
@@ -118,4 +137,4 @@ export const useFeatureFlags = (
   );
 
   return {error, flags, getFlag, getVariant, isLoading, refetch};
-};
+}


### PR DESCRIPTION
## Summary

Fixes the flood of "missing auth token" errors that the example-frontend logged before the user logged in (or immediately after logout / on refresh at `/`).

Before this change, `example-frontend` called `useGetMeQuery` in `hooks/useReadProfile` unconditionally from the root layout, and the (tabs) + admin screens each fired their own RTK Query hooks on mount. Those queries ran before the redirect-to-`/login` effect had a chance to unmount them, so the base query tried to attach a bearer token that wasn't there.

Changes:

- `hooks/useReadProfile` now gates `useGetMeQuery` on `useSelectCurrentUserId`.
- `(tabs)/index`, `(tabs)/profile`, `(tabs)/ai`, and `admin/AIAdminScreen` pass `{skip: !userId}` to their queries.
- `@terreno/rtk` `useFeatureFlags` accepts an optional `skip` flag (backwards compatible with the previous `basePath` string-or-options arg) so callers can suppress the `/feature-flags/evaluate` fetch.

## Review & Testing Checklist for Human

- [ ] Open the example-frontend in an incognito/logged-out browser and confirm there are no "Attempting to connect… no token" / 401 lines in the console until you actually sign in.
- [ ] Log in, then log out, and confirm the same — no tail of failed fetches at logout.
- [ ] Verify `useFeatureFlags(terrenoApi)` still works when called with no options and with the legacy `useFeatureFlags(api, "/custom-path")` string form.

### Notes

`useConsentForms` (inside `ConsentNavigator`) is already gated by `userId` at the `_layout.tsx` wrapper, so it was not touched. `gcs-settings.tsx` is only reachable after login, so its `fetchStatus` call was also left as-is.

Link to Devin session: https://app.devin.ai/sessions/dd67349c9675420b93d6874e3fdab6e7
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes when RTK Query hooks and feature-flag evaluation fire (could affect logged-in data loading) and adjusts CI deploy URL selection for PR previews based on detected backend changes.
> 
> **Overview**
> Reduces unauthenticated request noise in `example-frontend` by **skipping RTK Query calls until a `userId` is present**, applying `{skip: !userId}` to profile/todos/AI/admin queries and adding a `skip` option to `useFeatureFlags` (while keeping legacy string `basePath` support).
> 
> Updates the example-frontend deploy workflow to detect backend file changes on PRs and only point PR preview builds at the backend PR URL when backend changes are present; otherwise it falls back to the production backend URL. Adds tests for `resolveFeatureFlagsOptions` option normalization/back-compat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea88fdb62ca8b3dfb1a00e193c0c8ff45cbd5cd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->