### PR TITLE
[feature-flags] add tests to reach 100% coverage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "admin-backend": {
       "name": "@terreno/admin-backend",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "dependencies": {
         "@google-cloud/storage": "^7.15.0",
         "@terreno/api": "workspace:*",
@@ -36,7 +36,7 @@
     },
     "admin-frontend": {
       "name": "@terreno/admin-frontend",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "dependencies": {
         "@terreno/ui": "workspace:*",
         "expo-router": "catalog:",
@@ -67,7 +67,7 @@
     },
     "ai": {
       "name": "@terreno/ai",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "dependencies": {
         "@ai-sdk/mcp": "^1.0.21",
         "@google-cloud/storage": "^7.15.0",
@@ -99,7 +99,7 @@
     },
     "api": {
       "name": "@terreno/api",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "dependencies": {
         "@sentry/bun": "^10.25.0",
         "@sentry/profiling-node": "^10.25.0",
@@ -169,7 +169,7 @@
     },
     "api-health": {
       "name": "@terreno/api-health",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "dependencies": {
         "@terreno/api": "workspace:*",
         "express": "^5.2.1",
@@ -368,6 +368,9 @@
         "@types/bun": "^1.2.4",
         "@types/express": "^5.0.6",
         "@types/lodash": "catalog:",
+        "@types/supertest": "^6.0.2",
+        "passport-local-mongoose": "^9.0.1",
+        "supertest": "^7.0.0",
         "typescript": "catalog:",
       },
       "peerDependencies": {
@@ -394,7 +397,7 @@
     },
     "rtk": {
       "name": "@terreno/rtk",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "dependencies": {
         "@better-auth/expo": "^1.2.8",
         "@react-native-async-storage/async-storage": "catalog:",
@@ -431,7 +434,7 @@
     },
     "ui": {
       "name": "@terreno/ui",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "dependencies": {
         "@expo-google-fonts/nunito": "^0.4.2",
         "@expo-google-fonts/titillium-web": "^0.4.1",

--- a/feature-flags/bunfig.toml
+++ b/feature-flags/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+preload = ["../api/src/tests/bunSetup.ts"]
+root = "./src"

--- a/feature-flags/package.json
+++ b/feature-flags/package.json
@@ -14,6 +14,9 @@
     "@types/bun": "^1.2.4",
     "@types/express": "^5.0.6",
     "@types/lodash": "catalog:",
+    "@types/supertest": "^6.0.2",
+    "passport-local-mongoose": "^9.0.1",
+    "supertest": "^7.0.0",
     "typescript": "catalog:"
   },
   "homepage": "https://github.com/FlourishHealth/terreno#readme",

--- a/feature-flags/src/tests/evaluate.test.ts
+++ b/feature-flags/src/tests/evaluate.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from "bun:test";
-import {deterministicHash, evaluateFlag} from "../evaluate";
-import type {FeatureFlagDocument, SegmentFunction} from "../types";
+import {deterministicHash, evaluateAllFlags, evaluateFlag} from "../evaluate";
+import type {FeatureFlagDocument, FeatureFlagModel, SegmentFunction} from "../types";
 
 const createFlag = (overrides: Partial<FeatureFlagDocument> = {}): FeatureFlagDocument => {
   return {
@@ -330,5 +330,274 @@ describe("evaluateFlag", () => {
 
       expect(evaluateFlag(flag, "user1", {}, noSegments)).toBe(false);
     });
+
+    it("returns false when segment function throws", () => {
+      const segments: Record<string, SegmentFunction> = {
+        "throwing-segment": (): boolean => {
+          throw new Error("boom");
+        },
+      };
+
+      const flag = createFlag({
+        rolloutPercentage: 0,
+        rules: [{enabled: true, segment: "throwing-segment"}],
+      });
+
+      expect(evaluateFlag(flag, "user1", {}, segments)).toBe(false);
+    });
+
+    it("uses segment rule for variant flags", () => {
+      const segments: Record<string, SegmentFunction> = {
+        "pro-users": (user: unknown) => (user as {plan: string}).plan === "pro",
+      };
+
+      const flag = createFlag({
+        rules: [{segment: "pro-users", variant: "variant-a"}],
+        type: "variant",
+        variants: [
+          {key: "control", weight: 50},
+          {key: "variant-a", weight: 50},
+        ],
+      });
+
+      expect(evaluateFlag(flag, "user1", {plan: "pro"}, segments)).toBe("variant-a");
+    });
+  });
+
+  describe("malformed field rules", () => {
+    it("does not match a rule with no field and no segment", () => {
+      const flag = createFlag({
+        rolloutPercentage: 0,
+        rules: [{enabled: true}],
+      });
+
+      expect(evaluateFlag(flag, "user1", {anything: true}, noSegments)).toBe(false);
+    });
+
+    it("does not match a rule with a field but no operator", () => {
+      const flag = createFlag({
+        rolloutPercentage: 0,
+        rules: [{enabled: true, field: "admin"}],
+      });
+
+      expect(evaluateFlag(flag, "user1", {admin: true}, noSegments)).toBe(false);
+    });
+
+    it("does not match a rule with an unknown operator", () => {
+      const flag = createFlag({
+        rolloutPercentage: 0,
+        rules: [
+          {
+            enabled: true,
+            field: "admin",
+            operator: "bogus" as unknown as "eq",
+            value: true,
+          },
+        ],
+      });
+
+      expect(evaluateFlag(flag, "user1", {admin: true}, noSegments)).toBe(false);
+    });
+
+    it("does not match gt/lt when values are not numbers", () => {
+      const gtFlag = createFlag({
+        rolloutPercentage: 0,
+        rules: [{enabled: true, field: "age", operator: "gt", value: 18}],
+      });
+      expect(evaluateFlag(gtFlag, "user1", {age: "twenty"}, noSegments)).toBe(false);
+
+      const ltFlag = createFlag({
+        rolloutPercentage: 0,
+        rules: [{enabled: true, field: "age", operator: "lt", value: 18}],
+      });
+      expect(evaluateFlag(ltFlag, "user1", {age: undefined}, noSegments)).toBe(false);
+    });
+
+    it("does not match contains when values are not strings", () => {
+      const flag = createFlag({
+        rolloutPercentage: 0,
+        rules: [{enabled: true, field: "email", operator: "contains", value: "@company.com"}],
+      });
+
+      expect(evaluateFlag(flag, "user1", {email: 42}, noSegments)).toBe(false);
+    });
+
+    it("does not match in/nin when rule.value is not an array", () => {
+      const inFlag = createFlag({
+        rolloutPercentage: 0,
+        rules: [{enabled: true, field: "plan", operator: "in", value: "pro"}],
+      });
+      expect(evaluateFlag(inFlag, "user1", {plan: "pro"}, noSegments)).toBe(false);
+
+      const ninFlag = createFlag({
+        rolloutPercentage: 0,
+        rules: [{enabled: true, field: "plan", operator: "nin", value: "pro"}],
+      });
+      expect(evaluateFlag(ninFlag, "user1", {plan: "pro"}, noSegments)).toBe(false);
+    });
+
+    it("treats rule.enabled as false by default when undefined on a matching boolean rule", () => {
+      const flag = createFlag({
+        rolloutPercentage: 100,
+        rules: [{field: "admin", operator: "eq", value: true}],
+      });
+
+      // rule matches, but rule.enabled is undefined → evaluates to false
+      expect(evaluateFlag(flag, "user1", {admin: true}, noSegments)).toBe(false);
+    });
+
+    it("treats rule.variant as null when undefined on a matching variant rule", () => {
+      const flag = createFlag({
+        rules: [{field: "admin", operator: "eq", value: true}],
+        type: "variant",
+        variants: [
+          {key: "control", weight: 50},
+          {key: "variant-a", weight: 50},
+        ],
+      });
+
+      expect(evaluateFlag(flag, "user1", {admin: true}, noSegments)).toBeNull();
+    });
+  });
+
+  describe("variant fallback behavior", () => {
+    it("falls back to the last variant when weights do not sum to 100", () => {
+      const flag = createFlag({
+        type: "variant",
+        // Weights only sum to 10 — the hash will always exceed cumulative weight
+        variants: [
+          {key: "a", weight: 5},
+          {key: "b", weight: 5},
+        ],
+      });
+
+      // Pick a user whose hash is guaranteed >= 10
+      const userId = "this-user-hashes-high";
+      const hash = deterministicHash(`${userId}:${flag.key}`);
+      // Make sure our assumption holds before asserting the fallback
+      expect(hash).toBeGreaterThanOrEqual(10);
+
+      expect(evaluateFlag(flag, userId, {}, noSegments)).toBe("b");
+    });
+
+    it("returns null when an enabled variant flag has no variants defined", () => {
+      const flag = createFlag({
+        type: "variant",
+        variants: [],
+      });
+
+      expect(evaluateFlag(flag, "user1", {}, noSegments)).toBeNull();
+    });
+  });
+
+  describe("debug logging toggle", () => {
+    it("runs without logging when FEATURE_FLAGS_DEBUG is 'false'", () => {
+      const original = process.env.FEATURE_FLAGS_DEBUG;
+      process.env.FEATURE_FLAGS_DEBUG = "false";
+      try {
+        const flag = createFlag({
+          rolloutPercentage: 100,
+          rules: [{enabled: true, field: "admin", operator: "eq", value: true}],
+        });
+        expect(evaluateFlag(flag, "user1", {admin: true}, noSegments)).toBe(true);
+        expect(evaluateFlag(flag, "user2", {admin: false}, noSegments)).toBe(true);
+
+        const disabledFlag = createFlag({enabled: false});
+        expect(evaluateFlag(disabledFlag, "user3", {}, noSegments)).toBe(false);
+      } finally {
+        if (original === undefined) {
+          delete process.env.FEATURE_FLAGS_DEBUG;
+        } else {
+          process.env.FEATURE_FLAGS_DEBUG = original;
+        }
+      }
+    });
+  });
+});
+
+describe("evaluateAllFlags", () => {
+  const makeMockModel = (flags: FeatureFlagDocument[]): FeatureFlagModel => {
+    return {
+      find: async (query: Record<string, unknown>) => {
+        return flags.filter((flag) => {
+          if (
+            query.archived &&
+            typeof query.archived === "object" &&
+            "$ne" in (query.archived as Record<string, unknown>)
+          ) {
+            if (flag.archived) {
+              return false;
+            }
+          }
+          if (query.enabled !== undefined && flag.enabled !== query.enabled) {
+            return false;
+          }
+          return true;
+        });
+      },
+    } as unknown as FeatureFlagModel;
+  };
+
+  it("returns an empty object when there are no flags", async () => {
+    const model = makeMockModel([]);
+    const result = await evaluateAllFlags(model, "user1", {}, noSegments);
+    expect(result).toEqual({});
+  });
+
+  it("evaluates each enabled flag and keys results by flag key", async () => {
+    const flags = [
+      createFlag({key: "flag-a", rolloutPercentage: 100}),
+      createFlag({key: "flag-b", rolloutPercentage: 0}),
+      createFlag({
+        key: "flag-c",
+        rolloutPercentage: 0,
+        rules: [{enabled: true, field: "admin", operator: "eq", value: true}],
+      }),
+    ];
+
+    const model = makeMockModel(flags);
+    const result = await evaluateAllFlags(model, "user1", {admin: true}, noSegments);
+
+    expect(result["flag-a"]).toBe(true);
+    expect(result["flag-b"]).toBe(false);
+    expect(result["flag-c"]).toBe(true);
+  });
+
+  it("supports variant flags in the aggregate evaluation", async () => {
+    const flags = [
+      createFlag({
+        key: "variant-flag",
+        rules: [{segment: "pros", variant: "variant-a"}],
+        type: "variant",
+        variants: [
+          {key: "control", weight: 50},
+          {key: "variant-a", weight: 50},
+        ],
+      }),
+    ];
+
+    const segments: Record<string, SegmentFunction> = {
+      pros: (user: unknown) => (user as {pro: boolean}).pro === true,
+    };
+
+    const model = makeMockModel(flags);
+    const result = await evaluateAllFlags(model, "user1", {pro: true}, segments);
+    expect(result["variant-flag"]).toBe("variant-a");
+  });
+
+  it("runs with debug logging disabled", async () => {
+    const original = process.env.FEATURE_FLAGS_DEBUG;
+    process.env.FEATURE_FLAGS_DEBUG = "false";
+    try {
+      const model = makeMockModel([createFlag({key: "flag-a"})]);
+      const result = await evaluateAllFlags(model, "user1", {}, noSegments);
+      expect(result["flag-a"]).toBe(true);
+    } finally {
+      if (original === undefined) {
+        delete process.env.FEATURE_FLAGS_DEBUG;
+      } else {
+        process.env.FEATURE_FLAGS_DEBUG = original;
+      }
+    }
   });
 });

--- a/feature-flags/src/tests/featureFlagModel.test.ts
+++ b/feature-flags/src/tests/featureFlagModel.test.ts
@@ -1,0 +1,205 @@
+import {afterEach, describe, expect, it} from "bun:test";
+import {FeatureFlag} from "../featureFlagModel";
+
+describe("FeatureFlag model", () => {
+  afterEach(async () => {
+    await FeatureFlag.deleteMany({});
+  });
+
+  it("creates a boolean flag with defaults", async () => {
+    const flag = await FeatureFlag.create({
+      key: "new-checkout-flow",
+      name: "New Checkout Flow",
+    });
+
+    expect(flag.key).toBe("new-checkout-flow");
+    expect(flag.name).toBe("New Checkout Flow");
+    expect(flag.enabled).toBe(false);
+    expect(flag.archived).toBe(false);
+    expect(flag.type).toBe("boolean");
+    expect(flag.rolloutPercentage).toBe(100);
+    expect(flag.description).toBe("");
+    expect(flag.rules).toEqual([]);
+    expect(flag.variants).toEqual([]);
+  });
+
+  it("rejects unknown fields (strict: 'throw')", async () => {
+    await expect(
+      FeatureFlag.create({
+        key: "strict-test",
+        name: "Strict Test",
+        unknownField: true,
+      } as unknown as Record<string, unknown>)
+    ).rejects.toBeDefined();
+  });
+
+  it("requires a key and name", async () => {
+    await expect(
+      FeatureFlag.create({
+        name: "Missing key",
+      } as unknown as Record<string, unknown>)
+    ).rejects.toBeDefined();
+
+    await expect(
+      FeatureFlag.create({
+        key: "missing-name",
+      } as unknown as Record<string, unknown>)
+    ).rejects.toBeDefined();
+  });
+
+  it("enforces unique keys", async () => {
+    await FeatureFlag.syncIndexes();
+
+    await FeatureFlag.create({key: "dup-key", name: "First"});
+    await expect(FeatureFlag.create({key: "dup-key", name: "Second"})).rejects.toBeDefined();
+  });
+
+  it("clamps rolloutPercentage to the 0-100 range", async () => {
+    await expect(
+      FeatureFlag.create({
+        key: "over-rollout",
+        name: "Over",
+        rolloutPercentage: 150,
+      })
+    ).rejects.toBeDefined();
+
+    await expect(
+      FeatureFlag.create({
+        key: "under-rollout",
+        name: "Under",
+        rolloutPercentage: -5,
+      })
+    ).rejects.toBeDefined();
+  });
+
+  it("accepts variant flags with variants that sum to 100", async () => {
+    const flag = await FeatureFlag.create({
+      key: "variant-flag",
+      name: "Variant Flag",
+      type: "variant",
+      variants: [
+        {key: "control", weight: 40},
+        {key: "variant-a", weight: 60},
+      ],
+    });
+
+    expect(flag.type).toBe("variant");
+    expect(flag.variants.length).toBe(2);
+  });
+
+  it("rejects variant flags with no variants", async () => {
+    await expect(
+      FeatureFlag.create({
+        key: "variant-no-variants",
+        name: "No Variants",
+        type: "variant",
+        variants: [],
+      })
+    ).rejects.toMatchObject({title: "Variant flags must have at least one variant"});
+  });
+
+  it("rejects variant flags whose variant weights do not sum to 100", async () => {
+    await expect(
+      FeatureFlag.create({
+        key: "variant-bad-weights",
+        name: "Bad Weights",
+        type: "variant",
+        variants: [
+          {key: "control", weight: 10},
+          {key: "variant-a", weight: 10},
+        ],
+      })
+    ).rejects.toMatchObject({title: "Variant weights must sum to 100"});
+  });
+
+  it("allows boolean flags without variants", async () => {
+    const flag = await FeatureFlag.create({
+      key: "boolean-no-variants",
+      name: "Boolean",
+      type: "boolean",
+    });
+    expect(flag.variants).toEqual([]);
+  });
+
+  it("trims whitespace on keys", async () => {
+    const flag = await FeatureFlag.create({
+      key: "  padded-key  ",
+      name: "Padded",
+    });
+    expect(flag.key).toBe("padded-key");
+  });
+
+  it("stores complex rules including segments and field rules", async () => {
+    const flag = await FeatureFlag.create({
+      key: "complex-rules",
+      name: "Complex",
+      rules: [
+        {enabled: true, segment: "beta"},
+        {enabled: true, field: "plan", operator: "in", value: ["pro", "enterprise"]},
+        {enabled: false, field: "email", operator: "contains", value: "@example.com"},
+      ],
+    });
+    expect(flag.rules.length).toBe(3);
+    expect(flag.rules[0].segment).toBe("beta");
+    expect(flag.rules[1].operator).toBe("in");
+    expect(flag.rules[1].value).toEqual(["pro", "enterprise"]);
+    expect(flag.rules[2].enabled).toBe(false);
+  });
+
+  it("rejects invalid rule operators via the enum constraint", async () => {
+    await expect(
+      FeatureFlag.create({
+        key: "bad-op",
+        name: "Bad Operator",
+        rules: [{enabled: true, field: "plan", operator: "bogus", value: "pro"}],
+      })
+    ).rejects.toBeDefined();
+  });
+
+  it("rejects invalid type values via the enum constraint", async () => {
+    await expect(
+      FeatureFlag.create({
+        key: "bad-type",
+        name: "Bad Type",
+        type: "nonsense",
+      } as unknown as Record<string, unknown>)
+    ).rejects.toBeDefined();
+  });
+
+  it("supports the isDeleted soft-delete plugin", async () => {
+    const flag = await FeatureFlag.create({
+      key: "soft-delete",
+      name: "Soft",
+    });
+
+    expect(flag.deleted).toBe(false);
+
+    flag.deleted = true;
+    await flag.save();
+
+    const found = await FeatureFlag.findOne({key: "soft-delete"});
+    expect(found).toBeNull();
+
+    const foundWithDeleted = await FeatureFlag.findOne({deleted: true, key: "soft-delete"});
+    expect(foundWithDeleted?._id.toString()).toBe(flag._id.toString());
+  });
+
+  it("sets created/updated timestamps on save", async () => {
+    const flag = await FeatureFlag.create({
+      key: "timestamps",
+      name: "Timestamps",
+    });
+    expect(flag.created).toBeInstanceOf(Date);
+    expect(flag.updated).toBeInstanceOf(Date);
+  });
+
+  it("supports findExactlyOne and findOneOrNone plugins", async () => {
+    await FeatureFlag.create({key: "existing-flag", name: "Exists"});
+
+    const exact = await FeatureFlag.findExactlyOne({key: "existing-flag"});
+    expect(exact.name).toBe("Exists");
+
+    const maybe = await FeatureFlag.findOneOrNone({key: "missing-flag"});
+    expect(maybe).toBeNull();
+  });
+});

--- a/feature-flags/src/tests/featureFlagsApp.test.ts
+++ b/feature-flags/src/tests/featureFlagsApp.test.ts
@@ -1,0 +1,221 @@
+import {afterEach, beforeEach, describe, expect, it} from "bun:test";
+import {
+  addAuthRoutes,
+  apiErrorMiddleware,
+  apiUnauthorizedMiddleware,
+  setupAuth,
+  type UserModel as UserModelType,
+} from "@terreno/api";
+import {authAsUser, getBaseServer, setupDb, UserModel} from "@terreno/api/src/tests";
+import type express from "express";
+import supertest from "supertest";
+import type TestAgent from "supertest/lib/agent";
+
+import {FeatureFlag} from "../featureFlagModel";
+import {FeatureFlagsApp} from "../featureFlagsApp";
+import type {SegmentFunction} from "../types";
+
+const buildApp = (options?: {
+  basePath?: string;
+  segments?: Record<string, SegmentFunction>;
+}): express.Application => {
+  const app = getBaseServer();
+  setupAuth(app, UserModel as unknown as UserModelType);
+  addAuthRoutes(app, UserModel as unknown as UserModelType);
+
+  const plugin = new FeatureFlagsApp(options);
+  plugin.register(app);
+
+  app.use(apiUnauthorizedMiddleware);
+  app.use(apiErrorMiddleware);
+  return app;
+};
+
+describe("FeatureFlagsApp", () => {
+  let app: express.Application;
+  let adminAgent: TestAgent;
+  let notAdminAgent: TestAgent;
+
+  beforeEach(async () => {
+    await setupDb();
+    await FeatureFlag.deleteMany({});
+  });
+
+  afterEach(async () => {
+    await FeatureFlag.deleteMany({});
+  });
+
+  describe("construction", () => {
+    it("defaults basePath to /feature-flags and segments to an empty object", async () => {
+      app = buildApp();
+      adminAgent = await authAsUser(app, "admin");
+
+      const res = await adminAgent.get("/feature-flags/segments").expect(200);
+      expect(res.body.data).toEqual([]);
+    });
+
+    it("respects a custom basePath", async () => {
+      app = buildApp({basePath: "/flags"});
+      adminAgent = await authAsUser(app, "admin");
+
+      await adminAgent.get("/flags/segments").expect(200);
+      await adminAgent.get("/feature-flags/segments").expect(404);
+    });
+
+    it("accepts an empty options object", async () => {
+      app = buildApp({});
+      adminAgent = await authAsUser(app, "admin");
+
+      const res = await adminAgent.get("/feature-flags/segments").expect(200);
+      expect(res.body.data).toEqual([]);
+    });
+  });
+
+  describe("admin CRUD routes", () => {
+    beforeEach(async () => {
+      app = buildApp();
+      adminAgent = await authAsUser(app, "admin");
+      notAdminAgent = await authAsUser(app, "notAdmin");
+    });
+
+    it("lets admins create, list, read, update, and delete flags", async () => {
+      const createRes = await adminAgent
+        .post("/feature-flags/flags")
+        .send({enabled: true, key: "new-flag", name: "New Flag"})
+        .expect(201);
+
+      const flagId: string = createRes.body.data._id;
+      expect(createRes.body.data.key).toBe("new-flag");
+
+      const listRes = await adminAgent.get("/feature-flags/flags").expect(200);
+      expect(listRes.body.data.length).toBe(1);
+
+      const readRes = await adminAgent.get(`/feature-flags/flags/${flagId}`).expect(200);
+      expect(readRes.body.data.key).toBe("new-flag");
+
+      const updateRes = await adminAgent
+        .patch(`/feature-flags/flags/${flagId}`)
+        .send({rolloutPercentage: 50})
+        .expect(200);
+      expect(updateRes.body.data.rolloutPercentage).toBe(50);
+
+      await adminAgent.delete(`/feature-flags/flags/${flagId}`).expect(204);
+      const finalList = await adminAgent.get("/feature-flags/flags").expect(200);
+      expect(finalList.body.data.length).toBe(0);
+    });
+
+    it("rejects non-admins from the CRUD routes", async () => {
+      // modelRouter responds with 405 Method Not Allowed when permissions fail
+      await notAdminAgent.get("/feature-flags/flags").expect(405);
+      await notAdminAgent
+        .post("/feature-flags/flags")
+        .send({key: "nope", name: "Nope"})
+        .expect(405);
+    });
+
+    it("rejects unauthenticated requests to CRUD routes", async () => {
+      const unauth = supertest(app);
+      await unauth.get("/feature-flags/flags").expect(401);
+    });
+  });
+
+  describe("GET /feature-flags/evaluate", () => {
+    beforeEach(async () => {
+      const segments: Record<string, SegmentFunction> = {
+        admins: (user: unknown) => (user as {admin?: boolean}).admin === true,
+      };
+      app = buildApp({segments});
+    });
+
+    it("returns 401 for unauthenticated callers", async () => {
+      const unauth = supertest(app);
+      await unauth.get("/feature-flags/evaluate").expect(401);
+    });
+
+    it("returns all enabled, non-archived flag values for the current user", async () => {
+      await FeatureFlag.create({
+        enabled: true,
+        key: "rolled-out",
+        name: "Rolled out",
+        rolloutPercentage: 100,
+      });
+      await FeatureFlag.create({
+        enabled: false,
+        key: "disabled-flag",
+        name: "Disabled",
+        rolloutPercentage: 100,
+      });
+      await FeatureFlag.create({
+        archived: true,
+        enabled: true,
+        key: "archived-flag",
+        name: "Archived",
+        rolloutPercentage: 100,
+      });
+      await FeatureFlag.create({
+        enabled: true,
+        key: "admins-only",
+        name: "Admins",
+        rolloutPercentage: 0,
+        rules: [{enabled: true, segment: "admins"}],
+      });
+
+      adminAgent = await authAsUser(app, "admin");
+
+      const res = await adminAgent.get("/feature-flags/evaluate").expect(200);
+      expect(res.body.data["rolled-out"]).toBe(true);
+      expect(res.body.data["admins-only"]).toBe(true);
+      expect(res.body.data["disabled-flag"]).toBeUndefined();
+      expect(res.body.data["archived-flag"]).toBeUndefined();
+    });
+
+    it("includes an admin's own evaluated flags", async () => {
+      await FeatureFlag.create({
+        enabled: true,
+        key: "user-only",
+        name: "User only",
+        rolloutPercentage: 0,
+        rules: [{enabled: true, field: "admin", operator: "eq", value: true}],
+      });
+
+      adminAgent = await authAsUser(app, "admin");
+      const res = await adminAgent.get("/feature-flags/evaluate").expect(200);
+      expect(res.body.data["user-only"]).toBe(true);
+
+      notAdminAgent = await authAsUser(app, "notAdmin");
+      const notAdminRes = await notAdminAgent.get("/feature-flags/evaluate").expect(200);
+      // notAdmin isn't admin, rolloutPercentage is 0 → should evaluate false
+      expect(notAdminRes.body.data["user-only"]).toBe(false);
+    });
+  });
+
+  describe("GET /feature-flags/segments", () => {
+    beforeEach(async () => {
+      app = buildApp({
+        segments: {
+          admins: () => true,
+          "beta-testers": () => false,
+        },
+      });
+    });
+
+    it("returns the registered segment keys for admins", async () => {
+      adminAgent = await authAsUser(app, "admin");
+
+      const res = await adminAgent.get("/feature-flags/segments").expect(200);
+      expect(res.body.data.sort()).toEqual(["admins", "beta-testers"]);
+    });
+
+    it("rejects non-admin users", async () => {
+      notAdminAgent = await authAsUser(app, "notAdmin");
+
+      const res = await notAdminAgent.get("/feature-flags/segments").expect(403);
+      expect(res.body.title).toInclude("Only admins can view segments");
+    });
+
+    it("requires authentication", async () => {
+      const unauth = supertest(app);
+      await unauth.get("/feature-flags/segments").expect(401);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Brings `@terreno/feature-flags` test coverage from 79.59% lines / 83.33% funcs (on `evaluate.ts` only; no coverage at all on `featureFlagModel.ts` or `featureFlagsApp.ts`) up to **100% on all three source files**.

New tests cover:

- **`evaluate.ts`** — previously uncovered branches: malformed field rules (missing field, missing operator, unknown operator, non-string/non-number/non-array values), segment rule on a variant flag, segment function that throws, variant fallback when weights don't sum to 100, variant flag with empty variants array, and the `FEATURE_FLAGS_DEBUG=false` path. Also adds tests for `evaluateAllFlags` with a mock model (empty, mixed boolean/rule/variant flags, and the debug-off path).
- **`featureFlagModel.ts`** (new `featureFlagModel.test.ts`) — schema defaults, required fields, unique key index, `rolloutPercentage` min/max, enum validators for `type` and rule `operator`, `strict: "throw"` behavior, key trimming, pre-save validation of variant flags (must have ≥1 variant, weights must sum to 100), `isDeletedPlugin` soft-delete filtering, timestamps, and `findExactlyOne`/`findOneOrNone` plugins.
- **`featureFlagsApp.ts`** (new `featureFlagsApp.test.ts`) — default and custom `basePath`, admin CRUD lifecycle via `modelRouter`, non-admin rejection (405), unauthenticated rejection (401), `/evaluate` returning only enabled/non-archived flags for the current user with segment + field rules exercised, and `/segments` admin-only access.

Infrastructure:

- Added `feature-flags/bunfig.toml` so tests preload `../api/src/tests/bunSetup.ts` (mongo connection, Sentry mock, logger silencing) — matches the `admin-backend` setup.
- Added `supertest`, `@types/supertest`, and `passport-local-mongoose` as devDependencies (needed by `@terreno/api/src/tests` helpers).

Coverage after this PR (feature-flags files only):

```
 src/evaluate.ts          | 100.00 | 100.00
 src/featureFlagModel.ts  | 100.00 | 100.00
 src/featureFlagsApp.ts   | 100.00 | 100.00
```

73 tests pass, 0 fail. `bun run lint` and `bun run compile` both pass.

## Review & Testing Checklist for Human

- [ ] Confirm the added `bunfig.toml` / dev-dep additions are acceptable (mirrors `admin-backend`).
- [ ] Spot-check `featureFlagsApp.test.ts` — the non-admin CRUD test expects 405 (what `modelRouter` actually returns), not 403; confirm that's the desired contract.
- [ ] Verify CI passes on this branch.

### Notes

No production code was changed — this PR is tests + test infra only.


Link to Devin session: https://app.devin.ai/sessions/3ab0946512cd480db7841aca9f207319
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes plus Bun test config and devDependency updates; low production risk, with the main risk being longer/flakier CI due to added integration-style tests and DB setup.
> 
> **Overview**
> Raises `@terreno/feature-flags` coverage to 100% by expanding `evaluate.test.ts` to hit previously untested branches (malformed rules, segment failures, variant fallbacks, debug-off paths) and adding new suites for `FeatureFlag` schema behavior (`featureFlagModel.test.ts`) and `FeatureFlagsApp` routes (`featureFlagsApp.test.ts`, including auth/admin gating and CRUD/evaluate/segments behavior).
> 
> Adds `feature-flags/bunfig.toml` to preload the API test setup, and updates `feature-flags` devDependencies (and `bun.lock`) to include `supertest`/types and `passport-local-mongoose` needed for the new app tests; workspace package versions in `bun.lock` are bumped to `0.10.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d53cf9e321105db6237bb89248365808375920bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->