### PR TITLE
Add tests to bring mcp-server to 97%+ coverage

### DIFF
--- a/mcp-server/bunfig.toml
+++ b/mcp-server/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+preload = "./src/__tests__/preload.ts"
+coveragePathIgnorePatterns = ["**/__tests__/**"]

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -17,8 +17,8 @@
     "compile": "bun run sync-ui-docs && tsc && cp -r src/docs dist/",
     "compile:watch": "tsc -w",
     "sync-ui-docs": "cp ../demo/ui-types-documentation.json src/docs/ 2>/dev/null || true",
-    "test": "bun test",
-    "test:ci": "bun test"
+    "test": "bun test src/",
+    "test:ci": "bun test src/"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.0",

--- a/mcp-server/src/__tests__/bootstrap.test.ts
+++ b/mcp-server/src/__tests__/bootstrap.test.ts
@@ -1,0 +1,294 @@
+import {describe, expect, test} from "bun:test";
+import {
+  bootstrapPrompts,
+  bootstrapTools,
+  handleBootstrapPromptRequest,
+  handleBootstrapToolCall,
+} from "../bootstrap.js";
+
+describe("bootstrap", () => {
+  describe("bootstrapTools", () => {
+    test("should export bootstrap_app and bootstrap_ai_rules", () => {
+      const names = bootstrapTools.map((t) => t.name);
+      expect(names).toContain("bootstrap_app");
+      expect(names).toContain("bootstrap_ai_rules");
+    });
+
+    test("should have valid input schema structure", () => {
+      for (const tool of bootstrapTools) {
+        expect(tool.inputSchema.type).toBe("object");
+        expect(tool.inputSchema.required).toContain("appName");
+        expect(tool.inputSchema.required).toContain("appDisplayName");
+      }
+    });
+  });
+
+  describe("bootstrapPrompts", () => {
+    test("should export bootstrap_terreno_app prompt", () => {
+      const names = bootstrapPrompts.map((p) => p.name);
+      expect(names).toContain("bootstrap_terreno_app");
+    });
+
+    test("should have required arguments", () => {
+      const prompt = bootstrapPrompts.find((p) => p.name === "bootstrap_terreno_app");
+      expect(prompt).toBeDefined();
+      const argNames = prompt?.arguments.map((a) => a.name);
+      expect(argNames).toContain("appName");
+      expect(argNames).toContain("appDisplayName");
+    });
+  });
+
+  describe("handleBootstrapToolCall - bootstrap_app", () => {
+    test("should return error when appName is missing", () => {
+      const result = handleBootstrapToolCall("bootstrap_app", {
+        appDisplayName: "My App",
+      });
+      expect(result.content[0].text).toContain("Error");
+      expect(result.content[0].text).toContain("required");
+    });
+
+    test("should return error when appDisplayName is missing", () => {
+      const result = handleBootstrapToolCall("bootstrap_app", {
+        appName: "my-app",
+      });
+      expect(result.content[0].text).toContain("Error");
+    });
+
+    test("should return all expected files with required args", () => {
+      const result = handleBootstrapToolCall("bootstrap_app", {
+        appDisplayName: "My App",
+        appName: "my-app",
+      });
+      const text = result.content[0].text;
+
+      expect(text).toContain("# Bootstrap My App");
+      expect(text).toContain(".cursorrules");
+      expect(text).toContain(".cursor/mcp.json");
+      expect(text).toContain("CLAUDE.md");
+
+      // Backend files
+      expect(text).toContain("backend/package.json");
+      expect(text).toContain("backend/tsconfig.json");
+      expect(text).toContain("backend/biome.jsonc");
+      expect(text).toContain("backend/src/index.ts");
+      expect(text).toContain("backend/src/server.ts");
+      expect(text).toContain("backend/src/utils/database.ts");
+      expect(text).toContain("backend/src/models/modelPlugins.ts");
+      expect(text).toContain("backend/src/models/user.ts");
+      expect(text).toContain("backend/src/models/appConfiguration.ts");
+      expect(text).toContain("backend/src/models/index.ts");
+      expect(text).toContain("backend/src/api/users.ts");
+      expect(text).toContain("backend/src/types/index.ts");
+      expect(text).toContain("backend/src/types/models/userTypes.ts");
+
+      // Frontend files
+      expect(text).toContain("frontend/package.json");
+      expect(text).toContain("frontend/app.json");
+      expect(text).toContain("frontend/tsconfig.json");
+      expect(text).toContain("frontend/tsconfig.codegen.json");
+      expect(text).toContain("frontend/biome.jsonc");
+      expect(text).toContain("frontend/openapi-config.ts");
+      expect(text).toContain("frontend/scripts/generate-sdk.ts");
+      expect(text).toContain("frontend/app/_layout.tsx");
+      expect(text).toContain("frontend/app/login.tsx");
+      expect(text).toContain("frontend/app/+not-found.tsx");
+      expect(text).toContain("frontend/app/(tabs)/_layout.tsx");
+      expect(text).toContain("frontend/app/(tabs)/index.tsx");
+      expect(text).toContain("frontend/app/(tabs)/profile.tsx");
+      expect(text).toContain("frontend/app/(tabs)/admin/_layout.tsx");
+      expect(text).toContain("frontend/app/(tabs)/admin/index.tsx");
+      expect(text).toContain("frontend/app/(tabs)/admin/configuration.tsx");
+      expect(text).toContain("frontend/store/index.ts");
+      expect(text).toContain("frontend/store/appState.ts");
+      expect(text).toContain("frontend/store/errors.ts");
+      expect(text).toContain("frontend/store/sdk.ts");
+      expect(text).toContain("frontend/store/openApiSdk.ts");
+      expect(text).toContain("frontend/constants/theme.ts");
+      expect(text).toContain("frontend/utils/index.ts");
+      expect(text).toContain("frontend/.env");
+
+      // Workflows
+      expect(text).toContain(".github/workflows/backend-ci.yml");
+      expect(text).toContain(".github/workflows/frontend-ci.yml");
+    });
+
+    test("should include setup instructions", () => {
+      const result = handleBootstrapToolCall("bootstrap_app", {
+        appDisplayName: "Test App",
+        appName: "test-app",
+      });
+      const text = result.content[0].text;
+
+      expect(text).toContain("mkdir test-app");
+      expect(text).toContain("cd test-app");
+      expect(text).toContain("bun install");
+      expect(text).toContain("docker run");
+      expect(text).toContain("SpaceMono");
+      expect(text).toContain("bun run dev");
+      expect(text).toContain("bun run sdk");
+      expect(text).toContain("http://localhost:8082");
+    });
+
+    test("should use custom MCP server URL when provided", () => {
+      const result = handleBootstrapToolCall("bootstrap_app", {
+        appDisplayName: "Custom App",
+        appName: "custom-app",
+        mcpServerUrl: "https://custom.mcp.example.com",
+      });
+      expect(result.content[0].text).toContain("https://custom.mcp.example.com");
+    });
+
+    test("should use default MCP server URL when not provided", () => {
+      const result = handleBootstrapToolCall("bootstrap_app", {
+        appDisplayName: "Default App",
+        appName: "default-app",
+      });
+      expect(result.content[0].text).toContain("mcp.terreno.flourish.health");
+    });
+
+    test("should include generated backend server code", () => {
+      const result = handleBootstrapToolCall("bootstrap_app", {
+        appDisplayName: "Code App",
+        appName: "code-app",
+      });
+      const text = result.content[0].text;
+
+      expect(text).toContain("TerrenoApp");
+      expect(text).toContain("AdminApp");
+      expect(text).toContain("connectToMongoDB");
+      expect(text).toContain("userRouter");
+    });
+
+    test("should include generated frontend code", () => {
+      const result = handleBootstrapToolCall("bootstrap_app", {
+        appDisplayName: "FE App",
+        appName: "fe-app",
+      });
+      const text = result.content[0].text;
+
+      expect(text).toContain("generateAuthSlice");
+      expect(text).toContain("LoginScreen");
+      expect(text).toContain("TabLayout");
+      expect(text).toContain("HomeScreen");
+      expect(text).toContain("ProfileScreen");
+      expect(text).toContain("useEmailLoginMutation");
+      expect(text).toContain("useEmailSignUpMutation");
+      expect(text).toContain("persistReducer");
+      expect(text).toContain("primitives");
+      expect(text).toContain("AdminModelList");
+    });
+
+    test("should generate valid JSON in mcp.json settings", () => {
+      const result = handleBootstrapToolCall("bootstrap_app", {
+        appDisplayName: "JSON App",
+        appName: "json-app",
+      });
+      const text = result.content[0].text;
+      const match = text.match(/### `\.cursor\/mcp\.json`\n\n```json\n([\s\S]*?)\n```/);
+      expect(match).toBeTruthy();
+      if (match) {
+        const parsed = JSON.parse(match[1]);
+        expect(parsed.mcpServers.terreno).toBeDefined();
+        expect(parsed.mcpServers.terreno.type).toBe("http");
+      }
+    });
+
+    test("should use app name in workflow files", () => {
+      const result = handleBootstrapToolCall("bootstrap_app", {
+        appDisplayName: "Workflow App",
+        appName: "workflow-app",
+      });
+      const text = result.content[0].text;
+      expect(text).toContain("Backend CI");
+      expect(text).toContain("Frontend CI");
+    });
+  });
+
+  describe("handleBootstrapToolCall - bootstrap_ai_rules", () => {
+    test("should return error when appName is missing", () => {
+      const result = handleBootstrapToolCall("bootstrap_ai_rules", {
+        appDisplayName: "My App",
+      });
+      expect(result.content[0].text).toContain("Error");
+    });
+
+    test("should return error when appDisplayName is missing", () => {
+      const result = handleBootstrapToolCall("bootstrap_ai_rules", {
+        appName: "my-app",
+      });
+      expect(result.content[0].text).toContain("Error");
+    });
+
+    test("should generate all AI rules files with required args", () => {
+      const result = handleBootstrapToolCall("bootstrap_ai_rules", {
+        appDisplayName: "Rules App",
+        appName: "rules-app",
+      });
+      const text = result.content[0].text;
+
+      expect(text).toContain("# Bootstrap AI Rules for Rules App");
+      expect(text).toContain(".rulesync/rules/00-root.md");
+      expect(text).toContain(".rulesync/rules/01-claudecode-root.md");
+      expect(text).toContain("backend/AGENTS.md");
+      expect(text).toContain("backend/CLAUDE.md");
+      expect(text).toContain("frontend/AGENTS.md");
+      expect(text).toContain("frontend/CLAUDE.md");
+      expect(text).toContain("rulesync.jsonc");
+    });
+
+    test("should include setup instructions for rulesync", () => {
+      const result = handleBootstrapToolCall("bootstrap_ai_rules", {
+        appDisplayName: "R App",
+        appName: "r-app",
+      });
+      expect(result.content[0].text).toContain("rulesync sync");
+      expect(result.content[0].text).toContain("npm install -g rulesync");
+    });
+
+    test("should strip frontmatter from backend/frontend AGENTS files", () => {
+      const result = handleBootstrapToolCall("bootstrap_ai_rules", {
+        appDisplayName: "Strip App",
+        appName: "strip-app",
+      });
+      const text = result.content[0].text;
+
+      // The AGENTS.md content should not contain frontmatter markers when shown
+      const backendAgentsMatch = text.match(
+        /### `backend\/AGENTS\.md`\n\n```markdown\n([\s\S]*?)\n```/
+      );
+      expect(backendAgentsMatch).toBeTruthy();
+      if (backendAgentsMatch) {
+        expect(backendAgentsMatch[1].startsWith("---")).toBe(false);
+        expect(backendAgentsMatch[1]).toContain("Strip App Backend");
+      }
+    });
+  });
+
+  describe("handleBootstrapToolCall - unknown", () => {
+    test("should return error for unknown bootstrap tool", () => {
+      const result = handleBootstrapToolCall("bootstrap_unknown", {});
+      expect(result.content[0].text).toContain("Unknown bootstrap tool");
+    });
+  });
+
+  describe("handleBootstrapPromptRequest", () => {
+    test("should generate bootstrap prompt", () => {
+      const result = handleBootstrapPromptRequest("bootstrap_terreno_app", {
+        appDisplayName: "Prompt App",
+        appName: "prompt-app",
+      });
+      const text = result.messages[0].content.text;
+
+      expect(text).toContain("prompt-app");
+      expect(text).toContain("Prompt App");
+      expect(text).toContain("bootstrap_app");
+      expect(text).toContain("bootstrap_ai_rules");
+      expect(text).toContain("rulesync");
+    });
+
+    test("should return unknown message for unknown prompt", () => {
+      const result = handleBootstrapPromptRequest("unknown_prompt", {});
+      expect(result.messages[0].content.text).toContain("Unknown bootstrap prompt");
+    });
+  });
+});

--- a/mcp-server/src/__tests__/fixtures/docs/ui-types-documentation.json
+++ b/mcp-server/src/__tests__/fixtures/docs/ui-types-documentation.json
@@ -1,0 +1,33 @@
+{
+  "children": [
+    {
+      "name": "Common",
+      "children": [
+        {
+          "name": "ButtonProps",
+          "kind": 256,
+          "children": [
+            {
+              "name": "text",
+              "type": {"type": "intrinsic", "name": "string"},
+              "flags": {},
+              "comment": {"summary": [{"text": "Button text"}]}
+            },
+            {
+              "name": "onClick",
+              "type": {
+                "type": "reflection",
+                "declaration": {"signatures": [{}]}
+              },
+              "flags": {"isOptional": true}
+            }
+          ]
+        },
+        {
+          "name": "NotAnInterface",
+          "kind": 128
+        }
+      ]
+    }
+  ]
+}

--- a/mcp-server/src/__tests__/preload.ts
+++ b/mcp-server/src/__tests__/preload.ts
@@ -1,0 +1,13 @@
+import {copyFileSync, existsSync, mkdirSync} from "node:fs";
+import {dirname, join} from "node:path";
+
+// Copy the test fixture TypeDoc JSON into src/docs/ so buildResources()
+// exercises the component documentation code paths during tests. The target
+// path is gitignored, so leaving it in place between runs is harmless.
+const fixturePath = join(import.meta.dir, "fixtures", "docs", "ui-types-documentation.json");
+const targetPath = join(import.meta.dir, "..", "docs", "ui-types-documentation.json");
+
+if (existsSync(fixturePath)) {
+  mkdirSync(dirname(targetPath), {recursive: true});
+  copyFileSync(fixturePath, targetPath);
+}

--- a/mcp-server/src/__tests__/prompts.test.ts
+++ b/mcp-server/src/__tests__/prompts.test.ts
@@ -317,4 +317,40 @@ describe("prompts", () => {
       expect(result.messages[0].content.text).toContain("Unknown prompt");
     });
   });
+
+  describe("migrate_to_terreno_app", () => {
+    test("should return generic guide without serverFile", () => {
+      const result = handlePromptRequest("migrate_to_terreno_app", {});
+      const content = result.messages[0].content.text;
+
+      expect(content.length).toBeGreaterThan(0);
+      expect(content).not.toContain("Your Task");
+    });
+
+    test("should include task-specific instructions when serverFile is provided", () => {
+      const result = handlePromptRequest("migrate_to_terreno_app", {
+        serverFile: "src/myServer.ts",
+      });
+      const content = result.messages[0].content.text;
+
+      expect(content).toContain("src/myServer.ts");
+      expect(content).toContain("Your Task");
+      expect(content).toContain("TerrenoApp.create");
+      expect(content).toContain("HealthApp");
+    });
+  });
+
+  describe("bootstrap_terreno_app", () => {
+    test("should delegate to bootstrap prompt handler", () => {
+      const result = handlePromptRequest("bootstrap_terreno_app", {
+        appDisplayName: "My Bootstrap App",
+        appName: "my-bootstrap-app",
+      });
+      const content = result.messages[0].content.text;
+
+      expect(content).toContain("my-bootstrap-app");
+      expect(content).toContain("My Bootstrap App");
+      expect(content).toContain("bootstrap_app");
+    });
+  });
 });

--- a/mcp-server/src/__tests__/resources.test.ts
+++ b/mcp-server/src/__tests__/resources.test.ts
@@ -251,9 +251,9 @@ describe("componentToSlug", () => {
 
 describe("parseComponentsFromTypeDoc", () => {
   test("returns empty array when Common module is missing", () => {
-    expect(
-      parseComponentsFromTypeDoc({children: [{children: [], name: "Other"}]} as any)
-    ).toEqual([]);
+    expect(parseComponentsFromTypeDoc({children: [{children: [], name: "Other"}]} as any)).toEqual(
+      []
+    );
   });
 
   test("returns empty array when typedoc has no children", () => {

--- a/mcp-server/src/__tests__/resources.test.ts
+++ b/mcp-server/src/__tests__/resources.test.ts
@@ -1,5 +1,13 @@
 import {describe, expect, test} from "bun:test";
-import {resources} from "../resources.js";
+import {
+  componentToSlug,
+  extractTypeString,
+  formatComponentMarkdown,
+  generateComponentListMarkdown,
+  loadTypeDocJson,
+  parseComponentsFromTypeDoc,
+  resources,
+} from "../resources.js";
 
 describe("resources", () => {
   test("should have all required resources", () => {
@@ -137,5 +145,279 @@ describe("resources", () => {
       expect(patterns?.content).toContain("Error Handling");
       expect(patterns?.content).toContain("APIError");
     });
+  });
+});
+
+describe("loadTypeDocJson", () => {
+  test("should return null or object without throwing", () => {
+    const result = loadTypeDocJson();
+    expect(result === null || typeof result === "object").toBe(true);
+  });
+});
+
+describe("extractTypeString", () => {
+  test("returns unknown for null/undefined", () => {
+    expect(extractTypeString(null)).toBe("unknown");
+    expect(extractTypeString(undefined)).toBe("unknown");
+  });
+
+  test("handles intrinsic types", () => {
+    expect(extractTypeString({name: "string", type: "intrinsic"})).toBe("string");
+    expect(extractTypeString({name: "number", type: "intrinsic"})).toBe("number");
+  });
+
+  test("handles literal types", () => {
+    expect(extractTypeString({type: "literal", value: "primary"})).toBe('"primary"');
+    expect(extractTypeString({type: "literal", value: 42})).toBe("42");
+  });
+
+  test("handles union types", () => {
+    expect(
+      extractTypeString({
+        type: "union",
+        types: [
+          {type: "literal", value: "a"},
+          {type: "literal", value: "b"},
+        ],
+      })
+    ).toBe('"a" | "b"');
+  });
+
+  test("handles union type with empty types", () => {
+    expect(extractTypeString({type: "union"})).toBe("unknown");
+  });
+
+  test("handles array types", () => {
+    expect(
+      extractTypeString({
+        elementType: {name: "string", type: "intrinsic"},
+        type: "array",
+      })
+    ).toBe("string[]");
+  });
+
+  test("handles reference types without type arguments", () => {
+    expect(extractTypeString({name: "ReactNode", type: "reference"})).toBe("ReactNode");
+  });
+
+  test("handles reference types with type arguments", () => {
+    expect(
+      extractTypeString({
+        name: "Array",
+        type: "reference",
+        typeArguments: [{name: "string", type: "intrinsic"}],
+      })
+    ).toBe("Array<string>");
+  });
+
+  test("handles reflection with signatures as function", () => {
+    expect(
+      extractTypeString({
+        declaration: {signatures: [{}]},
+        type: "reflection",
+      })
+    ).toBe("function");
+  });
+
+  test("handles reflection without signatures as object", () => {
+    expect(
+      extractTypeString({
+        declaration: {},
+        type: "reflection",
+      })
+    ).toBe("object");
+  });
+
+  test("falls back to name for unknown types", () => {
+    expect(extractTypeString({name: "Custom", type: "weird"})).toBe("Custom");
+  });
+
+  test("falls back to unknown when no name", () => {
+    expect(extractTypeString({type: "weird"})).toBe("unknown");
+  });
+
+  test("falls back to unknown for reference without name", () => {
+    expect(extractTypeString({type: "reference"})).toBe("unknown");
+  });
+});
+
+describe("componentToSlug", () => {
+  test("lowercases and replaces spaces with dashes", () => {
+    expect(componentToSlug("Button")).toBe("button");
+    expect(componentToSlug("Text Field")).toBe("text-field");
+    expect(componentToSlug("Multi   Word Name")).toBe("multi-word-name");
+  });
+});
+
+describe("parseComponentsFromTypeDoc", () => {
+  test("returns empty array when Common module is missing", () => {
+    expect(
+      parseComponentsFromTypeDoc({children: [{children: [], name: "Other"}]} as any)
+    ).toEqual([]);
+  });
+
+  test("returns empty array when typedoc has no children", () => {
+    expect(parseComponentsFromTypeDoc({} as any)).toEqual([]);
+  });
+
+  test("returns empty array when Common has no children", () => {
+    expect(parseComponentsFromTypeDoc({children: [{name: "Common"}]} as any)).toEqual([]);
+  });
+
+  test("filters to only *Props interfaces and extracts props", () => {
+    const typeDoc: any = {
+      children: [
+        {
+          children: [
+            {
+              children: [
+                {
+                  comment: {
+                    blockTags: [
+                      {
+                        content: [{text: '```ts\n"primary"\n```'}],
+                        tag: "@default",
+                      },
+                    ],
+                    summary: [{text: "Visual variant"}],
+                  },
+                  flags: {isOptional: true},
+                  name: "variant",
+                  type: {
+                    type: "union",
+                    types: [
+                      {type: "literal", value: "primary"},
+                      {type: "literal", value: "secondary"},
+                    ],
+                  },
+                },
+                {
+                  flags: {},
+                  name: "text",
+                  type: {name: "string", type: "intrinsic"},
+                },
+              ],
+              kind: 256,
+              name: "ButtonProps",
+            },
+            {
+              kind: 256,
+              name: "NotAPropsInterface",
+            },
+            {
+              kind: 256,
+              name: "OtherProps",
+            },
+          ],
+          name: "Common",
+        },
+      ],
+    };
+
+    const components = parseComponentsFromTypeDoc(typeDoc);
+    expect(components.length).toBe(2);
+    const button = components.find((c) => c.name === "Button");
+    expect(button).toBeDefined();
+    expect(button?.interfaceName).toBe("ButtonProps");
+    expect(button?.props.length).toBe(2);
+
+    const variantProp = button?.props.find((p) => p.name === "variant");
+    expect(variantProp?.required).toBe(false);
+    expect(variantProp?.type).toBe('"primary" | "secondary"');
+    expect(variantProp?.description).toBe("Visual variant");
+    expect(variantProp?.defaultValue).toBe('"primary"');
+
+    const textProp = button?.props.find((p) => p.name === "text");
+    expect(textProp?.required).toBe(true);
+    expect(textProp?.type).toBe("string");
+  });
+
+  test("handles interface with no children", () => {
+    const typeDoc: any = {
+      children: [
+        {
+          children: [{kind: 256, name: "EmptyProps"}],
+          name: "Common",
+        },
+      ],
+    };
+    const components = parseComponentsFromTypeDoc(typeDoc);
+    expect(components.length).toBe(1);
+    expect(components[0].props).toEqual([]);
+  });
+});
+
+describe("formatComponentMarkdown", () => {
+  test("formats a component with props as markdown", () => {
+    const md = formatComponentMarkdown({
+      interfaceName: "ButtonProps",
+      name: "Button",
+      props: [
+        {
+          defaultValue: '"primary"',
+          description: "Visual variant",
+          name: "variant",
+          required: false,
+          type: '"primary" | "secondary"',
+        },
+        {
+          description: "",
+          name: "text",
+          required: true,
+          type: "string",
+        },
+      ],
+    });
+
+    expect(md).toContain("# Button");
+    expect(md).toContain("**Interface:** `ButtonProps`");
+    expect(md).toContain("## Props");
+    expect(md).toContain("`variant`");
+    expect(md).toContain("Visual variant");
+    expect(md).toContain('(default: `"primary"`)');
+    expect(md).toContain("`text`");
+    expect(md).toContain("| Yes |");
+  });
+
+  test("formats a component without props", () => {
+    const md = formatComponentMarkdown({
+      interfaceName: "SpacerProps",
+      name: "Spacer",
+      props: [],
+    });
+
+    expect(md).toContain("# Spacer");
+    expect(md).toContain("**Interface:** `SpacerProps`");
+    expect(md).not.toContain("## Props");
+  });
+});
+
+describe("generateComponentListMarkdown", () => {
+  test("generates markdown for a list of components", () => {
+    const md = generateComponentListMarkdown([
+      {
+        interfaceName: "ButtonProps",
+        name: "Button",
+        props: [
+          {description: "", name: "text", required: true, type: "string"},
+          {description: "", name: "onClick", required: false, type: "function"},
+        ],
+      },
+      {
+        interfaceName: "AvatarProps",
+        name: "Avatar",
+        props: [],
+      },
+    ]);
+
+    expect(md).toContain("# @terreno/ui Component Reference");
+    expect(md).toContain("**Total Components:** 2");
+    expect(md).toContain("| Avatar |");
+    expect(md).toContain("| Button |");
+    // Alphabetical: Avatar before Button
+    expect(md.indexOf("Avatar")).toBeLessThan(md.indexOf("Button"));
+    expect(md).toContain("**Required:** `text`");
+    expect(md).toContain("**Optional:** `onClick`");
+    expect(md).toContain("*No props*");
   });
 });

--- a/mcp-server/src/__tests__/resources.test.ts
+++ b/mcp-server/src/__tests__/resources.test.ts
@@ -7,6 +7,7 @@ import {
   loadTypeDocJson,
   parseComponentsFromTypeDoc,
   resources,
+  type TypeDocRoot,
 } from "../resources.js";
 
 describe("resources", () => {
@@ -251,21 +252,23 @@ describe("componentToSlug", () => {
 
 describe("parseComponentsFromTypeDoc", () => {
   test("returns empty array when Common module is missing", () => {
-    expect(parseComponentsFromTypeDoc({children: [{children: [], name: "Other"}]} as any)).toEqual(
-      []
-    );
+    expect(
+      parseComponentsFromTypeDoc({
+        children: [{children: [], id: 0, name: "Other"}],
+      })
+    ).toEqual([]);
   });
 
   test("returns empty array when typedoc has no children", () => {
-    expect(parseComponentsFromTypeDoc({} as any)).toEqual([]);
+    expect(parseComponentsFromTypeDoc({})).toEqual([]);
   });
 
   test("returns empty array when Common has no children", () => {
-    expect(parseComponentsFromTypeDoc({children: [{name: "Common"}]} as any)).toEqual([]);
+    expect(parseComponentsFromTypeDoc({children: [{id: 0, name: "Common"}]})).toEqual([]);
   });
 
   test("filters to only *Props interfaces and extracts props", () => {
-    const typeDoc: any = {
+    const typeDoc = {
       children: [
         {
           children: [
@@ -314,7 +317,7 @@ describe("parseComponentsFromTypeDoc", () => {
       ],
     };
 
-    const components = parseComponentsFromTypeDoc(typeDoc);
+    const components = parseComponentsFromTypeDoc(typeDoc as unknown as TypeDocRoot);
     expect(components.length).toBe(2);
     const button = components.find((c) => c.name === "Button");
     expect(button).toBeDefined();
@@ -333,10 +336,11 @@ describe("parseComponentsFromTypeDoc", () => {
   });
 
   test("handles interface with no children", () => {
-    const typeDoc: any = {
+    const typeDoc = {
       children: [
         {
-          children: [{kind: 256, name: "EmptyProps"}],
+          children: [{id: 1, kind: 256, name: "EmptyProps", variant: "declaration"}],
+          id: 0,
           name: "Common",
         },
       ],

--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -412,4 +412,194 @@ describe("tools", () => {
       expect(result.content[0].text).toContain("Unknown tool");
     });
   });
+
+  describe("generate_model edge cases", () => {
+    test("should generate interface types for non-string fields", () => {
+      const result = handleToolCall("generate_model", {
+        fields: [
+          {name: "count", required: true, type: "Number"},
+          {name: "isActive", required: true, type: "Boolean"},
+          {name: "startDate", required: false, type: "Date"},
+          {name: "ownerId", ref: "User", required: true, type: "ObjectId"},
+          {name: "tags", required: false, type: "Array"},
+        ],
+        name: "Event",
+      });
+      const content = result.content[0].text;
+
+      expect(content).toContain("count: number");
+      expect(content).toContain("isActive: boolean");
+      expect(content).toContain("startDate?: Date");
+      expect(content).toContain("ownerId: mongoose.Types.ObjectId");
+      expect(content).toContain("tags?: unknown[]");
+      expect(content).toContain('ref: "User"');
+    });
+
+    test("should support hasOwner and softDelete options", () => {
+      const result = handleToolCall("generate_model", {
+        fields: [{name: "title", required: true, type: "String"}],
+        hasOwner: true,
+        name: "Article",
+        softDelete: true,
+      });
+      const content = result.content[0].text;
+
+      expect(content).toContain("ownerId: mongoose.Types.ObjectId");
+      expect(content).toContain('ownerId: { type: mongoose.Schema.Types.ObjectId, ref: "User"');
+      expect(content).toContain("isDeletedPlugin");
+      expect(content).toContain("articleSchema.plugin(isDeletedPlugin)");
+    });
+
+    test("should support unique and default field props", () => {
+      const result = handleToolCall("generate_model", {
+        fields: [
+          {name: "email", required: true, type: "String", unique: true},
+          {default: "0", name: "count", required: false, type: "Number"},
+        ],
+        name: "Account",
+      });
+      const content = result.content[0].text;
+
+      expect(content).toContain("unique: true");
+      expect(content).toContain("default: 0");
+    });
+  });
+
+  describe("generate_route edge cases", () => {
+    test("should generate route with ownerFiltered", () => {
+      const result = handleToolCall("generate_route", {
+        modelName: "Task",
+        ownerFiltered: true,
+        permissions: {
+          create: "owner",
+          delete: "admin",
+          list: "any",
+          read: "authOrReadOnly",
+          update: "authenticated",
+        },
+        queryFields: ["title", "status"],
+        routePath: "/tasks",
+      });
+      const content = result.content[0].text;
+
+      expect(content).toContain("OwnerQueryFilter");
+      expect(content).toContain("UserDocument");
+      expect(content).toContain("Permissions.IsOwner");
+      expect(content).toContain("Permissions.IsAdmin");
+      expect(content).toContain("Permissions.IsAny");
+      expect(content).toContain("Permissions.IsAuthenticatedOrReadOnly");
+      expect(content).toContain('queryFields: ["title","status"]');
+      expect(content).toContain("preCreate");
+    });
+  });
+
+  describe("generate_screen edge cases", () => {
+    test("should fall back to empty template when type needs modelName but none given", () => {
+      const result = handleToolCall("generate_screen", {
+        name: "Orphan",
+        type: "list",
+      });
+      const content = result.content[0].text;
+
+      expect(content).toContain('Screen type "list" not fully supported');
+      expect(content).toContain("OrphanScreen");
+    });
+  });
+
+  describe("generate_form_fields edge cases", () => {
+    test("should generate password field", () => {
+      const result = handleToolCall("generate_form_fields", {
+        fields: [{label: "Password", name: "password", required: true, type: "password"}],
+      });
+      const content = result.content[0].text;
+
+      expect(content).toContain("PasswordField");
+      expect(content).toContain('label="Password"');
+      expect(content).toContain("error={errors.password}");
+    });
+
+    test("should generate textarea field", () => {
+      const result = handleToolCall("generate_form_fields", {
+        fields: [{name: "bio", type: "textarea"}],
+      });
+      const content = result.content[0].text;
+
+      expect(content).toContain("TextArea");
+    });
+
+    test("should generate datetime field", () => {
+      const result = handleToolCall("generate_form_fields", {
+        fields: [{name: "scheduledAt", type: "datetime"}],
+      });
+      const content = result.content[0].text;
+
+      expect(content).toContain("DateTimeField");
+      expect(content).toContain('mode="datetime"');
+    });
+
+    test("should generate select field with empty options", () => {
+      const result = handleToolCall("generate_form_fields", {
+        fields: [{name: "category", type: "select"}],
+      });
+      const content = result.content[0].text;
+
+      expect(content).toContain("SelectField");
+      expect(content).toContain("options={[]}");
+    });
+  });
+
+  describe("install_admin", () => {
+    test("should generate admin panel files and instructions", () => {
+      const result = handleToolCall("install_admin", {
+        models: [
+          {
+            displayName: "Todos",
+            listFields: ["title", "completed"],
+            modelName: "Todo",
+            routePath: "/todos",
+          },
+          {
+            displayName: "Users",
+            listFields: ["email"],
+            modelName: "User",
+            routePath: "/users",
+          },
+        ],
+      });
+      const content = result.content[0].text;
+
+      expect(content).toContain("# Install Admin Panel");
+      expect(content).toContain("frontend/app/(tabs)/admin/index.tsx");
+      expect(content).toContain("frontend/app/(tabs)/admin/[model].tsx");
+      expect(content).toContain("frontend/app/(tabs)/admin/[model]/create.tsx");
+      expect(content).toContain("frontend/app/(tabs)/admin/[model]/[id].tsx");
+      expect(content).toContain("AdminModelList");
+      expect(content).toContain("AdminModelTable");
+      expect(content).toContain("AdminModelForm");
+      expect(content).toContain("@terreno/admin-backend");
+      expect(content).toContain("@terreno/admin-frontend");
+      expect(content).toContain("import {Todo, User} from");
+      expect(content).toContain('displayName: "Todos"');
+      expect(content).toContain('routePath: "/todos"');
+      expect(content).toContain('["title","completed"]');
+    });
+  });
+
+  describe("handleToolCall - bootstrap dispatch", () => {
+    test("should delegate bootstrap_app to bootstrap handler", () => {
+      const result = handleToolCall("bootstrap_app", {
+        appDisplayName: "Dispatch App",
+        appName: "dispatch-app",
+      });
+      expect(result.content[0].text).toContain("# Bootstrap Dispatch App");
+    });
+
+    test("should delegate bootstrap_ai_rules to bootstrap handler", () => {
+      const result = handleToolCall("bootstrap_ai_rules", {
+        appDisplayName: "Rules App",
+        appName: "rules-app",
+      });
+      expect(result.content[0].text).toContain("Bootstrap AI Rules for Rules App");
+    });
+  });
 });

--- a/mcp-server/src/resources.ts
+++ b/mcp-server/src/resources.ts
@@ -57,7 +57,7 @@ interface TypeDocModule {
   children?: TypeDocInterface[];
 }
 
-interface TypeDocRoot {
+export interface TypeDocRoot {
   children?: TypeDocModule[];
 }
 

--- a/mcp-server/src/resources.ts
+++ b/mcp-server/src/resources.ts
@@ -73,7 +73,7 @@ interface ComponentDoc {
   }[];
 }
 
-const loadTypeDocJson = (): TypeDocRoot | null => {
+export const loadTypeDocJson = (): TypeDocRoot | null => {
   const filePath = join(getDocsRoot(), "ui-types-documentation.json");
   if (!existsSync(filePath)) {
     return null;
@@ -81,7 +81,7 @@ const loadTypeDocJson = (): TypeDocRoot | null => {
   return JSON.parse(readFileSync(filePath, "utf-8"));
 };
 
-const extractTypeString = (typeObj: any): string => {
+export const extractTypeString = (typeObj: any): string => {
   if (!typeObj) {
     return "unknown";
   }
@@ -120,7 +120,7 @@ const extractTypeString = (typeObj: any): string => {
   return typeObj.name ?? "unknown";
 };
 
-const parseComponentsFromTypeDoc = (typeDoc: TypeDocRoot): ComponentDoc[] => {
+export const parseComponentsFromTypeDoc = (typeDoc: TypeDocRoot): ComponentDoc[] => {
   const commonModule = typeDoc.children?.find((m) => m.name === "Common");
   if (!commonModule?.children) {
     return [];
@@ -163,11 +163,11 @@ const parseComponentsFromTypeDoc = (typeDoc: TypeDocRoot): ComponentDoc[] => {
   });
 };
 
-const componentToSlug = (name: string): string => {
+export const componentToSlug = (name: string): string => {
   return name.toLowerCase().replace(/\s+/g, "-");
 };
 
-const formatComponentMarkdown = (component: ComponentDoc): string => {
+export const formatComponentMarkdown = (component: ComponentDoc): string => {
   const lines: string[] = [
     `# ${component.name}`,
     "",
@@ -193,7 +193,7 @@ const formatComponentMarkdown = (component: ComponentDoc): string => {
   return lines.join("\n");
 };
 
-const generateComponentListMarkdown = (components: ComponentDoc[]): string => {
+export const generateComponentListMarkdown = (components: ComponentDoc[]): string => {
   const lines: string[] = [
     "# @terreno/ui Component Reference",
     "",


### PR DESCRIPTION
## Summary

Increases `@terreno/mcp-server` test coverage from ~51% lines / 58% functions to **97.33% lines / 98.77% functions**, exceeding the 95% target.

### Coverage by file (after)

| File | % Funcs | % Lines |
|------|---------|---------|
| bootstrap.ts | 95.08 | 96.32 |
| prompts.ts | 100.00 | 97.16 |
| resources.ts | 100.00 | 95.83 |
| tools.ts | 100.00 | 100.00 |
| **All files** | **98.77** | **97.33** |

### Changes

- **`src/__tests__/bootstrap.test.ts`** (new, 294 lines): Comprehensive tests for `bootstrap.ts`, covering tool/prompt schema, validation errors, generated file content for a full Terreno app (50+ files, setup instructions, MCP config, AI rules frontmatter stripping, etc.) — this file previously had 0% coverage.
- **`src/__tests__/resources.test.ts`** (+284 lines): Direct tests for the helper functions `loadTypeDocJson`, `extractTypeString`, `componentToSlug`, `parseComponentsFromTypeDoc`, `formatComponentMarkdown`, and `generateComponentListMarkdown`, including all branches in `extractTypeString` (intrinsic/literal/union/array/reference/reflection/fallback).
- **`src/__tests__/tools.test.ts`** (+190 lines): Tests for uncovered branches in `generate_model` (ObjectId/Boolean/Number/Date/Array/unique/default/softDelete/hasOwner), `generate_route` (owner-filtered, all permission types), `generate_screen` fallback template, remaining `generate_form_fields` types (password/textarea/datetime/select with empty options), and the `install_admin` tool.
- **`src/__tests__/prompts.test.ts`** (+36 lines): Tests for `migrate_to_terreno_app` (with and without `serverFile`) and `bootstrap_terreno_app` delegation.
- **`src/resources.ts`**: Exports 6 internal helpers (`loadTypeDocJson`, `extractTypeString`, `parseComponentsFromTypeDoc`, `componentToSlug`, `formatComponentMarkdown`, `generateComponentListMarkdown`) so they can be directly unit-tested. No implementation changes.
- **`bunfig.toml`** (new): Registers a test preload that copies a small `ui-types-documentation.json` fixture into `src/docs/` so `buildResources()` exercises the component-documentation code path during tests. Excludes test files from coverage reporting.
- **`src/__tests__/preload.ts`** + **`fixtures/docs/ui-types-documentation.json`**: The preload script and its fixture.
- **`package.json`**: `test` and `test:ci` now run `bun test src/` so compiled `dist/` output is never picked up as a test source.

## Review & Testing Checklist for Human

- [ ] Confirm that exporting the internal helpers in `resources.ts` (no behavior change, just `const` → `export const`) is acceptable as a testing-seam.
- [ ] Confirm the `bunfig.toml` preload approach is acceptable — it writes a gitignored fixture file into `src/docs/ui-types-documentation.json` at test start so the TypeDoc-driven component resources are populated during tests.
- [ ] Spot-check a couple of the new tests for meaningfulness (not just coverage-chasing) — suggested: `bootstrap_app` generates 50+ files, `install_admin`, `extractTypeString` union/array/reflection branches.

### Test plan

```bash
cd mcp-server
bun test src/ --coverage
bun run lint
bun run compile
```

Expected: 133 tests pass, 0 fail, overall coverage >= 97% lines / 98% functions.

### Notes

- No implementation code changes other than `export` keywords on `resources.ts` helpers.
- `dist/` was excluded from test discovery so post-compile test runs don't pick up stale compiled test files.


Link to Devin session: https://app.devin.ai/sessions/b43991e9b4a746c9863dd0033a4d2337
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily new/expanded test coverage plus test-runner configuration tweaks; only runtime change is exporting internal `resources.ts` helpers for unit testing.
> 
> **Overview**
> **Greatly expands automated coverage for `@terreno/mcp-server`.** Adds new test suites for bootstrap behavior, resource/documentation helpers, prompt generation, and tool generators (including many edge cases), plus a TypeDoc JSON fixture to exercise UI component-doc code paths during tests.
> 
> **Adjusts test execution/config.** Introduces `bunfig.toml` with a test `preload` that copies the fixture into `src/docs/` and ignores `__tests__` for coverage reporting, and updates `package.json` to run `bun test src/` so compiled `dist/` isn’t picked up.
> 
> **Small prod-surface change.** Exports several previously-internal helper functions/types from `resources.ts` (no logic changes) to enable direct unit testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df4ffdbb0e92264b81b73d553bb8f4470ad178dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->