### PR TITLE
[ui] add more tests to increase coverage

### DIFF
--- a/ui/src/AddressField.test.tsx
+++ b/ui/src/AddressField.test.tsx
@@ -1,5 +1,6 @@
 import {afterEach, beforeEach, describe, expect, it, mock} from "bun:test";
 import {fireEvent} from "@testing-library/react-native";
+import type {ReactTestInstance} from "react-test-renderer";
 
 import {AddressField} from "./AddressField";
 import {renderWithTheme} from "./test-utils";
@@ -149,7 +150,7 @@ describe("AddressField", () => {
       <AddressField {...defaultProps} onBlur={mockOnBlur} onChange={mockOnChange} />
     );
     const autocompletes = UNSAFE_getAllByProps({}).filter(
-      (el: any) =>
+      (el: ReactTestInstance) =>
         typeof el.props?.handleAutoCompleteChange === "function" &&
         typeof el.props?.handleAddressChange === "function"
     );

--- a/ui/src/AddressField.test.tsx
+++ b/ui/src/AddressField.test.tsx
@@ -117,4 +117,53 @@ describe("AddressField", () => {
     expect(address1Input.props.accessibilityState.disabled).toBe(true);
     expect(cityInput.props.accessibilityState.disabled).toBe(true);
   });
+
+  it("calls onChange when address2 changes", () => {
+    const {getByTestId} = renderWithTheme(
+      <AddressField {...defaultProps} onBlur={mockOnBlur} onChange={mockOnChange} />
+    );
+    fireEvent.changeText(getByTestId("test-address-address2"), "Suite 500");
+    expect(mockOnChange).toHaveBeenCalledWith({...defaultValue, address2: "Suite 500"});
+  });
+
+  it("calls onChange when countyName and countyCode change", () => {
+    const {getByTestId} = renderWithTheme(
+      <AddressField {...defaultProps} includeCounty onBlur={mockOnBlur} onChange={mockOnChange} />
+    );
+    fireEvent.changeText(getByTestId("test-address-county"), "Clark");
+    expect(mockOnChange).toHaveBeenCalledWith({...defaultValue, countyName: "Clark"});
+    fireEvent.changeText(getByTestId("test-address-county-code"), "999");
+    expect(mockOnChange).toHaveBeenCalledWith({...defaultValue, countyCode: "999"});
+  });
+
+  it("renders without throwing when value is undefined", () => {
+    expect(() =>
+      renderWithTheme(
+        <AddressField onBlur={mockOnBlur} onChange={mockOnChange} testID="no-value" />
+      )
+    ).not.toThrow();
+  });
+
+  it("invokes autocomplete callbacks with merged values", () => {
+    const {UNSAFE_getAllByProps} = renderWithTheme(
+      <AddressField {...defaultProps} onBlur={mockOnBlur} onChange={mockOnChange} />
+    );
+    const autocompletes = UNSAFE_getAllByProps({}).filter(
+      (el: any) =>
+        typeof el.props?.handleAutoCompleteChange === "function" &&
+        typeof el.props?.handleAddressChange === "function"
+    );
+    expect(autocompletes.length).toBeGreaterThan(0);
+    const ac = autocompletes[0];
+    // Trigger handleAddressChange for address1
+    ac.props.handleAddressChange("456 Oak Ave");
+    expect(mockOnChange).toHaveBeenCalledWith({...defaultValue, address1: "456 Oak Ave"});
+    // Trigger handleAutoCompleteChange with a new address object
+    ac.props.handleAutoCompleteChange({city: "Chicago", state: "IL"});
+    expect(mockOnChange).toHaveBeenCalledWith({
+      ...defaultValue,
+      city: "Chicago",
+      state: "IL",
+    });
+  });
 });

--- a/ui/src/Banner.test.tsx
+++ b/ui/src/Banner.test.tsx
@@ -103,4 +103,26 @@ describe("Banner", () => {
       expect(handleClick).toHaveBeenCalled();
     });
   });
+
+  it("invokes buttonOnClick when icon button is pressed", async () => {
+    const handleClick = mock(() => Promise.resolve());
+    const {getByText} = renderWithTheme(
+      <Banner
+        buttonIconName="arrow-right"
+        buttonOnClick={handleClick}
+        buttonText="Go"
+        id="test-icon-banner"
+        text="Banner"
+      />
+    );
+
+    await act(async () => {
+      fireEvent.press(getByText("Go"));
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    await waitFor(() => {
+      expect(handleClick).toHaveBeenCalled();
+    });
+  });
 });

--- a/ui/src/Button.test.tsx
+++ b/ui/src/Button.test.tsx
@@ -157,4 +157,75 @@ describe("Button", () => {
     const {getByLabelText} = renderWithTheme(<Button onClick={() => {}} text="Accessible" />);
     expect(getByLabelText("Accessible")).toBeTruthy();
   });
+
+  it("invokes onClick when confirmation primary button is pressed", async () => {
+    const handleClick = mock(() => Promise.resolve());
+    const {getByText, queryByText} = renderWithTheme(
+      <Button
+        confirmationText="Confirm action?"
+        modalTitle="Confirm Title"
+        onClick={handleClick}
+        text="Press Me"
+        withConfirmation
+      />
+    );
+
+    await act(async () => {
+      fireEvent.press(getByText("Press Me"));
+      await new Promise((resolve) => setTimeout(resolve, 600));
+    });
+
+    // Wait for confirmation modal
+    await waitFor(
+      () => {
+        expect(queryByText("Confirm Title")).toBeTruthy();
+      },
+      {timeout: 2000}
+    );
+
+    await act(async () => {
+      fireEvent.press(getByText("Confirm"));
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    await waitFor(() => {
+      expect(handleClick).toHaveBeenCalled();
+    });
+  });
+
+  it("dismisses confirmation modal when secondary button is pressed", async () => {
+    const handleClick = mock(() => Promise.resolve());
+    const {getByText, queryByText} = renderWithTheme(
+      <Button
+        confirmationText="Confirm action?"
+        modalTitle="Confirm Title"
+        onClick={handleClick}
+        text="Press Me"
+        withConfirmation
+      />
+    );
+
+    await act(async () => {
+      fireEvent.press(getByText("Press Me"));
+      await new Promise((resolve) => setTimeout(resolve, 600));
+    });
+
+    await waitFor(
+      () => {
+        expect(queryByText("Cancel")).toBeTruthy();
+      },
+      {timeout: 2000}
+    );
+
+    // Cancel does not throw and does not invoke onClick
+    expect(() => fireEvent.press(getByText("Cancel"))).not.toThrow();
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it("renders with tooltip on desktop (wrapped in Tooltip)", () => {
+    const {toJSON} = renderWithTheme(
+      <Button onClick={() => {}} text="Hover me" tooltipText="Tooltip text" />
+    );
+    expect(toJSON()).toMatchSnapshot();
+  });
 });

--- a/ui/src/DecimalRangeActionSheet.test.tsx
+++ b/ui/src/DecimalRangeActionSheet.test.tsx
@@ -1,5 +1,5 @@
-import {describe, expect, it} from "bun:test";
-import {render} from "@testing-library/react-native";
+import {describe, expect, it, mock} from "bun:test";
+import {act, render} from "@testing-library/react-native";
 import {createRef} from "react";
 
 import type {ActionSheet} from "./ActionSheet";
@@ -42,5 +42,56 @@ describe("DecimalRangeActionSheet", () => {
       </ThemeProvider>
     );
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("invokes onChange when whole picker changes", () => {
+    const actionSheetRef = createRef<ActionSheet>();
+    const handleChange = mock((_val: string) => {});
+    const {UNSAFE_getAllByProps} = render(
+      <ThemeProvider>
+        <DecimalRangeActionSheet
+          actionSheetRef={actionSheetRef}
+          max={10}
+          min={0}
+          onChange={handleChange}
+          value="5.5"
+        />
+      </ThemeProvider>
+    );
+    // The first Picker is the whole number one (selectedValue: "5")
+    const wholePickers = UNSAFE_getAllByProps({selectedValue: "5"});
+    const whole = wholePickers.find((p) => typeof p.props.onValueChange === "function");
+    act(() => {
+      if (whole) {
+        whole.props.onValueChange(7);
+      }
+    });
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it("invokes onChange when decimal picker changes", () => {
+    const actionSheetRef = createRef<ActionSheet>();
+    const handleChange = mock((_val: string) => {});
+    const {UNSAFE_getAllByProps} = render(
+      <ThemeProvider>
+        <DecimalRangeActionSheet
+          actionSheetRef={actionSheetRef}
+          max={10}
+          min={0}
+          onChange={handleChange}
+          value="5.5"
+        />
+      </ThemeProvider>
+    );
+    // The second Picker is the decimal one (selectedValue: "5")
+    const decimalPickers = UNSAFE_getAllByProps({selectedValue: "5"});
+    // Use the last one (second picker)
+    const decimal = decimalPickers[decimalPickers.length - 1];
+    act(() => {
+      if (decimal && typeof decimal.props.onValueChange === "function") {
+        decimal.props.onValueChange(3);
+      }
+    });
+    expect(handleChange).toHaveBeenCalled();
   });
 });

--- a/ui/src/HeightActionSheet.test.tsx
+++ b/ui/src/HeightActionSheet.test.tsx
@@ -1,5 +1,5 @@
-import {describe, expect, it} from "bun:test";
-import {render} from "@testing-library/react-native";
+import {describe, expect, it, mock} from "bun:test";
+import {act, render} from "@testing-library/react-native";
 import {createRef} from "react";
 
 import type {ActionSheet} from "./ActionSheet";
@@ -30,5 +30,60 @@ describe("HeightActionSheet", () => {
       </ThemeProvider>
     );
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("renders with title and min/max values", () => {
+    const actionSheetRef = createRef<ActionSheet>();
+    const {getByText} = render(
+      <ThemeProvider>
+        <HeightActionSheet
+          actionSheetRef={actionSheetRef}
+          max={84}
+          min={36}
+          onChange={() => {}}
+          title="Select Height"
+          value="60"
+        />
+      </ThemeProvider>
+    );
+    expect(getByText("Select Height")).toBeTruthy();
+  });
+
+  it("invokes onChange when feet picker changes", () => {
+    const actionSheetRef = createRef<ActionSheet>();
+    const handleChange = mock((_val: string) => {});
+    const {UNSAFE_getAllByProps} = render(
+      <ThemeProvider>
+        <HeightActionSheet actionSheetRef={actionSheetRef} onChange={handleChange} value="72" />
+      </ThemeProvider>
+    );
+    // feet picker has selectedValue "6" (72 / 12)
+    const feetPickers = UNSAFE_getAllByProps({selectedValue: "6"});
+    const feetPicker = feetPickers.find((p) => typeof p.props.onValueChange === "function");
+    act(() => {
+      if (feetPicker) {
+        feetPicker.props.onValueChange(5);
+      }
+    });
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it("invokes onChange when inches picker changes", () => {
+    const actionSheetRef = createRef<ActionSheet>();
+    const handleChange = mock((_val: string) => {});
+    const {UNSAFE_getAllByProps} = render(
+      <ThemeProvider>
+        <HeightActionSheet actionSheetRef={actionSheetRef} onChange={handleChange} value="73" />
+      </ThemeProvider>
+    );
+    // inches picker has selectedValue "1" (73 % 12)
+    const inchPickers = UNSAFE_getAllByProps({selectedValue: "1"});
+    const inchPicker = inchPickers.find((p) => typeof p.props.onValueChange === "function");
+    act(() => {
+      if (inchPicker) {
+        inchPicker.props.onValueChange(5);
+      }
+    });
+    expect(handleChange).toHaveBeenCalled();
   });
 });

--- a/ui/src/InfoModalIcon.test.tsx
+++ b/ui/src/InfoModalIcon.test.tsx
@@ -51,4 +51,20 @@ describe("InfoModalIcon", () => {
     fireEvent.press(infoIcon);
     expect(toJSON()).toMatchSnapshot();
   });
+
+  it("invokes primary Close button handler without throwing", () => {
+    const {getByTestId, getByText} = renderWithTheme(
+      <InfoModalIcon infoModalText="Dismissable text" infoModalTitle="Dismissable Title" />
+    );
+    fireEvent.press(getByTestId("info-icon"));
+    expect(() => fireEvent.press(getByText("Close"))).not.toThrow();
+  });
+
+  it("invokes onDismiss when the close (x) icon is pressed", () => {
+    const {getByTestId, getByLabelText} = renderWithTheme(
+      <InfoModalIcon infoModalText="Body" infoModalTitle="Close Me" />
+    );
+    fireEvent.press(getByTestId("info-icon"));
+    expect(() => fireEvent.press(getByLabelText("Close modal"))).not.toThrow();
+  });
 });

--- a/ui/src/InfoTooltipButton.test.tsx
+++ b/ui/src/InfoTooltipButton.test.tsx
@@ -19,4 +19,15 @@ describe("InfoTooltipButton", () => {
     // The component renders an IconButton with exclamation icon
     expect(toJSON()).toMatchSnapshot();
   });
+
+  it("is defined and is a function component", () => {
+    expect(InfoTooltipButton).toBeDefined();
+    expect(typeof InfoTooltipButton).toBe("function");
+  });
+
+  it("accepts a text prop without throwing", () => {
+    expect(() =>
+      renderWithTheme(<InfoTooltipButton text="Some details that explain the field" />)
+    ).not.toThrow();
+  });
 });

--- a/ui/src/Modal.test.tsx
+++ b/ui/src/Modal.test.tsx
@@ -247,4 +247,48 @@ describe("Modal", () => {
     );
     expect(toJSON()).toBeTruthy();
   });
+
+  it("invokes primaryButtonOnClick when primary button pressed while visible", async () => {
+    const handlePrimary = mock(() => {});
+    const {getByText} = renderWithTheme(
+      <Modal
+        onDismiss={() => {}}
+        primaryButtonOnClick={handlePrimary}
+        primaryButtonText="Submit"
+        title="Title"
+        visible
+      >
+        <Text>Content</Text>
+      </Modal>
+    );
+
+    await new Promise((resolve) => {
+      fireEvent.press(getByText("Submit"));
+      setTimeout(resolve, 600);
+    });
+
+    expect(handlePrimary).toHaveBeenCalled();
+  });
+
+  it("invokes secondaryButtonOnClick when secondary button pressed while visible", async () => {
+    const handleSecondary = mock(() => {});
+    const {getByText} = renderWithTheme(
+      <Modal
+        onDismiss={() => {}}
+        secondaryButtonOnClick={handleSecondary}
+        secondaryButtonText="Cancel"
+        title="Title"
+        visible
+      >
+        <Text>Content</Text>
+      </Modal>
+    );
+
+    await new Promise((resolve) => {
+      fireEvent.press(getByText("Cancel"));
+      setTimeout(resolve, 600);
+    });
+
+    expect(handleSecondary).toHaveBeenCalled();
+  });
 });

--- a/ui/src/NumberPickerActionSheet.test.tsx
+++ b/ui/src/NumberPickerActionSheet.test.tsx
@@ -1,6 +1,7 @@
 import {describe, expect, it, mock} from "bun:test";
-import {act, fireEvent, render} from "@testing-library/react-native";
+import {act, render} from "@testing-library/react-native";
 import {createRef} from "react";
+import type {ReactTestInstance} from "react-test-renderer";
 
 import type {ActionSheet} from "./ActionSheet";
 import {NumberPickerActionSheet} from "./NumberPickerActionSheet";
@@ -59,7 +60,9 @@ describe("NumberPickerActionSheet", () => {
       </ThemeProvider>
     );
     const pickers = UNSAFE_getAllByProps({selectedValue: "5"});
-    const picker = pickers.find((p) => typeof p.props.onValueChange === "function");
+    const picker = pickers.find(
+      (p: ReactTestInstance) => typeof p.props.onValueChange === "function"
+    );
     act(() => {
       if (picker) {
         picker.props.onValueChange(7);
@@ -68,10 +71,10 @@ describe("NumberPickerActionSheet", () => {
     expect(handleChange).toHaveBeenCalledWith("7");
   });
 
-  it("closes the action sheet when Close button is pressed", async () => {
+  it("closes the action sheet when Close button is pressed", () => {
     const setModalVisible = mock((_v: boolean) => {});
-    const actionSheetRef = {current: {setModalVisible}} as any;
-    const {getByText} = render(
+    const actionSheetRef = createRef<ActionSheet>();
+    const {UNSAFE_getAllByProps} = render(
       <ThemeProvider>
         <NumberPickerActionSheet
           actionSheetRef={actionSheetRef}
@@ -82,13 +85,19 @@ describe("NumberPickerActionSheet", () => {
         />
       </ThemeProvider>
     );
-    await act(async () => {
-      fireEvent.press(getByText("Close"));
-      await new Promise((resolve) => setTimeout(resolve, 1200));
+    // Replace the ref target with a mock after mount so the Button's onClick
+    // invokes our spy instead of the real ActionSheet instance.
+    (actionSheetRef as {current: {setModalVisible: typeof setModalVisible}}).current = {
+      setModalVisible,
+    };
+    const closeButtons = UNSAFE_getAllByProps({text: "Close"});
+    const closeButton = closeButtons.find(
+      (b: ReactTestInstance) => typeof b.props.onClick === "function"
+    );
+    expect(closeButton).toBeDefined();
+    act(() => {
+      closeButton?.props.onClick();
     });
-    // Allow extra time for debounced callback
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    // Confirm at least that pressing the Close button did not throw
-    expect(typeof setModalVisible).toBe("function");
+    expect(setModalVisible).toHaveBeenCalledWith(false);
   });
 });

--- a/ui/src/NumberPickerActionSheet.test.tsx
+++ b/ui/src/NumberPickerActionSheet.test.tsx
@@ -1,5 +1,5 @@
-import {describe, expect, it} from "bun:test";
-import {render} from "@testing-library/react-native";
+import {describe, expect, it, mock} from "bun:test";
+import {act, fireEvent, render} from "@testing-library/react-native";
 import {createRef} from "react";
 
 import type {ActionSheet} from "./ActionSheet";
@@ -42,5 +42,53 @@ describe("NumberPickerActionSheet", () => {
       </ThemeProvider>
     );
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("invokes onChange when picker value changes", () => {
+    const actionSheetRef = createRef<ActionSheet>();
+    const handleChange = mock((_val: string) => {});
+    const {UNSAFE_getAllByProps} = render(
+      <ThemeProvider>
+        <NumberPickerActionSheet
+          actionSheetRef={actionSheetRef}
+          max={10}
+          min={0}
+          onChange={handleChange}
+          value="5"
+        />
+      </ThemeProvider>
+    );
+    const pickers = UNSAFE_getAllByProps({selectedValue: "5"});
+    const picker = pickers.find((p) => typeof p.props.onValueChange === "function");
+    act(() => {
+      if (picker) {
+        picker.props.onValueChange(7);
+      }
+    });
+    expect(handleChange).toHaveBeenCalledWith("7");
+  });
+
+  it("closes the action sheet when Close button is pressed", async () => {
+    const setModalVisible = mock((_v: boolean) => {});
+    const actionSheetRef = {current: {setModalVisible}} as any;
+    const {getByText} = render(
+      <ThemeProvider>
+        <NumberPickerActionSheet
+          actionSheetRef={actionSheetRef}
+          max={10}
+          min={0}
+          onChange={() => {}}
+          value="5"
+        />
+      </ThemeProvider>
+    );
+    await act(async () => {
+      fireEvent.press(getByText("Close"));
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+    });
+    // Allow extra time for debounced callback
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    // Confirm at least that pressing the Close button did not throw
+    expect(typeof setModalVisible).toBe("function");
   });
 });

--- a/ui/src/Page.test.tsx
+++ b/ui/src/Page.test.tsx
@@ -1,4 +1,5 @@
 import {describe, expect, it, mock} from "bun:test";
+import {act, fireEvent, waitFor} from "@testing-library/react-native";
 
 import {Page} from "./Page";
 import {Text} from "./Text";
@@ -124,5 +125,42 @@ describe("Page", () => {
       </Page>
     );
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("invokes rightButtonOnClick when right button is pressed", async () => {
+    const handleRightClick = mock(() => {});
+    const {getByText} = renderWithTheme(
+      <Page
+        navigation={mockNavigation}
+        rightButton="Save"
+        rightButtonOnClick={handleRightClick}
+        title="Page"
+      >
+        <Text>Content</Text>
+      </Page>
+    );
+    await act(async () => {
+      fireEvent.press(getByText("Save"));
+      await new Promise((resolve) => setTimeout(resolve, 600));
+    });
+    await waitFor(() => expect(handleRightClick).toHaveBeenCalled());
+  });
+
+  it("renders without header when title and backButton are both absent", () => {
+    const {queryByText} = renderWithTheme(
+      <Page navigation={mockNavigation}>
+        <Text>Plain page</Text>
+      </Page>
+    );
+    expect(queryByText("Plain page")).toBeTruthy();
+  });
+
+  it("renders loading state with loadingText", () => {
+    const {getByText} = renderWithTheme(
+      <Page loading loadingText="Loading data..." navigation={mockNavigation}>
+        <Text>Content</Text>
+      </Page>
+    );
+    expect(getByText("Loading data...")).toBeTruthy();
   });
 });

--- a/ui/src/Pagination.test.tsx
+++ b/ui/src/Pagination.test.tsx
@@ -83,4 +83,20 @@ describe("Pagination", () => {
     const {toJSON} = renderWithTheme(<Pagination page={2} setPage={() => {}} totalPages={20} />);
     expect(toJSON()).toMatchSnapshot();
   });
+
+  it("renders 'more' button for large page sets without throwing when pressed", () => {
+    const handleSetPage = mock((_page: number) => {});
+    const {UNSAFE_getAllByProps} = renderWithTheme(
+      <Pagination page={10} setPage={handleSetPage} totalPages={20} />
+    );
+    // Find the "more" pagination buttons (they have iconName="ellipsis")
+    const moreIcons = UNSAFE_getAllByProps({iconName: "ellipsis"});
+    expect(moreIcons.length).toBeGreaterThan(0);
+    const morePressable = moreIcons[0].parent;
+    if (morePressable) {
+      expect(() => fireEvent.press(morePressable)).not.toThrow();
+    }
+    // Pressing "more" does nothing (onClick is no-op)
+    expect(handleSetPage).not.toHaveBeenCalled();
+  });
 });

--- a/ui/src/SegmentedControl.test.tsx
+++ b/ui/src/SegmentedControl.test.tsx
@@ -81,4 +81,42 @@ describe("SegmentedControl", () => {
     expect(getByText("Tab 3")).toBeTruthy();
     expect(toJSON()).toMatchSnapshot();
   });
+
+  it("invokes handleNext when next scroll button is pressed", () => {
+    const manyItems = ["Tab 1", "Tab 2", "Tab 3", "Tab 4", "Tab 5", "Tab 6"];
+    const {UNSAFE_getAllByProps, queryByText} = renderWithTheme(
+      <SegmentedControl items={manyItems} maxItems={3} selectedIndex={0} />
+    );
+    // Find the right chevron (next button) by its icon prop
+    const nextIcons = UNSAFE_getAllByProps({iconName: "chevron-right"});
+    expect(nextIcons.length).toBeGreaterThan(0);
+    const pressable = nextIcons[0].parent;
+    expect(pressable).toBeTruthy();
+    if (pressable) {
+      fireEvent.press(pressable);
+    }
+    // After pressing next, should display items starting at Tab 4
+    expect(queryByText("Tab 4")).toBeTruthy();
+    expect(queryByText("Tab 1")).toBeNull();
+  });
+
+  it("invokes handlePrevious when previous scroll button is pressed", () => {
+    const manyItems = ["Tab 1", "Tab 2", "Tab 3", "Tab 4", "Tab 5", "Tab 6"];
+    const {UNSAFE_getAllByProps, queryByText} = renderWithTheme(
+      <SegmentedControl items={manyItems} maxItems={3} selectedIndex={0} />
+    );
+    const nextIcons = UNSAFE_getAllByProps({iconName: "chevron-right"});
+    const nextPressable = nextIcons[0].parent;
+    if (nextPressable) {
+      fireEvent.press(nextPressable);
+    }
+    // Now scrolled forward; press previous to go back
+    const prevIcons = UNSAFE_getAllByProps({iconName: "chevron-left"});
+    const prevPressable = prevIcons[0].parent;
+    if (prevPressable) {
+      fireEvent.press(prevPressable);
+    }
+    // Should be back to Tab 1
+    expect(queryByText("Tab 1")).toBeTruthy();
+  });
 });

--- a/ui/src/SelectBadge.test.tsx
+++ b/ui/src/SelectBadge.test.tsx
@@ -1,4 +1,5 @@
-import {describe, expect, it} from "bun:test";
+import {describe, expect, it, mock} from "bun:test";
+import {act, fireEvent} from "@testing-library/react-native";
 
 import {SelectBadge} from "./SelectBadge";
 import {renderWithTheme} from "./test-utils";
@@ -99,5 +100,55 @@ describe("SelectBadge", () => {
       <SelectBadge disabled onChange={() => {}} options={defaultOptions} value="a" />
     );
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("toggles picker visibility when badge is pressed", () => {
+    const {getByLabelText} = renderWithTheme(
+      <SelectBadge onChange={() => {}} options={defaultOptions} value="a" />
+    );
+    const touchable = getByLabelText("Open select badge options");
+    expect(() => fireEvent.press(touchable)).not.toThrow();
+  });
+
+  it("invokes onChange when iOS picker value is changed and Save is pressed", () => {
+    const handleChange = mock((_val: string) => {});
+    const {getByLabelText, UNSAFE_getAllByProps} = renderWithTheme(
+      <SelectBadge onChange={handleChange} options={defaultOptions} value="a" />
+    );
+    // Open the iOS picker modal
+    act(() => {
+      fireEvent.press(getByLabelText("Open select badge options"));
+    });
+
+    // Change the picker's value via onValueChange
+    const pickers = UNSAFE_getAllByProps({selectedValue: "a"});
+    const picker = pickers.find((p) => typeof p.props.onValueChange === "function");
+    act(() => {
+      if (picker) {
+        picker.props.onValueChange("b");
+      }
+    });
+
+    // Tap Save to commit the change
+    act(() => {
+      fireEvent.press(getByLabelText("Save selected value"));
+    });
+    expect(handleChange).toHaveBeenCalledWith("b");
+  });
+
+  it("does not call onChange when iOS picker is dismissed", () => {
+    const handleChange = mock((_val: string) => {});
+    const {getByLabelText} = renderWithTheme(
+      <SelectBadge onChange={handleChange} options={defaultOptions} value="a" />
+    );
+    // Open the iOS picker modal
+    act(() => {
+      fireEvent.press(getByLabelText("Open select badge options"));
+    });
+    // Dismiss the picker by pressing the backdrop
+    act(() => {
+      fireEvent.press(getByLabelText("Dismiss picker modal"));
+    });
+    expect(handleChange).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/SignatureField.test.tsx
+++ b/ui/src/SignatureField.test.tsx
@@ -1,6 +1,7 @@
 import {describe, expect, it, mock} from "bun:test";
 import {forwardRef} from "react";
 import {View} from "react-native";
+import type {ReactTestInstance} from "react-test-renderer";
 
 import {SignatureField} from "./SignatureField";
 import {renderWithTheme} from "./test-utils";
@@ -69,7 +70,7 @@ describe("SignatureField", () => {
 
     // Find the inner Signature wrapper by looking for elements with onStart
     const elementsWithOnStart = UNSAFE_getAllByProps({}).filter(
-      (el: any) => typeof el.props?.onStart === "function"
+      (el: ReactTestInstance) => typeof el.props?.onStart === "function"
     );
     expect(elementsWithOnStart.length).toBeGreaterThan(0);
     const signatureEl = elementsWithOnStart[0];
@@ -84,7 +85,7 @@ describe("SignatureField", () => {
     const {UNSAFE_getAllByProps} = renderWithTheme(<SignatureField onChange={onChange} />);
 
     const elementsWithOnStart = UNSAFE_getAllByProps({}).filter(
-      (el: any) => typeof el.props?.onStart === "function"
+      (el: ReactTestInstance) => typeof el.props?.onStart === "function"
     );
     expect(elementsWithOnStart.length).toBeGreaterThan(0);
     const signatureEl = elementsWithOnStart[0];

--- a/ui/src/SignatureField.test.tsx
+++ b/ui/src/SignatureField.test.tsx
@@ -57,4 +57,38 @@ describe("SignatureField", () => {
     );
     expect(getByText("Signature is required")).toBeTruthy();
   });
+
+  it("invokes onStart and onEnd callbacks via the Signature component", () => {
+    const onStart = mock(() => {});
+    const onEnd = mock(() => {});
+    const onChange = mock((_v: string) => {});
+
+    const {UNSAFE_getAllByProps} = renderWithTheme(
+      <SignatureField onChange={onChange} onEnd={onEnd} onStart={onStart} />
+    );
+
+    // Find the inner Signature wrapper by looking for elements with onStart
+    const elementsWithOnStart = UNSAFE_getAllByProps({}).filter(
+      (el: any) => typeof el.props?.onStart === "function"
+    );
+    expect(elementsWithOnStart.length).toBeGreaterThan(0);
+    const signatureEl = elementsWithOnStart[0];
+    signatureEl.props.onStart();
+    signatureEl.props.onEnd();
+    expect(onStart).toHaveBeenCalled();
+    expect(onEnd).toHaveBeenCalled();
+  });
+
+  it("does not crash when onStart/onEnd are not provided", () => {
+    const onChange = mock((_v: string) => {});
+    const {UNSAFE_getAllByProps} = renderWithTheme(<SignatureField onChange={onChange} />);
+
+    const elementsWithOnStart = UNSAFE_getAllByProps({}).filter(
+      (el: any) => typeof el.props?.onStart === "function"
+    );
+    expect(elementsWithOnStart.length).toBeGreaterThan(0);
+    const signatureEl = elementsWithOnStart[0];
+    expect(() => signatureEl.props.onStart()).not.toThrow();
+    expect(() => signatureEl.props.onEnd()).not.toThrow();
+  });
 });

--- a/ui/src/Spinner.test.tsx
+++ b/ui/src/Spinner.test.tsx
@@ -71,4 +71,10 @@ describe("Spinner", () => {
 
     expect(toJSON()).toMatchSnapshot();
   });
+
+  it("clears the delay timer on unmount", () => {
+    const {unmount, toJSON} = renderWithTheme(<Spinner />);
+    expect(toJSON()).toBeNull();
+    expect(() => unmount()).not.toThrow();
+  });
 });

--- a/ui/src/Theme.test.tsx
+++ b/ui/src/Theme.test.tsx
@@ -1,5 +1,5 @@
 import {describe, expect, it} from "bun:test";
-import {render} from "@testing-library/react-native";
+import {act, render} from "@testing-library/react-native";
 import {Text, View} from "react-native";
 
 import {ThemeProvider, useTheme} from "./Theme";
@@ -148,6 +148,78 @@ describe("Theme", () => {
       expect(theme.radius).toBeDefined();
       expect(theme.radius.default).toBeDefined();
       expect(theme.radius.rounded).toBeDefined();
+    });
+
+    it("updates theme when setTheme is called", () => {
+      let captured: any;
+      const Capture = () => {
+        captured = useTheme();
+        return null;
+      };
+      render(
+        <ThemeProvider>
+          <Capture />
+        </ThemeProvider>
+      );
+      act(() => {
+        captured.setTheme({surface: {base: "error100"}});
+      });
+      expect(captured.theme.surface.base).toBe("#D33232");
+    });
+
+    it("updates primitives when setPrimitives is called", () => {
+      let captured: any;
+      const Capture = () => {
+        captured = useTheme();
+        return null;
+      };
+      render(
+        <ThemeProvider>
+          <Capture />
+        </ThemeProvider>
+      );
+      act(() => {
+        captured.setPrimitives({neutral000: "#AABBCC"});
+      });
+      expect(captured.theme.surface.base).toBe("#AABBCC");
+    });
+
+    it("resets theme to default when resetTheme is called", () => {
+      let captured: any;
+      const Capture = () => {
+        captured = useTheme();
+        return null;
+      };
+      render(
+        <ThemeProvider>
+          <Capture />
+        </ThemeProvider>
+      );
+      act(() => {
+        captured.setTheme({surface: {base: "error100"}});
+        captured.setPrimitives({neutral000: "#123456"});
+      });
+      act(() => {
+        captured.resetTheme();
+      });
+      expect(captured.theme.surface.base).toBe("#FFFFFF");
+    });
+
+    it("supports non-object top-level values when setTheme is called", () => {
+      let captured: any;
+      const Capture = () => {
+        captured = useTheme();
+        return null;
+      };
+      render(
+        <ThemeProvider>
+          <Capture />
+        </ThemeProvider>
+      );
+      act(() => {
+        captured.setTheme({primitives: undefined as any});
+      });
+      expect(captured.theme).toBeDefined();
     });
   });
 });

--- a/ui/src/Theme.test.tsx
+++ b/ui/src/Theme.test.tsx
@@ -4,6 +4,8 @@ import {Text, View} from "react-native";
 
 import {ThemeProvider, useTheme} from "./Theme";
 
+type ThemeContextValue = ReturnType<typeof useTheme>;
+
 const ThemeConsumer = () => {
   const {theme} = useTheme();
   return (
@@ -151,7 +153,7 @@ describe("Theme", () => {
     });
 
     it("updates theme when setTheme is called", () => {
-      let captured: any;
+      let captured: ThemeContextValue | undefined;
       const Capture = () => {
         captured = useTheme();
         return null;
@@ -162,13 +164,13 @@ describe("Theme", () => {
         </ThemeProvider>
       );
       act(() => {
-        captured.setTheme({surface: {base: "error100"}});
+        captured?.setTheme({surface: {base: "error100"}});
       });
-      expect(captured.theme.surface.base).toBe("#D33232");
+      expect(captured?.theme.surface.base).toBe("#D33232");
     });
 
     it("updates primitives when setPrimitives is called", () => {
-      let captured: any;
+      let captured: ThemeContextValue | undefined;
       const Capture = () => {
         captured = useTheme();
         return null;
@@ -179,13 +181,13 @@ describe("Theme", () => {
         </ThemeProvider>
       );
       act(() => {
-        captured.setPrimitives({neutral000: "#AABBCC"});
+        captured?.setPrimitives({neutral000: "#AABBCC"});
       });
-      expect(captured.theme.surface.base).toBe("#AABBCC");
+      expect(captured?.theme.surface.base).toBe("#AABBCC");
     });
 
     it("resets theme to default when resetTheme is called", () => {
-      let captured: any;
+      let captured: ThemeContextValue | undefined;
       const Capture = () => {
         captured = useTheme();
         return null;
@@ -196,17 +198,17 @@ describe("Theme", () => {
         </ThemeProvider>
       );
       act(() => {
-        captured.setTheme({surface: {base: "error100"}});
-        captured.setPrimitives({neutral000: "#123456"});
+        captured?.setTheme({surface: {base: "error100"}});
+        captured?.setPrimitives({neutral000: "#123456"});
       });
       act(() => {
-        captured.resetTheme();
+        captured?.resetTheme();
       });
-      expect(captured.theme.surface.base).toBe("#FFFFFF");
+      expect(captured?.theme.surface.base).toBe("#FFFFFF");
     });
 
     it("supports non-object top-level values when setTheme is called", () => {
-      let captured: any;
+      let captured: ThemeContextValue | undefined;
       const Capture = () => {
         captured = useTheme();
         return null;
@@ -217,9 +219,9 @@ describe("Theme", () => {
         </ThemeProvider>
       );
       act(() => {
-        captured.setTheme({primitives: undefined as any});
+        captured?.setTheme({primitives: undefined});
       });
-      expect(captured.theme).toBeDefined();
+      expect(captured?.theme).toBeDefined();
     });
   });
 });

--- a/ui/src/__snapshots__/Button.test.tsx.snap
+++ b/ui/src/__snapshots__/Button.test.tsx.snap
@@ -932,3 +932,71 @@ exports[`Button renders with confirmation modal props 1`] = `
   "type": "Pressable",
 }
 `;
+
+exports[`Button renders with tooltip on desktop (wrapped in Tooltip) 1`] = `
+{
+  "$$typeof": Symbol(react.test.json),
+  "children": [
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            {
+              "$$typeof": Symbol(react.test.json),
+              "children": [
+                "Hover me",
+              ],
+              "props": {
+                "style": {
+                  "color": "#FFFFFF",
+                  "fontSize": 16,
+                  "fontWeight": "700",
+                },
+              },
+              "type": "Text",
+            },
+          ],
+          "props": {
+            "style": {
+              "flexDirection": "row",
+            },
+            "testID": undefined,
+          },
+          "type": "View",
+        },
+      ],
+      "props": {
+        "style": {
+          "flexDirection": "row",
+        },
+        "testID": undefined,
+      },
+      "type": "View",
+    },
+  ],
+  "props": {
+    "accessibilityHint": "Press to perform action",
+    "aria-label": "Hover me",
+    "aria-role": "button",
+    "disabled": undefined,
+    "onPress": [Function: debounced],
+    "style": {
+      "alignItems": "center",
+      "alignSelf": "flex-start",
+      "backgroundColor": "#0E9DCD",
+      "borderColor": undefined,
+      "borderRadius": 360,
+      "borderWidth": undefined,
+      "flexDirection": "column",
+      "justifyContent": "center",
+      "paddingHorizontal": 20,
+      "paddingVertical": 8,
+      "width": "auto",
+    },
+    "testID": undefined,
+  },
+  "type": "Pressable",
+}
+`;

--- a/ui/src/table/TableHeaderCell.test.tsx
+++ b/ui/src/table/TableHeaderCell.test.tsx
@@ -1,4 +1,6 @@
 import {describe, expect, it, mock} from "bun:test";
+import {act, fireEvent, waitFor} from "@testing-library/react-native";
+
 import {Text} from "../Text";
 import {renderWithTheme} from "../test-utils";
 import {Table} from "./Table";
@@ -109,5 +111,145 @@ describe("TableHeaderCell", () => {
     );
     // Sortable header with active sort indicator
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("calls onSortChange with 'desc' when unsorted sortable header is clicked", async () => {
+    const handleSort = mock((_direction: string | undefined) => {});
+    const {getByLabelText} = renderWithTheme(
+      <Table columns={[100]}>
+        <TableHeader>
+          <TableHeaderCell index={0} onSortChange={handleSort} sortable title="Sortable" />
+        </TableHeader>
+        <TableRow>
+          <TableText value="Data" />
+        </TableRow>
+      </Table>
+    );
+    await act(async () => {
+      fireEvent.press(getByLabelText("sort"));
+    });
+    await waitFor(() => expect(handleSort).toHaveBeenCalledWith("desc"));
+  });
+
+  it("calls onSortChange with 'asc' when desc-sorted header is clicked", async () => {
+    const handleSort = mock((_direction: string | undefined) => {});
+    const {getByLabelText} = renderWithTheme(
+      <Table columns={[100]} sort={{column: 0, direction: "desc"}}>
+        <TableHeader>
+          <TableHeaderCell index={0} onSortChange={handleSort} sortable title="Sortable" />
+        </TableHeader>
+        <TableRow>
+          <TableText value="Data" />
+        </TableRow>
+      </Table>
+    );
+    await act(async () => {
+      fireEvent.press(getByLabelText("sort"));
+    });
+    await waitFor(() => expect(handleSort).toHaveBeenCalledWith("asc"));
+  });
+
+  it("calls onSortChange with undefined when asc-sorted header is clicked", async () => {
+    const handleSort = mock((_direction: string | undefined) => {});
+    const {getByLabelText} = renderWithTheme(
+      <Table columns={[100]} sort={{column: 0, direction: "asc"}}>
+        <TableHeader>
+          <TableHeaderCell index={0} onSortChange={handleSort} sortable title="Sortable" />
+        </TableHeader>
+        <TableRow>
+          <TableText value="Data" />
+        </TableRow>
+      </Table>
+    );
+    await act(async () => {
+      fireEvent.press(getByLabelText("sort"));
+    });
+    await waitFor(() => expect(handleSort).toHaveBeenCalledWith(undefined));
+  });
+
+  it("warns when no width is defined for the column index", () => {
+    const originalWarn = console.warn;
+    const warnMock = mock(() => {});
+    console.warn = warnMock;
+    try {
+      renderWithTheme(
+        <Table columns={[100]}>
+          <TableHeader>
+            <TableHeaderCell index={5} title="Out of range" />
+          </TableHeader>
+          <TableRow>
+            <TableText value="Data" />
+          </TableRow>
+        </Table>
+      );
+      expect(warnMock).toHaveBeenCalled();
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it("warns when both children and title are provided", () => {
+    const originalWarn = console.warn;
+    const warnMock = mock(() => {});
+    console.warn = warnMock;
+    try {
+      renderWithTheme(
+        <Table columns={[100]}>
+          <TableHeader>
+            <TableHeaderCell index={0} title="Title">
+              <Text>Child</Text>
+            </TableHeaderCell>
+          </TableHeader>
+          <TableRow>
+            <TableText value="Data" />
+          </TableRow>
+        </Table>
+      );
+      expect(warnMock).toHaveBeenCalled();
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it("logs error when sortable is true but onSortChange is missing", () => {
+    const originalError = console.error;
+    const errorMock = mock(() => {});
+    console.error = errorMock;
+    try {
+      renderWithTheme(
+        <Table columns={[100]}>
+          <TableHeader>
+            <TableHeaderCell index={0} sortable title="Sortable" />
+          </TableHeader>
+          <TableRow>
+            <TableText value="Data" />
+          </TableRow>
+        </Table>
+      );
+      expect(errorMock).toHaveBeenCalled();
+    } finally {
+      console.error = originalError;
+    }
+  });
+
+  it("logs error when neither children nor title is provided", () => {
+    const originalError = console.error;
+    const errorMock = mock(() => {});
+    console.error = errorMock;
+    try {
+      renderWithTheme(
+        <Table columns={[100]}>
+          <TableHeader>
+            <TableHeaderCell index={0} />
+          </TableHeader>
+          <TableRow>
+            <TableText value="Data" />
+          </TableRow>
+        </Table>
+      );
+      expect(errorMock).toHaveBeenCalled();
+    } finally {
+      console.error = originalError;
+    }
   });
 });

--- a/ui/src/table/TableRow.test.tsx
+++ b/ui/src/table/TableRow.test.tsx
@@ -1,4 +1,5 @@
 import {describe, expect, it} from "bun:test";
+
 import {Text} from "../Text";
 import {renderWithTheme} from "../test-utils";
 import {Table} from "./Table";
@@ -78,6 +79,38 @@ describe("TableRow", () => {
         </TableRow>
       </Table>
     );
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("renders initially expanded drawer contents when expanded is true", () => {
+    const {queryByText} = renderWithTheme(
+      <Table columns={[100]}>
+        <TableHeader>
+          <TableHeaderCell index={0} title="Name" />
+        </TableHeader>
+        <TableRow drawerContents={<Text>Always visible</Text>} expanded>
+          <TableText value="Row" />
+        </TableRow>
+      </Table>
+    );
+    expect(queryByText("Always visible")).toBeTruthy();
+  });
+
+  it("renders a placeholder cell when sibling row has drawer contents", () => {
+    const {toJSON} = renderWithTheme(
+      <Table columns={[100]}>
+        <TableHeader>
+          <TableHeaderCell index={0} title="Name" />
+        </TableHeader>
+        <TableRow drawerContents={<Text>Drawer</Text>}>
+          <TableText value="Has drawer" />
+        </TableRow>
+        <TableRow>
+          <TableText value="No drawer" />
+        </TableRow>
+      </Table>
+    );
+    // Snapshot captures the blank placeholder cell for the row without drawer contents
     expect(toJSON()).toMatchSnapshot();
   });
 });

--- a/ui/src/table/__snapshots__/TableRow.test.tsx.snap
+++ b/ui/src/table/__snapshots__/TableRow.test.tsx.snap
@@ -1389,3 +1389,406 @@ exports[`TableRow renders with custom color 1`] = `
   "type": "View",
 }
 `;
+
+exports[`TableRow renders a placeholder cell when sibling row has drawer contents 1`] = `
+{
+  "$$typeof": Symbol(react.test.json),
+  "children": [
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            {
+              "$$typeof": Symbol(react.test.json),
+              "children": [
+                {
+                  "$$typeof": Symbol(react.test.json),
+                  "children": [
+                    {
+                      "$$typeof": Symbol(react.test.json),
+                      "children": [
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": [
+                            {
+                              "$$typeof": Symbol(react.test.json),
+                              "children": null,
+                              "props": {
+                                "onPointerEnter": [Function: AsyncFunction],
+                                "onPointerLeave": [Function: AsyncFunction],
+                                "style": {
+                                  "width": 32,
+                                },
+                                "testID": undefined,
+                              },
+                              "type": "View",
+                            },
+                          ],
+                          "props": {
+                            "onPointerEnter": [Function: AsyncFunction],
+                            "onPointerLeave": [Function: AsyncFunction],
+                            "style": {
+                              "justifyContent": "center",
+                              "marginRight": 8,
+                              "paddingBottom": 16,
+                              "paddingLeft": 12,
+                              "paddingRight": 12,
+                              "paddingTop": 16,
+                            },
+                            "testID": undefined,
+                          },
+                          "type": "View",
+                        },
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": [
+                            {
+                              "$$typeof": Symbol(react.test.json),
+                              "children": [
+                                {
+                                  "$$typeof": Symbol(react.test.json),
+                                  "children": [
+                                    "Name",
+                                  ],
+                                  "props": {
+                                    "aria-label": "Table title: Name",
+                                    "aria-role": "header",
+                                    "ellipsizeMode": "tail",
+                                    "numberOfLines": 3,
+                                    "style": {
+                                      "color": "#1C1C1C",
+                                      "flexWrap": "wrap",
+                                      "fontFamily": "text",
+                                      "fontSize": 10,
+                                      "fontWeight": "700",
+                                      "lineHeight": 16,
+                                      "overflow": "hidden",
+                                      "textAlign": "left",
+                                      "textTransform": "uppercase",
+                                    },
+                                  },
+                                  "type": "Text",
+                                },
+                              ],
+                              "props": {
+                                "onPointerEnter": [Function: AsyncFunction],
+                                "onPointerLeave": [Function: AsyncFunction],
+                                "style": {
+                                  "accessibilityHint": "changes sort alphabetical order",
+                                  "accessibilityLabel": "sort",
+                                  "alignItems": "center",
+                                  "display": "flex",
+                                  "flexDirection": "row",
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                  "justifyContent": "flex-start",
+                                },
+                                "testID": undefined,
+                              },
+                              "type": "View",
+                            },
+                          ],
+                          "props": {
+                            "onPointerEnter": [Function: AsyncFunction],
+                            "onPointerLeave": [Function: AsyncFunction],
+                            "style": {
+                              "justifyContent": "center",
+                              "marginRight": 8,
+                              "paddingBottom": 16,
+                              "paddingLeft": 12,
+                              "paddingRight": 12,
+                              "paddingTop": 16,
+                              "width": 100,
+                            },
+                            "testID": undefined,
+                          },
+                          "type": "View",
+                        },
+                      ],
+                      "props": {
+                        "onPointerEnter": [Function: AsyncFunction],
+                        "onPointerLeave": [Function: AsyncFunction],
+                        "style": {
+                          "display": "flex",
+                          "flexDirection": "row",
+                          "paddingBottom": 4,
+                          "paddingTop": 4,
+                          "width": "100%",
+                        },
+                        "testID": undefined,
+                      },
+                      "type": "View",
+                    },
+                  ],
+                  "props": {
+                    "onPointerEnter": [Function: AsyncFunction],
+                    "onPointerLeave": [Function: AsyncFunction],
+                    "style": {
+                      "backgroundColor": "#FFFFFF",
+                      "borderBottom": "2px solid #e0e0e0",
+                      "dangerouslySetInlineStyle": {
+                        "__style": {
+                          "borderBottom": "2px solid #e0e0e0",
+                        },
+                      },
+                      "width": "100%",
+                    },
+                    "testID": undefined,
+                  },
+                  "type": "View",
+                },
+              ],
+              "props": {
+                "onPointerEnter": [Function: AsyncFunction],
+                "onPointerLeave": [Function: AsyncFunction],
+                "style": {
+                  "backgroundColor": "#FFFFFF",
+                  "flex": undefined,
+                },
+                "testID": undefined,
+              },
+              "type": "View",
+            },
+            {
+              "$$typeof": Symbol(react.test.json),
+              "children": [
+                {
+                  "$$typeof": Symbol(react.test.json),
+                  "children": [
+                    {
+                      "$$typeof": Symbol(react.test.json),
+                      "children": null,
+                      "props": {
+                        "onPointerEnter": [Function: AsyncFunction],
+                        "onPointerLeave": [Function: AsyncFunction],
+                        "style": {
+                          "justifyContent": "center",
+                          "marginRight": 8,
+                          "paddingBottom": 16,
+                          "paddingLeft": 12,
+                          "paddingRight": 12,
+                          "paddingTop": 16,
+                        },
+                        "testID": undefined,
+                      },
+                      "type": "View",
+                    },
+                    {
+                      "$$typeof": Symbol(react.test.json),
+                      "children": [
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": [
+                            "Has drawer",
+                          ],
+                          "props": {
+                            "style": {
+                              "color": "#1C1C1C",
+                              "fontFamily": "text",
+                              "fontSize": 14,
+                              "textAlign": undefined,
+                            },
+                          },
+                          "type": "Text",
+                        },
+                      ],
+                      "props": {
+                        "onPointerEnter": [Function: AsyncFunction],
+                        "onPointerLeave": [Function: AsyncFunction],
+                        "style": {
+                          "justifyContent": "center",
+                          "marginRight": 8,
+                          "paddingBottom": 16,
+                          "paddingLeft": 12,
+                          "paddingRight": 12,
+                          "paddingTop": 16,
+                          "width": 100,
+                        },
+                        "testID": undefined,
+                      },
+                      "type": "View",
+                    },
+                  ],
+                  "props": {
+                    "onPointerEnter": [Function: AsyncFunction],
+                    "onPointerLeave": [Function: AsyncFunction],
+                    "style": {
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "paddingBottom": 4,
+                      "paddingTop": 4,
+                      "width": "100%",
+                    },
+                    "testID": undefined,
+                  },
+                  "type": "View",
+                },
+              ],
+              "props": {
+                "onPointerEnter": [Function: AsyncFunction],
+                "onPointerLeave": [Function: AsyncFunction],
+                "style": {
+                  "backgroundColor": "#D9D9D9",
+                  "borderBottom": "1px solid #e0e0e0",
+                  "dangerouslySetInlineStyle": {
+                    "__style": {
+                      "borderBottom": "1px solid #e0e0e0",
+                    },
+                  },
+                  "width": "100%",
+                },
+                "testID": undefined,
+              },
+              "type": "View",
+            },
+            {
+              "$$typeof": Symbol(react.test.json),
+              "children": [
+                {
+                  "$$typeof": Symbol(react.test.json),
+                  "children": [
+                    {
+                      "$$typeof": Symbol(react.test.json),
+                      "children": [
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": null,
+                          "props": {
+                            "onPointerEnter": [Function: AsyncFunction],
+                            "onPointerLeave": [Function: AsyncFunction],
+                            "style": {
+                              "width": 32,
+                            },
+                            "testID": undefined,
+                          },
+                          "type": "View",
+                        },
+                      ],
+                      "props": {
+                        "onPointerEnter": [Function: AsyncFunction],
+                        "onPointerLeave": [Function: AsyncFunction],
+                        "style": {
+                          "justifyContent": "center",
+                          "marginRight": 8,
+                          "paddingBottom": 16,
+                          "paddingLeft": 12,
+                          "paddingRight": 12,
+                          "paddingTop": 16,
+                        },
+                        "testID": undefined,
+                      },
+                      "type": "View",
+                    },
+                    {
+                      "$$typeof": Symbol(react.test.json),
+                      "children": [
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": [
+                            "No drawer",
+                          ],
+                          "props": {
+                            "style": {
+                              "color": "#1C1C1C",
+                              "fontFamily": "text",
+                              "fontSize": 14,
+                              "textAlign": undefined,
+                            },
+                          },
+                          "type": "Text",
+                        },
+                      ],
+                      "props": {
+                        "onPointerEnter": [Function: AsyncFunction],
+                        "onPointerLeave": [Function: AsyncFunction],
+                        "style": {
+                          "justifyContent": "center",
+                          "marginRight": 8,
+                          "paddingBottom": 16,
+                          "paddingLeft": 12,
+                          "paddingRight": 12,
+                          "paddingTop": 16,
+                          "width": 100,
+                        },
+                        "testID": undefined,
+                      },
+                      "type": "View",
+                    },
+                  ],
+                  "props": {
+                    "onPointerEnter": [Function: AsyncFunction],
+                    "onPointerLeave": [Function: AsyncFunction],
+                    "style": {
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "paddingBottom": 4,
+                      "paddingTop": 4,
+                      "width": "100%",
+                    },
+                    "testID": undefined,
+                  },
+                  "type": "View",
+                },
+              ],
+              "props": {
+                "onPointerEnter": [Function: AsyncFunction],
+                "onPointerLeave": [Function: AsyncFunction],
+                "style": {
+                  "backgroundColor": "#FFFFFF",
+                  "borderBottom": "1px solid #e0e0e0",
+                  "dangerouslySetInlineStyle": {
+                    "__style": {
+                      "borderBottom": "1px solid #e0e0e0",
+                    },
+                  },
+                  "width": "100%",
+                },
+                "testID": undefined,
+              },
+              "type": "View",
+            },
+          ],
+          "props": {
+            "stickyHeaderIndices": [
+              0,
+            ],
+            "style": {
+              "flex": 1,
+              "maxHeight": undefined,
+              "maxWidth": "100%",
+              "width": 164,
+            },
+          },
+          "type": "ScrollView",
+        },
+      ],
+      "props": {
+        "horizontal": true,
+        "style": {
+          "maxWidth": "100%",
+          "width": 164,
+        },
+      },
+      "type": "ScrollView",
+    },
+  ],
+  "props": {
+    "onPointerEnter": [Function: AsyncFunction],
+    "onPointerLeave": [Function: AsyncFunction],
+    "style": {
+      "display": "flex",
+      "flexGrow": 1,
+      "flexShrink": 1,
+      "maxWidth": "100%",
+      "style": {
+        "position": "relative",
+      },
+      "width": 164,
+    },
+    "testID": undefined,
+  },
+  "type": "View",
+}
+`;

--- a/ui/src/table/tableContext.test.tsx
+++ b/ui/src/table/tableContext.test.tsx
@@ -3,18 +3,33 @@ import {render} from "@testing-library/react-native";
 import {useEffect} from "react";
 import {Text} from "react-native";
 
+import type {TableContextType} from "../Common";
 import {renderWithTheme} from "../test-utils";
 import {TableContextProvider, useTableContext} from "./tableContext";
 
+const captureContext = (): {
+  getContext: () => TableContextType;
+  Consumer: () => React.ReactElement;
+} => {
+  let captured: TableContextType | undefined;
+  const Consumer = () => {
+    captured = useTableContext();
+    return <Text>ok</Text>;
+  };
+  const getContext = (): TableContextType => {
+    if (!captured) {
+      throw new Error("Context was not captured");
+    }
+    return captured;
+  };
+  return {Consumer, getContext};
+};
+
 describe("tableContext", () => {
   it("exposes default values from useTableContext when no provider is present", () => {
-    let ctx: any;
-    const Consumer = () => {
-      ctx = useTableContext();
-      return <Text>ok</Text>;
-    };
+    const {getContext, Consumer} = captureContext();
     renderWithTheme(<Consumer />);
-    expect(ctx).toBeTruthy();
+    const ctx = getContext();
     expect(ctx.columns).toEqual([]);
     expect(ctx.stickyHeader).toBe(true);
     expect(ctx.alternateRowBackground).toBe(true);
@@ -27,11 +42,7 @@ describe("tableContext", () => {
 
   it("passes provided values through the provider", () => {
     const setSortColumn = mock(() => {});
-    let ctx: any;
-    const Consumer = () => {
-      ctx = useTableContext();
-      return <Text>ok</Text>;
-    };
+    const {getContext, Consumer} = captureContext();
     render(
       <TableContextProvider
         alternateRowBackground={false}
@@ -46,6 +57,7 @@ describe("tableContext", () => {
         <Consumer />
       </TableContextProvider>
     );
+    const ctx = getContext();
     expect(ctx.columns).toEqual([100, 200]);
     expect(ctx.hasDrawerContents).toBe(true);
     expect(ctx.stickyHeader).toBe(false);

--- a/ui/src/table/tableContext.test.tsx
+++ b/ui/src/table/tableContext.test.tsx
@@ -1,0 +1,84 @@
+import {describe, expect, it, mock} from "bun:test";
+import {render} from "@testing-library/react-native";
+import {useEffect} from "react";
+import {Text} from "react-native";
+
+import {renderWithTheme} from "../test-utils";
+import {TableContextProvider, useTableContext} from "./tableContext";
+
+describe("tableContext", () => {
+  it("exposes default values from useTableContext when no provider is present", () => {
+    let ctx: any;
+    const Consumer = () => {
+      ctx = useTableContext();
+      return <Text>ok</Text>;
+    };
+    renderWithTheme(<Consumer />);
+    expect(ctx).toBeTruthy();
+    expect(ctx.columns).toEqual([]);
+    expect(ctx.stickyHeader).toBe(true);
+    expect(ctx.alternateRowBackground).toBe(true);
+    expect(ctx.borderStyle).toBe("sm");
+    expect(ctx.hasDrawerContents).toBe(false);
+    expect(typeof ctx.setSortColumn).toBe("function");
+    // Invoke default setSortColumn to cover the no-op default
+    expect(() => ctx.setSortColumn({column: 0, direction: "asc"})).not.toThrow();
+  });
+
+  it("passes provided values through the provider", () => {
+    const setSortColumn = mock(() => {});
+    let ctx: any;
+    const Consumer = () => {
+      ctx = useTableContext();
+      return <Text>ok</Text>;
+    };
+    render(
+      <TableContextProvider
+        alternateRowBackground={false}
+        borderStyle="lg"
+        columns={[100, 200]}
+        hasDrawerContents
+        page={3}
+        setSortColumn={setSortColumn}
+        sortColumn={{column: 1, direction: "desc"}}
+        stickyHeader={false}
+      >
+        <Consumer />
+      </TableContextProvider>
+    );
+    expect(ctx.columns).toEqual([100, 200]);
+    expect(ctx.hasDrawerContents).toBe(true);
+    expect(ctx.stickyHeader).toBe(false);
+    expect(ctx.alternateRowBackground).toBe(false);
+    expect(ctx.borderStyle).toBe("lg");
+    expect(ctx.sortColumn).toEqual({column: 1, direction: "desc"});
+    ctx.setSortColumn({column: 0, direction: "asc"});
+    expect(setSortColumn).toHaveBeenCalled();
+  });
+
+  it("useEffect-based consumer can call setSortColumn without errors", () => {
+    const setSortColumn = mock(() => {});
+    const Consumer = () => {
+      const {setSortColumn: setter} = useTableContext();
+      useEffect(() => {
+        setter({column: 2, direction: "desc"});
+      }, [setter]);
+      return <Text>ok</Text>;
+    };
+    render(
+      <TableContextProvider
+        alternateRowBackground
+        borderStyle="sm"
+        columns={[100]}
+        hasDrawerContents={false}
+        page={1}
+        setSortColumn={setSortColumn}
+        sortColumn={undefined}
+        stickyHeader
+      >
+        <Consumer />
+      </TableContextProvider>
+    );
+    expect(setSortColumn).toHaveBeenCalledWith({column: 2, direction: "desc"});
+  });
+});


### PR DESCRIPTION
## Summary
Partial follow-up to #466 — adds additional tests in `@terreno/ui` to continue raising coverage toward 95%. All tests pass and lint is clean. This is an incremental step, not a full push to the 95% threshold.

Test additions by component:
- `AddressField`: address2/county field changes, undefined value, autocomplete callbacks
- `Banner`: button-with-icon press
- `Button`: confirmation modal primary/secondary interactions, tooltip wrapper
- `DecimalRangeActionSheet`: whole and decimal picker `onChange`
- `HeightActionSheet`: title rendering, feet and inches picker `onChange`
- `InfoModalIcon`, `InfoTooltipButton`: render-safety checks
- `Modal`: primary/secondary button interactions
- `NumberPickerActionSheet`: picker `onValueChange`, close button
- `Page`: right button callback, header-less render, loading text
- `Pagination`: additional rendering cases
- `SegmentedControl`: scroll-button navigation (next/previous)
- `SelectBadge`: additional option interactions
- `SignatureField`: `onStart` / `onEnd` callback invocation
- `Spinner`, `Theme`: extra render cases
- `table/TableHeaderCell`: 3-way sort cycle (none → desc → asc → none)
- `table/TableRow`: initially expanded drawer, placeholder cell
- `table/tableContext`: new tests covering default context, provider pass-through, and `setSortColumn` invocation

## Review & Testing Checklist for Human
- [ ] CI passes on this branch
- [ ] Spot-check a couple of the new tests to confirm they're exercising real behavior, not just rendering

### Notes
- No component/implementation code was changed — tests only (plus updated snapshots where tests exercise new rendering paths).
- Coverage is still below the 95% target; additional follow-up PRs will continue closing the gap.


Link to Devin session: https://app.devin.ai/sessions/695da118f64c42878d2965e2d078f1b8
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since the PR only adds/extends unit tests and updates snapshots, with no production runtime logic changes.
> 
> **Overview**
> Improves `@terreno/ui` test coverage by adding interaction and edge-case tests across many UI components (inputs, action sheets, modals, pagination/segmented control, and table widgets).
> 
> New assertions cover callback wiring (e.g., picker/value changes, confirmation/close flows, sorting cycle, context provider defaults) and a few render-safety cases (e.g., undefined values, unmount cleanup), with snapshot updates for newly exercised render paths (notably `Button` tooltip and `TableRow` placeholder cell).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1699870507b6529d6e4266251bf081d5e27582b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->