### PR TITLE
Enforce 95% coverage threshold in passing packages

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - "api/**"
+      - "scripts/check-coverage.ts"
       - ".github/workflows/api-ci.yml"
 
 defaults:

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: bun run lint
       - name: Build
         run: bun run compile
-      - name: Test
-        run: bun run test
+      - name: Test with coverage threshold
+        run: bun run test:coverage
         env:
           CI: true

--- a/.github/workflows/mcp-server-ci.yml
+++ b/.github/workflows/mcp-server-ci.yml
@@ -6,10 +6,12 @@ on:
       - main
     paths:
       - "mcp-server/**"
+      - "scripts/check-coverage.ts"
       - ".github/workflows/mcp-server-ci.yml"
   pull_request:
     paths:
       - "mcp-server/**"
+      - "scripts/check-coverage.ts"
       - ".github/workflows/mcp-server-ci.yml"
 
 defaults:

--- a/.github/workflows/mcp-server-ci.yml
+++ b/.github/workflows/mcp-server-ci.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Build
         run: bun run compile
 
-      - name: Test
-        run: bun run test:ci
+      - name: Test with coverage threshold
+        run: bun run test:coverage
         env:
           CI: true
 

--- a/.github/workflows/rtk-ci.yml
+++ b/.github/workflows/rtk-ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths:
       - "rtk/**"
+      - "scripts/check-coverage.ts"
       - ".github/workflows/rtk-ci.yml"
 
 jobs:

--- a/.github/workflows/rtk-ci.yml
+++ b/.github/workflows/rtk-ci.yml
@@ -46,3 +46,9 @@ jobs:
         run: bun run compile
         working-directory: rtk
 
+      - name: Test with coverage threshold
+        run: bun run test:coverage
+        working-directory: rtk
+        env:
+          CI: true
+

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Code coverage
 coverage/
+coverage-main/
+coverage-iso-*/
 *.lcov
 .nyc_output/
 

--- a/admin-backend/bunfig.toml
+++ b/admin-backend/bunfig.toml
@@ -2,4 +2,7 @@
 preload = ["../api/src/tests/bunSetup.ts"]
 root = "./src"
 coveragePathIgnorePatterns = ["**/*.test.ts", "../api/**", "dist/**", "**/node_modules/**"]
+# Enforced by scripts/check-coverage.ts; Bun parses this key but does not
+# fail the run when coverage is below threshold. See
+# https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
 coverageThreshold = { line = 95, function = 95 }

--- a/admin-backend/bunfig.toml
+++ b/admin-backend/bunfig.toml
@@ -1,4 +1,6 @@
 [test]
 preload = ["../api/src/tests/bunSetup.ts"]
 root = "./src"
-coveragePathIgnorePatterns = ["**/*.test.ts", "../api/**", "dist/**"]
+coverage = true
+coveragePathIgnorePatterns = ["**/*.test.ts", "../api/**", "dist/**", "**/node_modules/**"]
+coverageThreshold = { line = 95, function = 95 }

--- a/admin-backend/bunfig.toml
+++ b/admin-backend/bunfig.toml
@@ -1,6 +1,5 @@
 [test]
 preload = ["../api/src/tests/bunSetup.ts"]
 root = "./src"
-coverage = true
 coveragePathIgnorePatterns = ["**/*.test.ts", "../api/**", "dist/**", "**/node_modules/**"]
 coverageThreshold = { line = 95, function = 95 }

--- a/admin-backend/package.json
+++ b/admin-backend/package.json
@@ -49,7 +49,8 @@
     "lint": "biome check ./src",
     "lint:fix": "biome check --write ./src",
     "test": "bun test",
-    "test:ci": "bun test"
+    "test:ci": "bun test",
+    "test:coverage": "bun run ../scripts/check-coverage.ts"
   },
   "types": "dist/index.d.ts",
   "version": "0.10.0"

--- a/admin-frontend/package.json
+++ b/admin-frontend/package.json
@@ -47,7 +47,8 @@
     "lint:fix": "biome check --write .",
     "lint:unsafefix": "biome check --write --unsafe .",
     "test": "bun test && for f in ./src/isolated/*.isolated.tsx ./src/isolated/*.isolated.ts; do bun test \"$f\" || exit 1; done",
-    "test:ci": "bun run test"
+    "test:ci": "bun run test",
+    "test:coverage": "bun run ../scripts/check-coverage.ts"
   },
   "types": "dist/index.d.ts",
   "version": "0.10.0"

--- a/ai/bunfig.toml
+++ b/ai/bunfig.toml
@@ -1,3 +1,6 @@
 [test]
 preload = ["./src/tests/bunSetup.ts"]
 root = "./src"
+coverage = true
+coveragePathIgnorePatterns = ["**/*.test.ts", "**/tests/**", "../**", "dist/**", "**/node_modules/**"]
+coverageThreshold = { line = 95, function = 95 }

--- a/ai/bunfig.toml
+++ b/ai/bunfig.toml
@@ -2,4 +2,7 @@
 preload = ["./src/tests/bunSetup.ts"]
 root = "./src"
 coveragePathIgnorePatterns = ["**/*.test.ts", "**/tests/**", "../**", "dist/**", "**/node_modules/**"]
+# Enforced by scripts/check-coverage.ts; Bun parses this key but does not
+# fail the run when coverage is below threshold. See
+# https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
 coverageThreshold = { line = 95, function = 95 }

--- a/ai/bunfig.toml
+++ b/ai/bunfig.toml
@@ -1,6 +1,5 @@
 [test]
 preload = ["./src/tests/bunSetup.ts"]
 root = "./src"
-coverage = true
 coveragePathIgnorePatterns = ["**/*.test.ts", "**/tests/**", "../**", "dist/**", "**/node_modules/**"]
 coverageThreshold = { line = 95, function = 95 }

--- a/ai/package.json
+++ b/ai/package.json
@@ -63,7 +63,8 @@
     "lint:fix": "biome check --write ./src",
     "lint:unsafefix": "biome check --fix --unsafe ./src",
     "test": "bun test --preload ./src/tests/bunSetup.ts",
-    "test:ci": "bun test --preload ./src/tests/bunSetup.ts"
+    "test:ci": "bun test --preload ./src/tests/bunSetup.ts",
+    "test:coverage": "bun run ../scripts/check-coverage.ts"
   },
   "types": "dist/index.d.ts",
   "version": "0.10.0"

--- a/ai/package.json
+++ b/ai/package.json
@@ -62,8 +62,8 @@
     "lint": "biome check ./src",
     "lint:fix": "biome check --write ./src",
     "lint:unsafefix": "biome check --fix --unsafe ./src",
-    "test": "bun test --preload ./src/tests/bunSetup.ts",
-    "test:ci": "bun test --preload ./src/tests/bunSetup.ts",
+    "test": "bun test --preload ./src/tests/bunSetup.ts && for f in ./src/isolated/*.isolated.ts; do bun test --preload ./src/tests/bunSetup.ts \"$f\" || exit 1; done",
+    "test:ci": "bun test --preload ./src/tests/bunSetup.ts && for f in ./src/isolated/*.isolated.ts; do bun test --preload ./src/tests/bunSetup.ts \"$f\" || exit 1; done",
     "test:coverage": "bun run ../scripts/check-coverage.ts"
   },
   "types": "dist/index.d.ts",

--- a/ai/src/isolated/langfuseClient.isolated.ts
+++ b/ai/src/isolated/langfuseClient.isolated.ts
@@ -16,7 +16,7 @@ mock.module("@langfuse/client", () => ({
 }));
 
 const {getLangfuseClient, initLangfuseClient, isLangfuseInitialized, shutdownLangfuseClient} =
-  await import("./langfuseClient");
+  await import("../langfuseClient");
 
 describe("langfuseClient", () => {
   beforeEach(async () => {

--- a/ai/tsconfig.json
+++ b/ai/tsconfig.json
@@ -26,6 +26,13 @@
     "strictNullChecks": true,
     "target": "es5"
   },
-  "exclude": ["node_modules", "src/**/*.test.ts", "src/**/*.test.tsx", "src/tests"],
+  "exclude": [
+    "node_modules",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.isolated.ts",
+    "src/**/*.isolated.tsx",
+    "src/tests"
+  ],
   "include": ["src/**/*.ts*", "src/*.ts", "types.d.ts"]
 }

--- a/api-health/bunfig.toml
+++ b/api-health/bunfig.toml
@@ -1,5 +1,4 @@
 [test]
 root = "./src"
-coverage = true
 coveragePathIgnorePatterns = ["**/dist/**", "**/*.test.ts", "**/node_modules/**", "../**"]
 coverageThreshold = { line = 95, function = 95 }

--- a/api-health/bunfig.toml
+++ b/api-health/bunfig.toml
@@ -1,4 +1,7 @@
 [test]
 root = "./src"
 coveragePathIgnorePatterns = ["**/dist/**", "**/*.test.ts", "**/node_modules/**", "../**"]
+# Enforced by scripts/check-coverage.ts; Bun parses this key but does not
+# fail the run when coverage is below threshold. See
+# https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
 coverageThreshold = { line = 95, function = 95 }

--- a/api-health/bunfig.toml
+++ b/api-health/bunfig.toml
@@ -1,0 +1,5 @@
+[test]
+root = "./src"
+coverage = true
+coveragePathIgnorePatterns = ["**/dist/**", "**/*.test.ts", "**/node_modules/**", "../**"]
+coverageThreshold = { line = 95, function = 95 }

--- a/api-health/package.json
+++ b/api-health/package.json
@@ -40,7 +40,8 @@
     "lint": "biome check ./src",
     "lint:fix": "biome check --write ./src",
     "test": "bun test src/",
-    "test:ci": "bun test src/"
+    "test:ci": "bun test src/",
+    "test:coverage": "bun run ../scripts/check-coverage.ts"
   },
   "types": "dist/index.d.ts",
   "version": "0.10.0"

--- a/api/bunfig.toml
+++ b/api/bunfig.toml
@@ -2,6 +2,6 @@
 preload = ["./src/tests/bunSetup.ts"]
 root = "./src"
 coverage = true
-coveragePathIgnorePatterns = ["dist/**", "**/*.test.ts", "**/tests/**", "**/vendor/**"]
-coverageThreshold = { line = 80, function = 80 }
+coveragePathIgnorePatterns = ["dist/**", "**/*.test.ts", "**/tests/**", "**/vendor/**", "../**"]
+coverageThreshold = { line = 95, function = 95 }
 

--- a/api/bunfig.toml
+++ b/api/bunfig.toml
@@ -3,5 +3,8 @@ preload = ["./src/tests/bunSetup.ts"]
 root = "./src"
 coverage = true
 coveragePathIgnorePatterns = ["dist/**", "**/*.test.ts", "**/tests/**", "**/vendor/**", "../**"]
+# Enforced by scripts/check-coverage.ts; Bun parses this key but does not
+# fail the run when coverage is below threshold. See
+# https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
 coverageThreshold = { line = 95, function = 95 }
 

--- a/api/package.json
+++ b/api/package.json
@@ -100,6 +100,7 @@
     "lint:unsafefix": "biome check --fix --unsafe ./src",
     "test": "bun test --preload ./src/tests/bunSetup.ts --update-snapshots",
     "test:ci": "bun test --preload ./src/tests/bunSetup.ts",
+    "test:coverage": "bun run ../scripts/check-coverage.ts",
     "updateSnapshot": "bun test --update-snapshots"
   },
   "types": "dist/index.d.ts",

--- a/api/src/__snapshots__/openApi.test.ts.snap
+++ b/api/src/__snapshots__/openApi.test.ts.snap
@@ -221,6 +221,7 @@ exports[`openApi gets the openapi.json 1`] = `
                                   "type": "number",
                                 },
                                 "created": {
+                                  "description": "When this document was created",
                                   "format": "date-time",
                                   "type": "string",
                                 },
@@ -247,6 +248,7 @@ exports[`openApi gets the openapi.json 1`] = `
                                   "type": "string",
                                 },
                                 "updated": {
+                                  "description": "When this document was last updated",
                                   "format": "date-time",
                                   "type": "string",
                                 },
@@ -325,6 +327,7 @@ exports[`openApi gets the openapi.json 1`] = `
                                 "type": "number",
                               },
                               "created": {
+                                "description": "When this document was created",
                                 "format": "date-time",
                                 "type": "string",
                               },
@@ -351,6 +354,7 @@ exports[`openApi gets the openapi.json 1`] = `
                                 "type": "string",
                               },
                               "updated": {
+                                "description": "When this document was last updated",
                                 "format": "date-time",
                                 "type": "string",
                               },
@@ -536,6 +540,7 @@ exports[`openApi gets the openapi.json 1`] = `
                           "type": "number",
                         },
                         "created": {
+                          "description": "When this document was created",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -562,6 +567,7 @@ exports[`openApi gets the openapi.json 1`] = `
                           "type": "string",
                         },
                         "updated": {
+                          "description": "When this document was last updated",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -640,6 +646,7 @@ exports[`openApi gets the openapi.json 1`] = `
                         "type": "number",
                       },
                       "created": {
+                        "description": "When this document was created",
                         "format": "date-time",
                         "type": "string",
                       },
@@ -666,6 +673,7 @@ exports[`openApi gets the openapi.json 1`] = `
                         "type": "string",
                       },
                       "updated": {
+                        "description": "When this document was last updated",
                         "format": "date-time",
                         "type": "string",
                       },
@@ -780,6 +788,7 @@ exports[`openApi gets the openapi.json 1`] = `
                             "type": "number",
                           },
                           "created": {
+                            "description": "When this document was created",
                             "format": "date-time",
                             "type": "string",
                           },
@@ -806,6 +815,7 @@ exports[`openApi gets the openapi.json 1`] = `
                             "type": "string",
                           },
                           "updated": {
+                            "description": "When this document was last updated",
                             "format": "date-time",
                             "type": "string",
                           },
@@ -884,6 +894,7 @@ exports[`openApi gets the openapi.json 1`] = `
                           "type": "number",
                         },
                         "created": {
+                          "description": "When this document was created",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -910,6 +921,7 @@ exports[`openApi gets the openapi.json 1`] = `
                           "type": "string",
                         },
                         "updated": {
+                          "description": "When this document was last updated",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -1154,6 +1166,7 @@ exports[`openApi gets the openapi.json 1`] = `
                             "type": "number",
                           },
                           "created": {
+                            "description": "When this document was created",
                             "format": "date-time",
                             "type": "string",
                           },
@@ -1180,6 +1193,7 @@ exports[`openApi gets the openapi.json 1`] = `
                             "type": "string",
                           },
                           "updated": {
+                            "description": "When this document was last updated",
                             "format": "date-time",
                             "type": "string",
                           },
@@ -1258,6 +1272,7 @@ exports[`openApi gets the openapi.json 1`] = `
                           "type": "number",
                         },
                         "created": {
+                          "description": "When this document was created",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -1284,6 +1299,7 @@ exports[`openApi gets the openapi.json 1`] = `
                           "type": "string",
                         },
                         "updated": {
+                          "description": "When this document was last updated",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -1462,6 +1478,7 @@ exports[`openApi gets the openapi.json 1`] = `
                           "type": "number",
                         },
                         "created": {
+                          "description": "When this document was created",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -1488,6 +1505,7 @@ exports[`openApi gets the openapi.json 1`] = `
                           "type": "string",
                         },
                         "updated": {
+                          "description": "When this document was last updated",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -1566,6 +1584,7 @@ exports[`openApi gets the openapi.json 1`] = `
                         "type": "number",
                       },
                       "created": {
+                        "description": "When this document was created",
                         "format": "date-time",
                         "type": "string",
                       },
@@ -1592,6 +1611,7 @@ exports[`openApi gets the openapi.json 1`] = `
                         "type": "string",
                       },
                       "updated": {
+                        "description": "When this document was last updated",
                         "format": "date-time",
                         "type": "string",
                       },
@@ -1706,6 +1726,7 @@ exports[`openApi gets the openapi.json 1`] = `
                             "type": "number",
                           },
                           "created": {
+                            "description": "When this document was created",
                             "format": "date-time",
                             "type": "string",
                           },
@@ -1732,6 +1753,7 @@ exports[`openApi gets the openapi.json 1`] = `
                             "type": "string",
                           },
                           "updated": {
+                            "description": "When this document was last updated",
                             "format": "date-time",
                             "type": "string",
                           },
@@ -1810,6 +1832,7 @@ exports[`openApi gets the openapi.json 1`] = `
                           "type": "number",
                         },
                         "created": {
+                          "description": "When this document was created",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -1836,6 +1859,7 @@ exports[`openApi gets the openapi.json 1`] = `
                           "type": "string",
                         },
                         "updated": {
+                          "description": "When this document was last updated",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -2157,6 +2181,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                                   "type": "number",
                                 },
                                 "created": {
+                                  "description": "When this document was created",
                                   "format": "date-time",
                                   "type": "string",
                                 },
@@ -2183,6 +2208,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                                   "type": "string",
                                 },
                                 "updated": {
+                                  "description": "When this document was last updated",
                                   "format": "date-time",
                                   "type": "string",
                                 },
@@ -2261,6 +2287,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                                 "type": "number",
                               },
                               "created": {
+                                "description": "When this document was created",
                                 "format": "date-time",
                                 "type": "string",
                               },
@@ -2287,6 +2314,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                                 "type": "string",
                               },
                               "updated": {
+                                "description": "When this document was last updated",
                                 "format": "date-time",
                                 "type": "string",
                               },
@@ -2472,6 +2500,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                           "type": "number",
                         },
                         "created": {
+                          "description": "When this document was created",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -2498,6 +2527,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                           "type": "string",
                         },
                         "updated": {
+                          "description": "When this document was last updated",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -2576,6 +2606,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                         "type": "number",
                       },
                       "created": {
+                        "description": "When this document was created",
                         "format": "date-time",
                         "type": "string",
                       },
@@ -2602,6 +2633,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                         "type": "string",
                       },
                       "updated": {
+                        "description": "When this document was last updated",
                         "format": "date-time",
                         "type": "string",
                       },
@@ -2716,6 +2748,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                             "type": "number",
                           },
                           "created": {
+                            "description": "When this document was created",
                             "format": "date-time",
                             "type": "string",
                           },
@@ -2742,6 +2775,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                             "type": "string",
                           },
                           "updated": {
+                            "description": "When this document was last updated",
                             "format": "date-time",
                             "type": "string",
                           },
@@ -2820,6 +2854,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                           "type": "number",
                         },
                         "created": {
+                          "description": "When this document was created",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -2846,6 +2881,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                           "type": "string",
                         },
                         "updated": {
+                          "description": "When this document was last updated",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -3090,6 +3126,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                             "type": "number",
                           },
                           "created": {
+                            "description": "When this document was created",
                             "format": "date-time",
                             "type": "string",
                           },
@@ -3116,6 +3153,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                             "type": "string",
                           },
                           "updated": {
+                            "description": "When this document was last updated",
                             "format": "date-time",
                             "type": "string",
                           },
@@ -3194,6 +3232,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                           "type": "number",
                         },
                         "created": {
+                          "description": "When this document was created",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -3220,6 +3259,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                           "type": "string",
                         },
                         "updated": {
+                          "description": "When this document was last updated",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -3398,6 +3438,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                           "type": "number",
                         },
                         "created": {
+                          "description": "When this document was created",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -3424,6 +3465,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                           "type": "string",
                         },
                         "updated": {
+                          "description": "When this document was last updated",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -3502,6 +3544,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                         "type": "number",
                       },
                       "created": {
+                        "description": "When this document was created",
                         "format": "date-time",
                         "type": "string",
                       },
@@ -3528,6 +3571,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                         "type": "string",
                       },
                       "updated": {
+                        "description": "When this document was last updated",
                         "format": "date-time",
                         "type": "string",
                       },
@@ -3642,6 +3686,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                             "type": "number",
                           },
                           "created": {
+                            "description": "When this document was created",
                             "format": "date-time",
                             "type": "string",
                           },
@@ -3668,6 +3713,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                             "type": "string",
                           },
                           "updated": {
+                            "description": "When this document was last updated",
                             "format": "date-time",
                             "type": "string",
                           },
@@ -3746,6 +3792,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                           "type": "number",
                         },
                         "created": {
+                          "description": "When this document was created",
                           "format": "date-time",
                           "type": "string",
                         },
@@ -3772,6 +3819,7 @@ exports[`openApi gets the openapi.json with custom endpoint 1`] = `
                           "type": "string",
                         },
                         "updated": {
+                          "description": "When this document was last updated",
                           "format": "date-time",
                           "type": "string",
                         },

--- a/feature-flags/bunfig.toml
+++ b/feature-flags/bunfig.toml
@@ -1,6 +1,5 @@
 [test]
 preload = ["../api/src/tests/bunSetup.ts"]
 root = "./src"
-coverage = true
 coveragePathIgnorePatterns = ["**/dist/**", "**/*.test.ts", "**/tests/**", "**/node_modules/**", "../**"]
 coverageThreshold = { line = 95, function = 95 }

--- a/feature-flags/bunfig.toml
+++ b/feature-flags/bunfig.toml
@@ -2,4 +2,7 @@
 preload = ["../api/src/tests/bunSetup.ts"]
 root = "./src"
 coveragePathIgnorePatterns = ["**/dist/**", "**/*.test.ts", "**/tests/**", "**/node_modules/**", "../**"]
+# Enforced by scripts/check-coverage.ts; Bun parses this key but does not
+# fail the run when coverage is below threshold. See
+# https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
 coverageThreshold = { line = 95, function = 95 }

--- a/feature-flags/bunfig.toml
+++ b/feature-flags/bunfig.toml
@@ -1,3 +1,6 @@
 [test]
 preload = ["../api/src/tests/bunSetup.ts"]
 root = "./src"
+coverage = true
+coveragePathIgnorePatterns = ["**/dist/**", "**/*.test.ts", "**/tests/**", "**/node_modules/**", "../**"]
+coverageThreshold = { line = 95, function = 95 }

--- a/feature-flags/package.json
+++ b/feature-flags/package.json
@@ -47,7 +47,8 @@
     "lint": "biome check ./src",
     "lint:fix": "biome check --write ./src",
     "test": "bun test",
-    "test:ci": "bun test"
+    "test:ci": "bun test",
+    "test:coverage": "bun run ../scripts/check-coverage.ts"
   },
   "types": "dist/index.d.ts",
   "version": "0.7.0"

--- a/mcp-server/bunfig.toml
+++ b/mcp-server/bunfig.toml
@@ -1,3 +1,5 @@
 [test]
 preload = "./src/__tests__/preload.ts"
-coveragePathIgnorePatterns = ["**/__tests__/**"]
+coveragePathIgnorePatterns = ["**/__tests__/**", "**/dist/**"]
+coverage = true
+coverageThreshold = { line = 95, function = 95 }

--- a/mcp-server/bunfig.toml
+++ b/mcp-server/bunfig.toml
@@ -1,4 +1,7 @@
 [test]
 preload = "./src/__tests__/preload.ts"
 coveragePathIgnorePatterns = ["**/__tests__/**", "**/dist/**"]
+# Enforced by scripts/check-coverage.ts; Bun parses this key but does not
+# fail the run when coverage is below threshold. See
+# https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
 coverageThreshold = { line = 95, function = 95 }

--- a/mcp-server/bunfig.toml
+++ b/mcp-server/bunfig.toml
@@ -1,5 +1,4 @@
 [test]
 preload = "./src/__tests__/preload.ts"
 coveragePathIgnorePatterns = ["**/__tests__/**", "**/dist/**"]
-coverage = true
 coverageThreshold = { line = 95, function = 95 }

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -18,7 +18,8 @@
     "compile:watch": "tsc -w",
     "sync-ui-docs": "cp ../demo/ui-types-documentation.json src/docs/ 2>/dev/null || true",
     "test": "bun test src/",
-    "test:ci": "bun test src/"
+    "test:ci": "bun test src/",
+    "test:coverage": "bun run ../scripts/check-coverage.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.0",

--- a/rtk/bunfig.toml
+++ b/rtk/bunfig.toml
@@ -1,5 +1,7 @@
 [test]
 preload = ["./test-preload.ts"]
 root = "./src"
+coverage = true
 coverageSkipTestFiles = true
-coverageExclude = ["**/*.test.ts", "./test-preload.ts"]
+coveragePathIgnorePatterns = ["**/dist/**", "**/*.test.ts", "**/test-preload.ts", "**/node_modules/**"]
+coverageThreshold = { line = 95, function = 95 }

--- a/rtk/bunfig.toml
+++ b/rtk/bunfig.toml
@@ -3,4 +3,7 @@ preload = ["./test-preload.ts"]
 root = "./src"
 coverageSkipTestFiles = true
 coveragePathIgnorePatterns = ["**/dist/**", "**/*.test.ts", "**/test-preload.ts", "**/node_modules/**"]
+# Enforced by scripts/check-coverage.ts; Bun parses this key but does not
+# fail the run when coverage is below threshold. See
+# https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
 coverageThreshold = { line = 95, function = 95 }

--- a/rtk/bunfig.toml
+++ b/rtk/bunfig.toml
@@ -1,7 +1,6 @@
 [test]
 preload = ["./test-preload.ts"]
 root = "./src"
-coverage = true
 coverageSkipTestFiles = true
 coveragePathIgnorePatterns = ["**/dist/**", "**/*.test.ts", "**/test-preload.ts", "**/node_modules/**"]
 coverageThreshold = { line = 95, function = 95 }

--- a/rtk/package.json
+++ b/rtk/package.json
@@ -63,7 +63,8 @@
     "lint:fix": "biome check --write .",
     "lint:unsafefix": "biome check --write --unsafe .",
     "test": "bun test",
-    "test:ci": "bun test"
+    "test:ci": "bun test",
+    "test:coverage": "bun run ../scripts/check-coverage.ts"
   },
   "types": "dist/index.d.ts",
   "version": "0.10.0"

--- a/scripts/check-coverage.test.ts
+++ b/scripts/check-coverage.test.ts
@@ -1,0 +1,96 @@
+import {describe, expect, it} from "bun:test";
+
+import {evaluateCoverage, parseAllFilesRow, parseArgs, stripAnsi} from "./check-coverage";
+
+const ESC = String.fromCharCode(27);
+
+describe("parseArgs", () => {
+  it("defaults to 95 when no flags are passed", () => {
+    expect(parseArgs([])).toEqual({threshold: 95});
+  });
+
+  it("parses an integer threshold", () => {
+    expect(parseArgs(["--threshold=80"])).toEqual({threshold: 80});
+  });
+
+  it("parses a fractional threshold", () => {
+    expect(parseArgs(["--threshold=92.5"])).toEqual({threshold: 92.5});
+  });
+
+  it("ignores unrelated flags", () => {
+    expect(parseArgs(["--foo", "bar", "--threshold=50"])).toEqual({threshold: 50});
+  });
+
+  it("keeps the last value when the flag appears multiple times", () => {
+    expect(parseArgs(["--threshold=70", "--threshold=85"])).toEqual({threshold: 85});
+  });
+});
+
+describe("stripAnsi", () => {
+  it("returns the input unchanged when there are no escape codes", () => {
+    expect(stripAnsi("hello world")).toBe("hello world");
+  });
+
+  it("removes common color escape sequences", () => {
+    const coloured = `${ESC}[31mred${ESC}[0m and ${ESC}[1;32mbold green${ESC}[0m`;
+    expect(stripAnsi(coloured)).toBe("red and bold green");
+  });
+});
+
+describe("parseAllFilesRow", () => {
+  const buildReport = (funcPct: string, linePct: string): string =>
+    [
+      "-------------------|---------|---------|-------------------",
+      "File               | % Funcs | % Lines | Uncovered Line #s",
+      "-------------------|---------|---------|-------------------",
+      `All files          |  ${funcPct} |  ${linePct} |`,
+      " foo.ts            |  100.00 |  100.00 |",
+      "-------------------|---------|---------|-------------------",
+    ].join("\n");
+
+  it("parses the function and line coverage from a plain report", () => {
+    expect(parseAllFilesRow(buildReport("95.95", "96.13"))).toEqual({
+      functions: 95.95,
+      lines: 96.13,
+    });
+  });
+
+  it("parses the coverage row when the report contains ANSI colour codes", () => {
+    const coloured = buildReport(`${ESC}[32m100.00${ESC}[0m`, `${ESC}[32m100.00${ESC}[0m`);
+    expect(parseAllFilesRow(coloured)).toEqual({functions: 100, lines: 100});
+  });
+
+  it("returns null when the report does not contain an All files row", () => {
+    expect(parseAllFilesRow("nothing to see here")).toBeNull();
+  });
+
+  it("returns null when the All files row is malformed", () => {
+    expect(parseAllFilesRow("All files | not-a-number | not-a-number |")).toBeNull();
+  });
+});
+
+describe("evaluateCoverage", () => {
+  it("returns an empty list when both metrics meet the threshold", () => {
+    expect(evaluateCoverage({functions: 95, lines: 95}, 95)).toEqual([]);
+    expect(evaluateCoverage({functions: 99, lines: 100}, 95)).toEqual([]);
+  });
+
+  it("flags function coverage that is below the threshold", () => {
+    expect(evaluateCoverage({functions: 90, lines: 96}, 95)).toEqual([
+      {metric: "functions", actual: 90, threshold: 95},
+    ]);
+  });
+
+  it("flags line coverage that is below the threshold", () => {
+    expect(evaluateCoverage({functions: 96, lines: 90}, 95)).toEqual([
+      {metric: "lines", actual: 90, threshold: 95},
+    ]);
+  });
+
+  it("flags both metrics when both are below the threshold", () => {
+    expect(evaluateCoverage({functions: 80, lines: 85}, 95)).toEqual([
+      {metric: "functions", actual: 80, threshold: 95},
+      {metric: "lines", actual: 85, threshold: 95},
+    ]);
+  });
+});

--- a/scripts/check-coverage.test.ts
+++ b/scripts/check-coverage.test.ts
@@ -1,6 +1,14 @@
 import {describe, expect, it} from "bun:test";
 
-import {evaluateCoverage, parseAllFilesRow, parseArgs, stripAnsi} from "./check-coverage";
+import {
+  evaluateCoverage,
+  mergeLcov,
+  parseAllFilesRow,
+  parseArgs,
+  parseLcov,
+  stripAnsi,
+  summarizeLcov,
+} from "./check-coverage";
 
 const ESC = String.fromCharCode(27);
 
@@ -92,5 +100,226 @@ describe("evaluateCoverage", () => {
       {metric: "functions", actual: 80, threshold: 95},
       {metric: "lines", actual: 85, threshold: 95},
     ]);
+  });
+});
+
+const lcovRecord = ({
+  path,
+  functions,
+  lines,
+}: {
+  path: string;
+  functions: Array<{line: number; name: string; hits: number}>;
+  lines: Array<{line: number; hits: number}>;
+}): string => {
+  const sections: string[] = [`SF:${path}`];
+  for (const fn of functions) {
+    sections.push(`FN:${fn.line},${fn.name}`);
+  }
+  for (const fn of functions) {
+    sections.push(`FNDA:${fn.hits},${fn.name}`);
+  }
+  sections.push(`FNF:${functions.length}`);
+  sections.push(`FNH:${functions.filter((f) => f.hits > 0).length}`);
+  for (const ln of lines) {
+    sections.push(`DA:${ln.line},${ln.hits}`);
+  }
+  sections.push(`LF:${lines.length}`);
+  sections.push(`LH:${lines.filter((l) => l.hits > 0).length}`);
+  sections.push("end_of_record");
+  return sections.join("\n");
+};
+
+describe("parseLcov", () => {
+  it("records function names with per-function hit counts", () => {
+    const text = lcovRecord({
+      path: "src/foo.ts",
+      functions: [
+        {line: 1, name: "a", hits: 1},
+        {line: 5, name: "b", hits: 0},
+      ],
+      lines: [
+        {line: 1, hits: 3},
+        {line: 2, hits: 0},
+      ],
+    });
+    const result = parseLcov(text);
+    const entry = result.get("src/foo.ts");
+    expect(entry).toBeDefined();
+    expect(entry?.hasFnRecords).toBe(true);
+    expect(entry?.functions.get("1:a")).toBe(1);
+    expect(entry?.functions.get("5:b")).toBe(0);
+    expect(entry?.lines.get(1)).toBe(3);
+    expect(entry?.lines.get(2)).toBe(0);
+  });
+
+  it("disambiguates multiple FN records that share a name", () => {
+    const text = [
+      "SF:src/bar.ts",
+      "FN:1,<anonymous>",
+      "FN:1,<anonymous>",
+      "FNDA:2,<anonymous>",
+      "FNDA:0,<anonymous>",
+      "end_of_record",
+    ].join("\n");
+    const result = parseLcov(text);
+    const entry = result.get("src/bar.ts");
+    expect(entry).toBeDefined();
+    expect(entry?.functions.size).toBe(2);
+    expect(entry?.functions.get("1:<anonymous>")).toBe(2);
+    expect(entry?.functions.get("1:<anonymous>#2")).toBe(0);
+  });
+
+  it("ignores records without a current file", () => {
+    const result = parseLcov("DA:1,1\nFN:1,orphan\nend_of_record\n");
+    expect(result.size).toBe(0);
+  });
+});
+
+describe("mergeLcov", () => {
+  it("unions per-function hit counts across runs", () => {
+    const a = parseLcov(
+      lcovRecord({
+        path: "src/foo.ts",
+        functions: [
+          {line: 1, name: "one", hits: 1},
+          {line: 5, name: "two", hits: 1},
+          {line: 9, name: "three", hits: 0},
+        ],
+        lines: [{line: 1, hits: 2}],
+      })
+    );
+    const b = parseLcov(
+      lcovRecord({
+        path: "src/foo.ts",
+        functions: [
+          {line: 1, name: "one", hits: 0},
+          {line: 5, name: "two", hits: 0},
+          {line: 9, name: "three", hits: 4},
+        ],
+        lines: [{line: 1, hits: 5}],
+      })
+    );
+    const merged = mergeLcov(new Map(), a);
+    mergeLcov(merged, b);
+    const entry = merged.get("src/foo.ts");
+    expect(entry).toBeDefined();
+    expect(entry?.functions.get("1:one")).toBe(1);
+    expect(entry?.functions.get("5:two")).toBe(1);
+    expect(entry?.functions.get("9:three")).toBe(4);
+    expect(entry?.lines.get(1)).toBe(5);
+  });
+
+  it("copies files from source when target is missing them", () => {
+    const a = parseLcov(
+      lcovRecord({
+        path: "src/a.ts",
+        functions: [{line: 1, name: "fn", hits: 1}],
+        lines: [{line: 1, hits: 1}],
+      })
+    );
+    const b = parseLcov(
+      lcovRecord({
+        path: "src/b.ts",
+        functions: [{line: 1, name: "fn", hits: 1}],
+        lines: [{line: 1, hits: 1}],
+      })
+    );
+    const merged = mergeLcov(new Map(), a);
+    mergeLcov(merged, b);
+    expect(merged.get("src/a.ts")).toBeDefined();
+    expect(merged.get("src/b.ts")).toBeDefined();
+  });
+});
+
+describe("summarizeLcov", () => {
+  it("counts a function as hit once it has non-zero hits in any run", () => {
+    const coverage = parseLcov(
+      lcovRecord({
+        path: "src/foo.ts",
+        functions: [
+          {line: 1, name: "one", hits: 1},
+          {line: 5, name: "two", hits: 0},
+        ],
+        lines: [
+          {line: 1, hits: 1},
+          {line: 2, hits: 0},
+        ],
+      })
+    );
+    expect(summarizeLcov(coverage)).toEqual({functions: 50, lines: 50});
+  });
+
+  it("returns 100 for empty coverage to avoid division by zero", () => {
+    expect(summarizeLcov(new Map())).toEqual({functions: 100, lines: 100});
+  });
+
+  it("merging 1-8 and 6-10 hit sets reports the full union as hit", () => {
+    // Regression test: with FN/FNDA records, merging runs that cover different
+    // subsets of functions in the same file must take the true union, not the
+    // max(FNH) approximation.
+    const runA = parseLcov(
+      lcovRecord({
+        path: "src/file.ts",
+        functions: Array.from({length: 10}, (_, idx) => ({
+          line: idx + 1,
+          name: `fn${idx + 1}`,
+          hits: idx + 1 <= 8 ? 1 : 0,
+        })),
+        lines: [{line: 1, hits: 1}],
+      })
+    );
+    const runB = parseLcov(
+      lcovRecord({
+        path: "src/file.ts",
+        functions: Array.from({length: 10}, (_, idx) => ({
+          line: idx + 1,
+          name: `fn${idx + 1}`,
+          hits: idx + 1 >= 6 ? 1 : 0,
+        })),
+        lines: [{line: 1, hits: 1}],
+      })
+    );
+    const merged = mergeLcov(new Map(), runA);
+    mergeLcov(merged, runB);
+    expect(summarizeLcov(merged)).toEqual({functions: 100, lines: 100});
+  });
+
+  it("falls back to FNF/FNH aggregates when the LCOV producer omits FN records", () => {
+    // Bun 1.3.x emits FNF/FNH but not FN/FNDA. We must still report coverage
+    // in that case, even though we can't compute a true cross-run union.
+    const text = [
+      "SF:src/foo.ts",
+      "FNF:10",
+      "FNH:7",
+      "DA:1,1",
+      "DA:2,0",
+      "end_of_record",
+    ].join("\n");
+    const parsed = parseLcov(text);
+    expect(parsed.get("src/foo.ts")?.hasFnRecords).toBe(false);
+    expect(summarizeLcov(parsed)).toEqual({functions: 70, lines: 50});
+  });
+
+  it("prefers FN/FNDA data over aggregates when both are present in the merge target", () => {
+    // Once a file picks up FN records from any run, summarize should switch to
+    // the per-function path so it reflects the full union.
+    const withFn = parseLcov(
+      lcovRecord({
+        path: "src/foo.ts",
+        functions: [
+          {line: 1, name: "one", hits: 1},
+          {line: 5, name: "two", hits: 1},
+        ],
+        lines: [{line: 1, hits: 1}],
+      })
+    );
+    const aggregateOnly = parseLcov(
+      ["SF:src/foo.ts", "FNF:2", "FNH:0", "DA:1,0", "end_of_record"].join("\n")
+    );
+    const merged = mergeLcov(new Map(), aggregateOnly);
+    mergeLcov(merged, withFn);
+    expect(merged.get("src/foo.ts")?.hasFnRecords).toBe(true);
+    expect(summarizeLcov(merged)).toEqual({functions: 100, lines: 100});
   });
 });

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -1,17 +1,26 @@
 #!/usr/bin/env bun
 /**
- * Runs `bun test --coverage` in the working directory, then parses the
- * "All files" row of the text coverage reporter and fails with a non-zero
- * exit code if either the function or line coverage is below the threshold.
+ * Runs `bun test --coverage` in the working directory and fails with a
+ * non-zero exit code if either the function or line coverage is below the
+ * threshold.
  *
- * Bun's built-in `coverageThreshold` key is not enforced as of Bun 1.3.5,
- * so this script acts as the CI-side gate for the 95% minimum coverage
+ * Bun's built-in `coverageThreshold` key is not enforced as of Bun 1.3.5, so
+ * this script acts as the CI-side gate for the 95% minimum coverage
  * requirement declared in each package's bunfig.toml.
+ *
+ * When the package contains tests in `src/isolated/*.isolated.{ts,tsx}`, each
+ * isolated test file is run in its own `bun test` invocation (because those
+ * tests rely on module-level `mock.module` calls that leak across files and
+ * would otherwise pollute unrelated suites). The resulting LCOV coverage
+ * reports are merged so the reported percentage reflects the union of all
+ * passes.
  *
  * Usage:
  *   bun run ../scripts/check-coverage.ts [--threshold=95]
  */
 import {spawn} from "node:child_process";
+import {existsSync, readFileSync, readdirSync, rmSync} from "node:fs";
+import {join, resolve} from "node:path";
 
 export interface ParsedArgs {
   threshold: number;
@@ -78,9 +87,216 @@ export const evaluateCoverage = (
   return failures;
 };
 
-const runBunTest = async (): Promise<{exitCode: number; output: string}> => {
-  return new Promise((resolve, reject) => {
-    const child = spawn("bun", ["test", "--coverage", "--coverage-reporter=text"], {
+export interface FileCoverage {
+  /** line number -> max observed hit count across runs */
+  lines: Map<number, number>;
+  /**
+   * Per-function hit counts, keyed by `<line>:<name>`. Only populated when the
+   * LCOV producer emits `FN:`/`FNDA:` records. When present, the union of hit
+   * functions across merged runs is exact; when absent (e.g. Bun 1.3.x, which
+   * only writes FNF/FNH aggregates), we fall back to `functionsFound` /
+   * `functionsHit`.
+   */
+  functions: Map<string, number>;
+  /** Max "functions found" across merged runs; fallback when FN records absent. */
+  functionsFound: number;
+  /** Max "functions hit" across merged runs; fallback when FNDA records absent. */
+  functionsHit: number;
+  /** True when at least one merged run emitted FN records for this file. */
+  hasFnRecords: boolean;
+}
+
+const disambiguateKey = (key: string, functions: Map<string, number>): string => {
+  if (!functions.has(key)) {
+    return key;
+  }
+  let suffix = 2;
+  while (functions.has(`${key}#${suffix}`)) {
+    suffix += 1;
+  }
+  return `${key}#${suffix}`;
+};
+
+const createFileCoverage = (): FileCoverage => ({
+  functions: new Map(),
+  functionsFound: 0,
+  functionsHit: 0,
+  hasFnRecords: false,
+  lines: new Map(),
+});
+
+export const parseLcov = (text: string): Map<string, FileCoverage> => {
+  const result = new Map<string, FileCoverage>();
+  let current: FileCoverage | null = null;
+  // FN records come before FNDA. Anonymous functions can share a name, so we
+  // map the printed name -> ordered list of unique keys, and consume them in
+  // order as FNDA records are encountered.
+  let nameToKeys: Map<string, string[]> | null = null;
+  let fndaIndex: Map<string, number> | null = null;
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (line.startsWith("SF:")) {
+      const path = line.slice(3);
+      current = result.get(path) ?? createFileCoverage();
+      result.set(path, current);
+      nameToKeys = new Map();
+      fndaIndex = new Map();
+      continue;
+    }
+    if (!current || !nameToKeys || !fndaIndex) {
+      continue;
+    }
+    if (line.startsWith("DA:")) {
+      const [lineNo, hits] = line.slice(3).split(",").map(Number);
+      if (Number.isFinite(lineNo) && Number.isFinite(hits)) {
+        const prev = current.lines.get(lineNo);
+        if (prev === undefined || hits > prev) {
+          current.lines.set(lineNo, hits);
+        }
+      }
+      continue;
+    }
+    if (line.startsWith("FN:")) {
+      // FN:<line>,<name>
+      const rest = line.slice(3);
+      const commaIndex = rest.indexOf(",");
+      if (commaIndex < 0) {
+        continue;
+      }
+      const lineNo = rest.slice(0, commaIndex);
+      const name = rest.slice(commaIndex + 1);
+      const key = disambiguateKey(`${lineNo}:${name}`, current.functions);
+      current.functions.set(key, current.functions.get(key) ?? 0);
+      current.hasFnRecords = true;
+      const keys = nameToKeys.get(name) ?? [];
+      keys.push(key);
+      nameToKeys.set(name, keys);
+      continue;
+    }
+    if (line.startsWith("FNDA:")) {
+      // FNDA:<hits>,<name>
+      const rest = line.slice(5);
+      const commaIndex = rest.indexOf(",");
+      if (commaIndex < 0) {
+        continue;
+      }
+      const hits = Number(rest.slice(0, commaIndex));
+      const name = rest.slice(commaIndex + 1);
+      if (!Number.isFinite(hits)) {
+        continue;
+      }
+      const keys = nameToKeys.get(name);
+      if (!keys || keys.length === 0) {
+        continue;
+      }
+      const idx = fndaIndex.get(name) ?? 0;
+      const key = keys[Math.min(idx, keys.length - 1)];
+      fndaIndex.set(name, idx + 1);
+      const prev = current.functions.get(key) ?? 0;
+      if (hits > prev) {
+        current.functions.set(key, hits);
+      }
+      continue;
+    }
+    if (line.startsWith("FNF:")) {
+      const n = Number(line.slice(4));
+      if (Number.isFinite(n) && n > current.functionsFound) {
+        current.functionsFound = n;
+      }
+      continue;
+    }
+    if (line.startsWith("FNH:")) {
+      const n = Number(line.slice(4));
+      if (Number.isFinite(n) && n > current.functionsHit) {
+        current.functionsHit = n;
+      }
+      continue;
+    }
+    if (line === "end_of_record") {
+      current = null;
+      nameToKeys = null;
+      fndaIndex = null;
+    }
+  }
+  return result;
+};
+
+export const mergeLcov = (
+  target: Map<string, FileCoverage>,
+  source: Map<string, FileCoverage>
+): Map<string, FileCoverage> => {
+  for (const [path, src] of source.entries()) {
+    const existing = target.get(path);
+    if (!existing) {
+      target.set(path, {
+        functions: new Map(src.functions),
+        functionsFound: src.functionsFound,
+        functionsHit: src.functionsHit,
+        hasFnRecords: src.hasFnRecords,
+        lines: new Map(src.lines),
+      });
+      continue;
+    }
+    for (const [name, hits] of src.functions.entries()) {
+      const prev = existing.functions.get(name) ?? 0;
+      if (hits > prev) {
+        existing.functions.set(name, hits);
+      }
+    }
+    if (src.functionsFound > existing.functionsFound) {
+      existing.functionsFound = src.functionsFound;
+    }
+    if (src.functionsHit > existing.functionsHit) {
+      existing.functionsHit = src.functionsHit;
+    }
+    if (src.hasFnRecords) {
+      existing.hasFnRecords = true;
+    }
+    for (const [lineNo, hits] of src.lines.entries()) {
+      const prev = existing.lines.get(lineNo) ?? 0;
+      if (hits > prev) {
+        existing.lines.set(lineNo, hits);
+      }
+    }
+  }
+  return target;
+};
+
+export const summarizeLcov = (coverage: Map<string, FileCoverage>): CoverageSummary => {
+  let totalLines = 0;
+  let hitLines = 0;
+  let totalFns = 0;
+  let hitFns = 0;
+  for (const entry of coverage.values()) {
+    totalLines += entry.lines.size;
+    for (const hits of entry.lines.values()) {
+      if (hits > 0) {
+        hitLines += 1;
+      }
+    }
+    if (entry.hasFnRecords) {
+      totalFns += entry.functions.size;
+      for (const hits of entry.functions.values()) {
+        if (hits > 0) {
+          hitFns += 1;
+        }
+      }
+    } else {
+      totalFns += entry.functionsFound;
+      hitFns += entry.functionsHit;
+    }
+  }
+  return {
+    functions: totalFns === 0 ? 100 : (hitFns / totalFns) * 100,
+    lines: totalLines === 0 ? 100 : (hitLines / totalLines) * 100,
+  };
+};
+
+const runBunTest = async (
+  args: readonly string[]
+): Promise<{exitCode: number; output: string}> => {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn("bun", ["test", ...args], {
       env: {...process.env, FORCE_COLOR: "0"},
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -95,28 +311,108 @@ const runBunTest = async (): Promise<{exitCode: number; output: string}> => {
       output += text;
       process.stderr.write(text);
     });
-    child.on("error", reject);
+    child.on("error", rejectPromise);
     child.on("close", (code) => {
-      resolve({exitCode: code ?? 1, output});
+      resolvePromise({exitCode: code ?? 1, output});
     });
   });
 };
 
+const findIsolatedFiles = (cwd: string): string[] => {
+  const dir = join(cwd, "src", "isolated");
+  if (!existsSync(dir)) {
+    return [];
+  }
+  return readdirSync(dir)
+    .filter((f) => f.endsWith(".isolated.ts") || f.endsWith(".isolated.tsx"))
+    .map((f) => `./${join("src", "isolated", f)}`)
+    .sort();
+};
+
+const readLcov = (coverageDir: string): Map<string, FileCoverage> => {
+  const lcovPath = join(coverageDir, "lcov.info");
+  if (!existsSync(lcovPath)) {
+    return new Map();
+  }
+  return parseLcov(readFileSync(lcovPath, "utf8"));
+};
+
 const main = async (): Promise<void> => {
   const {threshold} = parseArgs(process.argv.slice(2));
-  const {exitCode, output} = await runBunTest();
+  const cwd = process.cwd();
+  const isolated = findIsolatedFiles(cwd);
 
-  if (exitCode !== 0) {
-    console.error(`\nbun test exited with code ${exitCode}`);
-    process.exit(exitCode);
+  if (isolated.length === 0) {
+    const {exitCode, output} = await runBunTest([
+      "--coverage",
+      "--coverage-reporter=text",
+    ]);
+    if (exitCode !== 0) {
+      console.error(`\nbun test exited with code ${exitCode}`);
+      process.exit(exitCode);
+    }
+    const summary = parseAllFilesRow(output);
+    if (!summary) {
+      console.error('\nCould not find an "All files" row in the coverage output.');
+      process.exit(1);
+    }
+    reportSummary(summary, threshold);
+    return;
   }
 
-  const summary = parseAllFilesRow(output);
-  if (!summary) {
-    console.error('\nCould not find an "All files" row in the coverage output.');
-    process.exit(1);
+  console.info(
+    `\nFound ${isolated.length} isolated test file(s); running separate coverage passes.\n`
+  );
+
+  const mergedCoverage = new Map<string, FileCoverage>();
+  const coverageDirs: string[] = [];
+
+  const mainDir = resolve(cwd, "coverage-main");
+  coverageDirs.push(mainDir);
+  rmSync(mainDir, {force: true, recursive: true});
+
+  const mainRun = await runBunTest([
+    "--coverage",
+    "--coverage-reporter=text",
+    "--coverage-reporter=lcov",
+    `--coverage-dir=${mainDir}`,
+  ]);
+  if (mainRun.exitCode !== 0) {
+    console.error(`\nbun test exited with code ${mainRun.exitCode}`);
+    process.exit(mainRun.exitCode);
+  }
+  mergeLcov(mergedCoverage, readLcov(mainDir));
+
+  for (let index = 0; index < isolated.length; index += 1) {
+    const testFile = isolated[index];
+    const dir = resolve(cwd, `coverage-iso-${index}`);
+    coverageDirs.push(dir);
+    rmSync(dir, {force: true, recursive: true});
+    console.info(`\n--- Isolated coverage pass for ${testFile} ---`);
+    const run = await runBunTest([
+      testFile,
+      "--coverage",
+      "--coverage-reporter=lcov",
+      `--coverage-dir=${dir}`,
+    ]);
+    if (run.exitCode !== 0) {
+      console.error(`\nbun test ${testFile} exited with code ${run.exitCode}`);
+      process.exit(run.exitCode);
+    }
+    mergeLcov(mergedCoverage, readLcov(dir));
   }
 
+  const summary = summarizeLcov(mergedCoverage);
+  reportSummary(summary, threshold);
+
+  if (!process.env.KEEP_COVERAGE) {
+    for (const dir of coverageDirs) {
+      rmSync(dir, {force: true, recursive: true});
+    }
+  }
+};
+
+const reportSummary = (summary: CoverageSummary, threshold: number): void => {
   console.info(
     `\nCoverage summary: functions=${summary.functions.toFixed(2)}%, ` +
       `lines=${summary.lines.toFixed(2)}% (threshold=${threshold}%)`

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -4,7 +4,10 @@
  * non-zero exit code if either the function or line coverage is below the
  * threshold.
  *
- * Bun's built-in `coverageThreshold` key is not enforced as of Bun 1.3.5, so
+ * Bun's built-in `coverageThreshold` key is parsed but does not cause a
+ * non-zero exit when coverage falls below the configured threshold (verified
+ * on Bun 1.3.10). See https://github.com/oven-sh/bun/issues/7367 and the
+ * pending fix in https://github.com/oven-sh/bun/pull/27933. Until that lands,
  * this script acts as the CI-side gate for the 95% minimum coverage
  * requirement declared in each package's bunfig.toml.
  *

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -13,13 +13,13 @@
  */
 import {spawn} from "node:child_process";
 
-interface ParsedArgs {
+export interface ParsedArgs {
   threshold: number;
 }
 
-const parseArgs = (): ParsedArgs => {
+export const parseArgs = (argv: readonly string[]): ParsedArgs => {
   let threshold = 95;
-  for (const arg of process.argv.slice(2)) {
+  for (const arg of argv) {
     const match = arg.match(/^--threshold=(\d+(?:\.\d+)?)$/);
     if (match) {
       threshold = Number(match[1]);
@@ -28,9 +28,55 @@ const parseArgs = (): ParsedArgs => {
   return {threshold};
 };
 
-const stripAnsi = (value: string): string =>
-  // eslint-disable-next-line no-control-regex
-  value.replace(/\u001b\[[0-9;]*m/g, "");
+const ESC = String.fromCharCode(27);
+const ANSI_PATTERN = new RegExp(`${ESC}\\[[0-9;]*m`, "g");
+
+export const stripAnsi = (value: string): string => value.replace(ANSI_PATTERN, "");
+
+export interface CoverageSummary {
+  functions: number;
+  lines: number;
+}
+
+export const parseAllFilesRow = (output: string): CoverageSummary | null => {
+  const cleaned = stripAnsi(output);
+  for (const rawLine of cleaned.split("\n")) {
+    const line = rawLine.trim();
+    if (!line.startsWith("All files")) {
+      continue;
+    }
+    const parts = line.split("|").map((segment) => segment.trim());
+    if (parts.length < 3) {
+      continue;
+    }
+    const functions = Number(parts[1]);
+    const lines = Number(parts[2]);
+    if (Number.isFinite(functions) && Number.isFinite(lines)) {
+      return {functions, lines};
+    }
+  }
+  return null;
+};
+
+export interface CoverageFailure {
+  metric: "functions" | "lines";
+  actual: number;
+  threshold: number;
+}
+
+export const evaluateCoverage = (
+  summary: CoverageSummary,
+  threshold: number
+): CoverageFailure[] => {
+  const failures: CoverageFailure[] = [];
+  if (summary.functions < threshold) {
+    failures.push({metric: "functions", actual: summary.functions, threshold});
+  }
+  if (summary.lines < threshold) {
+    failures.push({metric: "lines", actual: summary.lines, threshold});
+  }
+  return failures;
+};
 
 const runBunTest = async (): Promise<{exitCode: number; output: string}> => {
   return new Promise((resolve, reject) => {
@@ -56,28 +102,8 @@ const runBunTest = async (): Promise<{exitCode: number; output: string}> => {
   });
 };
 
-const parseAllFilesRow = (output: string): {functions: number; lines: number} | null => {
-  const cleaned = stripAnsi(output);
-  for (const rawLine of cleaned.split("\n")) {
-    const line = rawLine.trim();
-    if (!line.startsWith("All files")) {
-      continue;
-    }
-    const parts = line.split("|").map((segment) => segment.trim());
-    if (parts.length < 3) {
-      continue;
-    }
-    const functions = Number(parts[1]);
-    const lines = Number(parts[2]);
-    if (Number.isFinite(functions) && Number.isFinite(lines)) {
-      return {functions, lines};
-    }
-  }
-  return null;
-};
-
 const main = async (): Promise<void> => {
-  const {threshold} = parseArgs();
+  const {threshold} = parseArgs(process.argv.slice(2));
   const {exitCode, output} = await runBunTest();
 
   if (exitCode !== 0) {
@@ -91,26 +117,23 @@ const main = async (): Promise<void> => {
     process.exit(1);
   }
 
-  const {functions, lines} = summary;
   console.info(
-    `\nCoverage summary: functions=${functions.toFixed(2)}%, lines=${lines.toFixed(2)}% ` +
-      `(threshold=${threshold}%)`
+    `\nCoverage summary: functions=${summary.functions.toFixed(2)}%, ` +
+      `lines=${summary.lines.toFixed(2)}% (threshold=${threshold}%)`
   );
 
-  const failures: string[] = [];
-  if (functions < threshold) {
-    failures.push(`functions ${functions.toFixed(2)}% < ${threshold}%`);
-  }
-  if (lines < threshold) {
-    failures.push(`lines ${lines.toFixed(2)}% < ${threshold}%`);
-  }
-
+  const failures = evaluateCoverage(summary, threshold);
   if (failures.length > 0) {
-    console.error(`\nCoverage below threshold: ${failures.join(", ")}`);
+    const message = failures
+      .map((f) => `${f.metric} ${f.actual.toFixed(2)}% < ${f.threshold}%`)
+      .join(", ");
+    console.error(`\nCoverage below threshold: ${message}`);
     process.exit(1);
   }
 
   console.info("Coverage meets the minimum threshold.");
 };
 
-void main();
+if (import.meta.main) {
+  void main();
+}

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env bun
+/**
+ * Runs `bun test --coverage` in the working directory, then parses the
+ * "All files" row of the text coverage reporter and fails with a non-zero
+ * exit code if either the function or line coverage is below the threshold.
+ *
+ * Bun's built-in `coverageThreshold` key is not enforced as of Bun 1.3.5,
+ * so this script acts as the CI-side gate for the 95% minimum coverage
+ * requirement declared in each package's bunfig.toml.
+ *
+ * Usage:
+ *   bun run ../scripts/check-coverage.ts [--threshold=95]
+ */
+import {spawn} from "node:child_process";
+
+interface ParsedArgs {
+  threshold: number;
+}
+
+const parseArgs = (): ParsedArgs => {
+  let threshold = 95;
+  for (const arg of process.argv.slice(2)) {
+    const match = arg.match(/^--threshold=(\d+(?:\.\d+)?)$/);
+    if (match) {
+      threshold = Number(match[1]);
+    }
+  }
+  return {threshold};
+};
+
+const stripAnsi = (value: string): string =>
+  // eslint-disable-next-line no-control-regex
+  value.replace(/\u001b\[[0-9;]*m/g, "");
+
+const runBunTest = async (): Promise<{exitCode: number; output: string}> => {
+  return new Promise((resolve, reject) => {
+    const child = spawn("bun", ["test", "--coverage", "--coverage-reporter=text"], {
+      env: {...process.env, FORCE_COLOR: "0"},
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => {
+      const text = chunk.toString();
+      output += text;
+      process.stdout.write(text);
+    });
+    child.stderr.on("data", (chunk) => {
+      const text = chunk.toString();
+      output += text;
+      process.stderr.write(text);
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({exitCode: code ?? 1, output});
+    });
+  });
+};
+
+const parseAllFilesRow = (output: string): {functions: number; lines: number} | null => {
+  const cleaned = stripAnsi(output);
+  for (const rawLine of cleaned.split("\n")) {
+    const line = rawLine.trim();
+    if (!line.startsWith("All files")) {
+      continue;
+    }
+    const parts = line.split("|").map((segment) => segment.trim());
+    if (parts.length < 3) {
+      continue;
+    }
+    const functions = Number(parts[1]);
+    const lines = Number(parts[2]);
+    if (Number.isFinite(functions) && Number.isFinite(lines)) {
+      return {functions, lines};
+    }
+  }
+  return null;
+};
+
+const main = async (): Promise<void> => {
+  const {threshold} = parseArgs();
+  const {exitCode, output} = await runBunTest();
+
+  if (exitCode !== 0) {
+    console.error(`\nbun test exited with code ${exitCode}`);
+    process.exit(exitCode);
+  }
+
+  const summary = parseAllFilesRow(output);
+  if (!summary) {
+    console.error('\nCould not find an "All files" row in the coverage output.');
+    process.exit(1);
+  }
+
+  const {functions, lines} = summary;
+  console.info(
+    `\nCoverage summary: functions=${functions.toFixed(2)}%, lines=${lines.toFixed(2)}% ` +
+      `(threshold=${threshold}%)`
+  );
+
+  const failures: string[] = [];
+  if (functions < threshold) {
+    failures.push(`functions ${functions.toFixed(2)}% < ${threshold}%`);
+  }
+  if (lines < threshold) {
+    failures.push(`lines ${lines.toFixed(2)}% < ${threshold}%`);
+  }
+
+  if (failures.length > 0) {
+    console.error(`\nCoverage below threshold: ${failures.join(", ")}`);
+    process.exit(1);
+  }
+
+  console.info("Coverage meets the minimum threshold.");
+};
+
+void main();

--- a/ui/bunfig.toml
+++ b/ui/bunfig.toml
@@ -1,11 +1,15 @@
 [test]
 preload = ["./src/bunSetup.ts"]
 root = "./src"
+coverage = true
 coveragePathIgnorePatterns = [
   "dist/**",
   "src/bunSetup.ts",
   "src/test-utils.tsx",
   "**/*.test.ts",
   "**/*.test.tsx",
+  "**/*.stories.{ts,tsx}",
+  "**/node_modules/**",
 ]
+coverageThreshold = { line = 95, function = 95 }
 

--- a/ui/bunfig.toml
+++ b/ui/bunfig.toml
@@ -10,5 +10,8 @@ coveragePathIgnorePatterns = [
   "**/*.stories.{ts,tsx}",
   "**/node_modules/**",
 ]
+# Enforced by scripts/check-coverage.ts; Bun parses this key but does not
+# fail the run when coverage is below threshold. See
+# https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
 coverageThreshold = { line = 95, function = 95 }
 

--- a/ui/bunfig.toml
+++ b/ui/bunfig.toml
@@ -1,7 +1,6 @@
 [test]
 preload = ["./src/bunSetup.ts"]
 root = "./src"
-coverage = true
 coveragePathIgnorePatterns = [
   "dist/**",
   "src/bunSetup.ts",

--- a/ui/package.json
+++ b/ui/package.json
@@ -134,6 +134,7 @@
     "local": "tsc-watch --onSuccess \"cp -a dist/* ../flourish/node_modules/@terreno/ui/dist\"",
     "test": "TZ=America/New_York bun test --watch",
     "test:ci": "TZ=America/New_York bun test",
+    "test:coverage": "TZ=America/New_York bun run ../scripts/check-coverage.ts",
     "types": "bun typedoc"
   },
   "version": "0.10.0"


### PR DESCRIPTION
## Summary

Bun's `coverageThreshold` key in `bunfig.toml` is parsed but not actually enforced as of Bun 1.3.5 — `bun test --coverage` exits 0 even when coverage is below the configured threshold. This PR adds a small wrapper that enforces the minimum at the CI level.

- New `scripts/check-coverage.ts`: runs `bun test --coverage`, parses the "All files" row of the text reporter, and exits non-zero if either function or line coverage is below 95%.
- Every package's `bunfig.toml` now declares `coverageThreshold = { line = 95, function = 95 }` plus a cleaned-up `coveragePathIgnorePatterns` (test files, `dist/**`, vendor, and parent `../**` for packages that share `@terreno/api` test setup).
- Every package's `package.json` gained a `test:coverage` script that invokes the shared check.
- CI workflows for the packages that already meet the threshold now run `bun run test:coverage` instead of `bun run test:ci` so the gate is actually enforced:
  - `api-ci.yml` (95.95% funcs / 96.13% lines)
  - `mcp-server-ci.yml` (98.77% / 97.33%)
  - `rtk-ci.yml` — previously had no test step at all; now runs `test:coverage` (99.35% / 97.12%)
- `api-health/bunfig.toml` is new (the package previously had no bun test config at all); current coverage is 100% / 100%.
- `feature-flags/bunfig.toml` also had its ignore patterns widened so `../api/src/tests/bunSetup.ts` and other preloaded parent files stop counting against coverage; current coverage is 100% / 100%.

Also folded in two small fixes that were blocking the coverage check from running cleanly:

- Refreshed `api/src/__snapshots__/openApi.test.ts.snap` so the pre-existing `gets the openapi.json` / `gets the openapi.json with custom endpoint` tests (failing on master — noted in #463) now pass. The diff only adds the `description` fields that the live OpenAPI generator now emits for `created` / `updated` date-time schemas.
- Fixed two `admin-backend` tests that called `GET /admin/config` without authentication and therefore always 401'd. They now use the existing authenticated `adminAgent` / a fresh `authAsUser(app, "admin")` agent.

The `ui`, `admin-backend`, `admin-frontend`, and `ai` packages are below 95% and will be brought up in follow-up PRs — their bunfig declares the threshold but their CI workflow is intentionally left on `test:ci` in this PR so it doesn't turn red before the tests exist.

### Final coverage on enforced packages

```
api           | funcs 95.95% | lines 96.13%
api-health    | funcs 100.00%| lines 100.00%
mcp-server    | funcs 98.77% | lines 97.33%
rtk           | funcs 99.35% | lines 97.12%
feature-flags | funcs 100.00%| lines 100.00%
```

## Review & Testing Checklist for Human

- [ ] Confirm the approach of a shared `scripts/check-coverage.ts` + per-package `test:coverage` script is acceptable vs. something like a per-package shell snippet.
- [ ] Sanity check the refreshed `api/src/__snapshots__/openApi.test.ts.snap` — the diff is purely additive (`description` fields on `created`/`updated` timestamps), but worth a glance.
- [ ] Confirm you're OK with `rtk-ci.yml` now running tests (it previously only ran lint + build).
- [ ] Confirm you're OK with `ui`, `admin-backend`, `admin-frontend`, and `ai` keeping `test:ci` in CI for now (threshold is declared in their `bunfig.toml`, enforcement flips on in follow-up PRs once coverage reaches 95%).

### Notes

- `coverageThreshold` is left in every `bunfig.toml` even though Bun doesn't enforce it today — it documents intent and will take effect automatically if/when Bun ships runtime enforcement.
- `scripts/check-coverage.ts` accepts `--threshold=<n>` so individual packages can bump their own bar in the future without touching the script.

Link to Devin session: https://app.devin.ai/sessions/0c38d55ba3ec4c398c7956416c9235c1
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new CI gating logic that can cause previously-green pipelines to fail and relies on parsing Bun coverage output/LCOV merging, which could be brittle across Bun versions or reporter format changes.
> 
> **Overview**
> Adds a shared `scripts/check-coverage.ts` runner (with tests) that executes `bun test --coverage` and **fails CI** if function or line coverage drops below a configurable threshold (default **95%**), including special handling to run `src/isolated/*.isolated.*` tests in separate passes and merge LCOV.
> 
> Updates multiple packages to declare `coverageThreshold`/ignore patterns in `bunfig.toml`, adds `test:coverage` scripts, and switches the `api`, `mcp-server`, and `rtk` GitHub Actions workflows to run `test:coverage` (with RTK now running tests in CI). Also updates `.gitignore` to exclude the new temporary coverage directories and refreshes the API OpenAPI snapshot to include `created`/`updated` field descriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f966e9a9fc4e3f151f007fea24f4f81c42411201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->