### PR TITLE
test(ui): raise coverage above 95% for functions and lines

### DIFF
--- a/ui/bunfig.toml
+++ b/ui/bunfig.toml
@@ -1,5 +1,11 @@
 [test]
 preload = ["./src/bunSetup.ts"]
 root = "./src"
-coverageExclude = ["dist/**"]
+coveragePathIgnorePatterns = [
+  "dist/**",
+  "src/bunSetup.ts",
+  "src/test-utils.tsx",
+  "**/*.test.ts",
+  "**/*.test.tsx",
+]
 

--- a/ui/src/ConsentFormScreen.test.tsx
+++ b/ui/src/ConsentFormScreen.test.tsx
@@ -1,0 +1,152 @@
+import {describe, expect, it, mock} from "bun:test";
+import {act, fireEvent} from "@testing-library/react-native";
+
+import {ConsentFormScreen} from "./ConsentFormScreen";
+import {renderWithTheme} from "./test-utils";
+import type {ConsentFormPublic} from "./useConsentForms";
+
+const baseForm: ConsentFormPublic = {
+  active: true,
+  agreeButtonText: "I agree",
+  allowDecline: true,
+  captureSignature: false,
+  checkboxes: [],
+  content: {en: "Consent body", es: "Cuerpo de consentimiento"},
+  declineButtonText: "Decline",
+  defaultLocale: "en",
+  id: "consent-1",
+  order: 0,
+  required: true,
+  requireScrollToBottom: false,
+  slug: "consent",
+  title: "Consent",
+  type: "tos",
+  version: 1,
+};
+
+describe("ConsentFormScreen", () => {
+  it("renders with default state and a locale fallback", () => {
+    const onAgree = mock(() => {});
+    const {getByTestId, getByText} = renderWithTheme(
+      <ConsentFormScreen
+        form={{...baseForm, content: {en: "Hello"}}}
+        locale="fr"
+        onAgree={onAgree}
+      />
+    );
+    expect(getByTestId("consent-form-scroll-view")).toBeTruthy();
+    expect(getByText("I agree")).toBeTruthy();
+  });
+
+  it("substitutes variables in content", () => {
+    const {getByText} = renderWithTheme(
+      <ConsentFormScreen
+        form={{...baseForm, content: {en: "Hello {{name}}, {{missing}} stays"}}}
+        locale="en"
+        onAgree={() => {}}
+        variables={{name: "Ada"}}
+      />
+    );
+    // MarkdownView likely renders text children; fall back to checking testID if not.
+    try {
+      expect(getByText(/Hello Ada/)).toBeTruthy();
+    } catch {
+      // Some environments render markdown differently; the branch still executed.
+    }
+  });
+
+  it("invokes onAgree with signature and checkbox values", () => {
+    const onAgree = mock(() => {});
+    const form: ConsentFormPublic = {
+      ...baseForm,
+      captureSignature: false,
+      checkboxes: [
+        {label: "Required box", required: true},
+        {label: "Optional box", required: false},
+      ],
+    };
+    const {getByTestId} = renderWithTheme(
+      <ConsentFormScreen form={form} locale="en" onAgree={onAgree} />
+    );
+    // Toggle the required checkbox on and the optional one off/on
+    act(() => {
+      fireEvent.press(getByTestId("consent-form-checkbox-0"));
+      fireEvent.press(getByTestId("consent-form-checkbox-1"));
+      fireEvent.press(getByTestId("consent-form-checkbox-1"));
+    });
+    act(() => {
+      fireEvent.press(getByTestId("consent-form-agree-button"));
+    });
+    // Button has a debounce; wait briefly.
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(onAgree).toHaveBeenCalledTimes(1);
+        const call = onAgree.mock.calls[0]?.[0] as {
+          checkboxValues: Record<string, boolean>;
+          signature?: string;
+        };
+        expect(call.checkboxValues["0"]).toBe(true);
+        expect(call.signature).toBeUndefined();
+        resolve();
+      }, 600);
+    });
+  });
+
+  it("opens and confirms the confirmation modal before toggling checkbox on", () => {
+    const form: ConsentFormPublic = {
+      ...baseForm,
+      checkboxes: [{confirmationPrompt: "Really?", label: "Tricky", required: true}],
+    };
+    const {getByTestId, queryByText} = renderWithTheme(
+      <ConsentFormScreen form={form} locale="en" onAgree={() => {}} />
+    );
+    act(() => {
+      fireEvent.press(getByTestId("consent-form-checkbox-0"));
+    });
+    expect(queryByText("Really?")).toBeTruthy();
+  });
+
+  it("fires onDecline when decline is pressed", () => {
+    const onDecline = mock(() => {});
+    const {getByTestId} = renderWithTheme(
+      <ConsentFormScreen form={baseForm} locale="en" onAgree={() => {}} onDecline={onDecline} />
+    );
+    act(() => {
+      fireEvent.press(getByTestId("consent-form-decline-button"));
+    });
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(onDecline).toHaveBeenCalled();
+        resolve();
+      }, 600);
+    });
+  });
+
+  it("fires scroll handlers without crashing", () => {
+    const form = {...baseForm, requireScrollToBottom: true};
+    const {getByTestId} = renderWithTheme(
+      <ConsentFormScreen form={form} locale="en" onAgree={() => {}} />
+    );
+    const scroll = getByTestId("consent-form-scroll-view");
+    act(() => {
+      fireEvent(scroll, "contentSizeChange", 0, 300);
+      fireEvent(scroll, "layout", {nativeEvent: {layout: {height: 400}}});
+      fireEvent(scroll, "scroll", {
+        nativeEvent: {
+          contentOffset: {y: 100},
+          contentSize: {height: 300},
+          layoutMeasurement: {height: 210},
+        },
+      });
+    });
+    expect(scroll).toBeTruthy();
+  });
+
+  it("shows the scroll hint when content is still scrollable", () => {
+    const form = {...baseForm, requireScrollToBottom: true};
+    const {getByTestId} = renderWithTheme(
+      <ConsentFormScreen form={form} locale="en" onAgree={() => {}} />
+    );
+    expect(getByTestId("consent-form-scroll-hint")).toBeTruthy();
+  });
+});

--- a/ui/src/ConsentFormScreen.test.tsx
+++ b/ui/src/ConsentFormScreen.test.tsx
@@ -1,9 +1,26 @@
-import {describe, expect, it, mock} from "bun:test";
+import {afterAll, describe, expect, it, mock} from "bun:test";
 import {act, fireEvent} from "@testing-library/react-native";
+import {Text as RNText} from "react-native";
+
+// Mock MarkdownView with a simple Text passthrough so we can assert on the
+// rendered (variable-substituted) content without depending on
+// react-native-markdown-display's tokenization.
+mock.module("./MarkdownView", () => ({
+  MarkdownView: ({children}: {children: string}) => (
+    <RNText testID="markdown-view">{children}</RNText>
+  ),
+}));
 
 import {ConsentFormScreen} from "./ConsentFormScreen";
 import {renderWithTheme} from "./test-utils";
 import type {ConsentFormPublic} from "./useConsentForms";
+
+// Restore a no-op mock so other tests aren't affected.
+afterAll(() => {
+  mock.module("./MarkdownView", () => ({
+    MarkdownView: mock(() => null),
+  }));
+});
 
 const baseForm: ConsentFormPublic = {
   active: true,
@@ -38,8 +55,8 @@ describe("ConsentFormScreen", () => {
     expect(getByText("I agree")).toBeTruthy();
   });
 
-  it("substitutes variables in content", () => {
-    const {getByText} = renderWithTheme(
+  it("substitutes variables in content and preserves unknown placeholders", () => {
+    const {getByTestId} = renderWithTheme(
       <ConsentFormScreen
         form={{...baseForm, content: {en: "Hello {{name}}, {{missing}} stays"}}}
         locale="en"
@@ -47,12 +64,7 @@ describe("ConsentFormScreen", () => {
         variables={{name: "Ada"}}
       />
     );
-    // MarkdownView likely renders text children; fall back to checking testID if not.
-    try {
-      expect(getByText(/Hello Ada/)).toBeTruthy();
-    } catch {
-      // Some environments render markdown differently; the branch still executed.
-    }
+    expect(getByTestId("markdown-view").props.children).toBe("Hello Ada, {{missing}} stays");
   });
 
   it("invokes onAgree with signature and checkbox values", () => {

--- a/ui/src/ConsentFormScreen.test.tsx
+++ b/ui/src/ConsentFormScreen.test.tsx
@@ -2,6 +2,10 @@ import {afterAll, describe, expect, it, mock} from "bun:test";
 import {act, fireEvent} from "@testing-library/react-native";
 import {Text as RNText} from "react-native";
 
+// Capture the real MarkdownView export before mocking so we can restore it in
+// afterAll and avoid leaking a test-only mock to sibling test files.
+const RealMarkdownViewModule = require("./MarkdownView");
+
 // Mock MarkdownView with a simple Text passthrough so we can assert on the
 // rendered (variable-substituted) content without depending on
 // react-native-markdown-display's tokenization.
@@ -15,11 +19,10 @@ import {ConsentFormScreen} from "./ConsentFormScreen";
 import {renderWithTheme} from "./test-utils";
 import type {ConsentFormPublic} from "./useConsentForms";
 
-// Restore a no-op mock so other tests aren't affected.
+// Restore the real MarkdownView so downstream test files (e.g.
+// MarkdownView.test.tsx) see the un-mocked module regardless of test order.
 afterAll(() => {
-  mock.module("./MarkdownView", () => ({
-    MarkdownView: mock(() => null),
-  }));
+  mock.module("./MarkdownView", () => RealMarkdownViewModule);
 });
 
 const baseForm: ConsentFormPublic = {

--- a/ui/src/EmojiSelector.test.tsx
+++ b/ui/src/EmojiSelector.test.tsx
@@ -213,4 +213,98 @@ describe("EmojiSelector", () => {
     });
     expect(toJSON()).toBeTruthy();
   });
+
+  it("switches categories when a tab is pressed after layout", async () => {
+    const {root, UNSAFE_getAllByType} = renderWithTheme(
+      <EmojiSelector
+        category={Categories.people}
+        columns={6}
+        onEmojiSelected={mock(() => {})}
+        placeholder="Search"
+        showHistory={false}
+        showSearchBar
+        showSectionTitles
+        showTabs
+        theme="#007AFF"
+      />
+    );
+    await act(async () => {
+      (root as any).props.onLayout?.({
+        nativeEvent: {layout: {height: 600, width: 360, x: 0, y: 0}},
+      });
+    });
+    const {TouchableOpacity} = require("react-native");
+    const tabs = UNSAFE_getAllByType(TouchableOpacity);
+    expect(tabs.length).toBeGreaterThan(0);
+    // Press the first tab (e.g., "Smileys & Emotion") to exercise handleTabSelect.
+    await act(async () => {
+      tabs[0].props.onPress?.();
+    });
+  });
+
+  it("invokes onEmojiSelected when an emoji cell is pressed", async () => {
+    const onEmojiSelected = mock(() => {});
+    const {root, UNSAFE_getAllByType} = renderWithTheme(
+      <EmojiSelector
+        category={Categories.emotion}
+        columns={6}
+        onEmojiSelected={onEmojiSelected}
+        placeholder="Search"
+        showHistory
+        showSearchBar={false}
+        showSectionTitles
+        showTabs={false}
+        theme="#007AFF"
+      />
+    );
+    await act(async () => {
+      (root as any).props.onLayout?.({
+        nativeEvent: {layout: {height: 600, width: 360, x: 0, y: 0}},
+      });
+    });
+
+    const {FlatList} = require("react-native");
+    const [list] = UNSAFE_getAllByType(FlatList);
+    expect(list).toBeTruthy();
+    const data = list.props.data ?? [];
+    expect(data.length).toBeGreaterThan(0);
+    const first = data[0];
+    const cell = list.props.renderItem({index: 0, item: first});
+    // Invoke the emoji cell onPress to exercise handleEmojiSelect + addToHistoryAsync.
+    (cell.props as any).onPress?.();
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+    expect(onEmojiSelected).toHaveBeenCalled();
+  });
+
+  it("filters the emoji list when a search query is entered", async () => {
+    const {getByPlaceholderText, UNSAFE_getAllByType, root} = renderWithTheme(
+      <EmojiSelector
+        category={Categories.all}
+        columns={6}
+        onEmojiSelected={mock(() => {})}
+        placeholder="Search emojis"
+        showHistory={false}
+        showSearchBar
+        showSectionTitles
+        showTabs
+        theme="#007AFF"
+      />
+    );
+    await act(async () => {
+      (root as any).props.onLayout?.({
+        nativeEvent: {layout: {height: 600, width: 360, x: 0, y: 0}},
+      });
+    });
+
+    const input = getByPlaceholderText("Search emojis");
+    await act(async () => {
+      fireEvent.changeText(input, "smile");
+    });
+
+    const {FlatList} = require("react-native");
+    const [list] = UNSAFE_getAllByType(FlatList);
+    expect(list.props.data.length).toBeGreaterThan(0);
+  });
 });

--- a/ui/src/EmojiSelector.test.tsx
+++ b/ui/src/EmojiSelector.test.tsx
@@ -4,6 +4,18 @@ import {act, fireEvent} from "@testing-library/react-native";
 import EmojiSelector, {Categories, charFromEmojiObject} from "./EmojiSelector";
 import {renderWithTheme} from "./test-utils";
 
+interface LayoutEvent {
+  nativeEvent: {layout: {height: number; width: number; x: number; y: number}};
+}
+
+interface LayoutRoot {
+  props: {onLayout?: (event: LayoutEvent) => void};
+}
+
+interface RenderItemCell {
+  props: {onPress?: () => void};
+}
+
 describe("EmojiSelector", () => {
   it("renders search bar when showSearchBar is true", () => {
     const {getByPlaceholderText} = renderWithTheme(
@@ -207,7 +219,7 @@ describe("EmojiSelector", () => {
     );
     // Trigger the onLayout callback so state moves to ready.
     await act(async () => {
-      (root as any).props.onLayout?.({
+      (root as LayoutRoot).props.onLayout?.({
         nativeEvent: {layout: {height: 600, width: 360, x: 0, y: 0}},
       });
     });
@@ -229,7 +241,7 @@ describe("EmojiSelector", () => {
       />
     );
     await act(async () => {
-      (root as any).props.onLayout?.({
+      (root as LayoutRoot).props.onLayout?.({
         nativeEvent: {layout: {height: 600, width: 360, x: 0, y: 0}},
       });
     });
@@ -258,7 +270,7 @@ describe("EmojiSelector", () => {
       />
     );
     await act(async () => {
-      (root as any).props.onLayout?.({
+      (root as LayoutRoot).props.onLayout?.({
         nativeEvent: {layout: {height: 600, width: 360, x: 0, y: 0}},
       });
     });
@@ -271,7 +283,7 @@ describe("EmojiSelector", () => {
     const first = data[0];
     const cell = list.props.renderItem({index: 0, item: first});
     // Invoke the emoji cell onPress to exercise handleEmojiSelect + addToHistoryAsync.
-    (cell.props as any).onPress?.();
+    (cell.props as RenderItemCell["props"]).onPress?.();
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 20));
     });
@@ -293,7 +305,7 @@ describe("EmojiSelector", () => {
       />
     );
     await act(async () => {
-      (root as any).props.onLayout?.({
+      (root as LayoutRoot).props.onLayout?.({
         nativeEvent: {layout: {height: 600, width: 360, x: 0, y: 0}},
       });
     });

--- a/ui/src/InfoTooltipButton.test.tsx
+++ b/ui/src/InfoTooltipButton.test.tsx
@@ -1,4 +1,38 @@
-import {describe, expect, it} from "bun:test";
+import {afterAll, describe, expect, it, mock} from "bun:test";
+import {fireEvent} from "@testing-library/react-native";
+import {Pressable, Text as RNText} from "react-native";
+
+// Override the IconButton mock so the inline onClick arrow fires when pressed.
+mock.module("./IconButton", () => ({
+  IconButton: ({
+    accessibilityLabel,
+    accessibilityHint,
+    iconName,
+    onClick,
+    tooltipText,
+  }: {
+    accessibilityLabel?: string;
+    accessibilityHint?: string;
+    iconName: string;
+    onClick?: () => void;
+    tooltipText?: string;
+  }) => (
+    <Pressable
+      accessibilityHint={accessibilityHint}
+      accessibilityLabel={accessibilityLabel}
+      onPress={onClick}
+      testID={`icon-button-${iconName}`}
+    >
+      <RNText>{tooltipText}</RNText>
+    </Pressable>
+  ),
+}));
+
+afterAll(() => {
+  mock.module("./IconButton", () => ({
+    IconButton: mock(() => null),
+  }));
+});
 
 import {InfoTooltipButton} from "./InfoTooltipButton";
 import {renderWithTheme} from "./test-utils";
@@ -29,5 +63,12 @@ describe("InfoTooltipButton", () => {
     expect(() =>
       renderWithTheme(<InfoTooltipButton text="Some details that explain the field" />)
     ).not.toThrow();
+  });
+
+  it("fires the inline onClick handler when the IconButton is pressed", () => {
+    const {getByTestId} = renderWithTheme(
+      <InfoTooltipButton text="Some details that explain the field" />
+    );
+    expect(() => fireEvent.press(getByTestId("icon-button-exclamation"))).not.toThrow();
   });
 });

--- a/ui/src/MobileAddressAutoComplete.test.tsx
+++ b/ui/src/MobileAddressAutoComplete.test.tsx
@@ -8,12 +8,31 @@ import {renderWithTheme} from "./test-utils";
 
 // Capture the props passed to GooglePlacesAutocomplete so we can exercise the inline
 // callbacks (onPress, onFocus, onBlur, onChange, textInputProps, etc.)
-let lastGooglePlacesProps: any = null;
+interface CapturedGooglePlacesProps {
+  placeholder?: string;
+  textInputProps?: {
+    onFocus?: () => void;
+    onBlur?: () => void;
+    onChange?: (event: {nativeEvent: {text: string}}) => void;
+  };
+  onPress?: (
+    data: {description: string},
+    details: {
+      address_components: {
+        long_name: string;
+        short_name: string;
+        types: string[];
+      }[];
+    }
+  ) => void;
+}
+
+let lastGooglePlacesProps: CapturedGooglePlacesProps | null = null;
 const setAddressTextSpy = mock(() => {});
 
 // Mock react-native-google-places-autocomplete
 mock.module("react-native-google-places-autocomplete", () => ({
-  GooglePlacesAutocomplete: forwardRef((props: any, ref) => {
+  GooglePlacesAutocomplete: forwardRef((props: CapturedGooglePlacesProps, ref) => {
     lastGooglePlacesProps = props;
     const innerRef = useRef<any>({});
     useImperativeHandle(ref, () => ({
@@ -114,7 +133,7 @@ describe("MobileAddressAutocomplete", () => {
     );
     fireEvent.press(getByTestId("mock-google-places-select"));
     expect(handleAutoCompleteChange).toHaveBeenCalled();
-    const payload = handleAutoCompleteChange.mock.calls[0][0] as any;
+    const payload = handleAutoCompleteChange.mock.calls[0][0] as {address1?: string};
     expect(payload.address1).toContain("Main St");
     expect(setAddressTextSpy).toHaveBeenCalled();
   });
@@ -129,13 +148,13 @@ describe("MobileAddressAutocomplete", () => {
         inputValue=""
       />
     );
-    const tip = lastGooglePlacesProps.textInputProps;
-    expect(typeof tip.onFocus).toBe("function");
-    expect(typeof tip.onBlur).toBe("function");
-    expect(typeof tip.onChange).toBe("function");
-    tip.onFocus();
-    tip.onBlur();
-    tip.onChange({nativeEvent: {text: "456 Oak Ave"}});
+    const tip = lastGooglePlacesProps?.textInputProps;
+    expect(typeof tip?.onFocus).toBe("function");
+    expect(typeof tip?.onBlur).toBe("function");
+    expect(typeof tip?.onChange).toBe("function");
+    tip?.onFocus?.();
+    tip?.onBlur?.();
+    tip?.onChange?.({nativeEvent: {text: "456 Oak Ave"}});
     expect(handleAddressChange).toHaveBeenCalledWith("456 Oak Ave");
   });
 

--- a/ui/src/MobileAddressAutoComplete.test.tsx
+++ b/ui/src/MobileAddressAutoComplete.test.tsx
@@ -34,7 +34,7 @@ const setAddressTextSpy = mock(() => {});
 mock.module("react-native-google-places-autocomplete", () => ({
   GooglePlacesAutocomplete: forwardRef((props: CapturedGooglePlacesProps, ref) => {
     lastGooglePlacesProps = props;
-    const innerRef = useRef<any>({});
+    const innerRef = useRef<Record<string, unknown>>({});
     useImperativeHandle(ref, () => ({
       setAddressText: setAddressTextSpy,
       ...innerRef.current,

--- a/ui/src/MobileAddressAutoComplete.test.tsx
+++ b/ui/src/MobileAddressAutoComplete.test.tsx
@@ -1,17 +1,60 @@
 import {describe, expect, it, mock} from "bun:test";
-import {forwardRef} from "react";
-import {Text, View} from "react-native";
+import {fireEvent} from "@testing-library/react-native";
+import {forwardRef, useImperativeHandle, useRef} from "react";
+import {Pressable, Text, View} from "react-native";
 
 import {MobileAddressAutocomplete} from "./MobileAddressAutoComplete";
 import {renderWithTheme} from "./test-utils";
 
+// Capture the props passed to GooglePlacesAutocomplete so we can exercise the inline
+// callbacks (onPress, onFocus, onBlur, onChange, textInputProps, etc.)
+let lastGooglePlacesProps: any = null;
+const setAddressTextSpy = mock(() => {});
+
 // Mock react-native-google-places-autocomplete
 mock.module("react-native-google-places-autocomplete", () => ({
-  GooglePlacesAutocomplete: forwardRef(({placeholder}: any, ref) => (
-    <View ref={ref as any} testID="google-places-autocomplete">
-      <Text>{placeholder}</Text>
-    </View>
-  )),
+  GooglePlacesAutocomplete: forwardRef((props: any, ref) => {
+    lastGooglePlacesProps = props;
+    const innerRef = useRef<any>({});
+    useImperativeHandle(ref, () => ({
+      setAddressText: setAddressTextSpy,
+      ...innerRef.current,
+    }));
+    return (
+      <View testID="google-places-autocomplete">
+        <Text>{props.placeholder}</Text>
+        <Pressable
+          onPress={() =>
+            props.onPress?.(
+              {description: "123 Main St"},
+              {
+                address_components: [
+                  {long_name: "123", short_name: "123", types: ["street_number"]},
+                  {long_name: "Main St", short_name: "Main St", types: ["route"]},
+                  {long_name: "San Francisco", short_name: "SF", types: ["locality"]},
+                  {
+                    long_name: "California",
+                    short_name: "CA",
+                    types: ["administrative_area_level_1"],
+                  },
+                  {
+                    long_name: "San Francisco County",
+                    short_name: "SF County",
+                    types: ["administrative_area_level_2"],
+                  },
+                  {long_name: "United States", short_name: "US", types: ["country"]},
+                  {long_name: "94105", short_name: "94105", types: ["postal_code"]},
+                ],
+              }
+            )
+          }
+          testID="mock-google-places-select"
+        >
+          <Text>Select</Text>
+        </Pressable>
+      </View>
+    );
+  }),
 }));
 
 describe("MobileAddressAutocomplete", () => {
@@ -54,5 +97,73 @@ describe("MobileAddressAutocomplete", () => {
       />
     );
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("invokes handleAutoCompleteChange with processed address components", () => {
+    const handleAutoCompleteChange = mock(() => {});
+    const handleAddressChange = mock(() => {});
+    setAddressTextSpy.mockClear();
+    const {getByTestId} = renderWithTheme(
+      <MobileAddressAutocomplete
+        googleMapsApiKey="test-api-key"
+        handleAddressChange={handleAddressChange}
+        handleAutoCompleteChange={handleAutoCompleteChange}
+        includeCounty
+        inputValue=""
+      />
+    );
+    fireEvent.press(getByTestId("mock-google-places-select"));
+    expect(handleAutoCompleteChange).toHaveBeenCalled();
+    const payload = handleAutoCompleteChange.mock.calls[0][0] as any;
+    expect(payload.address1).toContain("Main St");
+    expect(setAddressTextSpy).toHaveBeenCalled();
+  });
+
+  it("fires onFocus, onBlur and onChange via textInputProps callbacks", () => {
+    const handleAddressChange = mock(() => {});
+    renderWithTheme(
+      <MobileAddressAutocomplete
+        googleMapsApiKey="test-api-key"
+        handleAddressChange={handleAddressChange}
+        handleAutoCompleteChange={() => {}}
+        inputValue=""
+      />
+    );
+    const tip = lastGooglePlacesProps.textInputProps;
+    expect(typeof tip.onFocus).toBe("function");
+    expect(typeof tip.onBlur).toBe("function");
+    expect(typeof tip.onChange).toBe("function");
+    tip.onFocus();
+    tip.onBlur();
+    tip.onChange({nativeEvent: {text: "456 Oak Ave"}});
+    expect(handleAddressChange).toHaveBeenCalledWith("456 Oak Ave");
+  });
+
+  it("falls back to the TextField and propagates its onChange without an API key", () => {
+    const handleAddressChange = mock(() => {});
+    const {UNSAFE_root} = renderWithTheme(
+      <MobileAddressAutocomplete
+        handleAddressChange={handleAddressChange}
+        handleAutoCompleteChange={() => {}}
+        inputValue=""
+        testID="mobile-fallback"
+      />
+    );
+    expect(UNSAFE_root).toBeTruthy();
+  });
+
+  it("wrapping TouchableOpacity clears focus when pressed", () => {
+    const {UNSAFE_getAllByType} = renderWithTheme(
+      <MobileAddressAutocomplete
+        googleMapsApiKey="test-api-key"
+        handleAddressChange={() => {}}
+        handleAutoCompleteChange={() => {}}
+        inputValue=""
+      />
+    );
+    const {TouchableOpacity} = require("react-native");
+    const [wrapper] = UNSAFE_getAllByType(TouchableOpacity);
+    expect(wrapper).toBeTruthy();
+    expect(() => wrapper.props.onPress?.()).not.toThrow();
   });
 });

--- a/ui/src/Modal.test.tsx
+++ b/ui/src/Modal.test.tsx
@@ -5,6 +5,16 @@ import {Modal} from "./Modal";
 import {Text} from "./Text";
 import {renderWithTheme} from "./test-utils";
 
+// Minimal shape of a test instance returned by UNSAFE_getAllByType that we rely on here.
+interface PressableTestInstance {
+  props: {
+    style?:
+      | {backgroundColor?: string; cursor?: string}
+      | {backgroundColor?: string; cursor?: string}[];
+    onPress?: (event?: {stopPropagation?: () => void}) => void;
+  };
+}
+
 describe("Modal", () => {
   it("renders correctly when visible", () => {
     const {toJSON} = renderWithTheme(
@@ -301,14 +311,16 @@ describe("Modal", () => {
     );
     // Find the backdrop Pressable (first Pressable in tree with a style that includes backgroundColor).
     const {Pressable} = require("react-native");
-    const pressables = UNSAFE_getAllByType(Pressable);
-    const backdrop = pressables.find((node: any) =>
-      Array.isArray(node.props.style)
-        ? node.props.style.some((s: any) => s?.backgroundColor?.includes?.("rgba"))
-        : node.props.style?.backgroundColor?.includes?.("rgba")
-    );
+    const pressables: PressableTestInstance[] = UNSAFE_getAllByType(Pressable);
+    const backdrop = pressables.find((node) => {
+      const style = node.props.style;
+      if (Array.isArray(style)) {
+        return style.some((s) => s?.backgroundColor?.includes?.("rgba"));
+      }
+      return style?.backgroundColor?.includes?.("rgba");
+    });
     expect(backdrop).toBeTruthy();
-    backdrop.props.onPress?.();
+    backdrop?.props.onPress?.();
     expect(handleDismiss).toHaveBeenCalled();
   });
 
@@ -320,11 +332,11 @@ describe("Modal", () => {
       </Modal>
     );
     const {Pressable} = require("react-native");
-    const pressables = UNSAFE_getAllByType(Pressable);
+    const pressables: PressableTestInstance[] = UNSAFE_getAllByType(Pressable);
     // Inner wrapper is the pressable with style {cursor: "auto"}.
-    const inner = pressables.find((node: any) => node.props.style?.cursor === "auto");
+    const inner = pressables.find((node) => node.props.style?.cursor === "auto");
     expect(inner).toBeTruthy();
-    inner.props.onPress?.({stopPropagation});
+    inner?.props.onPress?.({stopPropagation});
     expect(stopPropagation).toHaveBeenCalled();
   });
 
@@ -336,10 +348,10 @@ describe("Modal", () => {
       </Modal>
     );
     const {Pressable} = require("react-native");
-    const pressables = UNSAFE_getAllByType(Pressable);
-    const inner = pressables.find((node: any) => node.props.style?.cursor === "auto");
+    const pressables: PressableTestInstance[] = UNSAFE_getAllByType(Pressable);
+    const inner = pressables.find((node) => node.props.style?.cursor === "auto");
     expect(inner).toBeTruthy();
-    inner.props.onPress?.({stopPropagation});
+    inner?.props.onPress?.({stopPropagation});
     expect(stopPropagation).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/Modal.test.tsx
+++ b/ui/src/Modal.test.tsx
@@ -291,4 +291,55 @@ describe("Modal", () => {
 
     expect(handleSecondary).toHaveBeenCalled();
   });
+
+  it("dismisses when the backdrop is pressed and persistOnBackgroundClick is false", () => {
+    const handleDismiss = mock(() => {});
+    const {UNSAFE_getAllByType} = renderWithTheme(
+      <Modal onDismiss={handleDismiss} title="Title" visible>
+        <Text>Content</Text>
+      </Modal>
+    );
+    // Find the backdrop Pressable (first Pressable in tree with a style that includes backgroundColor).
+    const {Pressable} = require("react-native");
+    const pressables = UNSAFE_getAllByType(Pressable);
+    const backdrop = pressables.find((node: any) =>
+      Array.isArray(node.props.style)
+        ? node.props.style.some((s: any) => s?.backgroundColor?.includes?.("rgba"))
+        : node.props.style?.backgroundColor?.includes?.("rgba")
+    );
+    expect(backdrop).toBeTruthy();
+    backdrop.props.onPress?.();
+    expect(handleDismiss).toHaveBeenCalled();
+  });
+
+  it("stops propagation on the inner backdrop wrapper press", () => {
+    const stopPropagation = mock(() => {});
+    const {UNSAFE_getAllByType} = renderWithTheme(
+      <Modal onDismiss={() => {}} title="Title" visible>
+        <Text>Content</Text>
+      </Modal>
+    );
+    const {Pressable} = require("react-native");
+    const pressables = UNSAFE_getAllByType(Pressable);
+    // Inner wrapper is the pressable with style {cursor: "auto"}.
+    const inner = pressables.find((node: any) => node.props.style?.cursor === "auto");
+    expect(inner).toBeTruthy();
+    inner.props.onPress?.({stopPropagation});
+    expect(stopPropagation).toHaveBeenCalled();
+  });
+
+  it("does not stop propagation on the inner wrapper when persistOnBackgroundClick is true", () => {
+    const stopPropagation = mock(() => {});
+    const {UNSAFE_getAllByType} = renderWithTheme(
+      <Modal onDismiss={() => {}} persistOnBackgroundClick title="Title" visible>
+        <Text>Content</Text>
+      </Modal>
+    );
+    const {Pressable} = require("react-native");
+    const pressables = UNSAFE_getAllByType(Pressable);
+    const inner = pressables.find((node: any) => node.props.style?.cursor === "auto");
+    expect(inner).toBeTruthy();
+    inner.props.onPress?.({stopPropagation});
+    expect(stopPropagation).not.toHaveBeenCalled();
+  });
 });

--- a/ui/src/Page.test.tsx
+++ b/ui/src/Page.test.tsx
@@ -1,9 +1,48 @@
-import {describe, expect, it, mock} from "bun:test";
+import {afterAll, describe, expect, it, mock} from "bun:test";
 import {act, fireEvent, waitFor} from "@testing-library/react-native";
+import {Pressable, Text as RNText} from "react-native";
+
+// Override the IconButton mock so the inline onClick arrows fire when pressed.
+mock.module("./IconButton", () => ({
+  IconButton: ({
+    accessibilityLabel,
+    accessibilityHint,
+    iconName,
+    onClick,
+  }: {
+    accessibilityLabel?: string;
+    accessibilityHint?: string;
+    iconName: string;
+    onClick?: () => void;
+  }) => (
+    <Pressable
+      accessibilityHint={accessibilityHint}
+      accessibilityLabel={accessibilityLabel}
+      onPress={onClick}
+      testID={`icon-button-${iconName}`}
+    >
+      <RNText>{iconName}</RNText>
+    </Pressable>
+  ),
+}));
+
+const routerBack = mock(() => {});
+mock.module("expo-router", () => ({
+  router: {back: routerBack},
+}));
 
 import {Page} from "./Page";
 import {Text} from "./Text";
 import {renderWithTheme} from "./test-utils";
+
+// Restore the global null IconButton mock after this file finishes so that other
+// test files that expect the bunSetup.ts mock (e.g. IconButton.test.tsx) are not
+// affected by the override above.
+afterAll(() => {
+  mock.module("./IconButton", () => ({
+    IconButton: mock(() => null),
+  }));
+});
 
 describe("Page", () => {
   const mockNavigation = {
@@ -162,5 +201,41 @@ describe("Page", () => {
       </Page>
     );
     expect(getByText("Loading data...")).toBeTruthy();
+  });
+
+  it("invokes router.back when the back button is pressed", () => {
+    routerBack.mockClear();
+    const {getByTestId} = renderWithTheme(
+      <Page backButton navigation={mockNavigation} title="Page">
+        <Text>Content</Text>
+      </Page>
+    );
+    fireEvent.press(getByTestId("icon-button-chevron-left"));
+    expect(routerBack).toHaveBeenCalled();
+  });
+
+  it("invokes router.back when the close button is pressed", () => {
+    routerBack.mockClear();
+    const {getByTestId} = renderWithTheme(
+      <Page closeButton navigation={mockNavigation} title="Page">
+        <Text>Content</Text>
+      </Page>
+    );
+    fireEvent.press(getByTestId("icon-button-xmark"));
+    expect(routerBack).toHaveBeenCalled();
+  });
+
+  it("safely handles a missing rightButtonOnClick callback", async () => {
+    const {getByText} = renderWithTheme(
+      <Page navigation={mockNavigation} rightButton="Go" title="Page">
+        <Text>Content</Text>
+      </Page>
+    );
+    await act(async () => {
+      fireEvent.press(getByText("Go"));
+      await new Promise((resolve) => setTimeout(resolve, 600));
+    });
+    // No crash; the optional-chained call handles the missing prop.
+    expect(getByText("Go")).toBeTruthy();
   });
 });

--- a/ui/src/Page.test.tsx
+++ b/ui/src/Page.test.tsx
@@ -1,5 +1,6 @@
 import {afterAll, describe, expect, it, mock} from "bun:test";
 import {act, fireEvent, waitFor} from "@testing-library/react-native";
+import React, {type ReactNode} from "react";
 import {Pressable, Text as RNText} from "react-native";
 
 // Override the IconButton mock so the inline onClick arrows fire when pressed.
@@ -26,21 +27,68 @@ mock.module("./IconButton", () => ({
   ),
 }));
 
+// Override the expo-router mock so we can observe router.back() calls, but
+// preserve the full shape provided by bunSetup.ts (Link, Stack, Tabs, hooks,
+// and the rest of the router object) so other components that import from
+// "expo-router" don't see `undefined` for those exports.
 const routerBack = mock(() => {});
+interface MockChildrenProps {
+  children?: ReactNode;
+}
 mock.module("expo-router", () => ({
-  router: {back: routerBack},
+  Link: ({children, ...props}: MockChildrenProps) => React.createElement("Link", props, children),
+  router: {
+    back: routerBack,
+    canGoBack: mock(() => true),
+    navigate: mock(() => {}),
+    push: mock(() => {}),
+    replace: mock(() => {}),
+  },
+  Stack: ({children, ...props}: MockChildrenProps) => React.createElement("Stack", props, children),
+  Tabs: ({children, ...props}: MockChildrenProps) => React.createElement("Tabs", props, children),
+  useLocalSearchParams: mock(() => ({})),
+  useRouter: mock(() => ({
+    back: mock(() => {}),
+    canGoBack: mock(() => true),
+    navigate: mock(() => {}),
+    push: mock(() => {}),
+    replace: mock(() => {}),
+  })),
+  useSegments: mock(() => []),
 }));
 
 import {Page} from "./Page";
 import {Text} from "./Text";
 import {renderWithTheme} from "./test-utils";
 
-// Restore the global null IconButton mock after this file finishes so that other
-// test files that expect the bunSetup.ts mock (e.g. IconButton.test.tsx) are not
-// affected by the override above.
+// Restore the global mocks set up by bunSetup.ts after this file finishes so
+// that other test files (e.g. IconButton.test.tsx, ConsentFormScreen.test.tsx)
+// are not affected by the overrides above.
 afterAll(() => {
   mock.module("./IconButton", () => ({
     IconButton: mock(() => null),
+  }));
+  mock.module("expo-router", () => ({
+    Link: ({children, ...props}: MockChildrenProps) => React.createElement("Link", props, children),
+    router: {
+      back: mock(() => {}),
+      canGoBack: mock(() => true),
+      navigate: mock(() => {}),
+      push: mock(() => {}),
+      replace: mock(() => {}),
+    },
+    Stack: ({children, ...props}: MockChildrenProps) =>
+      React.createElement("Stack", props, children),
+    Tabs: ({children, ...props}: MockChildrenProps) => React.createElement("Tabs", props, children),
+    useLocalSearchParams: mock(() => ({})),
+    useRouter: mock(() => ({
+      back: mock(() => {}),
+      canGoBack: mock(() => true),
+      navigate: mock(() => {}),
+      push: mock(() => {}),
+      replace: mock(() => {}),
+    })),
+    useSegments: mock(() => []),
   }));
 });
 

--- a/ui/src/PickerSelect.test.tsx
+++ b/ui/src/PickerSelect.test.tsx
@@ -197,16 +197,19 @@ describe("PickerSelect", () => {
         fireEvent.press(getByTestId("ios_touchable_wrapper"));
       });
       const {TouchableOpacity} = require("react-native");
-      const touchables = UNSAFE_getAllByType(TouchableOpacity).filter(
-        (t: any) => typeof t.props.onPress === "function"
+      interface TouchableTestInstance {
+        props: {onPress?: () => void};
+      }
+      const touchables: TouchableTestInstance[] = UNSAFE_getAllByType(TouchableOpacity).filter(
+        (t: TouchableTestInstance) => typeof t.props.onPress === "function"
       );
       // The accessory view renders an up-arrow TouchableOpacity then a down-arrow one.
       expect(touchables.length).toBeGreaterThanOrEqual(2);
       await act(async () => {
-        touchables[0].props.onPress();
+        touchables[0].props.onPress?.();
       });
       await act(async () => {
-        touchables[1].props.onPress();
+        touchables[1].props.onPress?.();
       });
       expect(onUpArrow).toHaveBeenCalled();
       expect(onDownArrow).toHaveBeenCalled();

--- a/ui/src/PickerSelect.test.tsx
+++ b/ui/src/PickerSelect.test.tsx
@@ -1,4 +1,5 @@
 import {describe, expect, it, mock} from "bun:test";
+import {act, fireEvent} from "@testing-library/react-native";
 
 import {RNPickerSelect} from "./PickerSelect";
 import {renderWithTheme} from "./test-utils";
@@ -157,5 +158,122 @@ describe("PickerSelect", () => {
     const {rerender, toJSON} = renderWithTheme(<RNPickerSelect {...defaultProps} value="1" />);
     rerender(<RNPickerSelect {...defaultProps} value="3" />);
     expect(toJSON()).toBeTruthy();
+  });
+
+  describe("interactions on iOS", () => {
+    it("fires onOpen when the iOS wrapper is pressed and onClose when Done is pressed", async () => {
+      const onOpen = mock(() => {});
+      const onClose = mock(() => {});
+      const onDonePress = mock(() => {});
+      const {getByTestId} = renderWithTheme(
+        <RNPickerSelect
+          {...defaultProps}
+          onClose={onClose}
+          onDonePress={onDonePress}
+          onOpen={onOpen}
+        />
+      );
+
+      await act(async () => {
+        fireEvent.press(getByTestId("ios_touchable_wrapper"));
+      });
+      expect(onOpen).toHaveBeenCalled();
+
+      await act(async () => {
+        fireEvent.press(getByTestId("done_button"));
+      });
+      expect(onClose).toHaveBeenCalled();
+      expect(onDonePress).toHaveBeenCalled();
+    });
+
+    it("invokes up/down arrow callbacks when their touchables are pressed", async () => {
+      const onUpArrow = mock(() => {});
+      const onDownArrow = mock(() => {});
+      const {getByTestId, UNSAFE_getAllByType} = renderWithTheme(
+        <RNPickerSelect {...defaultProps} onDownArrow={onDownArrow} onUpArrow={onUpArrow} />
+      );
+      // Open the modal so the accessory view is rendered.
+      await act(async () => {
+        fireEvent.press(getByTestId("ios_touchable_wrapper"));
+      });
+      const {TouchableOpacity} = require("react-native");
+      const touchables = UNSAFE_getAllByType(TouchableOpacity).filter(
+        (t: any) => typeof t.props.onPress === "function"
+      );
+      // The accessory view renders an up-arrow TouchableOpacity then a down-arrow one.
+      expect(touchables.length).toBeGreaterThanOrEqual(2);
+      await act(async () => {
+        touchables[0].props.onPress();
+      });
+      await act(async () => {
+        touchables[1].props.onPress();
+      });
+      expect(onUpArrow).toHaveBeenCalled();
+      expect(onDownArrow).toHaveBeenCalled();
+    });
+
+    it("toggles the done button press state when pressed in/out", async () => {
+      const {getByTestId} = renderWithTheme(<RNPickerSelect {...defaultProps} />);
+      await act(async () => {
+        fireEvent.press(getByTestId("ios_touchable_wrapper"));
+      });
+      const doneButton = getByTestId("done_button");
+      await act(async () => {
+        fireEvent(doneButton, "pressIn");
+      });
+      await act(async () => {
+        fireEvent(doneButton, "pressOut");
+      });
+    });
+
+    it("does not open when disabled", async () => {
+      const onOpen = mock(() => {});
+      const {getByTestId} = renderWithTheme(
+        <RNPickerSelect {...defaultProps} disabled onOpen={onOpen} />
+      );
+      await act(async () => {
+        fireEvent.press(getByTestId("ios_touchable_wrapper"));
+      });
+      expect(onOpen).not.toHaveBeenCalled();
+    });
+
+    it("calls onValueChange and updates selected item when the Picker emits a change", async () => {
+      const mockOnValueChange = mock(() => {});
+      const {getByTestId} = renderWithTheme(
+        <RNPickerSelect {...defaultProps} onValueChange={mockOnValueChange} />
+      );
+      await act(async () => {
+        fireEvent.press(getByTestId("ios_touchable_wrapper"));
+      });
+      const picker = getByTestId("ios_picker");
+      await act(async () => {
+        picker.props.onValueChange?.("2", 1);
+      });
+      expect(mockOnValueChange).toHaveBeenCalledWith("2", 1);
+    });
+
+    it("updates orientation state when the iOS modal rotates", async () => {
+      const {getByTestId, toJSON} = renderWithTheme(<RNPickerSelect {...defaultProps} />);
+      await act(async () => {
+        fireEvent.press(getByTestId("ios_touchable_wrapper"));
+      });
+      const modal = getByTestId("ios_modal");
+      await act(async () => {
+        modal.props.onOrientationChange?.({nativeEvent: {orientation: "landscape"}});
+      });
+      expect(toJSON()).toBeTruthy();
+    });
+
+    it("closes the modal when the top overlay is pressed", async () => {
+      const onClose = mock(() => {});
+      const {getByTestId} = renderWithTheme(<RNPickerSelect {...defaultProps} onClose={onClose} />);
+      await act(async () => {
+        fireEvent.press(getByTestId("ios_touchable_wrapper"));
+      });
+      await act(async () => {
+        fireEvent.press(getByTestId("ios_modal_top"));
+      });
+      expect(onClose).toHaveBeenCalled();
+    });
   });
 });

--- a/ui/src/SideDrawer.test.tsx
+++ b/ui/src/SideDrawer.test.tsx
@@ -1,10 +1,18 @@
 import {describe, expect, it, mock} from "bun:test";
+import type {ReactNode} from "react";
 import {Pressable, Text as RNText, View} from "react-native";
 
 // Capture the props passed to Drawer so we can exercise the render callbacks.
-let lastDrawerProps: any = null;
+interface CapturedDrawerProps {
+  onOpen?: () => void;
+  onClose?: () => void;
+  renderDrawerContent?: () => ReactNode;
+  children?: ReactNode;
+}
+
+let lastDrawerProps: CapturedDrawerProps | null = null;
 mock.module("react-native-drawer-layout", () => ({
-  Drawer: (props: any) => {
+  Drawer: (props: CapturedDrawerProps) => {
     lastDrawerProps = props;
     return (
       <View testID="mock-drawer">
@@ -131,8 +139,8 @@ describe("SideDrawer", () => {
         <Text>Content</Text>
       </SideDrawer>
     );
-    lastDrawerProps.onOpen();
-    lastDrawerProps.onClose();
+    lastDrawerProps?.onOpen?.();
+    lastDrawerProps?.onClose?.();
     expect(handleOpen).toHaveBeenCalledTimes(1);
     expect(handleClose).toHaveBeenCalledTimes(1);
   });
@@ -153,8 +161,8 @@ describe("SideDrawer", () => {
       </SideDrawer>
     );
     expect(() => {
-      lastDrawerProps.onOpen();
-      lastDrawerProps.onClose();
+      lastDrawerProps?.onOpen?.();
+      lastDrawerProps?.onClose?.();
     }).not.toThrow();
   });
 });

--- a/ui/src/SideDrawer.test.tsx
+++ b/ui/src/SideDrawer.test.tsx
@@ -1,4 +1,25 @@
 import {describe, expect, it, mock} from "bun:test";
+import {Pressable, Text as RNText, View} from "react-native";
+
+// Capture the props passed to Drawer so we can exercise the render callbacks.
+let lastDrawerProps: any = null;
+mock.module("react-native-drawer-layout", () => ({
+  Drawer: (props: any) => {
+    lastDrawerProps = props;
+    return (
+      <View testID="mock-drawer">
+        {props.renderDrawerContent ? props.renderDrawerContent() : null}
+        <Pressable onPress={props.onOpen} testID="mock-drawer-open">
+          <RNText>open</RNText>
+        </Pressable>
+        <Pressable onPress={props.onClose} testID="mock-drawer-close">
+          <RNText>close</RNText>
+        </Pressable>
+        {props.children}
+      </View>
+    );
+  },
+}));
 
 import {SideDrawer} from "./SideDrawer";
 import {Text} from "./Text";
@@ -95,5 +116,45 @@ describe("SideDrawer", () => {
       </SideDrawer>
     );
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("invokes onOpen and onClose when Drawer triggers the callbacks", () => {
+    const handleOpen = mock(() => {});
+    const handleClose = mock(() => {});
+    renderWithTheme(
+      <SideDrawer
+        isOpen
+        onClose={handleClose}
+        onOpen={handleOpen}
+        renderContent={() => <Text>Drawer body</Text>}
+      >
+        <Text>Content</Text>
+      </SideDrawer>
+    );
+    lastDrawerProps.onOpen();
+    lastDrawerProps.onClose();
+    expect(handleOpen).toHaveBeenCalledTimes(1);
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the drawer content via the render callback", () => {
+    const {getByText} = renderWithTheme(
+      <SideDrawer isOpen renderContent={() => <Text>Rendered drawer body</Text>}>
+        <Text>Main</Text>
+      </SideDrawer>
+    );
+    expect(getByText("Rendered drawer body")).toBeTruthy();
+  });
+
+  it("exercises the default no-op callbacks when onOpen/onClose are omitted", () => {
+    renderWithTheme(
+      <SideDrawer isOpen renderContent={() => <Text>Default callbacks</Text>}>
+        <Text>Content</Text>
+      </SideDrawer>
+    );
+    expect(() => {
+      lastDrawerProps.onOpen();
+      lastDrawerProps.onClose();
+    }).not.toThrow();
   });
 });

--- a/ui/src/Slider.test.tsx
+++ b/ui/src/Slider.test.tsx
@@ -244,4 +244,63 @@ describe("Slider", () => {
       expect(toJSON()).toMatchSnapshot();
     });
   });
+
+  describe("advanced branches", () => {
+    it("renders icon-based value mapping when useIcons is true", () => {
+      const mockOnChange = mock(() => {});
+      const {toJSON} = renderWithTheme(
+        <Slider
+          maximumValue={2}
+          minimumValue={0}
+          onChange={mockOnChange}
+          showSelection
+          step={1}
+          useIcons
+          value={1}
+          valueMapping={[
+            {label: "face-frown", size: "md", value: 0},
+            {label: "face-meh", size: "lg", value: 1},
+            {label: "face-smile", size: "xl", value: 2},
+          ]}
+        />
+      );
+      expect(toJSON()).toBeTruthy();
+    });
+
+    it("renders custom labels alongside min and max labels", () => {
+      const mockOnChange = mock(() => {});
+      const {getByText} = renderWithTheme(
+        <Slider
+          labels={{
+            custom: [{label: "Middle", value: 50}],
+            max: "High",
+            min: "Low",
+          }}
+          maximumValue={100}
+          minimumValue={0}
+          onChange={mockOnChange}
+          value={50}
+        />
+      );
+      expect(getByText("Low")).toBeTruthy();
+      expect(getByText("Middle")).toBeTruthy();
+      expect(getByText("High")).toBeTruthy();
+    });
+
+    it("falls back to plain numeric formatter when valueMapping is empty", () => {
+      const mockOnChange = mock(() => {});
+      const {getByText} = renderWithTheme(
+        <Slider
+          maximumValue={10}
+          minimumValue={0}
+          onChange={mockOnChange}
+          showSelection
+          step={1}
+          value={7}
+          valueMapping={[]}
+        />
+      );
+      expect(getByText("7")).toBeTruthy();
+    });
+  });
 });

--- a/ui/src/TerrenoProvider.test.tsx
+++ b/ui/src/TerrenoProvider.test.tsx
@@ -5,14 +5,17 @@ import {Text, View} from "react-native";
 import {TerrenoProvider} from "./TerrenoProvider";
 import {useToast} from "./Toast";
 
+interface RafGlobal {
+  requestAnimationFrame?: (callback: FrameRequestCallback) => number;
+  cancelAnimationFrame?: (id: number) => void;
+}
+
 beforeAll(() => {
-  if (!(global as any).requestAnimationFrame) {
-    (global as any).requestAnimationFrame = (callback: FrameRequestCallback) => {
-      return setTimeout(() => callback(Date.now()), 0) as unknown as number;
-    };
-    (global as any).cancelAnimationFrame = (id: number) => {
-      clearTimeout(id);
-    };
+  const g = globalThis as RafGlobal;
+  if (!g.requestAnimationFrame) {
+    g.requestAnimationFrame = (callback) =>
+      setTimeout(() => callback(Date.now()), 0) as unknown as number;
+    g.cancelAnimationFrame = (id) => clearTimeout(id);
   }
 });
 

--- a/ui/src/TerrenoProvider.test.tsx
+++ b/ui/src/TerrenoProvider.test.tsx
@@ -1,8 +1,20 @@
-import {describe, expect, it} from "bun:test";
-import {render} from "@testing-library/react-native";
+import {beforeAll, describe, expect, it, mock} from "bun:test";
+import {act, render} from "@testing-library/react-native";
 import {Text, View} from "react-native";
 
 import {TerrenoProvider} from "./TerrenoProvider";
+import {useToast} from "./Toast";
+
+beforeAll(() => {
+  if (!(global as any).requestAnimationFrame) {
+    (global as any).requestAnimationFrame = (callback: FrameRequestCallback) => {
+      return setTimeout(() => callback(Date.now()), 0) as unknown as number;
+    };
+    (global as any).cancelAnimationFrame = (id: number) => {
+      clearTimeout(id);
+    };
+  }
+});
 
 describe("TerrenoProvider", () => {
   it("renders children correctly", () => {
@@ -32,5 +44,30 @@ describe("TerrenoProvider", () => {
       </TerrenoProvider>
     );
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("renders a toast via the configured renderToast prop", async () => {
+    const dismissSpy = mock(() => {});
+    let toastApi: ReturnType<typeof useToast> | null = null;
+
+    const ToastCaller = () => {
+      toastApi = useToast();
+      return <Text>App</Text>;
+    };
+
+    const {queryByText} = render(
+      <TerrenoProvider>
+        <ToastCaller />
+      </TerrenoProvider>
+    );
+
+    expect(toastApi).not.toBeNull();
+
+    await act(async () => {
+      toastApi?.info("Hello from toast", {onDismiss: dismissSpy});
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(queryByText("Hello from toast")).toBeTruthy();
   });
 });

--- a/ui/src/Theme.test.tsx
+++ b/ui/src/Theme.test.tsx
@@ -224,5 +224,20 @@ describe("Theme", () => {
       });
       expect(captured?.theme).toBeDefined();
     });
+
+    it("invokes the no-op default context setters when rendered without a provider", () => {
+      let captured: ThemeContextValue | undefined;
+      const Capture = () => {
+        captured = useTheme();
+        return null;
+      };
+      render(<Capture />);
+      // Exercise the default no-op callbacks on the context.
+      expect(() => {
+        captured?.resetTheme();
+        captured?.setPrimitives({neutral000: "#000000"});
+        captured?.setTheme({surface: {base: "neutral000"}});
+      }).not.toThrow();
+    });
   });
 });

--- a/ui/src/UnifiedAddressAutoComplete.test.tsx
+++ b/ui/src/UnifiedAddressAutoComplete.test.tsx
@@ -1,4 +1,6 @@
-import {describe, expect, it} from "bun:test";
+import {describe, expect, it, mock} from "bun:test";
+import {fireEvent} from "@testing-library/react-native";
+
 import {renderWithTheme} from "./test-utils";
 import {UnifiedAddressAutoCompleteField} from "./UnifiedAddressAutoComplete";
 
@@ -50,5 +52,21 @@ describe("UnifiedAddressAutoCompleteField", () => {
       <UnifiedAddressAutoCompleteField {...defaultProps} testID="address-field" />
     );
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("forwards typing to handleAddressChange via the fallback TextField", () => {
+    const handleAddressChange = mock(() => {});
+    const {UNSAFE_getAllByType} = renderWithTheme(
+      <UnifiedAddressAutoCompleteField
+        handleAddressChange={handleAddressChange}
+        handleAutoCompleteChange={() => {}}
+        inputValue=""
+      />
+    );
+    const {TextInput} = require("react-native");
+    const inputs = UNSAFE_getAllByType(TextInput);
+    expect(inputs.length).toBeGreaterThan(0);
+    fireEvent.changeText(inputs[0], "1600 Amphitheatre Pkwy");
+    expect(handleAddressChange).toHaveBeenCalledWith("1600 Amphitheatre Pkwy");
   });
 });

--- a/ui/src/WebAddressAutocomplete.test.tsx
+++ b/ui/src/WebAddressAutocomplete.test.tsx
@@ -51,9 +51,6 @@ describe("WebAddressAutocomplete", () => {
   });
 
   describe("with Google Maps available", () => {
-    const originalWindow = global.window;
-    const originalDocument = global.document;
-
     interface PlaceResult {
       address_components: {
         long_name: string;
@@ -61,6 +58,31 @@ describe("WebAddressAutocomplete", () => {
         types: string[];
       }[];
     }
+
+    interface GoogleMapsWindow {
+      google?: {
+        maps?: {
+          places?: {
+            Autocomplete?: unknown;
+          };
+        };
+      };
+      [key: string]: unknown;
+    }
+
+    interface MinimalDocument {
+      createElement: (tag: string) => HTMLScriptElement;
+      head: {appendChild: (node: unknown) => void};
+    }
+
+    interface TestGlobals {
+      window?: GoogleMapsWindow;
+      document?: MinimalDocument;
+    }
+
+    const testGlobal = globalThis as TestGlobals;
+    const originalWindow = testGlobal.window;
+    const originalDocument = testGlobal.document;
 
     let listeners: Record<string, () => void>;
     let placeResult: PlaceResult | null;
@@ -77,7 +99,7 @@ describe("WebAddressAutocomplete", () => {
         getPlace: () => placeResult,
       }));
 
-      (global as any).window = {
+      testGlobal.window = {
         google: {
           maps: {
             places: {
@@ -86,17 +108,19 @@ describe("WebAddressAutocomplete", () => {
           },
         },
       };
-      (global as any).document = originalDocument ?? {
-        createElement: () => ({}) as HTMLScriptElement,
-        head: {appendChild: () => {}},
-      };
+      testGlobal.document =
+        originalDocument ??
+        ({
+          createElement: () => ({}) as HTMLScriptElement,
+          head: {appendChild: () => {}},
+        } satisfies MinimalDocument);
     });
 
     afterEach(() => {
       // Leave a minimal window so React's effect cleanup (which assigns
       // `window[callbackName] = null`) does not blow up after teardown.
-      (global as any).window = originalWindow ?? {};
-      (global as any).document = originalDocument;
+      testGlobal.window = originalWindow ?? {};
+      testGlobal.document = originalDocument;
     });
 
     it("initializes the Autocomplete and wires up the place_changed listener", async () => {

--- a/ui/src/WebAddressAutocomplete.test.tsx
+++ b/ui/src/WebAddressAutocomplete.test.tsx
@@ -54,8 +54,16 @@ describe("WebAddressAutocomplete", () => {
     const originalWindow = global.window;
     const originalDocument = global.document;
 
+    interface PlaceResult {
+      address_components: {
+        long_name: string;
+        short_name: string;
+        types: string[];
+      }[];
+    }
+
     let listeners: Record<string, () => void>;
-    let placeResult: any;
+    let placeResult: PlaceResult | null;
     let autocompleteConstructor: ReturnType<typeof mock>;
 
     beforeEach(() => {

--- a/ui/src/WebAddressAutocomplete.test.tsx
+++ b/ui/src/WebAddressAutocomplete.test.tsx
@@ -1,4 +1,5 @@
-import {describe, expect, it, mock} from "bun:test";
+import {afterEach, beforeEach, describe, expect, it, mock} from "bun:test";
+import {act, fireEvent} from "@testing-library/react-native";
 
 import type {AddressInterface} from "./Common";
 import {renderWithTheme} from "./test-utils";
@@ -47,5 +48,101 @@ describe("WebAddressAutocomplete", () => {
   it("renders with includeCounty flag", () => {
     const {toJSON} = renderWithTheme(<WebAddressAutocomplete {...defaultProps} includeCounty />);
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  describe("with Google Maps available", () => {
+    const originalWindow = global.window;
+    const originalDocument = global.document;
+
+    let listeners: Record<string, () => void>;
+    let placeResult: any;
+    let autocompleteConstructor: ReturnType<typeof mock>;
+
+    beforeEach(() => {
+      listeners = {};
+      placeResult = null;
+
+      autocompleteConstructor = mock((_input: unknown, _opts: unknown) => ({
+        addListener: (event: string, cb: () => void) => {
+          listeners[event] = cb;
+        },
+        getPlace: () => placeResult,
+      }));
+
+      (global as any).window = {
+        google: {
+          maps: {
+            places: {
+              Autocomplete: autocompleteConstructor,
+            },
+          },
+        },
+      };
+      (global as any).document = originalDocument ?? {
+        createElement: () => ({}) as HTMLScriptElement,
+        head: {appendChild: () => {}},
+      };
+    });
+
+    afterEach(() => {
+      // Leave a minimal window so React's effect cleanup (which assigns
+      // `window[callbackName] = null`) does not blow up after teardown.
+      (global as any).window = originalWindow ?? {};
+      (global as any).document = originalDocument;
+    });
+
+    it("initializes the Autocomplete and wires up the place_changed listener", async () => {
+      const handleAutoCompleteChange = mock((_arg: AddressInterface) => {});
+      renderWithTheme(
+        <WebAddressAutocomplete
+          googleMapsApiKey="test-key"
+          handleAddressChange={() => {}}
+          handleAutoCompleteChange={handleAutoCompleteChange}
+          inputValue=""
+        />
+      );
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(autocompleteConstructor).toHaveBeenCalled();
+      expect(typeof listeners.place_changed).toBe("function");
+
+      // Simulate a selected place.
+      placeResult = {
+        address_components: [
+          {long_name: "5", short_name: "5", types: ["street_number"]},
+          {long_name: "Elm", short_name: "Elm", types: ["route"]},
+          {long_name: "Oakland", short_name: "OAK", types: ["locality"]},
+          {long_name: "California", short_name: "CA", types: ["administrative_area_level_1"]},
+          {long_name: "94601", short_name: "94601", types: ["postal_code"]},
+        ],
+      };
+      listeners.place_changed();
+      expect(handleAutoCompleteChange).toHaveBeenCalled();
+    });
+
+    it("invokes handleAddressChange from the fallback TextField's onChange", async () => {
+      const handleAddressChange = mock(() => {});
+      const {UNSAFE_getAllByType} = renderWithTheme(
+        <WebAddressAutocomplete
+          googleMapsApiKey="test-key"
+          handleAddressChange={handleAddressChange}
+          handleAutoCompleteChange={() => {}}
+          inputValue=""
+        />
+      );
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      const {TextInput} = require("react-native");
+      const inputs = UNSAFE_getAllByType(TextInput);
+      expect(inputs.length).toBeGreaterThan(0);
+      fireEvent.changeText(inputs[0], "321 Pine");
+      expect(handleAddressChange).toHaveBeenCalledWith("321 Pine");
+    });
   });
 });

--- a/ui/src/__snapshots__/InfoTooltipButton.test.tsx.snap
+++ b/ui/src/__snapshots__/InfoTooltipButton.test.tsx.snap
@@ -1,7 +1,76 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`InfoTooltipButton renders correctly with text 1`] = `null`;
+exports[`InfoTooltipButton renders correctly with text 1`] = `
+{
+  "$$typeof": Symbol(react.test.json),
+  "children": [
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        "Help information",
+      ],
+      "props": {
+        "style": undefined,
+      },
+      "type": "Text",
+    },
+  ],
+  "props": {
+    "accessibilityHint": "Show info tooltip",
+    "accessibilityLabel": "info",
+    "onPress": [Function],
+    "testID": "icon-button-exclamation",
+  },
+  "type": "Pressable",
+}
+`;
 
-exports[`InfoTooltipButton renders with different tooltip text 1`] = `null`;
+exports[`InfoTooltipButton renders with different tooltip text 1`] = `
+{
+  "$$typeof": Symbol(react.test.json),
+  "children": [
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        "Click for more details",
+      ],
+      "props": {
+        "style": undefined,
+      },
+      "type": "Text",
+    },
+  ],
+  "props": {
+    "accessibilityHint": "Show info tooltip",
+    "accessibilityLabel": "info",
+    "onPress": [Function],
+    "testID": "icon-button-exclamation",
+  },
+  "type": "Pressable",
+}
+`;
 
-exports[`InfoTooltipButton renders info icon 1`] = `null`;
+exports[`InfoTooltipButton renders info icon 1`] = `
+{
+  "$$typeof": Symbol(react.test.json),
+  "children": [
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        "Tooltip content",
+      ],
+      "props": {
+        "style": undefined,
+      },
+      "type": "Text",
+    },
+  ],
+  "props": {
+    "accessibilityHint": "Show info tooltip",
+    "accessibilityLabel": "info",
+    "onPress": [Function],
+    "testID": "icon-button-exclamation",
+  },
+  "type": "Pressable",
+}
+`;

--- a/ui/src/__snapshots__/MobileAddressAutoComplete.test.tsx.snap
+++ b/ui/src/__snapshots__/MobileAddressAutoComplete.test.tsx.snap
@@ -20,11 +20,28 @@ exports[`MobileAddressAutocomplete renders correctly with Google API key 1`] = `
               },
               "type": "Text",
             },
+            {
+              "$$typeof": Symbol(react.test.json),
+              "children": [
+                {
+                  "$$typeof": Symbol(react.test.json),
+                  "children": [
+                    "Select",
+                  ],
+                  "props": {
+                    "style": undefined,
+                  },
+                  "type": "Text",
+                },
+              ],
+              "props": {
+                "onPress": [Function],
+                "testID": "mock-google-places-select",
+              },
+              "type": "Pressable",
+            },
           ],
           "props": {
-            "ref": {
-              "current": null,
-            },
             "style": undefined,
             "testID": "google-places-autocomplete",
           },
@@ -163,11 +180,28 @@ exports[`MobileAddressAutocomplete renders disabled state 1`] = `
               },
               "type": "Text",
             },
+            {
+              "$$typeof": Symbol(react.test.json),
+              "children": [
+                {
+                  "$$typeof": Symbol(react.test.json),
+                  "children": [
+                    "Select",
+                  ],
+                  "props": {
+                    "style": undefined,
+                  },
+                  "type": "Text",
+                },
+              ],
+              "props": {
+                "onPress": [Function],
+                "testID": "mock-google-places-select",
+              },
+              "type": "Pressable",
+            },
           ],
           "props": {
-            "ref": {
-              "current": null,
-            },
             "style": undefined,
             "testID": "google-places-autocomplete",
           },
@@ -213,11 +247,28 @@ exports[`MobileAddressAutocomplete renders with input value 1`] = `
               },
               "type": "Text",
             },
+            {
+              "$$typeof": Symbol(react.test.json),
+              "children": [
+                {
+                  "$$typeof": Symbol(react.test.json),
+                  "children": [
+                    "Select",
+                  ],
+                  "props": {
+                    "style": undefined,
+                  },
+                  "type": "Text",
+                },
+              ],
+              "props": {
+                "onPress": [Function],
+                "testID": "mock-google-places-select",
+              },
+              "type": "Pressable",
+            },
           ],
           "props": {
-            "ref": {
-              "current": null,
-            },
             "style": undefined,
             "testID": "google-places-autocomplete",
           },

--- a/ui/src/__snapshots__/Page.test.tsx.snap
+++ b/ui/src/__snapshots__/Page.test.tsx.snap
@@ -307,7 +307,30 @@ exports[`Page renders with back button 1`] = `
                   "children": [
                     {
                       "$$typeof": Symbol(react.test.json),
-                      "children": null,
+                      "children": [
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": [
+                            {
+                              "$$typeof": Symbol(react.test.json),
+                              "children": [
+                                "chevron-left",
+                              ],
+                              "props": {
+                                "style": undefined,
+                              },
+                              "type": "Text",
+                            },
+                          ],
+                          "props": {
+                            "accessibilityHint": "Navigate back",
+                            "accessibilityLabel": "",
+                            "onPress": [Function],
+                            "testID": "icon-button-chevron-left",
+                          },
+                          "type": "Pressable",
+                        },
+                      ],
                       "props": {
                         "onPointerEnter": [Function: AsyncFunction],
                         "onPointerLeave": [Function: AsyncFunction],
@@ -496,7 +519,30 @@ exports[`Page renders with close button 1`] = `
                   "children": [
                     {
                       "$$typeof": Symbol(react.test.json),
-                      "children": null,
+                      "children": [
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": [
+                            {
+                              "$$typeof": Symbol(react.test.json),
+                              "children": [
+                                "xmark",
+                              ],
+                              "props": {
+                                "style": undefined,
+                              },
+                              "type": "Text",
+                            },
+                          ],
+                          "props": {
+                            "accessibilityHint": "Close page",
+                            "accessibilityLabel": "",
+                            "onPress": [Function],
+                            "testID": "icon-button-xmark",
+                          },
+                          "type": "Pressable",
+                        },
+                      ],
                       "props": {
                         "onPointerEnter": [Function: AsyncFunction],
                         "onPointerLeave": [Function: AsyncFunction],

--- a/ui/src/__snapshots__/SideDrawer.test.tsx.snap
+++ b/ui/src/__snapshots__/SideDrawer.test.tsx.snap
@@ -13,75 +13,28 @@ exports[`SideDrawer renders correctly when closed 1`] = `
             {
               "$$typeof": Symbol(react.test.json),
               "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Drawer content",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
+                "Drawer content",
               ],
-              "props": {},
-              "type": "View",
+              "props": {
+                "numberOfLines": 0,
+                "selectable": undefined,
+                "style": {
+                  "color": "#1C1C1C",
+                  "fontFamily": "text-regular",
+                  "fontSize": 14,
+                  "textAlign": "left",
+                },
+                "testID": undefined,
+              },
+              "type": "Text",
             },
           ],
           "props": {},
-          "type": "SafeAreaView",
+          "type": "View",
         },
       ],
-      "props": {
-        "ref": {
-          "current": null,
-        },
-        "style": [
-          {
-            "backgroundColor": "white",
-            "bottom": 0,
-            "maxWidth": "100%",
-            "top": 0,
-          },
-          {
-            "position": "absolute",
-            "zIndex": 1,
-          },
-          {
-            "width": "95%",
-          },
-          {
-            "left": "calc(95% * -1)",
-          },
-          {
-            "transform": "translateX(0)",
-            "transition": "transform 0.3s",
-          },
-          [
-            {
-              "borderColor": "gray",
-              "borderWidth": 1,
-              "height": "100%",
-              "width": "95%",
-            },
-            {
-              "backgroundColor": "#D9D9D9",
-            },
-            {},
-            {},
-          ],
-        ],
-        "testID": undefined,
-      },
-      "type": "View",
+      "props": {},
+      "type": "SafeAreaView",
     },
     {
       "$$typeof": Symbol(react.test.json),
@@ -89,118 +42,69 @@ exports[`SideDrawer renders correctly when closed 1`] = `
         {
           "$$typeof": Symbol(react.test.json),
           "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Main content",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
-              ],
-              "props": {},
-              "type": "View",
-            },
+            "open",
           ],
           "props": {
-            "aria-hidden": false,
-            "style": {
-              "flex": 1,
-            },
-            "testID": undefined,
+            "style": undefined,
           },
-          "type": "View",
-        },
-        {
-          "$$typeof": Symbol(react.test.json),
-          "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": null,
-              "props": {
-                "aria-label": "Close drawer",
-                "onPress": [Function],
-                "role": "button",
-                "style": [
-                  {
-                    "flex": 1,
-                  },
-                  {
-                    "pointerEvents": "none",
-                  },
-                ],
-              },
-              "type": "Pressable",
-            },
-          ],
-          "props": {
-            "aria-hidden": true,
-            "progress": FakeSharedValue {
-              "_isReanimatedSharedValue": true,
-              "_listeners": Map {},
-              "_value": 0,
-            },
-            "style": [
-              {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-              {
-                "WebkitTapHighlightColor": "transparent",
-                "backgroundColor": "rgba(0, 0, 0, 0.5)",
-                "transition": "opacity 0.3s",
-              },
-              {
-                "opacity": 0,
-                "pointerEvents": "none",
-              },
-              undefined,
-            ],
-            "testID": undefined,
-          },
-          "type": "View",
+          "type": "Text",
         },
       ],
       "props": {
-        "style": [
-          {
-            "flex": 1,
-          },
-          {
-            "transform": "translateX(0)",
-            "transition": "transform 0.3s",
-          },
-        ],
-        "testID": undefined,
+        "onPress": [Function],
+        "testID": "mock-drawer-open",
       },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "close",
+          ],
+          "props": {
+            "style": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {
+        "onPress": [Function],
+        "testID": "mock-drawer-close",
+      },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "Main content",
+          ],
+          "props": {
+            "numberOfLines": 0,
+            "selectable": undefined,
+            "style": {
+              "color": "#1C1C1C",
+              "fontFamily": "text-regular",
+              "fontSize": 14,
+              "textAlign": "left",
+            },
+            "testID": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {},
       "type": "View",
     },
   ],
   "props": {
-    "style": [
-      {
-        "flex": 1,
-        "flexDirection": "row",
-      },
-      undefined,
-    ],
-    "testID": undefined,
+    "style": undefined,
+    "testID": "mock-drawer",
   },
   "type": "View",
 }
@@ -219,75 +123,28 @@ exports[`SideDrawer renders correctly when open 1`] = `
             {
               "$$typeof": Symbol(react.test.json),
               "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Drawer content",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
+                "Drawer content",
               ],
-              "props": {},
-              "type": "View",
+              "props": {
+                "numberOfLines": 0,
+                "selectable": undefined,
+                "style": {
+                  "color": "#1C1C1C",
+                  "fontFamily": "text-regular",
+                  "fontSize": 14,
+                  "textAlign": "left",
+                },
+                "testID": undefined,
+              },
+              "type": "Text",
             },
           ],
           "props": {},
-          "type": "SafeAreaView",
+          "type": "View",
         },
       ],
-      "props": {
-        "ref": {
-          "current": null,
-        },
-        "style": [
-          {
-            "backgroundColor": "white",
-            "bottom": 0,
-            "maxWidth": "100%",
-            "top": 0,
-          },
-          {
-            "position": "absolute",
-            "zIndex": 1,
-          },
-          {
-            "width": "95%",
-          },
-          {
-            "left": "calc(95% * -1)",
-          },
-          {
-            "transform": "translateX(100%)",
-            "transition": "transform 0.3s",
-          },
-          [
-            {
-              "borderColor": "gray",
-              "borderWidth": 1,
-              "height": "100%",
-              "width": "95%",
-            },
-            {
-              "backgroundColor": "#D9D9D9",
-            },
-            {},
-            {},
-          ],
-        ],
-        "testID": undefined,
-      },
-      "type": "View",
+      "props": {},
+      "type": "SafeAreaView",
     },
     {
       "$$typeof": Symbol(react.test.json),
@@ -295,118 +152,69 @@ exports[`SideDrawer renders correctly when open 1`] = `
         {
           "$$typeof": Symbol(react.test.json),
           "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Main content",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
-              ],
-              "props": {},
-              "type": "View",
-            },
+            "open",
           ],
           "props": {
-            "aria-hidden": true,
-            "style": {
-              "flex": 1,
-            },
-            "testID": undefined,
+            "style": undefined,
           },
-          "type": "View",
-        },
-        {
-          "$$typeof": Symbol(react.test.json),
-          "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": null,
-              "props": {
-                "aria-label": "Close drawer",
-                "onPress": [Function],
-                "role": "button",
-                "style": [
-                  {
-                    "flex": 1,
-                  },
-                  {
-                    "pointerEvents": "auto",
-                  },
-                ],
-              },
-              "type": "Pressable",
-            },
-          ],
-          "props": {
-            "aria-hidden": false,
-            "progress": FakeSharedValue {
-              "_isReanimatedSharedValue": true,
-              "_listeners": Map {},
-              "_value": 1,
-            },
-            "style": [
-              {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-              {
-                "WebkitTapHighlightColor": "transparent",
-                "backgroundColor": "rgba(0, 0, 0, 0.5)",
-                "transition": "opacity 0.3s",
-              },
-              {
-                "opacity": 1,
-                "pointerEvents": "auto",
-              },
-              undefined,
-            ],
-            "testID": undefined,
-          },
-          "type": "View",
+          "type": "Text",
         },
       ],
       "props": {
-        "style": [
-          {
-            "flex": 1,
-          },
-          {
-            "transform": "translateX(0)",
-            "transition": "transform 0.3s",
-          },
-        ],
-        "testID": undefined,
+        "onPress": [Function],
+        "testID": "mock-drawer-open",
       },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "close",
+          ],
+          "props": {
+            "style": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {
+        "onPress": [Function],
+        "testID": "mock-drawer-close",
+      },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "Main content",
+          ],
+          "props": {
+            "numberOfLines": 0,
+            "selectable": undefined,
+            "style": {
+              "color": "#1C1C1C",
+              "fontFamily": "text-regular",
+              "fontSize": 14,
+              "textAlign": "left",
+            },
+            "testID": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {},
       "type": "View",
     },
   ],
   "props": {
-    "style": [
-      {
-        "flex": 1,
-        "flexDirection": "row",
-      },
-      undefined,
-    ],
-    "testID": undefined,
+    "style": undefined,
+    "testID": "mock-drawer",
   },
   "type": "View",
 }
@@ -425,75 +233,28 @@ exports[`SideDrawer renders with left position (default) 1`] = `
             {
               "$$typeof": Symbol(react.test.json),
               "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Left drawer",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
+                "Left drawer",
               ],
-              "props": {},
-              "type": "View",
+              "props": {
+                "numberOfLines": 0,
+                "selectable": undefined,
+                "style": {
+                  "color": "#1C1C1C",
+                  "fontFamily": "text-regular",
+                  "fontSize": 14,
+                  "textAlign": "left",
+                },
+                "testID": undefined,
+              },
+              "type": "Text",
             },
           ],
           "props": {},
-          "type": "SafeAreaView",
+          "type": "View",
         },
       ],
-      "props": {
-        "ref": {
-          "current": null,
-        },
-        "style": [
-          {
-            "backgroundColor": "white",
-            "bottom": 0,
-            "maxWidth": "100%",
-            "top": 0,
-          },
-          {
-            "position": "absolute",
-            "zIndex": 1,
-          },
-          {
-            "width": "95%",
-          },
-          {
-            "left": "calc(95% * -1)",
-          },
-          {
-            "transform": "translateX(100%)",
-            "transition": "transform 0.3s",
-          },
-          [
-            {
-              "borderColor": "gray",
-              "borderWidth": 1,
-              "height": "100%",
-              "width": "95%",
-            },
-            {
-              "backgroundColor": "#D9D9D9",
-            },
-            {},
-            {},
-          ],
-        ],
-        "testID": undefined,
-      },
-      "type": "View",
+      "props": {},
+      "type": "SafeAreaView",
     },
     {
       "$$typeof": Symbol(react.test.json),
@@ -501,118 +262,69 @@ exports[`SideDrawer renders with left position (default) 1`] = `
         {
           "$$typeof": Symbol(react.test.json),
           "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Content",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
-              ],
-              "props": {},
-              "type": "View",
-            },
+            "open",
           ],
           "props": {
-            "aria-hidden": true,
-            "style": {
-              "flex": 1,
-            },
-            "testID": undefined,
+            "style": undefined,
           },
-          "type": "View",
-        },
-        {
-          "$$typeof": Symbol(react.test.json),
-          "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": null,
-              "props": {
-                "aria-label": "Close drawer",
-                "onPress": [Function],
-                "role": "button",
-                "style": [
-                  {
-                    "flex": 1,
-                  },
-                  {
-                    "pointerEvents": "auto",
-                  },
-                ],
-              },
-              "type": "Pressable",
-            },
-          ],
-          "props": {
-            "aria-hidden": false,
-            "progress": FakeSharedValue {
-              "_isReanimatedSharedValue": true,
-              "_listeners": Map {},
-              "_value": 1,
-            },
-            "style": [
-              {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-              {
-                "WebkitTapHighlightColor": "transparent",
-                "backgroundColor": "rgba(0, 0, 0, 0.5)",
-                "transition": "opacity 0.3s",
-              },
-              {
-                "opacity": 1,
-                "pointerEvents": "auto",
-              },
-              undefined,
-            ],
-            "testID": undefined,
-          },
-          "type": "View",
+          "type": "Text",
         },
       ],
       "props": {
-        "style": [
-          {
-            "flex": 1,
-          },
-          {
-            "transform": "translateX(0)",
-            "transition": "transform 0.3s",
-          },
-        ],
-        "testID": undefined,
+        "onPress": [Function],
+        "testID": "mock-drawer-open",
       },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "close",
+          ],
+          "props": {
+            "style": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {
+        "onPress": [Function],
+        "testID": "mock-drawer-close",
+      },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "Content",
+          ],
+          "props": {
+            "numberOfLines": 0,
+            "selectable": undefined,
+            "style": {
+              "color": "#1C1C1C",
+              "fontFamily": "text-regular",
+              "fontSize": 14,
+              "textAlign": "left",
+            },
+            "testID": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {},
       "type": "View",
     },
   ],
   "props": {
-    "style": [
-      {
-        "flex": 1,
-        "flexDirection": "row",
-      },
-      undefined,
-    ],
-    "testID": undefined,
+    "style": undefined,
+    "testID": "mock-drawer",
   },
   "type": "View",
 }
@@ -631,104 +343,28 @@ exports[`SideDrawer renders with right position 1`] = `
             {
               "$$typeof": Symbol(react.test.json),
               "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Content",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
+                "Right drawer",
               ],
-              "props": {},
-              "type": "View",
-            },
-          ],
-          "props": {
-            "aria-hidden": true,
-            "style": {
-              "flex": 1,
-            },
-            "testID": undefined,
-          },
-          "type": "View",
-        },
-        {
-          "$$typeof": Symbol(react.test.json),
-          "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": null,
               "props": {
-                "aria-label": "Close drawer",
-                "onPress": [Function],
-                "role": "button",
-                "style": [
-                  {
-                    "flex": 1,
-                  },
-                  {
-                    "pointerEvents": "auto",
-                  },
-                ],
+                "numberOfLines": 0,
+                "selectable": undefined,
+                "style": {
+                  "color": "#1C1C1C",
+                  "fontFamily": "text-regular",
+                  "fontSize": 14,
+                  "textAlign": "left",
+                },
+                "testID": undefined,
               },
-              "type": "Pressable",
+              "type": "Text",
             },
           ],
-          "props": {
-            "aria-hidden": false,
-            "progress": FakeSharedValue {
-              "_isReanimatedSharedValue": true,
-              "_listeners": Map {},
-              "_value": 1,
-            },
-            "style": [
-              {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-              {
-                "WebkitTapHighlightColor": "transparent",
-                "backgroundColor": "rgba(0, 0, 0, 0.5)",
-                "transition": "opacity 0.3s",
-              },
-              {
-                "opacity": 1,
-                "pointerEvents": "auto",
-              },
-              undefined,
-            ],
-            "testID": undefined,
-          },
+          "props": {},
           "type": "View",
         },
       ],
-      "props": {
-        "style": [
-          {
-            "flex": 1,
-          },
-          {
-            "transform": "translateX(0)",
-            "transition": "transform 0.3s",
-          },
-        ],
-        "testID": undefined,
-      },
-      "type": "View",
+      "props": {},
+      "type": "SafeAreaView",
     },
     {
       "$$typeof": Symbol(react.test.json),
@@ -736,89 +372,69 @@ exports[`SideDrawer renders with right position 1`] = `
         {
           "$$typeof": Symbol(react.test.json),
           "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Right drawer",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
-              ],
-              "props": {},
-              "type": "View",
-            },
+            "open",
           ],
-          "props": {},
-          "type": "SafeAreaView",
+          "props": {
+            "style": undefined,
+          },
+          "type": "Text",
         },
       ],
       "props": {
-        "ref": {
-          "current": null,
-        },
-        "style": [
-          {
-            "backgroundColor": "white",
-            "bottom": 0,
-            "maxWidth": "100%",
-            "top": 0,
-          },
-          {
-            "position": "absolute",
-            "zIndex": 1,
-          },
-          {
-            "width": "95%",
-          },
-          {
-            "right": "calc(95% * -1)",
-          },
-          {
-            "transform": "translateX(-100%)",
-            "transition": "transform 0.3s",
-          },
-          [
-            {
-              "borderColor": "gray",
-              "borderWidth": 1,
-              "height": "100%",
-              "width": "95%",
-            },
-            {
-              "backgroundColor": "#D9D9D9",
-            },
-            {},
-            {},
-          ],
-        ],
-        "testID": undefined,
+        "onPress": [Function],
+        "testID": "mock-drawer-open",
       },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "close",
+          ],
+          "props": {
+            "style": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {
+        "onPress": [Function],
+        "testID": "mock-drawer-close",
+      },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "Content",
+          ],
+          "props": {
+            "numberOfLines": 0,
+            "selectable": undefined,
+            "style": {
+              "color": "#1C1C1C",
+              "fontFamily": "text-regular",
+              "fontSize": 14,
+              "textAlign": "left",
+            },
+            "testID": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {},
       "type": "View",
     },
   ],
   "props": {
-    "style": [
-      {
-        "flex": 1,
-        "flexDirection": "row",
-      },
-      undefined,
-    ],
-    "testID": undefined,
+    "style": undefined,
+    "testID": "mock-drawer",
   },
   "type": "View",
 }
@@ -837,75 +453,28 @@ exports[`SideDrawer renders with front drawer type (default) 1`] = `
             {
               "$$typeof": Symbol(react.test.json),
               "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Front drawer",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
+                "Front drawer",
               ],
-              "props": {},
-              "type": "View",
+              "props": {
+                "numberOfLines": 0,
+                "selectable": undefined,
+                "style": {
+                  "color": "#1C1C1C",
+                  "fontFamily": "text-regular",
+                  "fontSize": 14,
+                  "textAlign": "left",
+                },
+                "testID": undefined,
+              },
+              "type": "Text",
             },
           ],
           "props": {},
-          "type": "SafeAreaView",
+          "type": "View",
         },
       ],
-      "props": {
-        "ref": {
-          "current": null,
-        },
-        "style": [
-          {
-            "backgroundColor": "white",
-            "bottom": 0,
-            "maxWidth": "100%",
-            "top": 0,
-          },
-          {
-            "position": "absolute",
-            "zIndex": 1,
-          },
-          {
-            "width": "95%",
-          },
-          {
-            "left": "calc(95% * -1)",
-          },
-          {
-            "transform": "translateX(100%)",
-            "transition": "transform 0.3s",
-          },
-          [
-            {
-              "borderColor": "gray",
-              "borderWidth": 1,
-              "height": "100%",
-              "width": "95%",
-            },
-            {
-              "backgroundColor": "#D9D9D9",
-            },
-            {},
-            {},
-          ],
-        ],
-        "testID": undefined,
-      },
-      "type": "View",
+      "props": {},
+      "type": "SafeAreaView",
     },
     {
       "$$typeof": Symbol(react.test.json),
@@ -913,118 +482,69 @@ exports[`SideDrawer renders with front drawer type (default) 1`] = `
         {
           "$$typeof": Symbol(react.test.json),
           "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Content",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
-              ],
-              "props": {},
-              "type": "View",
-            },
+            "open",
           ],
           "props": {
-            "aria-hidden": true,
-            "style": {
-              "flex": 1,
-            },
-            "testID": undefined,
+            "style": undefined,
           },
-          "type": "View",
-        },
-        {
-          "$$typeof": Symbol(react.test.json),
-          "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": null,
-              "props": {
-                "aria-label": "Close drawer",
-                "onPress": [Function],
-                "role": "button",
-                "style": [
-                  {
-                    "flex": 1,
-                  },
-                  {
-                    "pointerEvents": "auto",
-                  },
-                ],
-              },
-              "type": "Pressable",
-            },
-          ],
-          "props": {
-            "aria-hidden": false,
-            "progress": FakeSharedValue {
-              "_isReanimatedSharedValue": true,
-              "_listeners": Map {},
-              "_value": 1,
-            },
-            "style": [
-              {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-              {
-                "WebkitTapHighlightColor": "transparent",
-                "backgroundColor": "rgba(0, 0, 0, 0.5)",
-                "transition": "opacity 0.3s",
-              },
-              {
-                "opacity": 1,
-                "pointerEvents": "auto",
-              },
-              undefined,
-            ],
-            "testID": undefined,
-          },
-          "type": "View",
+          "type": "Text",
         },
       ],
       "props": {
-        "style": [
-          {
-            "flex": 1,
-          },
-          {
-            "transform": "translateX(0)",
-            "transition": "transform 0.3s",
-          },
-        ],
-        "testID": undefined,
+        "onPress": [Function],
+        "testID": "mock-drawer-open",
       },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "close",
+          ],
+          "props": {
+            "style": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {
+        "onPress": [Function],
+        "testID": "mock-drawer-close",
+      },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "Content",
+          ],
+          "props": {
+            "numberOfLines": 0,
+            "selectable": undefined,
+            "style": {
+              "color": "#1C1C1C",
+              "fontFamily": "text-regular",
+              "fontSize": 14,
+              "textAlign": "left",
+            },
+            "testID": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {},
       "type": "View",
     },
   ],
   "props": {
-    "style": [
-      {
-        "flex": 1,
-        "flexDirection": "row",
-      },
-      undefined,
-    ],
-    "testID": undefined,
+    "style": undefined,
+    "testID": "mock-drawer",
   },
   "type": "View",
 }
@@ -1043,75 +563,28 @@ exports[`SideDrawer renders with back drawer type 1`] = `
             {
               "$$typeof": Symbol(react.test.json),
               "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Back drawer",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
+                "Back drawer",
               ],
-              "props": {},
-              "type": "View",
+              "props": {
+                "numberOfLines": 0,
+                "selectable": undefined,
+                "style": {
+                  "color": "#1C1C1C",
+                  "fontFamily": "text-regular",
+                  "fontSize": 14,
+                  "textAlign": "left",
+                },
+                "testID": undefined,
+              },
+              "type": "Text",
             },
           ],
           "props": {},
-          "type": "SafeAreaView",
+          "type": "View",
         },
       ],
-      "props": {
-        "ref": {
-          "current": null,
-        },
-        "style": [
-          {
-            "backgroundColor": "white",
-            "bottom": 0,
-            "maxWidth": "100%",
-            "top": 0,
-          },
-          {
-            "position": "absolute",
-            "zIndex": -1,
-          },
-          {
-            "width": "95%",
-          },
-          {
-            "left": "calc(95% * -1)",
-          },
-          {
-            "transform": "translateX(100%)",
-            "transition": "transform 0.3s",
-          },
-          [
-            {
-              "borderColor": "gray",
-              "borderWidth": 1,
-              "height": "100%",
-              "width": "95%",
-            },
-            {
-              "backgroundColor": "#D9D9D9",
-            },
-            {},
-            {},
-          ],
-        ],
-        "testID": undefined,
-      },
-      "type": "View",
+      "props": {},
+      "type": "SafeAreaView",
     },
     {
       "$$typeof": Symbol(react.test.json),
@@ -1119,118 +592,69 @@ exports[`SideDrawer renders with back drawer type 1`] = `
         {
           "$$typeof": Symbol(react.test.json),
           "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Content",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
-              ],
-              "props": {},
-              "type": "View",
-            },
+            "open",
           ],
           "props": {
-            "aria-hidden": true,
-            "style": {
-              "flex": 1,
-            },
-            "testID": undefined,
+            "style": undefined,
           },
-          "type": "View",
-        },
-        {
-          "$$typeof": Symbol(react.test.json),
-          "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": null,
-              "props": {
-                "aria-label": "Close drawer",
-                "onPress": [Function],
-                "role": "button",
-                "style": [
-                  {
-                    "flex": 1,
-                  },
-                  {
-                    "pointerEvents": "auto",
-                  },
-                ],
-              },
-              "type": "Pressable",
-            },
-          ],
-          "props": {
-            "aria-hidden": false,
-            "progress": FakeSharedValue {
-              "_isReanimatedSharedValue": true,
-              "_listeners": Map {},
-              "_value": 1,
-            },
-            "style": [
-              {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-              {
-                "WebkitTapHighlightColor": "transparent",
-                "backgroundColor": "rgba(0, 0, 0, 0.5)",
-                "transition": "opacity 0.3s",
-              },
-              {
-                "opacity": 1,
-                "pointerEvents": "auto",
-              },
-              undefined,
-            ],
-            "testID": undefined,
-          },
-          "type": "View",
+          "type": "Text",
         },
       ],
       "props": {
-        "style": [
-          {
-            "flex": 1,
-          },
-          {
-            "transform": "translateX(calc(95% * 1))",
-            "transition": "transform 0.3s",
-          },
-        ],
-        "testID": undefined,
+        "onPress": [Function],
+        "testID": "mock-drawer-open",
       },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "close",
+          ],
+          "props": {
+            "style": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {
+        "onPress": [Function],
+        "testID": "mock-drawer-close",
+      },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "Content",
+          ],
+          "props": {
+            "numberOfLines": 0,
+            "selectable": undefined,
+            "style": {
+              "color": "#1C1C1C",
+              "fontFamily": "text-regular",
+              "fontSize": 14,
+              "textAlign": "left",
+            },
+            "testID": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {},
       "type": "View",
     },
   ],
   "props": {
-    "style": [
-      {
-        "flex": 1,
-        "flexDirection": "row",
-      },
-      undefined,
-    ],
-    "testID": undefined,
+    "style": undefined,
+    "testID": "mock-drawer",
   },
   "type": "View",
 }
@@ -1249,75 +673,28 @@ exports[`SideDrawer renders with slide drawer type 1`] = `
             {
               "$$typeof": Symbol(react.test.json),
               "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Slide drawer",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
+                "Slide drawer",
               ],
-              "props": {},
-              "type": "View",
+              "props": {
+                "numberOfLines": 0,
+                "selectable": undefined,
+                "style": {
+                  "color": "#1C1C1C",
+                  "fontFamily": "text-regular",
+                  "fontSize": 14,
+                  "textAlign": "left",
+                },
+                "testID": undefined,
+              },
+              "type": "Text",
             },
           ],
           "props": {},
-          "type": "SafeAreaView",
+          "type": "View",
         },
       ],
-      "props": {
-        "ref": {
-          "current": null,
-        },
-        "style": [
-          {
-            "backgroundColor": "white",
-            "bottom": 0,
-            "maxWidth": "100%",
-            "top": 0,
-          },
-          {
-            "position": "absolute",
-            "zIndex": 1,
-          },
-          {
-            "width": "95%",
-          },
-          {
-            "left": "calc(95% * -1)",
-          },
-          {
-            "transform": "translateX(100%)",
-            "transition": "transform 0.3s",
-          },
-          [
-            {
-              "borderColor": "gray",
-              "borderWidth": 1,
-              "height": "100%",
-              "width": "95%",
-            },
-            {
-              "backgroundColor": "#D9D9D9",
-            },
-            {},
-            {},
-          ],
-        ],
-        "testID": undefined,
-      },
-      "type": "View",
+      "props": {},
+      "type": "SafeAreaView",
     },
     {
       "$$typeof": Symbol(react.test.json),
@@ -1325,118 +702,69 @@ exports[`SideDrawer renders with slide drawer type 1`] = `
         {
           "$$typeof": Symbol(react.test.json),
           "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Content",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
-              ],
-              "props": {},
-              "type": "View",
-            },
+            "open",
           ],
           "props": {
-            "aria-hidden": true,
-            "style": {
-              "flex": 1,
-            },
-            "testID": undefined,
+            "style": undefined,
           },
-          "type": "View",
-        },
-        {
-          "$$typeof": Symbol(react.test.json),
-          "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": null,
-              "props": {
-                "aria-label": "Close drawer",
-                "onPress": [Function],
-                "role": "button",
-                "style": [
-                  {
-                    "flex": 1,
-                  },
-                  {
-                    "pointerEvents": "auto",
-                  },
-                ],
-              },
-              "type": "Pressable",
-            },
-          ],
-          "props": {
-            "aria-hidden": false,
-            "progress": FakeSharedValue {
-              "_isReanimatedSharedValue": true,
-              "_listeners": Map {},
-              "_value": 1,
-            },
-            "style": [
-              {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-              {
-                "WebkitTapHighlightColor": "transparent",
-                "backgroundColor": "rgba(0, 0, 0, 0.5)",
-                "transition": "opacity 0.3s",
-              },
-              {
-                "opacity": 1,
-                "pointerEvents": "auto",
-              },
-              undefined,
-            ],
-            "testID": undefined,
-          },
-          "type": "View",
+          "type": "Text",
         },
       ],
       "props": {
-        "style": [
-          {
-            "flex": 1,
-          },
-          {
-            "transform": "translateX(calc(95% * 1))",
-            "transition": "transform 0.3s",
-          },
-        ],
-        "testID": undefined,
+        "onPress": [Function],
+        "testID": "mock-drawer-open",
       },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "close",
+          ],
+          "props": {
+            "style": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {
+        "onPress": [Function],
+        "testID": "mock-drawer-close",
+      },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "Content",
+          ],
+          "props": {
+            "numberOfLines": 0,
+            "selectable": undefined,
+            "style": {
+              "color": "#1C1C1C",
+              "fontFamily": "text-regular",
+              "fontSize": 14,
+              "textAlign": "left",
+            },
+            "testID": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {},
       "type": "View",
     },
   ],
   "props": {
-    "style": [
-      {
-        "flex": 1,
-        "flexDirection": "row",
-      },
-      undefined,
-    ],
-    "testID": undefined,
+    "style": undefined,
+    "testID": "mock-drawer",
   },
   "type": "View",
 }
@@ -1455,77 +783,28 @@ exports[`SideDrawer renders with custom drawer styles 1`] = `
             {
               "$$typeof": Symbol(react.test.json),
               "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Styled drawer",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
+                "Styled drawer",
               ],
-              "props": {},
-              "type": "View",
+              "props": {
+                "numberOfLines": 0,
+                "selectable": undefined,
+                "style": {
+                  "color": "#1C1C1C",
+                  "fontFamily": "text-regular",
+                  "fontSize": 14,
+                  "textAlign": "left",
+                },
+                "testID": undefined,
+              },
+              "type": "Text",
             },
           ],
           "props": {},
-          "type": "SafeAreaView",
+          "type": "View",
         },
       ],
-      "props": {
-        "ref": {
-          "current": null,
-        },
-        "style": [
-          {
-            "backgroundColor": "white",
-            "bottom": 0,
-            "maxWidth": "100%",
-            "top": 0,
-          },
-          {
-            "position": "absolute",
-            "zIndex": 1,
-          },
-          {
-            "width": "50%",
-          },
-          {
-            "left": "calc(50% * -1)",
-          },
-          {
-            "transform": "translateX(100%)",
-            "transition": "transform 0.3s",
-          },
-          [
-            {
-              "borderColor": "gray",
-              "borderWidth": 1,
-              "height": "100%",
-              "width": "95%",
-            },
-            {
-              "backgroundColor": "#D9D9D9",
-            },
-            {
-              "width": "50%",
-            },
-            {},
-          ],
-        ],
-        "testID": undefined,
-      },
-      "type": "View",
+      "props": {},
+      "type": "SafeAreaView",
     },
     {
       "$$typeof": Symbol(react.test.json),
@@ -1533,118 +812,69 @@ exports[`SideDrawer renders with custom drawer styles 1`] = `
         {
           "$$typeof": Symbol(react.test.json),
           "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Content",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
-              ],
-              "props": {},
-              "type": "View",
-            },
+            "open",
           ],
           "props": {
-            "aria-hidden": true,
-            "style": {
-              "flex": 1,
-            },
-            "testID": undefined,
+            "style": undefined,
           },
-          "type": "View",
-        },
-        {
-          "$$typeof": Symbol(react.test.json),
-          "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": null,
-              "props": {
-                "aria-label": "Close drawer",
-                "onPress": [Function],
-                "role": "button",
-                "style": [
-                  {
-                    "flex": 1,
-                  },
-                  {
-                    "pointerEvents": "auto",
-                  },
-                ],
-              },
-              "type": "Pressable",
-            },
-          ],
-          "props": {
-            "aria-hidden": false,
-            "progress": FakeSharedValue {
-              "_isReanimatedSharedValue": true,
-              "_listeners": Map {},
-              "_value": 1,
-            },
-            "style": [
-              {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-              {
-                "WebkitTapHighlightColor": "transparent",
-                "backgroundColor": "rgba(0, 0, 0, 0.5)",
-                "transition": "opacity 0.3s",
-              },
-              {
-                "opacity": 1,
-                "pointerEvents": "auto",
-              },
-              undefined,
-            ],
-            "testID": undefined,
-          },
-          "type": "View",
+          "type": "Text",
         },
       ],
       "props": {
-        "style": [
-          {
-            "flex": 1,
-          },
-          {
-            "transform": "translateX(0)",
-            "transition": "transform 0.3s",
-          },
-        ],
-        "testID": undefined,
+        "onPress": [Function],
+        "testID": "mock-drawer-open",
       },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "close",
+          ],
+          "props": {
+            "style": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {
+        "onPress": [Function],
+        "testID": "mock-drawer-close",
+      },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "Content",
+          ],
+          "props": {
+            "numberOfLines": 0,
+            "selectable": undefined,
+            "style": {
+              "color": "#1C1C1C",
+              "fontFamily": "text-regular",
+              "fontSize": 14,
+              "textAlign": "left",
+            },
+            "testID": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {},
       "type": "View",
     },
   ],
   "props": {
-    "style": [
-      {
-        "flex": 1,
-        "flexDirection": "row",
-      },
-      undefined,
-    ],
-    "testID": undefined,
+    "style": undefined,
+    "testID": "mock-drawer",
   },
   "type": "View",
 }
@@ -1663,75 +893,28 @@ exports[`SideDrawer accepts onOpen and onClose callbacks 1`] = `
             {
               "$$typeof": Symbol(react.test.json),
               "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Drawer",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
+                "Drawer",
               ],
-              "props": {},
-              "type": "View",
+              "props": {
+                "numberOfLines": 0,
+                "selectable": undefined,
+                "style": {
+                  "color": "#1C1C1C",
+                  "fontFamily": "text-regular",
+                  "fontSize": 14,
+                  "textAlign": "left",
+                },
+                "testID": undefined,
+              },
+              "type": "Text",
             },
           ],
           "props": {},
-          "type": "SafeAreaView",
+          "type": "View",
         },
       ],
-      "props": {
-        "ref": {
-          "current": null,
-        },
-        "style": [
-          {
-            "backgroundColor": "white",
-            "bottom": 0,
-            "maxWidth": "100%",
-            "top": 0,
-          },
-          {
-            "position": "absolute",
-            "zIndex": 1,
-          },
-          {
-            "width": "95%",
-          },
-          {
-            "left": "calc(95% * -1)",
-          },
-          {
-            "transform": "translateX(0)",
-            "transition": "transform 0.3s",
-          },
-          [
-            {
-              "borderColor": "gray",
-              "borderWidth": 1,
-              "height": "100%",
-              "width": "95%",
-            },
-            {
-              "backgroundColor": "#D9D9D9",
-            },
-            {},
-            {},
-          ],
-        ],
-        "testID": undefined,
-      },
-      "type": "View",
+      "props": {},
+      "type": "SafeAreaView",
     },
     {
       "$$typeof": Symbol(react.test.json),
@@ -1739,118 +922,69 @@ exports[`SideDrawer accepts onOpen and onClose callbacks 1`] = `
         {
           "$$typeof": Symbol(react.test.json),
           "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    "Content",
-                  ],
-                  "props": {
-                    "numberOfLines": 0,
-                    "selectable": undefined,
-                    "style": {
-                      "color": "#1C1C1C",
-                      "fontFamily": "text-regular",
-                      "fontSize": 14,
-                      "textAlign": "left",
-                    },
-                    "testID": undefined,
-                  },
-                  "type": "Text",
-                },
-              ],
-              "props": {},
-              "type": "View",
-            },
+            "open",
           ],
           "props": {
-            "aria-hidden": false,
-            "style": {
-              "flex": 1,
-            },
-            "testID": undefined,
+            "style": undefined,
           },
-          "type": "View",
-        },
-        {
-          "$$typeof": Symbol(react.test.json),
-          "children": [
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": null,
-              "props": {
-                "aria-label": "Close drawer",
-                "onPress": [Function],
-                "role": "button",
-                "style": [
-                  {
-                    "flex": 1,
-                  },
-                  {
-                    "pointerEvents": "none",
-                  },
-                ],
-              },
-              "type": "Pressable",
-            },
-          ],
-          "props": {
-            "aria-hidden": true,
-            "progress": FakeSharedValue {
-              "_isReanimatedSharedValue": true,
-              "_listeners": Map {},
-              "_value": 0,
-            },
-            "style": [
-              {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-              {
-                "WebkitTapHighlightColor": "transparent",
-                "backgroundColor": "rgba(0, 0, 0, 0.5)",
-                "transition": "opacity 0.3s",
-              },
-              {
-                "opacity": 0,
-                "pointerEvents": "none",
-              },
-              undefined,
-            ],
-            "testID": undefined,
-          },
-          "type": "View",
+          "type": "Text",
         },
       ],
       "props": {
-        "style": [
-          {
-            "flex": 1,
-          },
-          {
-            "transform": "translateX(0)",
-            "transition": "transform 0.3s",
-          },
-        ],
-        "testID": undefined,
+        "onPress": [class Function],
+        "testID": "mock-drawer-open",
       },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "close",
+          ],
+          "props": {
+            "style": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {
+        "onPress": [class Function],
+        "testID": "mock-drawer-close",
+      },
+      "type": "Pressable",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "Content",
+          ],
+          "props": {
+            "numberOfLines": 0,
+            "selectable": undefined,
+            "style": {
+              "color": "#1C1C1C",
+              "fontFamily": "text-regular",
+              "fontSize": 14,
+              "textAlign": "left",
+            },
+            "testID": undefined,
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {},
       "type": "View",
     },
   ],
   "props": {
-    "style": [
-      {
-        "flex": 1,
-        "flexDirection": "row",
-      },
-      undefined,
-    ],
-    "testID": undefined,
+    "style": undefined,
+    "testID": "mock-drawer",
   },
   "type": "View",
 }


### PR DESCRIPTION
## Summary

Adds tests across `@terreno/ui` to push the package above 95% coverage on both **functions** (95.16%) and **lines** (95.97%), up from the previous ~92.68% / ~94.82%.

Key changes:

- `ui/bunfig.toml` — switch from the (now removed) `coverageExclude` key to `coveragePathIgnorePatterns`, and exclude test setup/utilities and the `*.test.ts(x)` files themselves so coverage reflects real source code only.
- New / expanded test files (tests only — no component source changes):
  - `ConsentFormScreen.test.tsx` (new)
  - `EmojiSelector.test.tsx` — category switching, emoji selection, search filtering
  - `InfoTooltipButton.test.tsx` — press-interaction coverage via a scoped `IconButton` mock override (restored via `afterAll`)
  - `MobileAddressAutoComplete.test.tsx` / `WebAddressAutocomplete.test.tsx` / `UnifiedAddressAutoComplete.test.tsx` — exercise handlers and fallback TextField
  - `Modal.test.tsx`, `Page.test.tsx`, `SideDrawer.test.tsx`, `TerrenoProvider.test.tsx`, `Theme.test.tsx` — additional interaction and branch coverage
  - `PickerSelect.test.tsx` — iOS open/close/done, up/down arrows, orientation change, disabled, value change
  - `Slider.test.tsx` — icon mapping, custom labels, numeric formatter fallback

- `Page.test.tsx` installs a functional `IconButton` mock to exercise callbacks, and now restores the global `null` `IconButton` mock via `afterAll` so downstream test files (`IconButton.test.tsx`, `TableIconButton.test.tsx`, `TableRow.test.tsx`) are not affected.
- Snapshot files updated to reflect the functional mocks introduced in affected tests.

Result: `TZ=America/New_York bun test` — 1301 pass, 0 fail, 496 snapshots; `bun test --coverage` reports **95.16% functions / 95.97% lines** for the `ui` package. `bun run lint` is clean for `@terreno/ui` (unrelated lint errors exist in `@terreno/admin-backend` on `master`).

## Review & Testing Checklist for Human

- [ ] Sanity-check the `Page.test.tsx` / `InfoTooltipButton.test.tsx` pattern of overriding `IconButton` via `mock.module(...)` and restoring it in `afterAll`; confirm no other test file unintentionally relies on the overridden behavior.
- [ ] Confirm the new `coveragePathIgnorePatterns` excludes in `ui/bunfig.toml` match what you want reported in CI coverage (dist, `bunSetup.ts`, `test-utils.tsx`, and `*.test.ts(x)`).
- [ ] Run `cd ui && TZ=America/New_York bun test --coverage --coverage-reporter=text` locally and verify both functions and lines remain ≥ 95%.

### Notes

- No component/implementation source code was modified; only tests, snapshots, and the coverage config in `ui/bunfig.toml`.
- The remaining `@terreno/admin-backend` lint errors observed while running the monorepo-wide `bun run lint` are pre-existing on `master` and outside the scope of this PR.


Link to Devin session: https://app.devin.ai/sessions/fa33a21b66e94018b1a579a7bd964f97
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test code, snapshots, and Bun coverage configuration with no production runtime logic modified.
> 
> **Overview**
> Updates Bun test coverage configuration by replacing `coverageExclude` with `coveragePathIgnorePatterns` to ignore build output, test setup/utilities, and `*.test.ts(x)` files in coverage reporting.
> 
> Adds and expands UI component tests to cover more interaction and branch paths (e.g., consent form flows, emoji selection/search, address autocomplete behaviors, modal backdrop handling, page navigation buttons, picker iOS interactions, side drawer callbacks, slider value-mapping branches, theme/toast no-op paths), and refreshes snapshots impacted by more functional test mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ee68b8c094625e059fe54eacc3626ec2eddbe88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->