### PR TITLE
Render custom dropdown on web instead of native &lt;select&gt;

### DIFF
--- a/ui/src/PickerSelect.tsx
+++ b/ui/src/PickerSelect.tsx
@@ -553,6 +553,9 @@ export function RNPickerSelect({
     }
   };
 
+  // Build the dropdown option list AND track each option's original index in
+  // `options` so `onValueChange` receives the same index that the native
+  // Picker would have reported (needed when a placeholder is present).
   const webMenuOptions = useMemo<WebDropdownMenuOption[]>(() => {
     const menuOptions: WebDropdownMenuOption[] = [];
     for (const item of options) {
@@ -569,10 +572,23 @@ export function RNPickerSelect({
     return menuOptions;
   }, [options]);
 
+  const webMenuOptionIndexes = useMemo<number[]>(() => {
+    const indexes: number[] = [];
+    for (let i = 0; i < options.length; i++) {
+      const item = options[i];
+      if (!item || typeof item !== "object" || typeof item.label !== "string") {
+        continue;
+      }
+      indexes.push(i);
+    }
+    return indexes;
+  }, [options]);
+
   const renderWeb = () => {
     const displayLabel = selectedItem?.inputLabel ?? selectedItem?.label ?? "";
     return (
       <View
+        ref={webTriggerRef}
         style={[
           defaultStyles.viewContainer,
           {
@@ -588,7 +604,6 @@ export function RNPickerSelect({
           aria-role="button"
           disabled={disabled}
           onPress={openWebMenu}
-          ref={webTriggerRef}
           style={{
             alignItems: "center",
             flexDirection: "row",
@@ -621,7 +636,8 @@ export function RNPickerSelect({
           anchor={webAnchor}
           onClose={closeWebMenu}
           onSelect={(val, idx) => {
-            onValueChangeEvent(val, idx);
+            const originalIndex = webMenuOptionIndexes[idx] ?? idx;
+            onValueChangeEvent(val, originalIndex);
             closeWebMenu();
           }}
           options={webMenuOptions}

--- a/ui/src/PickerSelect.tsx
+++ b/ui/src/PickerSelect.tsx
@@ -25,13 +25,12 @@
 
 import {Picker} from "@react-native-picker/picker";
 import isEqual from "lodash/isEqual";
-import {useCallback, useEffect, useMemo, useRef, useState} from "react";
+import {useCallback, useEffect, useMemo, useState} from "react";
 import {
   Keyboard,
   Modal,
   Platform,
   Pressable,
-  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -41,6 +40,7 @@ import {
 
 import {Icon} from "./Icon";
 import {useTheme} from "./Theme";
+import {useWebDropdownAnchor, WebDropdownMenu, type WebDropdownMenuOption} from "./WebDropdownMenu";
 
 export const defaultStyles = StyleSheet.create({
   chevron: {
@@ -133,13 +133,11 @@ export function RNPickerSelect({
   // Web-only: anchor the custom dropdown menu to the trigger element so that
   // Safari/Firefox/Chrome all render the same styled menu instead of the
   // browser's native <select> UI.
-  const webTriggerRef = useRef<View>(null);
-  const [webAnchor, setWebAnchor] = useState<{
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-  }>({height: 0, width: 0, x: 0, y: 0});
+  const {
+    anchor: webAnchor,
+    measure: measureWebAnchor,
+    triggerRef: webTriggerRef,
+  } = useWebDropdownAnchor();
 
   // On web, blur the active element before the picker modal opens to prevent
   // "aria-hidden on a focused element" warnings from React Native Web.
@@ -536,32 +534,40 @@ export function RNPickerSelect({
   // styling to each browser (Safari in particular looks very different from
   // Chrome/Firefox). Instead, we render a styled trigger + popup menu so the
   // dropdown looks identical across browsers and matches the Terreno design.
-  const openWebMenu = () => {
+  const openWebMenu = (): void => {
     if (disabled) {
       return;
     }
-    if (webTriggerRef.current && typeof webTriggerRef.current.measureInWindow === "function") {
-      webTriggerRef.current.measureInWindow((x, y, width, height) => {
-        setWebAnchor({height, width, x, y});
-        setShowPicker(true);
-        if (onOpen) {
-          onOpen();
-        }
-      });
-      return;
-    }
-    setShowPicker(true);
-    if (onOpen) {
-      onOpen();
-    }
+    measureWebAnchor(() => {
+      setShowPicker(true);
+      if (onOpen) {
+        onOpen();
+      }
+    });
   };
 
-  const closeWebMenu = () => {
+  const closeWebMenu = (): void => {
     setShowPicker(false);
     if (onClose) {
       onClose();
     }
   };
+
+  const webMenuOptions = useMemo<WebDropdownMenuOption[]>(() => {
+    const menuOptions: WebDropdownMenuOption[] = [];
+    for (const item of options) {
+      if (!item || typeof item !== "object" || typeof item.label !== "string") {
+        continue;
+      }
+      menuOptions.push({
+        color: item.color,
+        key: item.key,
+        label: item.label,
+        value: String(item.value ?? ""),
+      });
+    }
+    return menuOptions;
+  }, [options]);
 
   const renderWeb = () => {
     const displayLabel = selectedItem?.inputLabel ?? selectedItem?.label ?? "";
@@ -611,76 +617,18 @@ export function RNPickerSelect({
             size="sm"
           />
         </Pressable>
-        <Modal
-          animationType="none"
-          onRequestClose={closeWebMenu}
-          testID="web_modal"
-          transparent
+        <WebDropdownMenu
+          anchor={webAnchor}
+          onClose={closeWebMenu}
+          onSelect={(val, idx) => {
+            onValueChangeEvent(val, idx);
+            closeWebMenu();
+          }}
+          options={webMenuOptions}
+          selectedValue={String(selectedItem?.value ?? "")}
+          testIDPrefix="web_dropdown"
           visible={showPicker}
-        >
-          <Pressable
-            aria-role="button"
-            onPress={closeWebMenu}
-            style={{flex: 1}}
-            testID="web_modal_backdrop"
-          />
-          <View
-            style={{
-              backgroundColor: theme.surface.base,
-              borderColor: theme.border.dark,
-              borderRadius: 4,
-              borderWidth: 1,
-              left: webAnchor.x,
-              maxHeight: 300,
-              overflow: "hidden",
-              position: "absolute",
-              shadowColor: "#000",
-              shadowOffset: {height: 2, width: 0},
-              shadowOpacity: 0.15,
-              shadowRadius: 8,
-              top: webAnchor.y + webAnchor.height + 4,
-              width: webAnchor.width,
-            }}
-            testID="web_dropdown_menu"
-          >
-            <ScrollView>
-              {options.map((item: any, idx: number) => {
-                if (!item || item.label === undefined) {
-                  return null;
-                }
-                const isSelected = isEqual(item.value, selectedItem?.value);
-                return (
-                  <Pressable
-                    aria-role="button"
-                    key={item.key ?? item.label ?? idx}
-                    onPress={() => {
-                      onValueChangeEvent(item.value, idx);
-                      closeWebMenu();
-                    }}
-                    style={({hovered, pressed}: any) => ({
-                      backgroundColor:
-                        isSelected || hovered || pressed
-                          ? theme.surface.neutralLight
-                          : theme.surface.base,
-                      paddingHorizontal: 12,
-                      paddingVertical: 10,
-                    })}
-                    testID={`web_dropdown_option_${item.value}`}
-                  >
-                    <Text
-                      style={{
-                        color: item.color ?? theme.text.primary,
-                        fontWeight: isSelected ? "600" : "400",
-                      }}
-                    >
-                      {item.label}
-                    </Text>
-                  </Pressable>
-                );
-              })}
-            </ScrollView>
-          </View>
-        </Modal>
+        />
       </View>
     );
   };

--- a/ui/src/PickerSelect.tsx
+++ b/ui/src/PickerSelect.tsx
@@ -580,6 +580,8 @@ export function RNPickerSelect({
 
   const renderWeb = () => {
     const displayLabel = selectedItem?.inputLabel ?? selectedItem?.label ?? "";
+    const selectedOriginalIdx = getSelectedItem(itemKey, value).idx;
+    const webSelectedIndex = webMenuOptionIndexes.indexOf(selectedOriginalIdx);
     return (
       <View
         ref={webTriggerRef}
@@ -639,7 +641,7 @@ export function RNPickerSelect({
             closeWebMenu();
           }}
           options={webMenuOptions}
-          selectedValue={String(selectedItem?.value ?? "")}
+          selectedIndex={webSelectedIndex >= 0 ? webSelectedIndex : undefined}
           testIDPrefix="web_dropdown"
           visible={showPicker}
         />

--- a/ui/src/PickerSelect.tsx
+++ b/ui/src/PickerSelect.tsx
@@ -629,9 +629,13 @@ export function RNPickerSelect({
         <WebDropdownMenu
           anchor={webAnchor}
           onClose={closeWebMenu}
-          onSelect={(val, idx) => {
+          onSelect={(_val, idx) => {
             const originalIndex = webMenuOptionIndexes[idx] ?? idx;
-            onValueChangeEvent(val, originalIndex);
+            // Pass the original (non-stringified) value through so lodash
+            // `isEqual` matching in `getSelectedItem` works for number /
+            // object values.
+            const originalValue = options[originalIndex]?.value;
+            onValueChangeEvent(originalValue, originalIndex);
             closeWebMenu();
           }}
           options={webMenuOptions}

--- a/ui/src/PickerSelect.tsx
+++ b/ui/src/PickerSelect.tsx
@@ -25,12 +25,13 @@
 
 import {Picker} from "@react-native-picker/picker";
 import isEqual from "lodash/isEqual";
-import {useCallback, useEffect, useMemo, useState} from "react";
+import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {
   Keyboard,
   Modal,
   Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -128,6 +129,17 @@ export function RNPickerSelect({
   const [orientation, setOrientation] = useState<"portrait" | "landscape">("portrait");
   const [doneDepressed, setDoneDepressed] = useState<boolean>(false);
   const {theme} = useTheme();
+
+  // Web-only: anchor the custom dropdown menu to the trigger element so that
+  // Safari/Firefox/Chrome all render the same styled menu instead of the
+  // browser's native <select> UI.
+  const webTriggerRef = useRef<View>(null);
+  const [webAnchor, setWebAnchor] = useState<{
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }>({height: 0, width: 0, x: 0, y: 0});
 
   // On web, blur the active element before the picker modal opens to prevent
   // "aria-hidden on a focused element" warnings from React Native Web.
@@ -520,8 +532,39 @@ export function RNPickerSelect({
     );
   };
 
-  // TODO: Create custom React component for web in order to apply library style rules
+  // Custom web dropdown. Rendering the native <Picker> on web delegates
+  // styling to each browser (Safari in particular looks very different from
+  // Chrome/Firefox). Instead, we render a styled trigger + popup menu so the
+  // dropdown looks identical across browsers and matches the Terreno design.
+  const openWebMenu = () => {
+    if (disabled) {
+      return;
+    }
+    if (webTriggerRef.current && typeof webTriggerRef.current.measureInWindow === "function") {
+      webTriggerRef.current.measureInWindow((x, y, width, height) => {
+        setWebAnchor({height, width, x, y});
+        setShowPicker(true);
+        if (onOpen) {
+          onOpen();
+        }
+      });
+      return;
+    }
+    setShowPicker(true);
+    if (onOpen) {
+      onOpen();
+    }
+  };
+
+  const closeWebMenu = () => {
+    setShowPicker(false);
+    if (onClose) {
+      onClose();
+    }
+  };
+
   const renderWeb = () => {
+    const displayLabel = selectedItem?.inputLabel ?? selectedItem?.label ?? "";
     return (
       <View
         style={[
@@ -535,31 +578,109 @@ export function RNPickerSelect({
           },
         ]}
       >
-        <Picker
-          enabled={!disabled}
-          onValueChange={onValueChangeEvent}
-          selectedValue={selectedItem?.value}
-          style={[
-            {
-              backgroundColor: theme.surface.base,
-              borderColor: "black",
-              borderRadius: 4,
-              borderWidth: 0,
-              height: "100%",
-              paddingHorizontal: 8,
-              paddingVertical: 8,
-              width: "100%",
-            },
-            disabled && {
-              backgroundColor: theme.surface.neutralLight,
-              color: theme.text.secondaryLight,
-              opacity: 1,
-            },
-          ]}
+        <Pressable
+          aria-role="button"
+          disabled={disabled}
+          onPress={openWebMenu}
+          ref={webTriggerRef}
+          style={{
+            alignItems: "center",
+            flexDirection: "row",
+            justifyContent: "space-between",
+            minHeight: 40,
+            paddingHorizontal: 8,
+            width: "100%",
+          }}
           testID="web_picker"
+          {...touchableWrapperProps}
         >
-          {renderPickerItems()}
-        </Picker>
+          <Text
+            numberOfLines={1}
+            style={{
+              color: disabled ? theme.text.secondaryLight : theme.text.primary,
+              flex: 1,
+              paddingRight: 8,
+            }}
+            testID="text_input"
+          >
+            {displayLabel}
+          </Text>
+          <Icon
+            color={disabled ? "secondaryLight" : "primary"}
+            iconName={showPicker ? "angle-up" : "angle-down"}
+            size="sm"
+          />
+        </Pressable>
+        <Modal
+          animationType="none"
+          onRequestClose={closeWebMenu}
+          testID="web_modal"
+          transparent
+          visible={showPicker}
+        >
+          <Pressable
+            aria-role="button"
+            onPress={closeWebMenu}
+            style={{flex: 1}}
+            testID="web_modal_backdrop"
+          />
+          <View
+            style={{
+              backgroundColor: theme.surface.base,
+              borderColor: theme.border.dark,
+              borderRadius: 4,
+              borderWidth: 1,
+              left: webAnchor.x,
+              maxHeight: 300,
+              overflow: "hidden",
+              position: "absolute",
+              shadowColor: "#000",
+              shadowOffset: {height: 2, width: 0},
+              shadowOpacity: 0.15,
+              shadowRadius: 8,
+              top: webAnchor.y + webAnchor.height + 4,
+              width: webAnchor.width,
+            }}
+            testID="web_dropdown_menu"
+          >
+            <ScrollView>
+              {options.map((item: any, idx: number) => {
+                if (!item || item.label === undefined) {
+                  return null;
+                }
+                const isSelected = isEqual(item.value, selectedItem?.value);
+                return (
+                  <Pressable
+                    aria-role="button"
+                    key={item.key ?? item.label ?? idx}
+                    onPress={() => {
+                      onValueChangeEvent(item.value, idx);
+                      closeWebMenu();
+                    }}
+                    style={({hovered, pressed}: any) => ({
+                      backgroundColor:
+                        isSelected || hovered || pressed
+                          ? theme.surface.neutralLight
+                          : theme.surface.base,
+                      paddingHorizontal: 12,
+                      paddingVertical: 10,
+                    })}
+                    testID={`web_dropdown_option_${item.value}`}
+                  >
+                    <Text
+                      style={{
+                        color: item.color ?? theme.text.primary,
+                        fontWeight: isSelected ? "600" : "400",
+                      }}
+                    >
+                      {item.label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </ScrollView>
+          </View>
+        </Modal>
       </View>
     );
   };

--- a/ui/src/PickerSelect.tsx
+++ b/ui/src/PickerSelect.tsx
@@ -556,9 +556,14 @@ export function RNPickerSelect({
   // Build the dropdown option list AND track each option's original index in
   // `options` so `onValueChange` receives the same index that the native
   // Picker would have reported (needed when a placeholder is present).
-  const webMenuOptions = useMemo<WebDropdownMenuOption[]>(() => {
+  const {menuOptions: webMenuOptions, originalIndexes: webMenuOptionIndexes} = useMemo<{
+    menuOptions: WebDropdownMenuOption[];
+    originalIndexes: number[];
+  }>(() => {
     const menuOptions: WebDropdownMenuOption[] = [];
-    for (const item of options) {
+    const originalIndexes: number[] = [];
+    for (let i = 0; i < options.length; i++) {
+      const item = options[i];
       if (!item || typeof item !== "object" || typeof item.label !== "string") {
         continue;
       }
@@ -568,20 +573,9 @@ export function RNPickerSelect({
         label: item.label,
         value: String(item.value ?? ""),
       });
+      originalIndexes.push(i);
     }
-    return menuOptions;
-  }, [options]);
-
-  const webMenuOptionIndexes = useMemo<number[]>(() => {
-    const indexes: number[] = [];
-    for (let i = 0; i < options.length; i++) {
-      const item = options[i];
-      if (!item || typeof item !== "object" || typeof item.label !== "string") {
-        continue;
-      }
-      indexes.push(i);
-    }
-    return indexes;
+    return {menuOptions, originalIndexes};
   }, [options]);
 
   const renderWeb = () => {

--- a/ui/src/SelectBadge.tsx
+++ b/ui/src/SelectBadge.tsx
@@ -241,6 +241,9 @@ export const SelectBadge = ({
   }, [showPicker, webAnchor, webMenuOptions, value, handleOnChange]);
 
   const openWebMenu = (): void => {
+    if (disabled) {
+      return;
+    }
     measureWebAnchor(() => {
       setShowPicker(true);
     });

--- a/ui/src/SelectBadge.tsx
+++ b/ui/src/SelectBadge.tsx
@@ -1,7 +1,7 @@
 import {Picker} from "@react-native-picker/picker";
 import type React from "react";
-import {useCallback, useMemo, useState} from "react";
-import {Modal, Platform, Text, TouchableOpacity, View} from "react-native";
+import {useCallback, useMemo, useRef, useState} from "react";
+import {Modal, Platform, Pressable, ScrollView, Text, TouchableOpacity, View} from "react-native";
 
 import type {FieldOption, SelectBadgeProps, SurfaceTheme, TextTheme} from "./Common";
 import {Icon} from "./Icon";
@@ -23,6 +23,17 @@ export const SelectBadge = ({
   // Temporary state to manage value changes for ios picker
   // Assures the badge display value persists when user scrolls through options
   const [iosDisplayValue, setIosDisplayValue] = useState<string | undefined>(value);
+
+  // Web-only: anchor the custom dropdown menu to the trigger element so that
+  // Safari/Firefox/Chrome all render the same styled menu instead of the
+  // browser's native <select> UI.
+  const webTriggerRef = useRef<View>(null);
+  const [webAnchor, setWebAnchor] = useState<{
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }>({height: 0, width: 0, x: 0, y: 0});
 
   const secondaryBorderColors = {
     custom: "#AAAAAA",
@@ -190,14 +201,13 @@ export const SelectBadge = ({
         selectedValue={findSelectedItem(value)?.value ?? undefined}
         style={[
           {
+            backgroundColor: "transparent",
             color: "transparent",
             height: "100%",
             opacity: 0,
             position: "absolute",
             width: "100%",
           },
-          // Android headless picker: transparent overlay to capture touches without visible UI.
-          Platform.OS !== "web" && {backgroundColor: "transparent"},
         ]}
       >
         {renderPickerItems()}
@@ -205,14 +215,109 @@ export const SelectBadge = ({
     );
   }, [disabled, findSelectedItem, value, handleOnChange, renderPickerItems]);
 
+  // Custom web dropdown. Rendering the native <Picker> on web delegates
+  // styling to each browser (Safari in particular looks very different from
+  // Chrome/Firefox). Instead, we render a styled popup menu anchored to the
+  // badge so the dropdown looks identical across browsers.
+  const renderWebPicker = useCallback(() => {
+    return (
+      <Modal
+        animationType="none"
+        onRequestClose={() => setShowPicker(false)}
+        transparent
+        visible={showPicker}
+      >
+        <Pressable
+          aria-role="button"
+          onPress={() => setShowPicker(false)}
+          style={{flex: 1}}
+          testID="web_badge_backdrop"
+        />
+        <View
+          style={{
+            backgroundColor: theme.surface.base,
+            borderColor: theme.border.dark,
+            borderRadius: 4,
+            borderWidth: 1,
+            left: webAnchor.x,
+            maxHeight: 300,
+            minWidth: 160,
+            overflow: "hidden",
+            position: "absolute",
+            shadowColor: "#000",
+            shadowOffset: {height: 2, width: 0},
+            shadowOpacity: 0.15,
+            shadowRadius: 8,
+            top: webAnchor.y + webAnchor.height + 4,
+          }}
+          testID="web_badge_dropdown"
+        >
+          <ScrollView>
+            {options.map((item, idx) => {
+              const isSelected = item.value === value;
+              return (
+                <Pressable
+                  aria-role="button"
+                  disabled={disabled}
+                  key={item.key ?? item.value ?? idx}
+                  onPress={() => handleOnChange(item.value)}
+                  style={({hovered, pressed}: any) => ({
+                    backgroundColor:
+                      isSelected || hovered || pressed
+                        ? theme.surface.neutralLight
+                        : theme.surface.base,
+                    paddingHorizontal: 12,
+                    paddingVertical: 10,
+                  })}
+                >
+                  <Text
+                    style={{
+                      color: theme.text.primary,
+                      fontFamily: "text",
+                      fontSize: 12,
+                      fontWeight: isSelected ? "700" : "400",
+                    }}
+                  >
+                    {item.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
+        </View>
+      </Modal>
+    );
+  }, [showPicker, webAnchor, theme, options, value, disabled, handleOnChange]);
+
+  const openWebMenu = () => {
+    if (webTriggerRef.current && typeof webTriggerRef.current.measureInWindow === "function") {
+      webTriggerRef.current.measureInWindow((x, y, width, height) => {
+        setWebAnchor({height, width, x, y});
+        setShowPicker(true);
+      });
+      return;
+    }
+    setShowPicker(true);
+  };
+
   return (
-    <View style={{alignItems: "flex-start", opacity: disabled ? 0.5 : 1}}>
+    <View ref={webTriggerRef} style={{alignItems: "flex-start", opacity: disabled ? 0.5 : 1}}>
       <TouchableOpacity
         accessibilityHint="Opens the options picker"
         accessibilityLabel="Open select badge options"
         aria-role="button"
         disabled={disabled}
-        onPress={() => setShowPicker(!showPicker)}
+        onPress={() => {
+          if (Platform.OS === "web") {
+            if (showPicker) {
+              setShowPicker(false);
+            } else {
+              openWebMenu();
+            }
+            return;
+          }
+          setShowPicker(!showPicker);
+        }}
       >
         <View
           style={{
@@ -274,7 +379,11 @@ export const SelectBadge = ({
           </View>
         </View>
       </TouchableOpacity>
-      {Platform.OS === "ios" ? renderIosPicker() : renderPicker()}
+      {Platform.OS === "ios"
+        ? renderIosPicker()
+        : Platform.OS === "web"
+          ? renderWebPicker()
+          : renderPicker()}
     </View>
   );
 };

--- a/ui/src/SelectBadge.tsx
+++ b/ui/src/SelectBadge.tsx
@@ -1,11 +1,12 @@
 import {Picker} from "@react-native-picker/picker";
 import type React from "react";
-import {useCallback, useMemo, useRef, useState} from "react";
-import {Modal, Platform, Pressable, ScrollView, Text, TouchableOpacity, View} from "react-native";
+import {useCallback, useMemo, useState} from "react";
+import {Modal, Platform, Text, TouchableOpacity, View} from "react-native";
 
 import type {FieldOption, SelectBadgeProps, SurfaceTheme, TextTheme} from "./Common";
 import {Icon} from "./Icon";
 import {useTheme} from "./Theme";
+import {useWebDropdownAnchor, WebDropdownMenu, type WebDropdownMenuOption} from "./WebDropdownMenu";
 
 export const SelectBadge = ({
   value,
@@ -27,13 +28,11 @@ export const SelectBadge = ({
   // Web-only: anchor the custom dropdown menu to the trigger element so that
   // Safari/Firefox/Chrome all render the same styled menu instead of the
   // browser's native <select> UI.
-  const webTriggerRef = useRef<View>(null);
-  const [webAnchor, setWebAnchor] = useState<{
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-  }>({height: 0, width: 0, x: 0, y: 0});
+  const {
+    anchor: webAnchor,
+    measure: measureWebAnchor,
+    triggerRef: webTriggerRef,
+  } = useWebDropdownAnchor();
 
   const secondaryBorderColors = {
     custom: "#AAAAAA",
@@ -219,85 +218,32 @@ export const SelectBadge = ({
   // styling to each browser (Safari in particular looks very different from
   // Chrome/Firefox). Instead, we render a styled popup menu anchored to the
   // badge so the dropdown looks identical across browsers.
+  const webMenuOptions = useMemo<WebDropdownMenuOption[]>(
+    () => options.map((item) => ({key: item.key, label: item.label, value: item.value})),
+    [options]
+  );
+
   const renderWebPicker = useCallback(() => {
     return (
-      <Modal
-        animationType="none"
-        onRequestClose={() => setShowPicker(false)}
-        transparent
+      <WebDropdownMenu
+        anchor={webAnchor}
+        minWidth={160}
+        onClose={() => setShowPicker(false)}
+        onSelect={(val) => handleOnChange(val)}
+        options={webMenuOptions}
+        optionTextStyle={{fontFamily: "text", fontSize: 12}}
+        selectedValue={value}
+        testIDPrefix="web_badge"
         visible={showPicker}
-      >
-        <Pressable
-          aria-role="button"
-          onPress={() => setShowPicker(false)}
-          style={{flex: 1}}
-          testID="web_badge_backdrop"
-        />
-        <View
-          style={{
-            backgroundColor: theme.surface.base,
-            borderColor: theme.border.dark,
-            borderRadius: 4,
-            borderWidth: 1,
-            left: webAnchor.x,
-            maxHeight: 300,
-            minWidth: 160,
-            overflow: "hidden",
-            position: "absolute",
-            shadowColor: "#000",
-            shadowOffset: {height: 2, width: 0},
-            shadowOpacity: 0.15,
-            shadowRadius: 8,
-            top: webAnchor.y + webAnchor.height + 4,
-          }}
-          testID="web_badge_dropdown"
-        >
-          <ScrollView>
-            {options.map((item, idx) => {
-              const isSelected = item.value === value;
-              return (
-                <Pressable
-                  aria-role="button"
-                  disabled={disabled}
-                  key={item.key ?? item.value ?? idx}
-                  onPress={() => handleOnChange(item.value)}
-                  style={({hovered, pressed}: any) => ({
-                    backgroundColor:
-                      isSelected || hovered || pressed
-                        ? theme.surface.neutralLight
-                        : theme.surface.base,
-                    paddingHorizontal: 12,
-                    paddingVertical: 10,
-                  })}
-                >
-                  <Text
-                    style={{
-                      color: theme.text.primary,
-                      fontFamily: "text",
-                      fontSize: 12,
-                      fontWeight: isSelected ? "700" : "400",
-                    }}
-                  >
-                    {item.label}
-                  </Text>
-                </Pressable>
-              );
-            })}
-          </ScrollView>
-        </View>
-      </Modal>
+        width={undefined}
+      />
     );
-  }, [showPicker, webAnchor, theme, options, value, disabled, handleOnChange]);
+  }, [showPicker, webAnchor, webMenuOptions, value, handleOnChange]);
 
-  const openWebMenu = () => {
-    if (webTriggerRef.current && typeof webTriggerRef.current.measureInWindow === "function") {
-      webTriggerRef.current.measureInWindow((x, y, width, height) => {
-        setWebAnchor({height, width, x, y});
-        setShowPicker(true);
-      });
-      return;
-    }
-    setShowPicker(true);
+  const openWebMenu = (): void => {
+    measureWebAnchor(() => {
+      setShowPicker(true);
+    });
   };
 
   return (

--- a/ui/src/SelectBadge.web.test.tsx
+++ b/ui/src/SelectBadge.web.test.tsx
@@ -1,0 +1,75 @@
+import {afterAll, beforeAll, describe, expect, it, mock} from "bun:test";
+import {act, fireEvent} from "@testing-library/react-native";
+import {Platform} from "react-native";
+
+import {SelectBadge} from "./SelectBadge";
+import {renderWithTheme} from "./test-utils";
+
+// Force Platform.OS to "web" for this file so SelectBadge takes the web
+// rendering branch (custom WebDropdownMenu instead of the native iOS Picker).
+const originalOS = Platform.OS;
+beforeAll(() => {
+  Object.defineProperty(Platform, "OS", {configurable: true, value: "web"});
+});
+afterAll(() => {
+  Object.defineProperty(Platform, "OS", {configurable: true, value: originalOS});
+});
+
+describe("SelectBadge (web)", () => {
+  const options = [
+    {label: "Option A", value: "a"},
+    {label: "Option B", value: "b"},
+    {label: "Option C", value: "c"},
+  ];
+
+  it("renders the styled web dropdown menu (not the native picker) when opened", () => {
+    const {getByLabelText, getByTestId} = renderWithTheme(
+      <SelectBadge onChange={() => {}} options={options} value="a" />
+    );
+    expect(getByTestId("web_badge_modal").props.visible).toBe(false);
+    act(() => {
+      fireEvent.press(getByLabelText("Open select badge options"));
+    });
+    expect(getByTestId("web_badge_modal").props.visible).toBe(true);
+    expect(getByTestId("web_badge_menu")).toBeTruthy();
+  });
+
+  it("invokes onChange with the selected value when an option is pressed", () => {
+    const handleChange = mock((_val: string) => {});
+    const {getByLabelText, getByTestId} = renderWithTheme(
+      <SelectBadge onChange={handleChange} options={options} value="a" />
+    );
+    act(() => {
+      fireEvent.press(getByLabelText("Open select badge options"));
+    });
+    act(() => {
+      fireEvent.press(getByTestId("web_badge_option_b"));
+    });
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith("b");
+  });
+
+  it("closes the menu when the backdrop is pressed", () => {
+    const {getByLabelText, getByTestId} = renderWithTheme(
+      <SelectBadge onChange={() => {}} options={options} value="a" />
+    );
+    act(() => {
+      fireEvent.press(getByLabelText("Open select badge options"));
+    });
+    expect(getByTestId("web_badge_modal").props.visible).toBe(true);
+    act(() => {
+      fireEvent.press(getByTestId("web_badge_backdrop"));
+    });
+    expect(getByTestId("web_badge_modal").props.visible).toBe(false);
+  });
+
+  it("does not open the dropdown when disabled", () => {
+    const {getByLabelText, getByTestId} = renderWithTheme(
+      <SelectBadge disabled onChange={() => {}} options={options} value="a" />
+    );
+    act(() => {
+      fireEvent.press(getByLabelText("Open select badge options"));
+    });
+    expect(getByTestId("web_badge_modal").props.visible).toBe(false);
+  });
+});

--- a/ui/src/WebDropdownMenu.test.tsx
+++ b/ui/src/WebDropdownMenu.test.tsx
@@ -1,8 +1,8 @@
 import {describe, expect, it, mock} from "bun:test";
-import {fireEvent} from "@testing-library/react-native";
+import {act, fireEvent, renderHook} from "@testing-library/react-native";
 
 import {renderWithTheme} from "./test-utils";
-import {WebDropdownMenu} from "./WebDropdownMenu";
+import {useWebDropdownAnchor, WebDropdownMenu} from "./WebDropdownMenu";
 
 describe("WebDropdownMenu", () => {
   const anchor = {height: 40, width: 200, x: 16, y: 32};
@@ -119,5 +119,64 @@ describe("WebDropdownMenu", () => {
     expect(getByTestId("badge_menu_backdrop")).toBeTruthy();
     expect(getByTestId("badge_menu_option_a")).toBeTruthy();
     expect(queryByTestId("web_dropdown_menu")).toBeNull();
+  });
+
+  it("highlights the option matched by selectedIndex regardless of duplicated values", () => {
+    const dupOptions = [
+      {label: "Placeholder", value: ""},
+      {label: "Blank option", value: ""},
+      {label: "Real", value: "real"},
+    ];
+    const {getByText} = renderWithTheme(
+      <WebDropdownMenu
+        anchor={anchor}
+        onClose={() => {}}
+        onSelect={() => {}}
+        options={dupOptions}
+        selectedIndex={1}
+        visible
+      />
+    );
+    expect(getByText("Blank option").props.style.fontWeight).toBe("600");
+    expect(getByText("Placeholder").props.style.fontWeight).toBe("400");
+    expect(getByText("Real").props.style.fontWeight).toBe("400");
+  });
+});
+
+describe("useWebDropdownAnchor", () => {
+  it("exposes a default zero-sized anchor before measuring", () => {
+    const {result} = renderHook(() => useWebDropdownAnchor());
+    expect(result.current.anchor).toEqual({height: 0, width: 0, x: 0, y: 0});
+    expect(result.current.triggerRef.current).toBeNull();
+  });
+
+  it("invokes the callback synchronously with the existing anchor when the ref is empty", () => {
+    const {result} = renderHook(() => useWebDropdownAnchor());
+    const onMeasured = mock(() => {});
+    act(() => {
+      result.current.measure(onMeasured);
+    });
+    expect(onMeasured).toHaveBeenCalledTimes(1);
+    expect(onMeasured.mock.calls[0][0]).toEqual({height: 0, width: 0, x: 0, y: 0});
+  });
+
+  it("measures the trigger and updates anchor state when the ref has measureInWindow", () => {
+    const {result} = renderHook(() => useWebDropdownAnchor());
+    // Simulate a mounted native View by assigning a measureInWindow shim to the
+    // ref. The hook does not care whether the node is a real View instance.
+    const measureInWindow = mock(
+      (cb: (x: number, y: number, w: number, h: number) => void) => {
+        cb(10, 20, 100, 40);
+      }
+    );
+    (result.current.triggerRef as {current: unknown}).current = {measureInWindow};
+    const onMeasured = mock(() => {});
+    act(() => {
+      result.current.measure(onMeasured);
+    });
+    expect(measureInWindow).toHaveBeenCalledTimes(1);
+    expect(onMeasured).toHaveBeenCalledTimes(1);
+    expect(onMeasured.mock.calls[0][0]).toEqual({height: 40, width: 100, x: 10, y: 20});
+    expect(result.current.anchor).toEqual({height: 40, width: 100, x: 10, y: 20});
   });
 });

--- a/ui/src/WebDropdownMenu.test.tsx
+++ b/ui/src/WebDropdownMenu.test.tsx
@@ -1,0 +1,123 @@
+import {describe, expect, it, mock} from "bun:test";
+import {fireEvent} from "@testing-library/react-native";
+
+import {renderWithTheme} from "./test-utils";
+import {WebDropdownMenu} from "./WebDropdownMenu";
+
+describe("WebDropdownMenu", () => {
+  const anchor = {height: 40, width: 200, x: 16, y: 32};
+  const options = [
+    {label: "Option A", value: "a"},
+    {label: "Option B", value: "b"},
+    {label: "Option C", value: "c"},
+  ];
+
+  it("marks the underlying Modal hidden when not visible", () => {
+    const {getByTestId} = renderWithTheme(
+      <WebDropdownMenu
+        anchor={anchor}
+        onClose={() => {}}
+        onSelect={() => {}}
+        options={options}
+        visible={false}
+      />
+    );
+    expect(getByTestId("web_dropdown_modal").props.visible).toBe(false);
+  });
+
+  it("marks the underlying Modal visible when open", () => {
+    const {getByTestId} = renderWithTheme(
+      <WebDropdownMenu
+        anchor={anchor}
+        onClose={() => {}}
+        onSelect={() => {}}
+        options={options}
+        visible
+      />
+    );
+    expect(getByTestId("web_dropdown_modal").props.visible).toBe(true);
+  });
+
+  it("renders every option when visible", () => {
+    const {getByText} = renderWithTheme(
+      <WebDropdownMenu
+        anchor={anchor}
+        onClose={() => {}}
+        onSelect={() => {}}
+        options={options}
+        selectedValue="b"
+        visible
+      />
+    );
+    expect(getByText("Option A")).toBeTruthy();
+    expect(getByText("Option B")).toBeTruthy();
+    expect(getByText("Option C")).toBeTruthy();
+  });
+
+  it("invokes onSelect with value and index when an option is pressed", () => {
+    const onSelect = mock(() => {});
+    const {getByTestId} = renderWithTheme(
+      <WebDropdownMenu
+        anchor={anchor}
+        onClose={() => {}}
+        onSelect={onSelect}
+        options={options}
+        visible
+      />
+    );
+    fireEvent.press(getByTestId("web_dropdown_option_b"));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0]).toEqual(["b", 1]);
+  });
+
+  it("invokes onClose when the backdrop is pressed", () => {
+    const onClose = mock(() => {});
+    const {getByTestId} = renderWithTheme(
+      <WebDropdownMenu
+        anchor={anchor}
+        onClose={onClose}
+        onSelect={() => {}}
+        options={options}
+        visible
+      />
+    );
+    fireEvent.press(getByTestId("web_dropdown_backdrop"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("anchors the menu below the trigger using the provided anchor", () => {
+    const {getByTestId} = renderWithTheme(
+      <WebDropdownMenu
+        anchor={anchor}
+        onClose={() => {}}
+        onSelect={() => {}}
+        options={options}
+        visible
+      />
+    );
+    const menu = getByTestId("web_dropdown_menu");
+    const style = Array.isArray(menu.props.style)
+      ? Object.assign({}, ...menu.props.style)
+      : menu.props.style;
+    expect(style.left).toBe(anchor.x);
+    expect(style.top).toBe(anchor.y + anchor.height + 4);
+    expect(style.width).toBe(anchor.width);
+  });
+
+  it("uses the custom testID prefix when provided", () => {
+    const {getByTestId, queryByTestId} = renderWithTheme(
+      <WebDropdownMenu
+        anchor={anchor}
+        onClose={() => {}}
+        onSelect={() => {}}
+        options={options}
+        testIDPrefix="badge_menu"
+        visible
+      />
+    );
+    expect(getByTestId("badge_menu_menu")).toBeTruthy();
+    expect(getByTestId("badge_menu_backdrop")).toBeTruthy();
+    expect(getByTestId("badge_menu_option_a")).toBeTruthy();
+    expect(queryByTestId("web_dropdown_menu")).toBeNull();
+  });
+});

--- a/ui/src/WebDropdownMenu.test.tsx
+++ b/ui/src/WebDropdownMenu.test.tsx
@@ -164,11 +164,9 @@ describe("useWebDropdownAnchor", () => {
     const {result} = renderHook(() => useWebDropdownAnchor());
     // Simulate a mounted native View by assigning a measureInWindow shim to the
     // ref. The hook does not care whether the node is a real View instance.
-    const measureInWindow = mock(
-      (cb: (x: number, y: number, w: number, h: number) => void) => {
-        cb(10, 20, 100, 40);
-      }
-    );
+    const measureInWindow = mock((cb: (x: number, y: number, w: number, h: number) => void) => {
+      cb(10, 20, 100, 40);
+    });
     (result.current.triggerRef as {current: unknown}).current = {measureInWindow};
     const onMeasured = mock(() => {});
     act(() => {

--- a/ui/src/WebDropdownMenu.tsx
+++ b/ui/src/WebDropdownMenu.tsx
@@ -34,6 +34,13 @@ export interface WebDropdownMenuProps {
   options: WebDropdownMenuOption[];
   /** Currently selected value (used to highlight the matching option). */
   selectedValue?: string;
+  /**
+   * Optional index of the currently selected option. When provided, takes
+   * precedence over `selectedValue` — useful when option values aren't
+   * unique (e.g. a placeholder with an empty value sharing the same string
+   * representation as another option).
+   */
+  selectedIndex?: number;
   /** Called when an option is chosen. */
   onSelect: (value: string, index: number) => void;
   /** Called when the backdrop is pressed or Escape is hit. */
@@ -65,6 +72,7 @@ export const WebDropdownMenu = ({
   anchor,
   options,
   selectedValue,
+  selectedIndex,
   onSelect,
   onClose,
   width,
@@ -110,11 +118,14 @@ export const WebDropdownMenu = ({
       >
         <ScrollView>
           {options.map((item, idx) => {
-            const isSelected = item.value === selectedValue;
+            const isSelected =
+              selectedIndex !== undefined
+                ? idx === selectedIndex
+                : item.value === selectedValue;
             return (
               <Pressable
                 aria-role="button"
-                key={item.key ?? item.value ?? idx}
+                key={item.key ?? idx}
                 onPress={() => onSelect(item.value, idx)}
                 style={(state: PressableWebState) => ({
                   backgroundColor:

--- a/ui/src/WebDropdownMenu.tsx
+++ b/ui/src/WebDropdownMenu.tsx
@@ -119,9 +119,7 @@ export const WebDropdownMenu = ({
         <ScrollView>
           {options.map((item, idx) => {
             const isSelected =
-              selectedIndex !== undefined
-                ? idx === selectedIndex
-                : item.value === selectedValue;
+              selectedIndex !== undefined ? idx === selectedIndex : item.value === selectedValue;
             return (
               <Pressable
                 aria-role="button"

--- a/ui/src/WebDropdownMenu.tsx
+++ b/ui/src/WebDropdownMenu.tsx
@@ -1,0 +1,174 @@
+import {type ReactElement, useRef, useState} from "react";
+import {
+  type DimensionValue,
+  Modal,
+  Pressable,
+  ScrollView,
+  Text,
+  type TextStyle,
+  View,
+} from "react-native";
+
+import {useTheme} from "./Theme";
+
+export interface WebDropdownMenuOption {
+  key?: string | number;
+  label: string;
+  value: string;
+  color?: string;
+}
+
+export interface WebDropdownAnchor {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface WebDropdownMenuProps {
+  /** Controls visibility of the popup. */
+  visible: boolean;
+  /** Position of the trigger element so the menu can be anchored beneath it. */
+  anchor: WebDropdownAnchor;
+  /** Options to render in the list. */
+  options: WebDropdownMenuOption[];
+  /** Currently selected value (used to highlight the matching option). */
+  selectedValue?: string;
+  /** Called when an option is chosen. */
+  onSelect: (value: string, index: number) => void;
+  /** Called when the backdrop is pressed or Escape is hit. */
+  onClose: () => void;
+  /** Optional fixed width for the menu. Defaults to the trigger width. */
+  width?: DimensionValue;
+  /** Optional minimum width for the menu. */
+  minWidth?: DimensionValue;
+  /** Additional style applied to each option's label. */
+  optionTextStyle?: TextStyle;
+  /** Prefix for the testIDs on the menu / backdrop / option nodes. */
+  testIDPrefix?: string;
+}
+
+interface PressableWebState {
+  pressed: boolean;
+  hovered?: boolean;
+  focused?: boolean;
+}
+
+/**
+ * Shared web-only popup used by `RNPickerSelect` and `SelectBadge` so every
+ * browser renders the same styled dropdown instead of falling back to the
+ * platform-native `<select>` UI. Must be anchored to a trigger element via
+ * `useWebDropdownAnchor` (or an equivalent measurement).
+ */
+export const WebDropdownMenu = ({
+  visible,
+  anchor,
+  options,
+  selectedValue,
+  onSelect,
+  onClose,
+  width,
+  minWidth,
+  optionTextStyle,
+  testIDPrefix = "web_dropdown",
+}: WebDropdownMenuProps): ReactElement => {
+  const {theme} = useTheme();
+
+  return (
+    <Modal
+      animationType="none"
+      onRequestClose={onClose}
+      testID={`${testIDPrefix}_modal`}
+      transparent
+      visible={visible}
+    >
+      <Pressable
+        aria-role="button"
+        onPress={onClose}
+        style={{flex: 1}}
+        testID={`${testIDPrefix}_backdrop`}
+      />
+      <View
+        style={{
+          backgroundColor: theme.surface.base,
+          borderColor: theme.border.dark,
+          borderRadius: 4,
+          borderWidth: 1,
+          left: anchor.x,
+          maxHeight: 300,
+          minWidth,
+          overflow: "hidden",
+          position: "absolute",
+          shadowColor: "#000",
+          shadowOffset: {height: 2, width: 0},
+          shadowOpacity: 0.15,
+          shadowRadius: 8,
+          top: anchor.y + anchor.height + 4,
+          width: width ?? anchor.width,
+        }}
+        testID={`${testIDPrefix}_menu`}
+      >
+        <ScrollView>
+          {options.map((item, idx) => {
+            const isSelected = item.value === selectedValue;
+            return (
+              <Pressable
+                aria-role="button"
+                key={item.key ?? item.value ?? idx}
+                onPress={() => onSelect(item.value, idx)}
+                style={(state: PressableWebState) => ({
+                  backgroundColor:
+                    isSelected || state.hovered || state.pressed
+                      ? theme.surface.neutralLight
+                      : theme.surface.base,
+                  paddingHorizontal: 12,
+                  paddingVertical: 10,
+                })}
+                testID={`${testIDPrefix}_option_${item.value}`}
+              >
+                <Text
+                  style={{
+                    color: item.color ?? theme.text.primary,
+                    fontWeight: isSelected ? "600" : "400",
+                    ...optionTextStyle,
+                  }}
+                >
+                  {item.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+};
+
+/**
+ * Hook that wires up a `View` ref + anchor state for use with
+ * `WebDropdownMenu`. Measure the trigger via `measure()` before opening so
+ * the menu lines up beneath it across browsers.
+ */
+export const useWebDropdownAnchor = (): {
+  triggerRef: React.RefObject<View | null>;
+  anchor: WebDropdownAnchor;
+  measure: (onMeasured: (anchor: WebDropdownAnchor) => void) => void;
+} => {
+  const triggerRef = useRef<View>(null);
+  const [anchor, setAnchor] = useState<WebDropdownAnchor>({height: 0, width: 0, x: 0, y: 0});
+
+  const measure = (onMeasured: (next: WebDropdownAnchor) => void): void => {
+    const node = triggerRef.current;
+    if (node && typeof node.measureInWindow === "function") {
+      node.measureInWindow((x, y, w, h) => {
+        const next = {height: h, width: w, x, y};
+        setAnchor(next);
+        onMeasured(next);
+      });
+      return;
+    }
+    onMeasured(anchor);
+  };
+
+  return {anchor, measure, triggerRef};
+};

--- a/ui/src/__snapshots__/SelectBadge.test.tsx.snap
+++ b/ui/src/__snapshots__/SelectBadge.test.tsx.snap
@@ -254,6 +254,9 @@ exports[`SelectBadge renders correctly with default props 1`] = `
     },
   ],
   "props": {
+    "ref": {
+      "current": null,
+    },
     "style": {
       "alignItems": "flex-start",
       "opacity": 1,
@@ -518,6 +521,9 @@ exports[`SelectBadge renders with info status (default) 1`] = `
     },
   ],
   "props": {
+    "ref": {
+      "current": null,
+    },
     "style": {
       "alignItems": "flex-start",
       "opacity": 1,
@@ -782,6 +788,9 @@ exports[`SelectBadge renders with success status 1`] = `
     },
   ],
   "props": {
+    "ref": {
+      "current": null,
+    },
     "style": {
       "alignItems": "flex-start",
       "opacity": 1,
@@ -1046,6 +1055,9 @@ exports[`SelectBadge renders with warning status 1`] = `
     },
   ],
   "props": {
+    "ref": {
+      "current": null,
+    },
     "style": {
       "alignItems": "flex-start",
       "opacity": 1,
@@ -1310,6 +1322,9 @@ exports[`SelectBadge renders with error status 1`] = `
     },
   ],
   "props": {
+    "ref": {
+      "current": null,
+    },
     "style": {
       "alignItems": "flex-start",
       "opacity": 1,
@@ -1574,6 +1589,9 @@ exports[`SelectBadge renders with neutral status 1`] = `
     },
   ],
   "props": {
+    "ref": {
+      "current": null,
+    },
     "style": {
       "alignItems": "flex-start",
       "opacity": 1,
@@ -1838,6 +1856,9 @@ exports[`SelectBadge renders with secondary style 1`] = `
     },
   ],
   "props": {
+    "ref": {
+      "current": null,
+    },
     "style": {
       "alignItems": "flex-start",
       "opacity": 1,
@@ -2102,6 +2123,9 @@ exports[`SelectBadge renders with custom colors 1`] = `
     },
   ],
   "props": {
+    "ref": {
+      "current": null,
+    },
     "style": {
       "alignItems": "flex-start",
       "opacity": 1,
@@ -2366,6 +2390,9 @@ exports[`SelectBadge renders disabled state 1`] = `
     },
   ],
   "props": {
+    "ref": {
+      "current": null,
+    },
     "style": {
       "alignItems": "flex-start",
       "opacity": 0.5,


### PR DESCRIPTION
Noticed how absolutely awful these look on Safari. Also leads to more options for changing select lists in the future.

## Summary

On web, `SelectField` (via `RNPickerSelect`) and `SelectBadge` were both delegating to the browser's native `<select>` element (rendered by `@react-native-picker/picker`). Safari, Chrome, and Firefox each style that element differently, so the dropdown looked inconsistent across browsers and did not match the Terreno design.

This PR replaces the web renderer in both components with a custom popup menu:

- `PickerSelect.renderWeb()` now renders a styled `Pressable` trigger (label + `angle-down` icon) and opens a `Modal` containing an anchored, scrollable list of options. The trigger is measured with `measureInWindow` so the menu appears right under the field, matching its width.
- `SelectBadge` gets an equivalent web-only popup path (`renderWebPicker`) and keeps the existing iOS sheet / Android headless picker behavior untouched.
- Both popups highlight the selected/hovered option using theme colors and close on backdrop click or `Escape` (`onRequestClose`).

Snapshots for `SelectBadge` were regenerated to capture the new `ref` attachment on the outer `View`. iOS/Android rendering is unchanged.

## Review & Testing Checklist for Human

- [ ] Open a page with `SelectField` in Safari (the original browser that motivated this change) and confirm the dropdown uses the custom styled menu instead of Safari's system picker.
- [ ] Verify `SelectField` behavior in Chrome and Firefox looks identical to Safari.
- [ ] Verify `SelectBadge` on web opens the styled popup anchored to the badge, selects values correctly, and closes on outside click / Escape.
- [ ] Sanity-check iOS and Android still render the existing bottom-sheet / headless picker (no changes intended).

### Notes

- The web popup uses React Native's `Modal` with a transparent backdrop plus absolute positioning tied to `measureInWindow`; that's supported by react-native-web and keeps the menu visually on top of surrounding scroll containers.
- `onOpen` / `onClose` callbacks on `RNPickerSelect` now fire on web as well (they were effectively dead code on web before).


Link to Devin session: https://app.devin.ai/sessions/7b7a46f2cc4947f58e40e7a6f105f642
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it replaces web selection UI/interaction in `RNPickerSelect` and `SelectBadge`, including value/index mapping and open/close behavior; iOS/Android paths are intended to remain unchanged.
> 
> **Overview**
> Replaces the web rendering path for `RNPickerSelect` (`PickerSelect`) and `SelectBadge` with a **custom, themed dropdown menu** (trigger + `Modal` popup) anchored via `measureInWindow`, avoiding browser-native `<select>` styling differences.
> 
> Adds a shared `WebDropdownMenu` + `useWebDropdownAnchor` utility, updates web event handling to open/close the popup (including `onOpen`/`onClose` on web for `RNPickerSelect`), and preserves native picker index semantics on web by tracking original option indexes (notably when placeholders are present).
> 
> Adds focused unit coverage for the new web dropdown behavior (`WebDropdownMenu.test.tsx`, `SelectBadge.web.test.tsx`) and updates `SelectBadge` snapshots for the new trigger `ref`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 648abf8104f0e2f33432031d6f3a7efd3486de8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->