### PR TITLE
[alignRules] useConsentForms.test.ts, useSubmitConsent.test.ts, Common.ts

### DIFF
--- a/demo/stories/SignatureField.stories.tsx
+++ b/demo/stories/SignatureField.stories.tsx
@@ -2,12 +2,12 @@ import {SignatureField} from "@terreno/ui";
 import {type ReactElement, useState} from "react";
 
 export const SignatureFieldDemo = (): ReactElement => {
-  const [, setSignature] = useState();
+  const [, setSignature] = useState<string>();
   return <SignatureField onChange={setSignature} />;
 };
 
 export const SignatureFieldDemoCompleted = (): ReactElement => {
-  const [, setSignature] = useState();
+  const [, setSignature] = useState<string>();
   return (
     <SignatureField
       disabled
@@ -19,13 +19,13 @@ export const SignatureFieldDemoCompleted = (): ReactElement => {
 };
 
 export const SignatureFieldDemoDisabled = (): ReactElement => {
-  const [, setSignature] = useState();
+  const [, setSignature] = useState<string>();
   return (
     <SignatureField disabled disabledText="Complete form before signing" onChange={setSignature} />
   );
 };
 
 export const SignatureFieldDemoWithError = (): ReactElement => {
-  const [, setSignature] = useState();
+  const [, setSignature] = useState<string>();
   return <SignatureField errorText="Signature is required." onChange={setSignature} />;
 };

--- a/ui/src/Common.ts
+++ b/ui/src/Common.ts
@@ -1,7 +1,7 @@
 import type {CountryCode} from "libphonenumber-js";
 import type React from "react";
 import type {ReactElement, ReactNode} from "react";
-import type {ListRenderItemInfo, StyleProp, TextStyle, ViewStyle} from "react-native";
+import type {ImageStyle, ListRenderItemInfo, StyleProp, TextStyle, ViewStyle} from "react-native";
 import type {DimensionValue} from "react-native/Libraries/StyleSheet/StyleSheetTypes";
 import type {Styles} from "react-native-google-places-autocomplete";
 import type {SvgProps} from "react-native-svg";
@@ -455,9 +455,7 @@ export interface BoxPropsBase {
   mdColumn?: UnsignedUpTo12;
   lgColumn?: UnsignedUpTo12;
   dangerouslySetInlineStyle?: {
-    __style: {
-      [key: string]: any;
-    };
+    __style: Record<string, string | number>;
   };
   direction?: "row" | "column";
   smDirection?: "row" | "column";
@@ -528,7 +526,7 @@ export interface BoxPropsBase {
 
   onClick?: () => void | Promise<void>;
   className?: string;
-  style?: any;
+  style?: StyleProp<ViewStyle>;
   onHoverStart?: () => void | Promise<void>;
   onHoverEnd?: () => void | Promise<void>;
   scroll?: boolean;
@@ -554,7 +552,7 @@ export type BoxProps =
 export type BoxColor = SurfaceColor | "transparent";
 
 export interface ErrorBoundaryProps {
-  onError?: (error: Error, stack: any) => void;
+  onError?: (error: Error, stack: string) => void;
   children?: ReactNode;
 }
 
@@ -652,7 +650,7 @@ export interface TextFieldProps extends BaseFieldProps, HelperTextProps, ErrorTe
   multiline?: boolean;
   rows?: number;
 
-  inputRef?: any;
+  inputRef?: (instance: unknown) => void;
   trimOnBlur?: boolean;
 
   aiSuggestion?: AiSuggestionProps;
@@ -782,7 +780,7 @@ export interface ImageProps {
   size?: string;
   srcSet?: string;
   fullWidth?: boolean;
-  style?: any;
+  style?: ImageStyle;
 }
 
 export interface BackButtonInterface {
@@ -830,6 +828,11 @@ export interface LayoutChangeEvent {
   };
 }
 
+export interface SplitPageListItem {
+  id: string;
+  [key: string]: unknown;
+}
+
 export interface SplitPageProps {
   /**
    * can accept either one React Child or any array of ReactChild. If this is not provided,
@@ -850,15 +853,15 @@ export interface SplitPageProps {
   loading?: boolean;
   color?: SurfaceColor;
   keyboardOffset?: number;
-  renderListViewItem: (itemInfo: ListRenderItemInfo<any>) => ReactElement | null;
+  renderListViewItem: (itemInfo: ListRenderItemInfo<SplitPageListItem>) => ReactElement | null;
   renderListViewHeader?: () => ReactElement | null;
   renderContent?: (index?: number) => ReactElement | ReactElement[] | null;
-  listViewData: any[];
-  listViewExtraData?: any;
+  listViewData: SplitPageListItem[];
+  listViewExtraData?: unknown;
   listViewWidth?: number;
   listViewMaxWidth?: number;
   renderChild?: () => ReactChild;
-  onSelectionChange?: (value?: any) => void | Promise<void>;
+  onSelectionChange?: (value?: unknown) => void | Promise<void>;
 }
 
 export type PermissionKind =
@@ -896,7 +899,7 @@ export interface AddressInterface {
 export interface TransformValueOptions {
   func?: (value: string) => string;
   options?: {
-    [key: string]: any;
+    [key: string]: unknown;
   };
 }
 
@@ -1662,7 +1665,8 @@ export interface DateTimeActionSheetProps {
   type?: "date" | "time" | "datetime";
   // Returns an ISO 8601 string. If mode is "time", the date portion is today.
   onChange: OnChangeCallback;
-  actionSheetRef: React.RefObject<any>;
+  // noExplicitAny: ActionSheet is a local class component; importing it here would create a circular dependency
+  actionSheetRef: React.RefObject<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
   visible: boolean;
   onDismiss: () => void;
   timezone?: string;
@@ -1673,7 +1677,8 @@ export interface DecimalRangeActionSheetProps {
   min: number;
   max: number;
   onChange: OnChangeCallback;
-  actionSheetRef: React.RefObject<any>;
+  // noExplicitAny: ActionSheet is a local class component; importing it here would create a circular dependency
+  actionSheetRef: React.RefObject<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 export interface DecimalRangeActionSheetState {
@@ -1732,7 +1737,8 @@ export type FieldProps =
 export interface HeightActionSheetProps {
   value?: string;
   onChange: OnChangeCallback;
-  actionSheetRef: React.RefObject<any>;
+  // noExplicitAny: ActionSheet is a local class component; importing it here would create a circular dependency
+  actionSheetRef: React.RefObject<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
   /** Minimum height in total inches */
   min?: number;
   /** Maximum height in total inches */
@@ -1743,14 +1749,21 @@ export interface HeightActionSheetProps {
 
 export interface HyperlinkProps {
   linkDefault?: boolean;
-  linkify?: any;
-  linkStyle?: StyleProp<any>;
+  // noExplicitAny: linkify-it has no resolvable type declarations in this tsconfig (types: [])
+  linkify?: {
+    pretest: (text: string) => boolean;
+    test: (text: string) => boolean;
+    match: (
+      text: string
+    ) => Array<{index: number; lastIndex: number; text: string; url: string}> | null;
+  };
+  linkStyle?: StyleProp<TextStyle>;
   linkText?: string | ((url: string) => string);
   onPress?: (url: string) => void;
   onLongPress?: (url: string, text: string) => void;
-  injectViewProps?: (url: string) => any;
+  injectViewProps?: (url: string) => Record<string, unknown>;
   children?: React.ReactNode;
-  style?: StyleProp<any>;
+  style?: StyleProp<ViewStyle>;
 }
 
 export interface IconButtonProps {
@@ -1899,11 +1912,11 @@ export interface ModalProps {
   /**
    * The function to call when the primary button is clicked.
    */
-  primaryButtonOnClick?: (value?: any) => void | Promise<void>;
+  primaryButtonOnClick?: (value?: unknown) => void | Promise<void>;
   /**
    * The function to call when the secondary button is clicked.
    */
-  secondaryButtonOnClick?: (value?: any) => void | Promise<void>;
+  secondaryButtonOnClick?: (value?: unknown) => void | Promise<void>;
 }
 
 export interface NumberPickerActionSheetProps {
@@ -1911,11 +1924,12 @@ export interface NumberPickerActionSheetProps {
   min: number;
   max: number;
   onChange: OnChangeCallback;
-  actionSheetRef: React.RefObject<any>;
+  // noExplicitAny: ActionSheet is a local class component; importing it here would create a circular dependency
+  actionSheetRef: React.RefObject<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 export interface PageProps {
-  navigation?: any;
+  navigation?: unknown;
   scroll?: boolean;
   loading?: boolean;
   loadingText?: string;
@@ -1928,11 +1942,11 @@ export interface PageProps {
   color?: SurfaceColor;
   maxWidth?: number | string;
   keyboardOffset?: number;
-  footer?: any;
+  footer?: ReactNode;
   rightButton?: string;
   rightButtonOnClick?: () => void;
-  children?: any;
-  onError?: (error: Error, stack: any) => void;
+  children?: ReactNode;
+  onError?: (error: Error, stack: string) => void;
 }
 
 export interface ProgressBarProps {
@@ -1955,7 +1969,7 @@ export interface RadioFieldProps {
 export interface SignatureFieldProps {
   disabled?: boolean; // default "default"
   value?: string;
-  onChange: (value: any) => void;
+  onChange: (value: string) => void;
   title?: string; // default "Signature"
   onStart?: () => void;
   onEnd?: () => void;
@@ -2235,7 +2249,8 @@ export interface TextFieldPickerActionSheetProps {
   value?: string;
   mode?: "date" | "time";
   onChange: OnChangeCallback;
-  actionSheetRef: React.RefObject<any>;
+  // noExplicitAny: ActionSheet is a local class component; importing it here would create a circular dependency
+  actionSheetRef: React.RefObject<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 export interface ToastProps {
@@ -2354,17 +2369,20 @@ export type TapToEditProps =
 
 export interface BaseTapToEditProps extends Omit<FieldProps, "onChange" | "value"> {
   title: string;
-  value: any;
+  // noExplicitAny: value type varies by TapToEdit variant (string, number, address, etc.); a discriminated union would require a major refactor of TapToEdit consumers
+  value: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
   /**
    * Not required if not editable.
    */
-  setValue?: (value: any) => void;
+  // noExplicitAny: must match flexible value type above
+  setValue?: (value: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
 
   /**
    * Not required if not editable.
    */
-  onSave?: (value: any) => void | Promise<void>;
+  // noExplicitAny: must match flexible value type above
+  onSave?: (value: any) => void | Promise<void>; // eslint-disable-line @typescript-eslint/no-explicit-any
 
   /**
    * If false, the field will not be editable and will be disabled
@@ -2376,7 +2394,8 @@ export interface BaseTapToEditProps extends Omit<FieldProps, "onChange" | "value
    * Enable edit mode from outside the component.
    */
   isEditing?: boolean;
-  transform?: (value: any) => string;
+  // noExplicitAny: must match flexible value type above
+  transform?: (value: any) => string; // eslint-disable-line @typescript-eslint/no-explicit-any
   /**
    * Show a confirmation modal before saving the value.
    * @default false
@@ -2431,7 +2450,7 @@ export interface APIError {
     source?: string;
     pointer?: string;
     parameter?: string;
-    meta?: {[id: string]: any};
+    meta?: {[id: string]: unknown};
   };
 }
 
@@ -2464,7 +2483,8 @@ export interface ModelFields {
 
 export interface OpenAPISpec {
   paths: {
-    [key: string]: any;
+    // noExplicitAny: OpenAPI path items have deeply nested dynamic structure; fully typing would require duplicating the OpenAPI 3.0 spec
+    [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   };
 }
 
@@ -2496,7 +2516,7 @@ export interface ModelAdminFieldConfig {
 
 // The props for a custom column component for ModelAdmin.
 export interface ModelAdminCustomComponentProps extends Omit<FieldProps, "name"> {
-  doc: any; // The rest of the document.
+  doc: Record<string, unknown>;
   fieldKey: string; // Dot notation representation of the field.
   // user: User;
   editing: boolean; // Allow for inline editing of the field.

--- a/ui/src/Common.ts
+++ b/ui/src/Common.ts
@@ -1666,7 +1666,7 @@ export interface DateTimeActionSheetProps {
   // Returns an ISO 8601 string. If mode is "time", the date portion is today.
   onChange: OnChangeCallback;
   // noExplicitAny: ActionSheet is a local class component; importing it here would create a circular dependency
-  actionSheetRef: React.RefObject<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  actionSheetRef: React.RefObject<any>;
   visible: boolean;
   onDismiss: () => void;
   timezone?: string;
@@ -1678,7 +1678,7 @@ export interface DecimalRangeActionSheetProps {
   max: number;
   onChange: OnChangeCallback;
   // noExplicitAny: ActionSheet is a local class component; importing it here would create a circular dependency
-  actionSheetRef: React.RefObject<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  actionSheetRef: React.RefObject<any>;
 }
 
 export interface DecimalRangeActionSheetState {
@@ -1738,7 +1738,7 @@ export interface HeightActionSheetProps {
   value?: string;
   onChange: OnChangeCallback;
   // noExplicitAny: ActionSheet is a local class component; importing it here would create a circular dependency
-  actionSheetRef: React.RefObject<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  actionSheetRef: React.RefObject<any>;
   /** Minimum height in total inches */
   min?: number;
   /** Maximum height in total inches */
@@ -1925,7 +1925,7 @@ export interface NumberPickerActionSheetProps {
   max: number;
   onChange: OnChangeCallback;
   // noExplicitAny: ActionSheet is a local class component; importing it here would create a circular dependency
-  actionSheetRef: React.RefObject<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  actionSheetRef: React.RefObject<any>;
 }
 
 export interface PageProps {
@@ -2250,7 +2250,7 @@ export interface TextFieldPickerActionSheetProps {
   mode?: "date" | "time";
   onChange: OnChangeCallback;
   // noExplicitAny: ActionSheet is a local class component; importing it here would create a circular dependency
-  actionSheetRef: React.RefObject<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  actionSheetRef: React.RefObject<any>;
 }
 
 export interface ToastProps {
@@ -2370,19 +2370,19 @@ export type TapToEditProps =
 export interface BaseTapToEditProps extends Omit<FieldProps, "onChange" | "value"> {
   title: string;
   // noExplicitAny: value type varies by TapToEdit variant (string, number, address, etc.); a discriminated union would require a major refactor of TapToEdit consumers
-  value: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  value: any;
 
   /**
    * Not required if not editable.
    */
   // noExplicitAny: must match flexible value type above
-  setValue?: (value: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+  setValue?: (value: any) => void;
 
   /**
    * Not required if not editable.
    */
   // noExplicitAny: must match flexible value type above
-  onSave?: (value: any) => void | Promise<void>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  onSave?: (value: any) => void | Promise<void>;
 
   /**
    * If false, the field will not be editable and will be disabled
@@ -2395,7 +2395,7 @@ export interface BaseTapToEditProps extends Omit<FieldProps, "onChange" | "value
    */
   isEditing?: boolean;
   // noExplicitAny: must match flexible value type above
-  transform?: (value: any) => string; // eslint-disable-line @typescript-eslint/no-explicit-any
+  transform?: (value: any) => string;
   /**
    * Show a confirmation modal before saving the value.
    * @default false
@@ -2484,7 +2484,7 @@ export interface ModelFields {
 export interface OpenAPISpec {
   paths: {
     // noExplicitAny: OpenAPI path items have deeply nested dynamic structure; fully typing would require duplicating the OpenAPI 3.0 spec
-    [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
   };
 }
 

--- a/ui/src/useConsentForms.test.ts
+++ b/ui/src/useConsentForms.test.ts
@@ -3,30 +3,48 @@ import {renderHook} from "@testing-library/react-native";
 
 import {detectLocale, useConsentForms} from "./useConsentForms";
 
+type ConsentFormsApi = Parameters<typeof useConsentForms>[0];
+
+interface MockQueryDef {
+  onQueryStarted?: (
+    arg: unknown,
+    helpers: {queryFulfilled: Promise<{data?: unknown[]}>}
+  ) => Promise<void>;
+  providesTags?: string[];
+  query: () => string;
+}
+
+interface MockInjectOptions {
+  endpoints: (build: {query: (def: MockQueryDef) => unknown}) => Record<string, unknown>;
+  overrideExisting?: boolean;
+}
+
+const typedGlobal = globalThis as unknown as {navigator: {language?: string} | undefined};
+
 mock.module("expo-localization", () => ({
   getLocales: () => [{languageTag: "es-ES"}],
 }));
 
 describe("detectLocale", () => {
   it("returns locale from expo-localization in native test env", () => {
-    const originalNavigator = (globalThis as any).navigator;
-    (globalThis as any).navigator = undefined;
+    const originalNavigator = typedGlobal.navigator;
+    typedGlobal.navigator = undefined;
     const locale = detectLocale();
-    (globalThis as any).navigator = originalNavigator;
+    typedGlobal.navigator = originalNavigator;
     expect(typeof locale).toBe("string");
     expect(locale.length).toBeGreaterThan(0);
   });
 
   it("falls back to en when expo-localization throws and no navigator", () => {
-    const originalNavigator = (globalThis as any).navigator;
-    (globalThis as any).navigator = undefined;
+    const originalNavigator = typedGlobal.navigator;
+    typedGlobal.navigator = undefined;
     mock.module("expo-localization", () => ({
       getLocales: () => {
         throw new Error("not available");
       },
     }));
     const locale = detectLocale();
-    (globalThis as any).navigator = originalNavigator;
+    typedGlobal.navigator = originalNavigator;
     // Reset mock
     mock.module("expo-localization", () => ({
       getLocales: () => [{languageTag: "es-ES"}],
@@ -35,10 +53,10 @@ describe("detectLocale", () => {
   });
 
   it("returns navigator.language when available", () => {
-    const originalNavigator = (globalThis as any).navigator;
-    (globalThis as any).navigator = {language: "fr-FR"};
+    const originalNavigator = typedGlobal.navigator;
+    typedGlobal.navigator = {language: "fr-FR"};
     const locale = detectLocale();
-    (globalThis as any).navigator = originalNavigator;
+    typedGlobal.navigator = originalNavigator;
     expect(locale).toBe("fr-FR");
   });
 });
@@ -54,10 +72,10 @@ describe("useConsentForms", () => {
     }));
     const api = {
       enhanceEndpoints: mock(() => ({
-        injectEndpoints: mock((opts: any) => {
+        injectEndpoints: mock((opts: MockInjectOptions) => {
           // Call endpoint builder to exercise provides/onQueryStarted
           const build = {
-            query: mock((def: any) => {
+            query: mock((def: MockQueryDef) => {
               // Call onQueryStarted with a successful result
               if (def.onQueryStarted) {
                 void def.onQueryStarted(undefined, {
@@ -78,21 +96,21 @@ describe("useConsentForms", () => {
   };
 
   it("returns an array of forms when response is an array", () => {
-    const {api} = buildApi({data: [{id: "1", title: "Form 1"} as any]});
-    const {result} = renderHook(() => useConsentForms(api as any));
+    const {api} = buildApi({data: [{id: "1", title: "Form 1"}]});
+    const {result} = renderHook(() => useConsentForms(api as unknown as ConsentFormsApi));
     expect(result.current.forms).toBeDefined();
     expect(Array.isArray(result.current.forms)).toBe(true);
   });
 
   it("unwraps .data property when response is object shape", () => {
-    const {api} = buildApi({data: {data: [{id: "2"} as any]}});
-    const {result} = renderHook(() => useConsentForms(api as any, "/api"));
+    const {api} = buildApi({data: {data: [{id: "2"}]}});
+    const {result} = renderHook(() => useConsentForms(api as unknown as ConsentFormsApi, "/api"));
     expect(Array.isArray(result.current.forms)).toBe(true);
   });
 
   it("returns empty array when no data is present", () => {
     const {api} = buildApi({data: undefined, isLoading: true});
-    const {result} = renderHook(() => useConsentForms(api as any));
+    const {result} = renderHook(() => useConsentForms(api as unknown as ConsentFormsApi));
     expect(result.current.forms).toEqual([]);
     expect(result.current.isLoading).toBe(true);
   });
@@ -101,9 +119,9 @@ describe("useConsentForms", () => {
     const refetch = mock(() => {});
     const api = {
       enhanceEndpoints: mock(() => ({
-        injectEndpoints: mock((opts: any) => {
+        injectEndpoints: mock((opts: MockInjectOptions) => {
           const build = {
-            query: mock((def: any) => {
+            query: mock((def: MockQueryDef) => {
               if (def.onQueryStarted) {
                 void def.onQueryStarted(undefined, {
                   queryFulfilled: Promise.reject(new Error("failed")),
@@ -124,7 +142,7 @@ describe("useConsentForms", () => {
         }),
       })),
     };
-    const {result} = renderHook(() => useConsentForms(api as any));
+    const {result} = renderHook(() => useConsentForms(api as unknown as ConsentFormsApi));
     expect(result.current.error).toBe("error");
   });
 });

--- a/ui/src/useSubmitConsent.test.ts
+++ b/ui/src/useSubmitConsent.test.ts
@@ -1,7 +1,24 @@
 import {describe, expect, it, mock} from "bun:test";
 import {renderHook} from "@testing-library/react-native";
 
+import type {SubmitConsentBody} from "./useSubmitConsent";
 import {useSubmitConsent} from "./useSubmitConsent";
+
+type SubmitConsentApi = Parameters<typeof useSubmitConsent>[0];
+
+interface MockMutationDef {
+  invalidatesTags?: string[];
+  query: (body: SubmitConsentBody) => {
+    body: SubmitConsentBody;
+    method: string;
+    url: string;
+  };
+}
+
+interface MockInjectOptions {
+  endpoints: (build: {mutation: (def: MockMutationDef) => unknown}) => Record<string, unknown>;
+  overrideExisting?: boolean;
+}
 
 describe("useSubmitConsent", () => {
   const buildApi = () => {
@@ -13,9 +30,9 @@ describe("useSubmitConsent", () => {
     ]);
     const api = {
       enhanceEndpoints: mock(() => ({
-        injectEndpoints: mock((opts: any) => {
+        injectEndpoints: mock((opts: MockInjectOptions) => {
           const build = {
-            mutation: mock((def: any) => {
+            mutation: mock((def: MockMutationDef) => {
               // Exercise the query builder
               const result = def.query({
                 agreed: true,
@@ -37,7 +54,7 @@ describe("useSubmitConsent", () => {
 
   it("returns submit function and state", () => {
     const {api} = buildApi();
-    const {result} = renderHook(() => useSubmitConsent(api as any));
+    const {result} = renderHook(() => useSubmitConsent(api as unknown as SubmitConsentApi));
     expect(typeof result.current.submit).toBe("function");
     expect(result.current.isSubmitting).toBe(false);
     expect(result.current.error).toBeUndefined();
@@ -45,7 +62,7 @@ describe("useSubmitConsent", () => {
 
   it("calls submit mutation when submit is invoked", async () => {
     const {api, submitMutation, unwrap} = buildApi();
-    const {result} = renderHook(() => useSubmitConsent(api as any, "/api"));
+    const {result} = renderHook(() => useSubmitConsent(api as unknown as SubmitConsentApi, "/api"));
     const response = await result.current.submit({
       agreed: true,
       consentFormId: "f1",
@@ -58,7 +75,7 @@ describe("useSubmitConsent", () => {
 
   it("uses empty baseUrl when none provided", () => {
     const {api} = buildApi();
-    const {result} = renderHook(() => useSubmitConsent(api as any));
+    const {result} = renderHook(() => useSubmitConsent(api as unknown as SubmitConsentApi));
     expect(result.current.submit).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

Replaces `any` types with explicit types across 3 frontend files in `ui/src/`:

**`useConsentForms.test.ts`** — Replaced 19 `any` instances:
- `(globalThis as any).navigator` → typed via `globalThis as unknown as {navigator: ...}`
- Mock callback params (`opts: any`, `def: any`) → proper `MockInjectOptions` and `MockQueryDef` interfaces
- `api as any` → `api as unknown as ConsentFormsApi` using `Parameters<typeof useConsentForms>[0]`
- Removed unnecessary `as any` casts on test data objects

**`useSubmitConsent.test.ts`** — Replaced 5 `any` instances:
- Same pattern: mock callback params typed via `MockMutationDef` and `MockInjectOptions` interfaces
- `api as any` → `api as unknown as SubmitConsentApi`

**`Common.ts`** — Replaced 24 `any` instances:
- `dangerouslySetInlineStyle.__style` → `Record<string, string | number>`
- `BoxPropsBase.style` → `StyleProp<ViewStyle>`
- `ErrorBoundaryProps.onError` stack param → `string`
- `TextFieldProps.inputRef` → `(instance: unknown) => void`
- `ImageProps.style` → `ImageStyle`
- `SplitPageProps` list data → new `SplitPageListItem` interface with `{id: string; [key: string]: unknown}`
- `ModalProps` button callbacks → `(value?: unknown)`
- `PageProps` children/footer → `ReactNode`, navigation → `unknown`
- `SignatureFieldProps.onChange` → `(value: string) => void`
- `HyperlinkProps` link styles → `StyleProp<TextStyle>`, `StyleProp<ViewStyle>`
- `ModelAdminCustomComponentProps.doc` → `Record<string, unknown>`
- Various index signatures → `unknown` values

**Left `noExplicitAny` comments (with justification) for:**
- `actionSheetRef: React.RefObject<any>` (5 occurrences) — local `ActionSheet` class; importing would create circular dependency
- `BaseTapToEditProps` value/setValue/onSave/transform (4 occurrences) — value type varies by TapToEdit variant; discriminated union would require major refactor
- `OpenAPISpec.paths` — deeply nested dynamic structure
- `HyperlinkProps.linkify` — `linkify-it` has no resolvable type declarations in this tsconfig

**Downstream fix:** Updated `demo/stories/SignatureField.stories.tsx` to use `useState<string>()` to match the now-typed `onChange` prop.

## Review & Testing Checklist for Human
- [ ] Verify `Common.ts` type changes don't break any UI component usage in the app (especially `SplitPage`, `Image`, `Box`, `Modal`, `TapToEdit`)
- [ ] Confirm the `noExplicitAny` justifications are acceptable — these are the cases where replacing `any` would require non-trivial refactoring
- [ ] Run the test suite (`bun run test`) to verify the test file changes don't break existing tests
- [ ] Check that `SignatureField` stories still render correctly in the demo app

### Notes
- All files are in the `ui/` package (frontend only) — no frontend/backend mixing
- `bun run lint` and `bun run compile` pass locally with zero errors across all packages

Link to Devin session: https://app.devin.ai/sessions/0100d312e17041b2acc535cebf237f2f
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly type-safety improvements, but it changes public `@terreno/ui` prop types (notably `SignatureFieldProps.onChange` and `SplitPageProps` data typing), which can cause downstream TypeScript compile errors in consumers.
> 
> **Overview**
> **Reduces `any` usage across the UI package by tightening TypeScript types** in `ui/src/Common.ts` and related hook tests.
> 
> This replaces several public prop fields previously typed as `any` with more specific types (e.g., `BoxPropsBase.style`, `ImageProps.style`, `ErrorBoundaryProps`/`PageProps` `onError` stack, `ModalProps` callbacks, `SplitPageProps` list item/data typing via new `SplitPageListItem`, and `SignatureFieldProps.onChange` now requiring a `string`).
> 
> Tests for `useConsentForms` and `useSubmitConsent` are updated to use typed mock interfaces and safer casts, and the `SignatureField` demo stories now type state as `string` to match the updated `onChange` contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bf56cb234666b1bf6e005eed6b19cef4220dfa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->