### PR TITLE
Support primitive arrays in the admin panel

### DIFF
--- a/admin-backend/src/adminApp.models.test.ts
+++ b/admin-backend/src/adminApp.models.test.ts
@@ -126,6 +126,24 @@ describe("AdminApp /admin/config", () => {
     expect(foodMeta.fields.eatenBy.ref).toBe("User");
   });
 
+  it("extracts itemType for primitive string arrays", async () => {
+    const res = await adminAgent.get("/admin/config").expect(200);
+    const [foodMeta] = res.body.models;
+    // tags is [String] — should expose itemType so the frontend renders a primitive list
+    expect(foodMeta.fields.tags.type).toBe("array");
+    expect(foodMeta.fields.tags.itemType).toBe("string");
+    expect(foodMeta.fields.tags.items).toBeUndefined();
+  });
+
+  it("extracts itemType and itemRef for arrays of ObjectId references", async () => {
+    const res = await adminAgent.get("/admin/config").expect(200);
+    const [foodMeta] = res.body.models;
+    // eatenBy is [{type: ObjectId, ref: "User"}] — should expose both itemType and itemRef
+    expect(foodMeta.fields.eatenBy.type).toBe("array");
+    expect(foodMeta.fields.eatenBy.itemType).toBe("objectid");
+    expect(foodMeta.fields.eatenBy.itemRef).toBe("User");
+  });
+
   it("returns 403 for non-admin users", async () => {
     const res = await notAdminAgent.get("/admin/config").expect(403);
     expect(res.body.title).toInclude("Admin access required");

--- a/admin-backend/src/adminApp.ts
+++ b/admin-backend/src/adminApp.ts
@@ -86,8 +86,14 @@ interface AdminFieldMeta {
   ref?: string;
   searchable?: boolean;
   widget?: string;
-  /** For array fields: metadata about each item's sub-fields */
+  /** For array fields of sub-documents: metadata about each item's sub-fields */
   items?: Record<string, AdminFieldMeta>;
+  /** For array fields of primitives: the item type (string/number/boolean/objectid) */
+  itemType?: string;
+  /** For array fields of primitives: enum values for each item */
+  itemEnum?: string[];
+  /** For array fields of ObjectId refs: the referenced model name */
+  itemRef?: string;
 }
 
 interface AdminModelMeta {
@@ -150,6 +156,10 @@ interface OpenApiProperty {
   items?: {
     properties?: Record<string, OpenApiProperty>;
     required?: string[];
+    type?: string;
+    enum?: string[];
+    format?: string;
+    $ref?: string;
   };
 }
 
@@ -177,6 +187,17 @@ const extractFieldMeta = (
         prop.items.properties as Record<string, OpenApiProperty>,
         itemRequired
       );
+    }
+
+    // For array fields of primitives, capture the item type and enum
+    if (prop.type === "array" && prop.items && !prop.items.properties) {
+      const itemProp = prop.items as OpenApiProperty;
+      if (itemProp.type) {
+        fields[key].itemType = itemProp.type;
+      }
+      if (itemProp.enum) {
+        fields[key].itemEnum = itemProp.enum;
+      }
     }
 
     // Check for ObjectId references in the raw property
@@ -280,9 +301,36 @@ export class AdminApp {
           if (pathOptions?.ref) {
             field.ref = pathOptions.ref;
           }
-          // Handle array of refs
+          // Handle array of refs (legacy: also set ref for back-compat)
           if (Array.isArray(pathOptions?.type) && pathOptions.type[0]?.ref) {
             field.ref = pathOptions.type[0].ref;
+          }
+          // For arrays, use the caster to infer the primitive item type/ref.
+          // Mongoose caster.instance is "String" | "Number" | "Boolean" | "ObjectID".
+          if (schemaPath.instance === "Array") {
+            const caster = (
+              schemaPath as unknown as {
+                caster?: {instance?: string; options?: {ref?: string; enum?: string[]}};
+              }
+            ).caster;
+            if (caster?.instance && !field.items) {
+              const instanceToType: Record<string, string> = {
+                Boolean: "boolean",
+                Number: "number",
+                ObjectID: "objectid",
+                String: "string",
+              };
+              const mapped = instanceToType[caster.instance];
+              if (mapped) {
+                field.itemType = mapped;
+              }
+              if (caster.options?.ref) {
+                field.itemRef = caster.options.ref;
+              }
+              if (caster.options?.enum) {
+                field.itemEnum = caster.options.enum;
+              }
+            }
           }
         }
       }

--- a/admin-backend/src/adminApp.ts
+++ b/admin-backend/src/adminApp.ts
@@ -318,6 +318,8 @@ export class AdminApp {
                 Boolean: "boolean",
                 Number: "number",
                 ObjectID: "objectid",
+                ObjectId: "objectid",
+                SchemaObjectId: "objectid",
                 String: "string",
               };
               const mapped = instanceToType[caster.instance];

--- a/admin-frontend/src/AdminFieldRenderer.tsx
+++ b/admin-frontend/src/AdminFieldRenderer.tsx
@@ -8,6 +8,7 @@ import {
 import startCase from "lodash/startCase";
 import React from "react";
 import {AdminNestedArrayField} from "./AdminNestedArrayField";
+import {AdminPrimitiveArrayField} from "./AdminPrimitiveArrayField";
 import {AdminRefField} from "./AdminRefField";
 import {CheckboxListEditor} from "./CheckboxListEditor";
 import {LocaleContentEditor} from "./LocaleContentEditor";
@@ -263,6 +264,25 @@ export const AdminFieldRenderer: React.FC<AdminFieldRendererProps> = ({
         testID={`admin-field-${fieldKey}`}
         title={label}
         value={displayValue}
+      />
+    );
+  }
+
+  // Array of primitives (string, number, boolean) or ObjectId refs
+  if (fieldConfig.type === "array" && fieldConfig.itemType && !fieldConfig.items) {
+    return (
+      <AdminPrimitiveArrayField
+        api={api}
+        baseUrl={baseUrl}
+        errorText={errorText}
+        helperText={helperText}
+        itemEnum={fieldConfig.itemEnum}
+        itemRef={fieldConfig.itemRef}
+        itemType={fieldConfig.itemType}
+        modelConfigs={modelConfigs}
+        onChange={onChange}
+        title={label}
+        value={value ?? []}
       />
     );
   }

--- a/admin-frontend/src/AdminFieldRenderer.tsx
+++ b/admin-frontend/src/AdminFieldRenderer.tsx
@@ -124,8 +124,8 @@ export const AdminFieldRenderer: React.FC<AdminFieldRendererProps> = ({
     }
   }
 
-  // ObjectId with ref -> reference field
-  if (fieldConfig.ref && modelConfigs) {
+  // ObjectId with ref -> reference field (skip arrays — those go to AdminPrimitiveArrayField)
+  if (fieldConfig.ref && modelConfigs && fieldConfig.type !== "array") {
     const refModel = modelConfigs.find((m) => m.name === fieldConfig.ref);
     if (refModel) {
       return (

--- a/admin-frontend/src/AdminPrimitiveArrayField.test.tsx
+++ b/admin-frontend/src/AdminPrimitiveArrayField.test.tsx
@@ -1,0 +1,186 @@
+import {describe, expect, it, mock} from "bun:test";
+import {renderWithTheme} from "@terreno/ui/src/test-utils";
+import React from "react";
+import {act, fireEvent} from "../../ui/node_modules/@testing-library/react-native";
+import {AdminPrimitiveArrayField} from "./AdminPrimitiveArrayField";
+
+const press = async (el: any): Promise<void> => {
+  await act(async () => {
+    fireEvent.press(el);
+    await new Promise((r) => setTimeout(r, 150));
+  });
+};
+
+const mockApi: any = {
+  endpoints: {},
+  reducerPath: "test",
+};
+
+describe("AdminPrimitiveArrayField", () => {
+  it("renders empty state when no items", () => {
+    const {getByText, getByTestId} = renderWithTheme(
+      <AdminPrimitiveArrayField
+        api={mockApi}
+        baseUrl="/admin"
+        itemType="string"
+        onChange={() => {}}
+        title="Tags"
+        value={[]}
+      />
+    );
+    expect(getByText(/No items/i)).toBeDefined();
+    expect(getByTestId("admin-array-add-Tags")).toBeDefined();
+  });
+
+  it("renders existing string items as TextFields", () => {
+    const {getByTestId} = renderWithTheme(
+      <AdminPrimitiveArrayField
+        api={mockApi}
+        baseUrl="/admin"
+        itemType="string"
+        onChange={() => {}}
+        title="Tags"
+        value={["foo", "bar"]}
+      />
+    );
+    expect(getByTestId("admin-array-item-0")).toBeDefined();
+    expect(getByTestId("admin-array-item-1")).toBeDefined();
+    expect(getByTestId("admin-array-remove-0")).toBeDefined();
+    expect(getByTestId("admin-array-remove-1")).toBeDefined();
+  });
+
+  it("adds a new item with the type's default", async () => {
+    const onChange = mock((_: unknown) => undefined);
+    const {getByTestId} = renderWithTheme(
+      <AdminPrimitiveArrayField
+        api={mockApi}
+        baseUrl="/admin"
+        itemType="string"
+        onChange={onChange}
+        title="Tags"
+        value={["foo"]}
+      />
+    );
+    await press(getByTestId("admin-array-add-Tags"));
+    expect(onChange).toHaveBeenCalled();
+    const next = (onChange.mock.calls[0] as any)[0];
+    expect(next).toEqual(["foo", ""]);
+  });
+
+  it("removes an item when the remove button is pressed", async () => {
+    const onChange = mock((_: unknown) => undefined);
+    const {getByTestId} = renderWithTheme(
+      <AdminPrimitiveArrayField
+        api={mockApi}
+        baseUrl="/admin"
+        itemType="string"
+        onChange={onChange}
+        title="Tags"
+        value={["a", "b", "c"]}
+      />
+    );
+    await press(getByTestId("admin-array-remove-1"));
+    expect(onChange).toHaveBeenCalled();
+    const next = (onChange.mock.calls[0] as any)[0];
+    expect(next).toEqual(["a", "c"]);
+  });
+
+  it("updates a string item when its TextField changes", () => {
+    const onChange = mock((_: unknown) => undefined);
+    const {getByTestId} = renderWithTheme(
+      <AdminPrimitiveArrayField
+        api={mockApi}
+        baseUrl="/admin"
+        itemType="string"
+        onChange={onChange}
+        title="Tags"
+        value={["old"]}
+      />
+    );
+    fireEvent.changeText(getByTestId("admin-array-item-0"), "new");
+    expect(onChange).toHaveBeenCalled();
+    const next = (onChange.mock.calls[0] as any)[0];
+    expect(next).toEqual(["new"]);
+  });
+
+  it("coerces number input via Number()", () => {
+    const onChange = mock((_: unknown) => undefined);
+    const {getByTestId} = renderWithTheme(
+      <AdminPrimitiveArrayField
+        api={mockApi}
+        baseUrl="/admin"
+        itemType="number"
+        onChange={onChange}
+        title="Scores"
+        value={[1, 2]}
+      />
+    );
+    fireEvent.changeText(getByTestId("admin-array-item-0"), "42");
+    const next = (onChange.mock.calls[0] as any)[0];
+    expect(next).toEqual([42, 2]);
+  });
+
+  it("uses the boolean default when adding to a [Boolean] field", async () => {
+    const onChange = mock((_: unknown) => undefined);
+    const {getByTestId} = renderWithTheme(
+      <AdminPrimitiveArrayField
+        api={mockApi}
+        baseUrl="/admin"
+        itemType="boolean"
+        onChange={onChange}
+        title="Flags"
+        value={[]}
+      />
+    );
+    await press(getByTestId("admin-array-add-Flags"));
+    const next = (onChange.mock.calls[0] as any)[0];
+    expect(next).toEqual([false]);
+  });
+
+  it("uses the number default when adding to a [Number] field", async () => {
+    const onChange = mock((_: unknown) => undefined);
+    const {getByTestId} = renderWithTheme(
+      <AdminPrimitiveArrayField
+        api={mockApi}
+        baseUrl="/admin"
+        itemType="number"
+        onChange={onChange}
+        title="Scores"
+        value={[]}
+      />
+    );
+    await press(getByTestId("admin-array-add-Scores"));
+    const next = (onChange.mock.calls[0] as any)[0];
+    expect(next).toEqual([0]);
+  });
+
+  it("renders enum items as a SelectField", () => {
+    const {toJSON} = renderWithTheme(
+      <AdminPrimitiveArrayField
+        api={mockApi}
+        baseUrl="/admin"
+        itemEnum={["low", "medium", "high"]}
+        itemType="string"
+        onChange={() => {}}
+        title="Levels"
+        value={["low"]}
+      />
+    );
+    // SelectField has no testID prop here, so just sanity-check the tree renders
+    expect(toJSON()).toBeDefined();
+  });
+
+  it("handles non-array values gracefully", () => {
+    const {toJSON} = renderWithTheme(
+      <AdminPrimitiveArrayField
+        api={mockApi}
+        baseUrl="/admin"
+        itemType="string"
+        onChange={() => {}}
+        title="Tags"
+        value={undefined as any}
+      />
+    );
+    expect(toJSON()).toBeDefined();
+  });
+});

--- a/admin-frontend/src/AdminPrimitiveArrayField.tsx
+++ b/admin-frontend/src/AdminPrimitiveArrayField.tsx
@@ -1,0 +1,183 @@
+import type {Api} from "@reduxjs/toolkit/query/react";
+import {
+  BooleanField,
+  Box,
+  Button,
+  Heading,
+  IconButton,
+  SelectField,
+  Text,
+  TextField,
+} from "@terreno/ui";
+import startCase from "lodash/startCase";
+import React, {useCallback} from "react";
+import {AdminRefField} from "./AdminRefField";
+
+interface AdminPrimitiveArrayFieldProps {
+  title: string;
+  helperText?: string;
+  errorText?: string;
+  itemType: string;
+  itemEnum?: string[];
+  itemRef?: string;
+  value: any[];
+  onChange: (value: any[]) => void;
+  api: Api<any, any, any, any>;
+  baseUrl: string;
+  modelConfigs?: Array<{name: string; routePath: string}>;
+}
+
+const defaultForType = (itemType: string): any => {
+  if (itemType === "boolean") {
+    return false;
+  }
+  if (itemType === "number") {
+    return 0;
+  }
+  return "";
+};
+
+/**
+ * Renders an editable list of primitive values (string, number, boolean) or ObjectId refs.
+ * Used for Mongoose schemas like `tags: [String]`, `scores: [Number]`, `flags: [Boolean]`,
+ * or `memberIds: [{type: ObjectId, ref: "User"}]`.
+ */
+export const AdminPrimitiveArrayField: React.FC<AdminPrimitiveArrayFieldProps> = ({
+  title,
+  helperText,
+  errorText,
+  itemType,
+  itemEnum,
+  itemRef,
+  value,
+  onChange,
+  api,
+  baseUrl,
+  modelConfigs,
+}) => {
+  const arrayValue = Array.isArray(value) ? value : [];
+
+  const handleAdd = useCallback(() => {
+    onChange([...arrayValue, defaultForType(itemType)]);
+  }, [arrayValue, itemType, onChange]);
+
+  const handleRemove = useCallback(
+    (index: number) => {
+      onChange(arrayValue.filter((_, i) => i !== index));
+    },
+    [arrayValue, onChange]
+  );
+
+  const handleUpdate = useCallback(
+    (index: number, itemValue: any) => {
+      onChange(arrayValue.map((item, i) => (i === index ? itemValue : item)));
+    },
+    [arrayValue, onChange]
+  );
+
+  const refModel =
+    itemType === "objectid" && itemRef && modelConfigs
+      ? modelConfigs.find((m) => m.name === itemRef)
+      : undefined;
+
+  const renderItemInput = (item: any, index: number): React.ReactElement => {
+    if (itemType === "boolean") {
+      return (
+        <BooleanField
+          onChange={(val: boolean) => handleUpdate(index, val)}
+          title=""
+          value={Boolean(item)}
+        />
+      );
+    }
+    if (itemEnum && itemEnum.length > 0) {
+      return (
+        <SelectField
+          onChange={(val: string) => handleUpdate(index, val)}
+          options={itemEnum.map((v) => ({label: startCase(v), value: v}))}
+          title=""
+          value={item ?? ""}
+        />
+      );
+    }
+    if (itemType === "objectid" && refModel) {
+      return (
+        <AdminRefField
+          api={api}
+          baseUrl={baseUrl}
+          onChange={(val: string) => handleUpdate(index, val)}
+          refModelName={refModel.name}
+          routePath={refModel.routePath}
+          title=""
+          value={item ?? ""}
+        />
+      );
+    }
+    if (itemType === "number") {
+      return (
+        <TextField
+          onChange={(text: string) => {
+            const num = Number(text);
+            handleUpdate(index, Number.isNaN(num) ? text : num);
+          }}
+          testID={`admin-array-item-${index}`}
+          title=""
+          value={item != null ? String(item) : ""}
+        />
+      );
+    }
+    // Default: string
+    return (
+      <TextField
+        onChange={(val: string) => handleUpdate(index, val)}
+        testID={`admin-array-item-${index}`}
+        title=""
+        value={item ?? ""}
+      />
+    );
+  };
+
+  return (
+    <Box gap={2}>
+      <Box alignItems="center" direction="row" justifyContent="between">
+        <Heading size="sm">{title}</Heading>
+        <Button
+          iconName="plus"
+          onClick={handleAdd}
+          testID={`admin-array-add-${title}`}
+          text="Add"
+          variant="outline"
+        />
+      </Box>
+      {helperText ? (
+        <Text color="secondaryDark" size="sm">
+          {helperText}
+        </Text>
+      ) : null}
+      {errorText ? (
+        <Text color="error" size="sm">
+          {errorText}
+        </Text>
+      ) : null}
+
+      {arrayValue.length === 0 ? (
+        <Box alignItems="center" padding={3}>
+          <Text color="secondaryDark">No items. Click &quot;Add&quot; to create one.</Text>
+        </Box>
+      ) : (
+        arrayValue.map((item, index) => (
+          <Box alignItems="center" direction="row" gap={2} key={`item-${index}`}>
+            <Box flex="grow">{renderItemInput(item, index)}</Box>
+            <IconButton
+              accessibilityLabel="Remove item"
+              iconName="trash"
+              onClick={() => handleRemove(index)}
+              testID={`admin-array-remove-${index}`}
+              variant="destructive"
+            />
+          </Box>
+        ))
+      )}
+    </Box>
+  );
+};

--- a/admin-frontend/src/AdminPrimitiveArrayField.tsx
+++ b/admin-frontend/src/AdminPrimitiveArrayField.tsx
@@ -20,14 +20,17 @@ interface AdminPrimitiveArrayFieldProps {
   itemType: string;
   itemEnum?: string[];
   itemRef?: string;
-  value: any[];
-  onChange: (value: any[]) => void;
+  value: PrimitiveItem[];
+  onChange: (value: PrimitiveItem[]) => void;
+  // biome-ignore lint/suspicious/noExplicitAny: RTK Query Api type is generic; admin code is type-erased here
   api: Api<any, any, any, any>;
   baseUrl: string;
   modelConfigs?: Array<{name: string; routePath: string}>;
 }
 
-const defaultForType = (itemType: string): any => {
+type PrimitiveItem = string | number | boolean;
+
+const defaultForType = (itemType: string): PrimitiveItem => {
   if (itemType === "boolean") {
     return false;
   }
@@ -69,7 +72,7 @@ export const AdminPrimitiveArrayField: React.FC<AdminPrimitiveArrayFieldProps> =
   );
 
   const handleUpdate = useCallback(
-    (index: number, itemValue: any) => {
+    (index: number, itemValue: PrimitiveItem) => {
       onChange(arrayValue.map((item, i) => (i === index ? itemValue : item)));
     },
     [arrayValue, onChange]
@@ -80,7 +83,7 @@ export const AdminPrimitiveArrayField: React.FC<AdminPrimitiveArrayFieldProps> =
       ? modelConfigs.find((m) => m.name === itemRef)
       : undefined;
 
-  const renderItemInput = (item: any, index: number): React.ReactElement => {
+  const renderItemInput = (item: PrimitiveItem, index: number): React.ReactElement => {
     if (itemType === "boolean") {
       return (
         <BooleanField
@@ -96,7 +99,7 @@ export const AdminPrimitiveArrayField: React.FC<AdminPrimitiveArrayFieldProps> =
           onChange={(val: string) => handleUpdate(index, val)}
           options={itemEnum.map((v) => ({label: startCase(v), value: v}))}
           title=""
-          value={item ?? ""}
+          value={item != null ? String(item) : ""}
         />
       );
     }
@@ -109,7 +112,7 @@ export const AdminPrimitiveArrayField: React.FC<AdminPrimitiveArrayFieldProps> =
           refModelName={refModel.name}
           routePath={refModel.routePath}
           title=""
-          value={item ?? ""}
+          value={item != null ? String(item) : ""}
         />
       );
     }
@@ -132,7 +135,7 @@ export const AdminPrimitiveArrayField: React.FC<AdminPrimitiveArrayFieldProps> =
         onChange={(val: string) => handleUpdate(index, val)}
         testID={`admin-array-item-${index}`}
         title=""
-        value={item ?? ""}
+        value={item != null ? String(item) : ""}
       />
     );
   };

--- a/admin-frontend/src/index.tsx
+++ b/admin-frontend/src/index.tsx
@@ -4,6 +4,7 @@ export {AdminModelList} from "./AdminModelList";
 export {AdminModelTable} from "./AdminModelTable";
 export {AdminNestedArrayField} from "./AdminNestedArrayField";
 export {AdminObjectPicker} from "./AdminObjectPicker";
+export {AdminPrimitiveArrayField} from "./AdminPrimitiveArrayField";
 export {AdminRefField} from "./AdminRefField";
 export {AdminScriptList} from "./AdminScriptList";
 export {AdminScriptRunModal} from "./AdminScriptRunModal";

--- a/admin-frontend/src/types.ts
+++ b/admin-frontend/src/types.ts
@@ -9,8 +9,14 @@ export interface AdminFieldConfig {
   ref?: string;
   searchable?: boolean;
   widget?: string;
-  /** For array fields: metadata about each item's sub-fields */
+  /** For array fields of sub-documents: metadata about each item's sub-fields */
   items?: Record<string, AdminFieldConfig>;
+  /** For array fields of primitives: the item type (string/number/boolean/objectid) */
+  itemType?: string;
+  /** For array fields of primitives: enum values for each item */
+  itemEnum?: string[];
+  /** For array fields of ObjectId refs: the referenced model name */
+  itemRef?: string;
 }
 
 export interface AdminModelConfig {

--- a/example-backend/src/__snapshots__/openapi.test.ts.snap
+++ b/example-backend/src/__snapshots__/openapi.test.ts.snap
@@ -3629,6 +3629,22 @@ exports[`OpenAPI spec generation matches snapshot 1`] = `
                             "description": "The user who owns this todo",
                             "type": "schemaobjectid",
                           },
+                          "priority": {
+                            "description": "Priority level of the todo",
+                            "enum": [
+                              "low",
+                              "medium",
+                              "high",
+                            ],
+                            "type": "string",
+                          },
+                          "tags": {
+                            "description": "Free-form tags for categorization",
+                            "items": {
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
                           "title": {
                             "description": "The title of the todo item",
                             "type": "string",
@@ -3743,6 +3759,22 @@ exports[`OpenAPI spec generation matches snapshot 1`] = `
                     "description": "The user who owns this todo",
                     "type": "schemaobjectid",
                   },
+                  "priority": {
+                    "description": "Priority level of the todo",
+                    "enum": [
+                      "low",
+                      "medium",
+                      "high",
+                    ],
+                    "type": "string",
+                  },
+                  "tags": {
+                    "description": "Free-form tags for categorization",
+                    "items": {
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
                   "title": {
                     "description": "The title of the todo item",
                     "type": "string",
@@ -3784,6 +3816,22 @@ exports[`OpenAPI spec generation matches snapshot 1`] = `
                     "ownerId": {
                       "description": "The user who owns this todo",
                       "type": "schemaobjectid",
+                    },
+                    "priority": {
+                      "description": "Priority level of the todo",
+                      "enum": [
+                        "low",
+                        "medium",
+                        "high",
+                      ],
+                      "type": "string",
+                    },
+                    "tags": {
+                      "description": "Free-form tags for categorization",
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
                     },
                     "title": {
                       "description": "The title of the todo item",
@@ -3958,6 +4006,22 @@ exports[`OpenAPI spec generation matches snapshot 1`] = `
                       "description": "The user who owns this todo",
                       "type": "schemaobjectid",
                     },
+                    "priority": {
+                      "description": "Priority level of the todo",
+                      "enum": [
+                        "low",
+                        "medium",
+                        "high",
+                      ],
+                      "type": "string",
+                    },
+                    "tags": {
+                      "description": "Free-form tags for categorization",
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
                     "title": {
                       "description": "The title of the todo item",
                       "type": "string",
@@ -4065,6 +4129,22 @@ exports[`OpenAPI spec generation matches snapshot 1`] = `
                     "description": "The user who owns this todo",
                     "type": "schemaobjectid",
                   },
+                  "priority": {
+                    "description": "Priority level of the todo",
+                    "enum": [
+                      "low",
+                      "medium",
+                      "high",
+                    ],
+                    "type": "string",
+                  },
+                  "tags": {
+                    "description": "Free-form tags for categorization",
+                    "items": {
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
                   "title": {
                     "description": "The title of the todo item",
                     "type": "string",
@@ -4106,6 +4186,22 @@ exports[`OpenAPI spec generation matches snapshot 1`] = `
                     "ownerId": {
                       "description": "The user who owns this todo",
                       "type": "schemaobjectid",
+                    },
+                    "priority": {
+                      "description": "Priority level of the todo",
+                      "enum": [
+                        "low",
+                        "medium",
+                        "high",
+                      ],
+                      "type": "string",
+                    },
+                    "tags": {
+                      "description": "Free-form tags for categorization",
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
                     },
                     "title": {
                       "description": "The title of the todo item",

--- a/example-backend/src/models/todo.ts
+++ b/example-backend/src/models/todo.ts
@@ -15,6 +15,16 @@ const todoSchema = new mongoose.Schema<TodoDocument, TodoModel>(
       required: true,
       type: mongoose.Schema.Types.ObjectId,
     },
+    priority: {
+      description: "Priority level of the todo",
+      enum: ["low", "medium", "high"],
+      type: String,
+    },
+    tags: {
+      default: [],
+      description: "Free-form tags for categorization",
+      type: [String],
+    },
     title: {
       description: "The title of the todo item",
       required: true,

--- a/example-backend/src/types/models/todoTypes.ts
+++ b/example-backend/src/types/models/todoTypes.ts
@@ -15,4 +15,6 @@ export type TodoDocument = BaseDocument &
     title: string;
     completed: boolean;
     ownerId: mongoose.Types.ObjectId;
+    tags: string[];
+    priority?: "low" | "medium" | "high";
   };


### PR DESCRIPTION
## Summary

Adds first-class support for primitive array fields (`[String]`, `[Number]`, `[Boolean]`, `[{type: ObjectId, ref}]`, and enum-constrained variants) in the admin panel. Previously these fell through to a raw JSON textarea. Now they render as an add/remove list of typed inputs.

## Human Testing Steps

- [ ] Open the example backend admin panel and navigate to Todos
- [ ] Create or edit a Todo — verify the `tags` field renders as an editable list of string inputs with Add/Remove buttons (not a JSON textarea)
- [ ] Verify the `priority` field renders as a SelectField with low/medium/high options
- [ ] Add a few tags, save, and confirm they persist on reload
- [ ] Verify all other field types (boolean, number, ref, nested arrays) still render correctly

## Changes

- `admin-backend/adminApp.ts`: emit `itemType`, `itemEnum`, `itemRef` metadata for primitive array schema paths, reading from Mongoose's `caster` (reliable even when OpenAPI items schema is absent)
- `admin-frontend/AdminPrimitiveArrayField.tsx`: new component — add/remove rows of `TextField` / `BooleanField` / `SelectField` (enums) / `AdminRefField` (ObjectId refs)
- `admin-frontend/AdminFieldRenderer.tsx`: route `type:"array"` with `itemType` to the new component; sub-document arrays and JSON fallback unchanged
- `admin-frontend/types.ts`: mirror `itemType`, `itemEnum`, `itemRef` on `AdminFieldConfig`
- `admin-frontend/index.tsx`: export `AdminPrimitiveArrayField`
- `example-backend/models/todo.ts`: add `tags: [String]` and `priority: enum` fields to demonstrate the feature
- `example-backend/openapi.test.ts.snap`: regenerated to include new Todo fields

## Automated Tests

- `admin-backend`: 85 passed
- `admin-frontend`: 155 passed
- `example-backend`: 71 passed (snapshot updated for new Todo fields)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how admin model field metadata is derived for array schema paths and introduces new form rendering for array fields, which could affect editing/saving of existing models’ array data. Risk is mitigated by added backend/frontend tests covering primitive arrays and ObjectId-ref arrays.
> 
> **Overview**
> Adds first-class admin-panel support for *primitive array fields* and *arrays of ObjectId refs* so they no longer fall back to a raw JSON textarea.
> 
> The backend now emits `itemType`/`itemEnum`/`itemRef` for array fields (including inferring types/refs via the Mongoose array caster) and extends tests to assert this metadata for `[String]` and `[{type: ObjectId, ref}]` arrays.
> 
> The frontend introduces `AdminPrimitiveArrayField` (with add/remove rows and typed inputs, including enum selects and ref pickers) and updates `AdminFieldRenderer`/types/exports to route eligible `type:"array"` fields to it; the example `Todo` model and OpenAPI snapshot are updated to demonstrate `tags` and `priority`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b53da302595426bd8f8a803f666ab9bb489509f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->