### PR TITLE
[alignRules] api/src/api.ts, example-backend/src/modelInterfaces.ts, example-backend/src/websockets.ts

### DIFF
--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -36,13 +36,15 @@ import {isValidObjectId} from "./utils";
 
 export type JSONPrimitive = string | number | boolean | null;
 export interface JSONArray extends Array<JSONValue> {}
-export type JSONObject = {[member: string]: JSONValue};
+export interface JSONObject {
+  [member: string]: JSONValue;
+}
 export type JSONValue = JSONPrimitive | JSONObject | JSONArray;
 
-export function addPopulateToQuery(
+export const addPopulateToQuery = (
   builtQuery: mongoose.Query<any[], any, Record<string, never>, any>,
   populatePaths?: PopulatePath[]
-) {
+) => {
   const paths = populatePaths ?? [];
   let query = builtQuery;
 
@@ -52,7 +54,7 @@ export function addPopulateToQuery(
     query = builtQuery.populate({path, select});
   }
   return query;
-}
+};
 
 // TODOS:
 // Support bulk actions
@@ -312,11 +314,11 @@ export interface ModelRouterOptions<T> {
 }
 
 // Ensures query params are allowed. Also checks nested query params when using $and/$or.
-function checkQueryParamAllowed(
+const checkQueryParamAllowed = (
   queryParam: string,
   queryParamValue: any,
   queryFields: string[] = []
-) {
+) => {
   // Check the values of each of the complex query params. We don't support recursive queries here,
   // just one level of and/or
   if (COMPLEX_QUERY_PARAMS.includes(queryParam)) {
@@ -334,7 +336,7 @@ function checkQueryParamAllowed(
       title: `${queryParam} is not allowed as a query param.`,
     });
   }
-}
+};
 
 // Handles dot notation patches, creates a normal object to be used for updates.
 // function flattenDotNotationPatch(data: any) {
@@ -358,10 +360,10 @@ function checkQueryParamAllowed(
 // Helper to determine if validation should be enabled for a specific operation.
 // When options.validation is not set, returns true — the middleware's own
 // isConfigured check will decide whether to actually validate.
-function shouldValidate(
+const shouldValidate = (
   options: ModelRouterOptions<any>,
   operation: "create" | "update" | "query"
-): boolean {
+): boolean => {
   // Check route-specific validation option first
   if (options.validation !== undefined) {
     if (typeof options.validation === "boolean") {
@@ -378,14 +380,14 @@ function shouldValidate(
 
   // Default: let middleware's isConfigured check decide
   return true;
-}
+};
 
 // Get body validation middleware if validation is enabled
-function getBodyValidationMiddleware<T>(
+const getBodyValidationMiddleware = <T>(
   model: Model<T>,
   options: ModelRouterOptions<T>,
   operation: "create" | "update"
-): (req: Request, res: Response, next: NextFunction) => void {
+): ((req: Request, res: Response, next: NextFunction) => void) => {
   const validationOptions: import("./openApiValidator").RequestBodyValidatorOptions = {};
   if (!shouldValidate(options, operation)) {
     validationOptions.enabled = false;
@@ -408,13 +410,13 @@ function getBodyValidationMiddleware<T>(
   }
 
   return validateModelRequestBody(model, validationOptions);
-}
+};
 
 // Get query validation middleware if validation is enabled
-function getQueryValidationMiddleware<T>(
+const getQueryValidationMiddleware = <T>(
   model: Model<T>,
   options: ModelRouterOptions<T>
-): (req: Request, res: Response, next: NextFunction) => void {
+): ((req: Request, res: Response, next: NextFunction) => void) => {
   const querySchema = buildQuerySchemaFromFields(model, options.queryFields);
   const validationOptions: import("./openApiValidator").QueryValidatorOptions = {};
   if (!shouldValidate(options, "query")) {
@@ -425,7 +427,7 @@ function getQueryValidationMiddleware<T>(
   }
 
   return validateQueryParams(querySchema, validationOptions);
-}
+};
 
 /**
  * Registration object returned by modelRouter when called with a path.

--- a/example-backend/src/modelInterfaces.ts
+++ b/example-backend/src/modelInterfaces.ts
@@ -2,28 +2,28 @@ import type {FindExactlyOnePlugin, FindOneOrNonePlugin} from "@terreno/api";
 import type mongoose from "mongoose";
 
 // Base types for all models
-export type BaseDocument = mongoose.Document & {
+export interface BaseDocument extends mongoose.Document {
   _id: mongoose.Types.ObjectId;
   createdAt: Date;
   updatedAt: Date;
-};
+}
 
 // User Model
-export type UserMethods = {
+export interface UserMethods {
   getDisplayName: (this: UserDocument) => string;
-};
+}
 
-export type UserStatics = FindExactlyOnePlugin<UserDocument> &
-  FindOneOrNonePlugin<UserDocument> & {
-    findByEmail: (email: string) => Promise<UserDocument | null>;
-  };
+export interface UserStatics
+  extends FindExactlyOnePlugin<UserDocument>,
+    FindOneOrNonePlugin<UserDocument> {
+  findByEmail: (email: string) => Promise<UserDocument | null>;
+}
 
-export type UserModel = mongoose.Model<UserDocument, object, UserMethods> & UserStatics;
+export interface UserModel extends mongoose.Model<UserDocument, object, UserMethods>, UserStatics {}
 
-export type UserDocument = BaseDocument &
-  UserMethods & {
-    email: string;
-    name: string;
-  };
+export interface UserDocument extends BaseDocument, UserMethods {
+  email: string;
+  name: string;
+}
 
 // Add additional model interfaces below following the same pattern

--- a/example-backend/src/websockets.ts
+++ b/example-backend/src/websockets.ts
@@ -437,7 +437,7 @@ const emitter = async (change: ChangeStreamDocument): Promise<void> => {
   }
 };
 
-type EventDataMapping = {
+interface EventDataMapping {
   notificationEvent: {conversationId?: string; sound: string};
   invalidateTagEvent: {collection: string};
   messageNotificationEvent: {
@@ -455,7 +455,7 @@ type EventDataMapping = {
     unreadCount: number;
     tagCount: number;
   };
-};
+}
 type EventData<T extends keyof EventDataMapping> = EventDataMapping[T];
 
 export const emitEvent = <T extends keyof EventDataMapping>(


### PR DESCRIPTION
## Summary

Align three randomly-selected backend files with the repo's configured rules. No logic, behavior, or variable renames — only style compliance changes.

### Changes per file

**`api/src/api.ts`**
- Convert `type JSONObject` → `interface JSONObject` (rule: prefer interfaces over types)
- Convert top-level `function` declarations to `const` arrow functions: `addPopulateToQuery`, `checkQueryParamAllowed`, `shouldValidate`, `getBodyValidationMiddleware`, `getQueryValidationMiddleware` (rule: prefer const arrow functions over `function` keyword)

**`example-backend/src/modelInterfaces.ts`**
- Convert all five `type` aliases (`BaseDocument`, `UserMethods`, `UserStatics`, `UserModel`, `UserDocument`) to `interface` declarations using `extends` (rule: prefer interfaces over types)

**`example-backend/src/websockets.ts`**
- Convert `type EventDataMapping` → `interface EventDataMapping` (rule: prefer interfaces over types)

## Review & Testing Checklist for Human
- [ ] Verify `bun run compile` passes for `@terreno/api` and `@terreno/example-backend` (confirmed locally, confirm in CI)
- [ ] Verify `bun run lint` has no new warnings in these files
- [ ] Spot-check that no downstream consumers break from `type` → `interface` conversion (interfaces and type aliases are structurally equivalent in TS, so this should be transparent)

### Notes
- `modelRouter` in `api/src/api.ts` uses function overloads and was intentionally left as `function` since TypeScript requires the `function` keyword for overloaded signatures.
- `_buildModelRouter` was kept as `function` because it is hoisted (called before its source-order definition inside `modelRouter`).
- All pre-existing lint/compile errors in unrelated packages (e.g. `admin-frontend`) are unchanged.


Link to Devin session: https://app.devin.ai/sessions/18c3d35cd0de41acb3c9984dfedfd06d
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure typing/style refactors (type/interface and declaration form changes) with no intended logic changes; main risk is accidental TS signature/hoisting differences, but changes are limited to helpers/types.
> 
> **Overview**
> **Style-only TypeScript alignment** across `api/src/api.ts`, `example-backend/src/modelInterfaces.ts`, and `example-backend/src/websockets.ts`.
> 
> Converts several `type` aliases to `interface` declarations (including `JSONObject`, model interfaces, and `EventDataMapping`) and rewrites a handful of helper `function` declarations to `const` arrow functions (e.g., `addPopulateToQuery`, validation/query helpers) to match repo conventions, without intended runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1afc361798710727628328f50ae79aba99e84fb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->