### PR TITLE
[alignRules] useSubmitConsent.test.ts, useConsentForms.test.ts, Common.ts

### DIFF
--- a/demo/stories/SignatureField.stories.tsx
+++ b/demo/stories/SignatureField.stories.tsx
@@ -2,12 +2,12 @@ import {SignatureField} from "@terreno/ui";
 import {type ReactElement, useState} from "react";
 
 export const SignatureFieldDemo = (): ReactElement => {
-  const [, setSignature] = useState();
+  const [, setSignature] = useState<string>();
   return <SignatureField onChange={setSignature} />;
 };
 
 export const SignatureFieldDemoCompleted = (): ReactElement => {
-  const [, setSignature] = useState();
+  const [, setSignature] = useState<string>();
   return (
     <SignatureField
       disabled
@@ -19,13 +19,13 @@ export const SignatureFieldDemoCompleted = (): ReactElement => {
 };
 
 export const SignatureFieldDemoDisabled = (): ReactElement => {
-  const [, setSignature] = useState();
+  const [, setSignature] = useState<string>();
   return (
     <SignatureField disabled disabledText="Complete form before signing" onChange={setSignature} />
   );
 };
 
 export const SignatureFieldDemoWithError = (): ReactElement => {
-  const [, setSignature] = useState();
+  const [, setSignature] = useState<string>();
   return <SignatureField errorText="Signature is required." onChange={setSignature} />;
 };

--- a/ui/src/Common.ts
+++ b/ui/src/Common.ts
@@ -1,7 +1,14 @@
 import type {CountryCode} from "libphonenumber-js";
 import type React from "react";
 import type {ReactElement, ReactNode} from "react";
-import type {ListRenderItemInfo, StyleProp, TextStyle, ViewStyle} from "react-native";
+import type {
+  ImageStyle,
+  ListRenderItemInfo,
+  StyleProp,
+  TextInput,
+  TextStyle,
+  ViewStyle,
+} from "react-native";
 import type {DimensionValue} from "react-native/Libraries/StyleSheet/StyleSheetTypes";
 import type {Styles} from "react-native-google-places-autocomplete";
 import type {SvgProps} from "react-native-svg";
@@ -456,6 +463,7 @@ export interface BoxPropsBase {
   lgColumn?: UnsignedUpTo12;
   dangerouslySetInlineStyle?: {
     __style: {
+      // noExplicitAny: escape hatch for arbitrary inline style values
       [key: string]: any;
     };
   };
@@ -528,7 +536,7 @@ export interface BoxPropsBase {
 
   onClick?: () => void | Promise<void>;
   className?: string;
-  style?: any;
+  style?: StyleProp<ViewStyle>;
   onHoverStart?: () => void | Promise<void>;
   onHoverEnd?: () => void | Promise<void>;
   scroll?: boolean;
@@ -554,7 +562,7 @@ export type BoxProps =
 export type BoxColor = SurfaceColor | "transparent";
 
 export interface ErrorBoundaryProps {
-  onError?: (error: Error, stack: any) => void;
+  onError?: (error: Error, stack: string) => void;
   children?: ReactNode;
 }
 
@@ -652,7 +660,7 @@ export interface TextFieldProps extends BaseFieldProps, HelperTextProps, ErrorTe
   multiline?: boolean;
   rows?: number;
 
-  inputRef?: any;
+  inputRef?: (ref: TextInput | null) => void;
   trimOnBlur?: boolean;
 
   aiSuggestion?: AiSuggestionProps;
@@ -782,7 +790,7 @@ export interface ImageProps {
   size?: string;
   srcSet?: string;
   fullWidth?: boolean;
-  style?: any;
+  style?: ImageStyle;
 }
 
 export interface BackButtonInterface {
@@ -850,14 +858,18 @@ export interface SplitPageProps {
   loading?: boolean;
   color?: SurfaceColor;
   keyboardOffset?: number;
+  // noExplicitAny: ListRenderItemInfo generic type depends on the consumer's data shape
   renderListViewItem: (itemInfo: ListRenderItemInfo<any>) => ReactElement | null;
   renderListViewHeader?: () => ReactElement | null;
   renderContent?: (index?: number) => ReactElement | ReactElement[] | null;
+  // noExplicitAny: list data type varies by consumer's data model
   listViewData: any[];
+  // noExplicitAny: FlatList extraData accepts varying types
   listViewExtraData?: any;
   listViewWidth?: number;
   listViewMaxWidth?: number;
   renderChild?: () => ReactChild;
+  // noExplicitAny: callback value type varies by consumer's data model
   onSelectionChange?: (value?: any) => void | Promise<void>;
 }
 
@@ -896,6 +908,7 @@ export interface AddressInterface {
 export interface TransformValueOptions {
   func?: (value: string) => string;
   options?: {
+    // noExplicitAny: transform option values have varying types depending on the transform function
     [key: string]: any;
   };
 }
@@ -1745,6 +1758,7 @@ export interface HeightActionSheetProps {
 
 export interface HyperlinkProps {
   linkDefault?: boolean;
+  // noExplicitAny: type comes from external linkify-it library which lacks an exported type
   linkify?: any;
   linkStyle?: StyleProp<any>;
   linkText?: string | ((url: string) => string);
@@ -1901,10 +1915,12 @@ export interface ModalProps {
   /**
    * The function to call when the primary button is clicked.
    */
+  // noExplicitAny: callback value type varies by consumer context
   primaryButtonOnClick?: (value?: any) => void | Promise<void>;
   /**
    * The function to call when the secondary button is clicked.
    */
+  // noExplicitAny: callback value type varies by consumer context
   secondaryButtonOnClick?: (value?: any) => void | Promise<void>;
 }
 
@@ -1917,6 +1933,7 @@ export interface NumberPickerActionSheetProps {
 }
 
 export interface PageProps {
+  // noExplicitAny: React Navigation type varies by navigation stack configuration
   navigation?: any;
   scroll?: boolean;
   loading?: boolean;
@@ -1930,11 +1947,11 @@ export interface PageProps {
   color?: SurfaceColor;
   maxWidth?: number | string;
   keyboardOffset?: number;
-  footer?: any;
+  footer?: ReactNode;
   rightButton?: string;
   rightButtonOnClick?: () => void;
-  children?: any;
-  onError?: (error: Error, stack: any) => void;
+  children?: ReactChildren;
+  onError?: (error: Error, stack: string) => void;
 }
 
 export interface ProgressBarProps {
@@ -1957,7 +1974,7 @@ export interface RadioFieldProps {
 export interface SignatureFieldProps {
   disabled?: boolean; // default "default"
   value?: string;
-  onChange: (value: any) => void;
+  onChange: (value: string) => void;
   title?: string; // default "Signature"
   onStart?: () => void;
   onEnd?: () => void;
@@ -2356,16 +2373,19 @@ export type TapToEditProps =
 
 export interface BaseTapToEditProps extends Omit<FieldProps, "onChange" | "value"> {
   title: string;
+  // noExplicitAny: value type varies across TapToEdit field types (text, number, date, etc.)
   value: any;
 
   /**
    * Not required if not editable.
    */
+  // noExplicitAny: value type varies across TapToEdit field types
   setValue?: (value: any) => void;
 
   /**
    * Not required if not editable.
    */
+  // noExplicitAny: value type varies across TapToEdit field types
   onSave?: (value: any) => void | Promise<void>;
 
   /**
@@ -2378,6 +2398,7 @@ export interface BaseTapToEditProps extends Omit<FieldProps, "onChange" | "value
    * Enable edit mode from outside the component.
    */
   isEditing?: boolean;
+  // noExplicitAny: input value type varies across TapToEdit field types
   transform?: (value: any) => string;
   /**
    * Show a confirmation modal before saving the value.
@@ -2433,6 +2454,7 @@ export interface APIError {
     source?: string;
     pointer?: string;
     parameter?: string;
+    // noExplicitAny: API error meta field has no fixed schema
     meta?: {[id: string]: any};
   };
 }
@@ -2466,6 +2488,7 @@ export interface ModelFields {
 
 export interface OpenAPISpec {
   paths: {
+    // noExplicitAny: OpenAPI spec path items have complex nested structures
     [key: string]: any;
   };
 }
@@ -2498,7 +2521,8 @@ export interface ModelAdminFieldConfig {
 
 // The props for a custom column component for ModelAdmin.
 export interface ModelAdminCustomComponentProps extends Omit<FieldProps, "name"> {
-  doc: any; // The rest of the document.
+  // noExplicitAny: document shape varies by model used with ModelAdmin
+  doc: any;
   fieldKey: string; // Dot notation representation of the field.
   // user: User;
   editing: boolean; // Allow for inline editing of the field.

--- a/ui/src/Common.ts
+++ b/ui/src/Common.ts
@@ -864,8 +864,7 @@ export interface SplitPageProps {
   renderContent?: (index?: number) => ReactElement | ReactElement[] | null;
   // noExplicitAny: list data type varies by consumer's data model
   listViewData: any[];
-  // noExplicitAny: FlatList extraData accepts varying types
-  listViewExtraData?: any;
+  listViewExtraData?: unknown;
   listViewWidth?: number;
   listViewMaxWidth?: number;
   renderChild?: () => ReactChild;
@@ -908,8 +907,7 @@ export interface AddressInterface {
 export interface TransformValueOptions {
   func?: (value: string) => string;
   options?: {
-    // noExplicitAny: transform option values have varying types depending on the transform function
-    [key: string]: any;
+    [key: string]: unknown;
   };
 }
 
@@ -2454,8 +2452,7 @@ export interface APIError {
     source?: string;
     pointer?: string;
     parameter?: string;
-    // noExplicitAny: API error meta field has no fixed schema
-    meta?: {[id: string]: any};
+    meta?: {[id: string]: unknown};
   };
 }
 
@@ -2488,7 +2485,7 @@ export interface ModelFields {
 
 export interface OpenAPISpec {
   paths: {
-    // noExplicitAny: OpenAPI spec path items have complex nested structures
+    // noExplicitAny: OpenAPI path items are deeply accessed with chained property lookups
     [key: string]: any;
   };
 }

--- a/ui/src/useConsentForms.test.ts
+++ b/ui/src/useConsentForms.test.ts
@@ -1,7 +1,26 @@
 import {describe, expect, it, mock} from "bun:test";
 import {renderHook} from "@testing-library/react-native";
 
+import type {ConsentFormPublic} from "./useConsentForms";
 import {detectLocale, useConsentForms} from "./useConsentForms";
+
+type ConsentFormsApi = Parameters<typeof useConsentForms>[0];
+
+interface GlobalThisWithNavigator {
+  navigator: {language: string} | undefined;
+}
+
+interface MockQueryDef {
+  onQueryStarted?: (
+    _arg: unknown,
+    helpers: {queryFulfilled: Promise<{data: ConsentFormPublic[]}> | Promise<never>}
+  ) => Promise<void>;
+  query: () => string;
+}
+
+interface MockInjectOpts {
+  endpoints: (build: {query: (def: MockQueryDef) => string}) => Record<string, unknown>;
+}
 
 mock.module("expo-localization", () => ({
   getLocales: () => [{languageTag: "es-ES"}],
@@ -9,24 +28,26 @@ mock.module("expo-localization", () => ({
 
 describe("detectLocale", () => {
   it("returns locale from expo-localization in native test env", () => {
-    const originalNavigator = (globalThis as any).navigator;
-    (globalThis as any).navigator = undefined;
+    const g = globalThis as unknown as GlobalThisWithNavigator;
+    const originalNavigator = g.navigator;
+    g.navigator = undefined;
     const locale = detectLocale();
-    (globalThis as any).navigator = originalNavigator;
+    g.navigator = originalNavigator;
     expect(typeof locale).toBe("string");
     expect(locale.length).toBeGreaterThan(0);
   });
 
   it("falls back to en when expo-localization throws and no navigator", () => {
-    const originalNavigator = (globalThis as any).navigator;
-    (globalThis as any).navigator = undefined;
+    const g = globalThis as unknown as GlobalThisWithNavigator;
+    const originalNavigator = g.navigator;
+    g.navigator = undefined;
     mock.module("expo-localization", () => ({
       getLocales: () => {
         throw new Error("not available");
       },
     }));
     const locale = detectLocale();
-    (globalThis as any).navigator = originalNavigator;
+    g.navigator = originalNavigator;
     // Reset mock
     mock.module("expo-localization", () => ({
       getLocales: () => [{languageTag: "es-ES"}],
@@ -35,10 +56,11 @@ describe("detectLocale", () => {
   });
 
   it("returns navigator.language when available", () => {
-    const originalNavigator = (globalThis as any).navigator;
-    (globalThis as any).navigator = {language: "fr-FR"};
+    const g = globalThis as unknown as GlobalThisWithNavigator;
+    const originalNavigator = g.navigator;
+    g.navigator = {language: "fr-FR"};
     const locale = detectLocale();
-    (globalThis as any).navigator = originalNavigator;
+    g.navigator = originalNavigator;
     expect(locale).toBe("fr-FR");
   });
 });
@@ -54,10 +76,10 @@ describe("useConsentForms", () => {
     }));
     const api = {
       enhanceEndpoints: mock(() => ({
-        injectEndpoints: mock((opts: any) => {
+        injectEndpoints: mock((opts: MockInjectOpts) => {
           // Call endpoint builder to exercise provides/onQueryStarted
           const build = {
-            query: mock((def: any) => {
+            query: mock((def: MockQueryDef) => {
               // Call onQueryStarted with a successful result
               if (def.onQueryStarted) {
                 void def.onQueryStarted(undefined, {
@@ -78,21 +100,21 @@ describe("useConsentForms", () => {
   };
 
   it("returns an array of forms when response is an array", () => {
-    const {api} = buildApi({data: [{id: "1", title: "Form 1"} as any]});
-    const {result} = renderHook(() => useConsentForms(api as any));
+    const {api} = buildApi({data: [{id: "1", title: "Form 1"} as unknown as ConsentFormPublic]});
+    const {result} = renderHook(() => useConsentForms(api as unknown as ConsentFormsApi));
     expect(result.current.forms).toBeDefined();
     expect(Array.isArray(result.current.forms)).toBe(true);
   });
 
   it("unwraps .data property when response is object shape", () => {
-    const {api} = buildApi({data: {data: [{id: "2"} as any]}});
-    const {result} = renderHook(() => useConsentForms(api as any, "/api"));
+    const {api} = buildApi({data: {data: [{id: "2"} as unknown as ConsentFormPublic]}});
+    const {result} = renderHook(() => useConsentForms(api as unknown as ConsentFormsApi, "/api"));
     expect(Array.isArray(result.current.forms)).toBe(true);
   });
 
   it("returns empty array when no data is present", () => {
     const {api} = buildApi({data: undefined, isLoading: true});
-    const {result} = renderHook(() => useConsentForms(api as any));
+    const {result} = renderHook(() => useConsentForms(api as unknown as ConsentFormsApi));
     expect(result.current.forms).toEqual([]);
     expect(result.current.isLoading).toBe(true);
   });
@@ -101,9 +123,9 @@ describe("useConsentForms", () => {
     const refetch = mock(() => {});
     const api = {
       enhanceEndpoints: mock(() => ({
-        injectEndpoints: mock((opts: any) => {
+        injectEndpoints: mock((opts: MockInjectOpts) => {
           const build = {
-            query: mock((def: any) => {
+            query: mock((def: MockQueryDef) => {
               if (def.onQueryStarted) {
                 void def.onQueryStarted(undefined, {
                   queryFulfilled: Promise.reject(new Error("failed")),
@@ -124,7 +146,7 @@ describe("useConsentForms", () => {
         }),
       })),
     };
-    const {result} = renderHook(() => useConsentForms(api as any));
+    const {result} = renderHook(() => useConsentForms(api as unknown as ConsentFormsApi));
     expect(result.current.error).toBe("error");
   });
 });

--- a/ui/src/useSubmitConsent.test.ts
+++ b/ui/src/useSubmitConsent.test.ts
@@ -1,7 +1,18 @@
 import {describe, expect, it, mock} from "bun:test";
 import {renderHook} from "@testing-library/react-native";
 
+import type {SubmitConsentBody} from "./useSubmitConsent";
 import {useSubmitConsent} from "./useSubmitConsent";
+
+type SubmitConsentApi = Parameters<typeof useSubmitConsent>[0];
+
+interface MockMutationDef {
+  query: (body: SubmitConsentBody) => {method: string; url: string};
+}
+
+interface MockInjectOpts {
+  endpoints: (build: {mutation: (def: MockMutationDef) => string}) => Record<string, unknown>;
+}
 
 describe("useSubmitConsent", () => {
   const buildApi = () => {
@@ -13,9 +24,9 @@ describe("useSubmitConsent", () => {
     ]);
     const api = {
       enhanceEndpoints: mock(() => ({
-        injectEndpoints: mock((opts: any) => {
+        injectEndpoints: mock((opts: MockInjectOpts) => {
           const build = {
-            mutation: mock((def: any) => {
+            mutation: mock((def: MockMutationDef) => {
               // Exercise the query builder
               const result = def.query({
                 agreed: true,
@@ -37,7 +48,7 @@ describe("useSubmitConsent", () => {
 
   it("returns submit function and state", () => {
     const {api} = buildApi();
-    const {result} = renderHook(() => useSubmitConsent(api as any));
+    const {result} = renderHook(() => useSubmitConsent(api as unknown as SubmitConsentApi));
     expect(typeof result.current.submit).toBe("function");
     expect(result.current.isSubmitting).toBe(false);
     expect(result.current.error).toBeUndefined();
@@ -45,7 +56,7 @@ describe("useSubmitConsent", () => {
 
   it("calls submit mutation when submit is invoked", async () => {
     const {api, submitMutation, unwrap} = buildApi();
-    const {result} = renderHook(() => useSubmitConsent(api as any, "/api"));
+    const {result} = renderHook(() => useSubmitConsent(api as unknown as SubmitConsentApi, "/api"));
     const response = await result.current.submit({
       agreed: true,
       consentFormId: "f1",
@@ -58,7 +69,7 @@ describe("useSubmitConsent", () => {
 
   it("uses empty baseUrl when none provided", () => {
     const {api} = buildApi();
-    const {result} = renderHook(() => useSubmitConsent(api as any));
+    const {result} = renderHook(() => useSubmitConsent(api as unknown as SubmitConsentApi));
     expect(result.current.submit).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

Replace `as any` / `: any` with explicit types across 3 files in `@terreno/ui`:

**`ui/src/useSubmitConsent.test.ts`** (5 instances):
- Replaced `(opts: any)` and `(def: any)` mock params with typed interfaces (`MockInjectOpts`, `MockMutationDef`)
- Replaced `api as any` casts with `api as unknown as SubmitConsentApi` using `Parameters<typeof useSubmitConsent>[0]`

**`ui/src/useConsentForms.test.ts`** (19 instances):
- Replaced `(globalThis as any).navigator` with a typed `GlobalThisWithNavigator` interface cast
- Replaced mock `(opts: any)` / `(def: any)` params with `MockInjectOpts` / `MockQueryDef` interfaces
- Replaced `as any` data casts with `as unknown as ConsentFormPublic`
- Replaced `api as any` casts with `api as unknown as ConsentFormsApi`

**`ui/src/Common.ts`** (24 instances):
- 8 fixed with proper types:
  - `style?: any` → `StyleProp<ViewStyle>` (BoxPropsBase)
  - `style?: any` → `ImageStyle` (ImageProps)
  - `onError` `stack: any` → `string` (ErrorBoundaryProps, PageProps)
  - `inputRef?: any` → `(ref: TextInput | null) => void` (TextFieldProps)
  - `footer?: any` → `ReactNode`, `children?: any` → `ReactChildren` (PageProps)
  - `onChange: (value: any)` → `(value: string)` (SignatureFieldProps)
- 3 converted to `unknown` (per Bugbot review):
  - `listViewExtraData?: any` → `unknown`
  - `TransformValueOptions.options` index → `[key: string]: unknown`
  - `APIError.meta` index → `[key: string]: unknown`
- 13 annotated with `noExplicitAny:` comments explaining why each cannot be resolved (callback contravariance, escape hatches, external types, deep property access)

Also fixed downstream compile error in `demo/stories/SignatureField.stories.tsx` (`useState()` → `useState<string>()`) caused by the `SignatureFieldProps.onChange` type tightening.

## Review & Testing Checklist for Human
- [ ] Verify that `inputRef?: (ref: TextInput | null) => void` matches all callsites (TextField, TapToEdit, WebAddressAutocomplete, CustomSelectField)
- [ ] Verify `SignatureFieldProps.onChange: (value: string)` is correct — the signature canvas always returns a string (base64 data URI)
- [ ] Spot-check that remaining `noExplicitAny:` annotations are reasonable (13 cases in Common.ts where the type genuinely varies by consumer or has contravariance/access constraints)

### Notes
- No logic, behavior, or variable naming changes — only type annotations and noExplicitAny comments
- All lint (`bun run lint`) and compile (`bun run compile`) pass locally across all packages
- All E2E tests pass in CI

Link to Devin session: https://app.devin.ai/sessions/386db0e542ff41b0b2d9a797d4ac1bc5
Requested by: @joshgachnang