### PR TITLE
[alignRules] populate.ts, langfuseClient.ts

### DIFF
--- a/ai/src/langfuseClient.test.ts
+++ b/ai/src/langfuseClient.test.ts
@@ -1,4 +1,4 @@
-import {afterEach, describe, expect, it} from "bun:test";
+import {afterEach, beforeEach, describe, expect, it} from "bun:test";
 
 import {
   getLangfuseClient,
@@ -8,6 +8,10 @@ import {
 } from "./langfuseClient";
 
 describe("langfuseClient", () => {
+  beforeEach(async () => {
+    await shutdownLangfuseClient();
+  });
+
   afterEach(async () => {
     await shutdownLangfuseClient();
   });

--- a/ai/src/langfuseClient.test.ts
+++ b/ai/src/langfuseClient.test.ts
@@ -1,0 +1,68 @@
+import {afterEach, describe, expect, it} from "bun:test";
+
+import {
+  getLangfuseClient,
+  initLangfuseClient,
+  isLangfuseInitialized,
+  shutdownLangfuseClient,
+} from "./langfuseClient";
+
+describe("langfuseClient", () => {
+  afterEach(async () => {
+    await shutdownLangfuseClient();
+  });
+
+  it("throws when getLangfuseClient is called before initialization", () => {
+    expect(() => getLangfuseClient()).toThrow(
+      "Langfuse client not initialized. Call initLangfuseClient first."
+    );
+  });
+
+  it("isLangfuseInitialized returns false before initialization", () => {
+    expect(isLangfuseInitialized()).toBe(false);
+  });
+
+  it("initLangfuseClient creates and returns a client", () => {
+    const client = initLangfuseClient({
+      publicKey: "pk-test",
+      secretKey: "sk-test",
+    });
+    expect(client).toBeDefined();
+    expect(isLangfuseInitialized()).toBe(true);
+  });
+
+  it("getLangfuseClient returns the initialized client", () => {
+    const initialized = initLangfuseClient({
+      publicKey: "pk-test",
+      secretKey: "sk-test",
+    });
+    const retrieved = getLangfuseClient();
+    expect(retrieved).toBe(initialized);
+  });
+
+  it("initLangfuseClient accepts a custom baseUrl", () => {
+    const client = initLangfuseClient({
+      baseUrl: "https://custom.langfuse.com",
+      publicKey: "pk-test",
+      secretKey: "sk-test",
+    });
+    expect(client).toBeDefined();
+  });
+
+  it("shutdownLangfuseClient resets the instance", async () => {
+    initLangfuseClient({
+      publicKey: "pk-test",
+      secretKey: "sk-test",
+    });
+    expect(isLangfuseInitialized()).toBe(true);
+    await shutdownLangfuseClient();
+    expect(isLangfuseInitialized()).toBe(false);
+    expect(() => getLangfuseClient()).toThrow();
+  });
+
+  it("shutdownLangfuseClient is a no-op when not initialized", async () => {
+    expect(isLangfuseInitialized()).toBe(false);
+    await shutdownLangfuseClient();
+    expect(isLangfuseInitialized()).toBe(false);
+  });
+});

--- a/api/src/populate.test.ts
+++ b/api/src/populate.test.ts
@@ -196,4 +196,69 @@ describe("getOpenApiSpecForModel edge cases", () => {
     });
     expect(result.properties).toBeDefined();
   });
+
+  it("uses openApiComponent $ref when provided", () => {
+    const result = getOpenApiSpecForModel(FoodModel, {
+      populatePaths: [{openApiComponent: "UserComponent", path: "ownerId"}],
+    });
+    expect(result.properties.ownerId).toEqual({
+      $ref: "#/components/schemas/UserComponent",
+    });
+  });
+
+  it("populates array ref fields (eatenBy)", () => {
+    const result = getOpenApiSpecForModel(FoodModel, {
+      populatePaths: [{path: "eatenBy"}],
+    });
+    expect(result.properties.eatenBy).toBeDefined();
+    expect((result.properties.eatenBy as any).items).toBeDefined();
+  });
+
+  it("populates nested ref in sub-schema (likesIds.userId)", () => {
+    const result = getOpenApiSpecForModel(FoodModel, {
+      populatePaths: [{path: "likesIds.userId"}],
+    });
+    expect(result.properties.likesIds).toBeDefined();
+  });
+
+  it("includes virtuals from model schema", () => {
+    const result = getOpenApiSpecForModel(FoodModel);
+    expect(result.properties.description).toBeDefined();
+    expect((result.properties.description as any).type).toBe("any");
+  });
+
+  it("includes virtuals from child schemas", () => {
+    const childSub = new Schema({amount: {description: "Amount", type: Number}});
+    childSub.virtual("displayAmount").get(function () {
+      return `${this.amount} units`;
+    });
+    const parentSchema = new Schema({
+      detail: {description: "Single embedded detail", type: childSub},
+      title: {description: "Title", type: String},
+    });
+    const ParentModel =
+      mongoose.models.ParentWithChildVirtual ||
+      mongoose.model("ParentWithChildVirtual", parentSchema);
+    const result = getOpenApiSpecForModel(ParentModel);
+    const detail = result.properties.detail as any;
+    expect(detail.properties.displayAmount).toBeDefined();
+    expect(detail.properties.displayAmount.type).toBe("any");
+  });
+});
+
+describe("filterKeys (via getOpenApiSpecForModel populatePaths)", () => {
+  it("filters populated fields using dot-notation keys", () => {
+    const result = getOpenApiSpecForModel(FoodModel, {
+      populatePaths: [{fields: ["name"], path: "ownerId"}],
+    });
+    const ownerProps = (result.properties.ownerId as any).properties || result.properties.ownerId;
+    expect(ownerProps.name).toBeDefined();
+  });
+
+  it("rejects prototype pollution keys in nested dot-notation", () => {
+    const result = getOpenApiSpecForModel(FoodModel, {
+      populatePaths: [{fields: ["__proto__.polluted"], path: "ownerId"}],
+    });
+    expect(result.properties).toBeDefined();
+  });
 });

--- a/api/src/populate.test.ts
+++ b/api/src/populate.test.ts
@@ -249,16 +249,24 @@ describe("getOpenApiSpecForModel edge cases", () => {
 describe("filterKeys (via getOpenApiSpecForModel populatePaths)", () => {
   it("filters populated fields using dot-notation keys", () => {
     const result = getOpenApiSpecForModel(FoodModel, {
-      populatePaths: [{fields: ["name"], path: "ownerId"}],
+      populatePaths: [{fields: ["name.nested"], path: "ownerId"}],
     });
-    const ownerProps = (result.properties.ownerId as any).properties || result.properties.ownerId;
+    const ownerProps = (result.properties.ownerId as any).properties;
     expect(ownerProps.name).toBeDefined();
+    expect(typeof ownerProps.name).toBe("object");
   });
 
   it("rejects prototype pollution keys in nested dot-notation", () => {
+    const pristinePolluted = (Object.prototype as any).polluted;
     const result = getOpenApiSpecForModel(FoodModel, {
       populatePaths: [{fields: ["__proto__.polluted"], path: "ownerId"}],
     });
     expect(result.properties).toBeDefined();
+    expect((Object.prototype as any).polluted).toBe(pristinePolluted);
+    const ownerProps = (result.properties.ownerId as any).properties;
+    expect(ownerProps).toBeDefined();
+    expect("__proto__" in ownerProps === false || ownerProps.__proto__ === Object.prototype).toBe(
+      true
+    );
   });
 });

--- a/api/src/populate.test.ts
+++ b/api/src/populate.test.ts
@@ -257,16 +257,13 @@ describe("filterKeys (via getOpenApiSpecForModel populatePaths)", () => {
   });
 
   it("rejects prototype pollution keys in nested dot-notation", () => {
-    const pristinePolluted = (Object.prototype as any).polluted;
     const result = getOpenApiSpecForModel(FoodModel, {
       populatePaths: [{fields: ["__proto__.polluted"], path: "ownerId"}],
     });
     expect(result.properties).toBeDefined();
-    expect((Object.prototype as any).polluted).toBe(pristinePolluted);
+    expect((Object.prototype as any).polluted).toBeUndefined();
     const ownerProps = (result.properties.ownerId as any).properties;
     expect(ownerProps).toBeDefined();
-    expect("__proto__" in ownerProps === false || ownerProps.__proto__ === Object.prototype).toBe(
-      true
-    );
+    expect(Object.keys(ownerProps)).not.toContain("__proto__");
   });
 });


### PR DESCRIPTION
## Summary
Improve test coverage for two backend files:

- **api/src/populate.ts**: 86.84% → 90.53% lines covered. Added 7 targeted tests covering: `openApiComponent` `$ref` handling, array ref field population, nested sub-schema refs, model/child-schema virtuals, dot-notation `filterKeys`, and prototype pollution rejection.
- **ai/src/langfuseClient.ts**: 80% → 100% lines covered. Created new test file with 7 tests covering: error throw path in `getLangfuseClient`, initialization, custom baseUrl, shutdown reset, and no-op shutdown.

## Review & Testing Checklist for Human
- [ ] Verify `bun run api:test` passes and `populate.ts` coverage is ≥90%
- [ ] Verify `bun run ai:test` passes and `langfuseClient.ts` coverage is ≥90%
- [ ] Confirm no source code was modified — only test files changed

### Notes
- All tests use existing patterns and utilities from the codebase
- Lint (`bun run lint`) and typecheck (`bun run compile`) pass locally

Link to Devin session: https://app.devin.ai/sessions/afe983e5908048c6a69df49381ad5b45
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production logic modifications; risk is limited to potential flaky/overly strict assertions.
> 
> **Overview**
> Improves backend test coverage by adding a new `ai/src/langfuseClient.test.ts` suite validating `initLangfuseClient`/`getLangfuseClient` error paths, initialization state, custom `baseUrl`, and `shutdownLangfuseClient` reset/no-op behavior.
> 
> Extends `api/src/populate.test.ts` with additional cases around `getOpenApiSpecForModel`, covering `openApiComponent` `$ref` output, array and nested ref population, virtual fields from model and child schemas, and `filterKeys` dot-notation allowlists including prototype-pollution key rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae140efccf10a78ec39537023b70ee6d753acf8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->