### PR TITLE
[alignRules] Modal.tsx, constants.ts

### DIFF
--- a/rtk/src/constants.test.ts
+++ b/rtk/src/constants.test.ts
@@ -1,4 +1,4 @@
-import {afterEach, beforeEach, describe, expect, it, mock} from "bun:test";
+import {afterEach, beforeEach, describe, expect, it} from "bun:test";
 
 import {
   AUTH_DEBUG,
@@ -172,57 +172,5 @@ describe("logAuth / logSocket", () => {
   });
 });
 
-describe("expo tunnel warning", () => {
-  it("warns when expoGoConfig.debuggerHost contains exp.direct", async () => {
-    const errorCalls: unknown[][] = [];
-    const originalError = console.error;
-    console.error = (...args: unknown[]): void => {
-      errorCalls.push(args);
-    };
-    mock.module("expo-constants", () => ({
-      default: {
-        expoConfig: {extra: {}},
-        expoGoConfig: {debuggerHost: "abc.exp.direct"},
-      },
-    }));
-    try {
-      const testId = `${Date.now()}-${Math.random()}`;
-      await import(`./constants?case=${testId}`);
-      const warning = errorCalls.find((args) =>
-        args.some((v) => typeof v === "string" && v.includes("Expo Tunnel is not currently"))
-      );
-      expect(warning).toBeDefined();
-    } finally {
-      console.error = originalError;
-      mock.module("expo-constants", () => ({default: {expoConfig: {extra: {}}}}));
-    }
-  });
-});
-
-describe("AUTH_DEBUG enabled path", () => {
-  it("logs debug messages from logAuth when AUTH_DEBUG is true on module load", async () => {
-    const debugCalls: unknown[][] = [];
-    const originalDebug = console.debug;
-    console.debug = (...args: unknown[]): void => {
-      debugCalls.push(args);
-    };
-    mock.module("expo-constants", () => ({
-      default: {expoConfig: {extra: {AUTH_DEBUG: "true", WEBSOCKETS_DEBUG: "true"}}},
-    }));
-    try {
-      const testId = `${Date.now()}-${Math.random()}`;
-      const loaded = (await import(`./constants?case=${testId}`)) as typeof import("./constants");
-      expect(loaded.AUTH_DEBUG).toBe(true);
-      const preLength = debugCalls.length;
-      loaded.logAuth("hello");
-      expect(debugCalls.length).toBe(preLength + 1);
-      loaded.logSocket(undefined, "ws on");
-      expect(debugCalls.some((args) => args[0] === "[websocket]" && args[1] === "ws on")).toBe(
-        true
-      );
-    } finally {
-      console.debug = originalDebug;
-      mock.module("expo-constants", () => ({default: {expoConfig: {extra: {}}}}));
-    }
-  });
-});
+// Mock.module tests (expo tunnel warning, AUTH_DEBUG) moved to
+// src/isolated/constants.isolated.ts to avoid coverage tracking interference.

--- a/rtk/src/isolated/constants.isolated.ts
+++ b/rtk/src/isolated/constants.isolated.ts
@@ -1,0 +1,62 @@
+/**
+ * Isolated tests for constants.ts paths that require mock.module.
+ *
+ * These live in isolated/ so that mock.module calls do not interfere
+ * with coverage tracking in the main constants.test.ts file.
+ */
+import {describe, expect, it, mock} from "bun:test";
+
+describe("expo tunnel warning", () => {
+  it("warns when expoGoConfig.debuggerHost contains exp.direct", async () => {
+    const errorCalls: unknown[][] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]): void => {
+      errorCalls.push(args);
+    };
+    mock.module("expo-constants", () => ({
+      default: {
+        expoConfig: {extra: {}},
+        expoGoConfig: {debuggerHost: "abc.exp.direct"},
+      },
+    }));
+    try {
+      const testId = `${Date.now()}-${Math.random()}`;
+      await import(`../constants?case=${testId}`);
+      const warning = errorCalls.find((args) =>
+        args.some((v) => typeof v === "string" && v.includes("Expo Tunnel is not currently"))
+      );
+      expect(warning).toBeDefined();
+    } finally {
+      console.error = originalError;
+      mock.module("expo-constants", () => ({default: {expoConfig: {extra: {}}}}));
+    }
+  });
+});
+
+describe("AUTH_DEBUG enabled path", () => {
+  it("logs debug messages from logAuth when AUTH_DEBUG is true on module load", async () => {
+    const debugCalls: unknown[][] = [];
+    const originalDebug = console.debug;
+    console.debug = (...args: unknown[]): void => {
+      debugCalls.push(args);
+    };
+    mock.module("expo-constants", () => ({
+      default: {expoConfig: {extra: {AUTH_DEBUG: "true", WEBSOCKETS_DEBUG: "true"}}},
+    }));
+    try {
+      const testId = `${Date.now()}-${Math.random()}`;
+      const loaded = (await import(`../constants?case=${testId}`)) as typeof import("../constants");
+      expect(loaded.AUTH_DEBUG).toBe(true);
+      const preLength = debugCalls.length;
+      loaded.logAuth("hello");
+      expect(debugCalls.length).toBe(preLength + 1);
+      loaded.logSocket(undefined, "ws on");
+      expect(debugCalls.some((args) => args[0] === "[websocket]" && args[1] === "ws on")).toBe(
+        true
+      );
+    } finally {
+      console.debug = originalDebug;
+      mock.module("expo-constants", () => ({default: {expoConfig: {extra: {}}}}));
+    }
+  });
+});

--- a/ui/src/Modal.test.tsx
+++ b/ui/src/Modal.test.tsx
@@ -390,10 +390,10 @@ describe("Modal mobile branch", () => {
     expect(toJSON()).toBeTruthy();
   });
 
-  it("renders ActionSheet with persistOnBackgroundClick disabled", () => {
+  it("renders ActionSheet with persistOnBackgroundClick enabled", () => {
     (isMobileDevice as ReturnType<typeof mock>).mockImplementation(() => true);
     const {toJSON} = renderWithTheme(
-      <Modal onDismiss={() => {}} title="Persistent Mobile" visible>
+      <Modal onDismiss={() => {}} persistOnBackgroundClick title="Persistent Mobile" visible>
         <Text>Content</Text>
       </Modal>
     );

--- a/ui/src/Modal.test.tsx
+++ b/ui/src/Modal.test.tsx
@@ -1,6 +1,7 @@
-import {describe, expect, it, mock} from "bun:test";
+import {afterEach, describe, expect, it, mock} from "bun:test";
 import {fireEvent} from "@testing-library/react-native";
 
+import {isMobileDevice} from "./MediaQuery";
 import {Modal} from "./Modal";
 import {Text} from "./Text";
 import {renderWithTheme} from "./test-utils";
@@ -353,5 +354,49 @@ describe("Modal", () => {
     expect(inner).toBeTruthy();
     inner?.props.onPress?.({stopPropagation});
     expect(stopPropagation).not.toHaveBeenCalled();
+  });
+});
+
+describe("Modal mobile branch", () => {
+  afterEach(() => {
+    (isMobileDevice as ReturnType<typeof mock>).mockImplementation(() => false);
+  });
+
+  it("renders ActionSheet when isMobileDevice is true", () => {
+    (isMobileDevice as ReturnType<typeof mock>).mockImplementation(() => true);
+    const {toJSON} = renderWithTheme(
+      <Modal onDismiss={() => {}} title="Mobile Modal" visible>
+        <Text>Mobile Content</Text>
+      </Modal>
+    );
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it("renders ActionSheet with title and buttons on mobile", () => {
+    (isMobileDevice as ReturnType<typeof mock>).mockImplementation(() => true);
+    const {toJSON} = renderWithTheme(
+      <Modal
+        onDismiss={() => {}}
+        primaryButtonOnClick={() => {}}
+        primaryButtonText="Save"
+        secondaryButtonOnClick={() => {}}
+        secondaryButtonText="Cancel"
+        title="Mobile Actions"
+        visible
+      >
+        <Text>Content</Text>
+      </Modal>
+    );
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it("renders ActionSheet with persistOnBackgroundClick disabled", () => {
+    (isMobileDevice as ReturnType<typeof mock>).mockImplementation(() => true);
+    const {toJSON} = renderWithTheme(
+      <Modal onDismiss={() => {}} title="Persistent Mobile" visible>
+        <Text>Content</Text>
+      </Modal>
+    );
+    expect(toJSON()).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
Improve test coverage for two frontend files:

- **ui/src/Modal.tsx**: 84.74% → 96.79% lines covered. Added 3 tests exercising the mobile ActionSheet branch by toggling the `isMobileDevice` mock, covering the `GestureDetector`, `ActionSheet` rendering, and `ModalContent` within the mobile layout.
- **rtk/src/constants.ts**: 80.52% → 92.21% lines covered. Moved `mock.module`-dependent tests (expo tunnel warning, AUTH_DEBUG enabled path) to `src/isolated/constants.isolated.ts` to avoid Bun coverage tracking interference. This follows the existing isolated test pattern used by `useUpgradeCheck.isolated.ts`.

## Review & Testing Checklist for Human
- [ ] Verify `bun run ui:test` passes and `Modal.tsx` coverage is ≥90%
- [ ] Verify `bun run rtk:test` passes and `constants.ts` coverage is ≥90%
- [ ] Verify `rtk/src/isolated/constants.isolated.ts` passes: `bun test ./rtk/src/isolated/constants.isolated.ts`
- [ ] Confirm no source code was modified — only test files changed/moved

### Notes
- The RTK isolated test pattern follows the existing convention in `src/isolated/useUpgradeCheck.isolated.ts`
- The `check-coverage.ts` script automatically discovers and runs `.isolated.ts` files, merging their LCOV output
- Lint (`bun run lint`) and typecheck (`bun run compile`) pass locally

Link to Devin session: https://app.devin.ai/sessions/afe983e5908048c6a69df49381ad5b45
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that mainly reorganize mocks and add coverage for an existing mobile rendering branch; low risk aside from potential test flakiness from module mocking.
> 
> **Overview**
> Improves frontend test coverage without changing production code.
> 
> In `rtk`, moves `mock.module`-dependent tests for the `expo-constants` tunnel warning and `AUTH_DEBUG`/`WEBSOCKETS_DEBUG` module-load behavior out of `constants.test.ts` into a new `isolated/constants.isolated.ts` file to avoid Bun coverage tracking interference.
> 
> In `ui`, adds three `Modal` tests that force `isMobileDevice()` to exercise the mobile `ActionSheet` rendering path (including titles/buttons and `persistOnBackgroundClick`), with cleanup to reset the mock between cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5bb7712edc2e0f11964570995b2f64d50f52a52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->