### PR TITLE
Add subpath exports for langfuseClient and langfuseApp

### DIFF
--- a/ai/package.json
+++ b/ai/package.json
@@ -32,6 +32,14 @@
     ".": {
       "default": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./langfuseClient": {
+      "default": "./dist/langfuseClient.js",
+      "types": "./dist/langfuseClient.d.ts"
+    },
+    "./langfuseApp": {
+      "default": "./dist/langfuseApp.js",
+      "types": "./dist/langfuseApp.d.ts"
     }
   },
   "homepage": "https://github.com/FlourishHealth/terreno#readme",


### PR DESCRIPTION
## Summary
Adds `./langfuseClient` and `./langfuseApp` subpath exports to `@terreno/ai` so downstream projects can import only the Langfuse modules they need without pulling in the full package entry point (which transitively loads OTEL SDK, GCS, MCP, etc.).

## Human Testing Steps
- [ ] In a downstream project, replace the `require.resolve` workaround with `import { getLangfuseClient, initLangfuseClient, isLangfuseInitialized, shutdownLangfuseClient } from "@terreno/ai/langfuseClient"`
- [ ] Verify the import resolves and types are correct

## Changes
- `ai/package.json`: added `./langfuseClient` and `./langfuseApp` subpath exports pointing to the compiled dist files

## Automated Tests
- Lint: passed
- TypeScript compile: passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `@terreno/ai` package `exports` map to expose additional entrypoints; runtime behavior is unchanged aside from enabling new import paths.
> 
> **Overview**
> Adds Node/TS subpath exports in `@terreno/ai` for `./langfuseClient` and `./langfuseApp`, each pointing at their compiled `dist` JS and `.d.ts` files.
> 
> This lets downstream consumers import Langfuse-specific modules directly (without going through the root entrypoint) to avoid pulling in unrelated transitive initialization/code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50530eedfb85fb95b2370904562f197d458195f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->