### PR TITLE
[alignRules] tools.ts, resources.ts, prompts.ts

### DIFF
--- a/mcp-server/src/resources.ts
+++ b/mcp-server/src/resources.ts
@@ -39,7 +39,6 @@ interface TypeDocType {
   typeArguments?: TypeDocType[];
   declaration?: {signatures?: unknown[]};
 }
-
 interface TypeDocProp {
   id: number;
   name: string;


### PR DESCRIPTION
## Summary
Replace all `any` types with explicit types in three `mcp-server` files:

**`mcp-server/src/resources.ts`** (4 instances):
- Defined a `TypeDocType` interface to replace `any` in `TypeDocProp.type`, `extractTypeString` parameter, and `.map()` callbacks
- Added null-coalescing fallback for `typeObj.name` when type is `"intrinsic"`

**`mcp-server/src/tools.ts`** (1 instance):
- Changed `catch (err: any)` to `catch (err: unknown)` with typed assertion in generated form template

**`mcp-server/src/prompts.ts`** (1 instance):
- Same pattern as tools.ts — `catch (err: unknown)` with typed assertion in generated form template

## Review & Testing Checklist for Human
- [ ] Verify `TypeDocType` interface covers all variants handled by `extractTypeString` — check against actual TypeDoc JSON output
- [ ] Confirm template literal changes in tools.ts and prompts.ts produce valid generated code

### Notes
- All changes are in the `mcp-server` package (backend only)
- Lint (`bun lint`) and TypeScript compile (`bun tsc --noEmit` in mcp-server) pass locally
- Files with existing `noExplicitAny` comments were skipped

Link to Devin session: https://app.devin.ai/sessions/f85781bf70704905abdd5bf9cb5fe9c5
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-safety refactor with minimal behavior change; primary risk is mismatches between the new `TypeDocType` interface and real TypeDoc JSON shapes affecting doc generation.
> 
> **Overview**
> Tightens TypeScript types in `mcp-server` by removing remaining `any` usage in the TypeDoc parsing and code-generation templates.
> 
> In `resources.ts`, introduces a `TypeDocType` shape and threads it through props/type extraction (including safer fallbacks when a TypeDoc node is missing expected fields). In `tools.ts` and `prompts.ts`, switches generated template error handling from `catch (err: any)` to `catch (err: unknown)` with explicit narrowing for API field errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6c2d2e113395a1a842617ff1bcdbe7e1d268820. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->