### PR TITLE
[alignRules] openApiBuilder.ts, todos.ts, todoTypes.ts

### DIFF
--- a/api/src/openApiBuilder.ts
+++ b/api/src/openApiBuilder.ts
@@ -75,7 +75,7 @@ import {
  * };
  * ```
  */
-export type OpenApiSchemaProperty = {
+export interface OpenApiSchemaProperty {
   /** The JSON Schema type (e.g., "string", "number", "boolean", "object", "array") */
   type: string;
   /** Human-readable description of the property */
@@ -90,7 +90,7 @@ export type OpenApiSchemaProperty = {
   additionalProperties?: OpenApiSchemaProperty | boolean;
   /** Whether this property is required in the parent object */
   required?: boolean;
-};
+}
 
 /**
  * Defines the top-level schema for request bodies and responses.
@@ -151,7 +151,7 @@ export type OpenApiSchema = {
  * };
  * ```
  */
-export type OpenApiParameter = {
+export interface OpenApiParameter {
   /** Location of the parameter */
   in: "query" | "path" | "header";
   /** Name of the parameter */
@@ -162,7 +162,7 @@ export type OpenApiParameter = {
   schema: OpenApiSchemaProperty;
   /** Human-readable description of the parameter */
   description?: string;
-};
+}
 
 /**
  * Defines a response in an OpenAPI operation.
@@ -188,7 +188,7 @@ export type OpenApiParameter = {
  * };
  * ```
  */
-export type OpenApiResponse = {
+export interface OpenApiResponse {
   /** Human-readable description of the response */
   description: string;
   /** Content definitions keyed by media type */
@@ -197,7 +197,7 @@ export type OpenApiResponse = {
       schema: OpenApiSchema;
     };
   };
-};
+}
 
 /**
  * Internal configuration object for the OpenAPI middleware builder.
@@ -817,8 +817,8 @@ export class OpenApiMiddlewareBuilder {
  * router.get("/analytics/stats", statsMiddleware, getStatsHandler);
  * ```
  */
-export function createOpenApiBuilder(
+export const createOpenApiBuilder = (
   options: Partial<ModelRouterOptions<unknown>>
-): OpenApiMiddlewareBuilder {
+): OpenApiMiddlewareBuilder => {
   return new OpenApiMiddlewareBuilder(options);
-}
+};

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "admin-backend": {
       "name": "@terreno/admin-backend",
-      "version": "0.10.0",
+      "version": "0.11.1",
       "dependencies": {
         "@google-cloud/storage": "^7.15.0",
         "@terreno/api": "workspace:*",
@@ -36,7 +36,7 @@
     },
     "admin-frontend": {
       "name": "@terreno/admin-frontend",
-      "version": "0.10.0",
+      "version": "0.11.1",
       "dependencies": {
         "@terreno/ui": "workspace:*",
         "expo-router": "catalog:",
@@ -67,7 +67,7 @@
     },
     "ai": {
       "name": "@terreno/ai",
-      "version": "0.10.0",
+      "version": "0.11.1",
       "dependencies": {
         "@ai-sdk/mcp": "^1.0.21",
         "@google-cloud/storage": "^7.15.0",
@@ -99,7 +99,7 @@
     },
     "api": {
       "name": "@terreno/api",
-      "version": "0.10.0",
+      "version": "0.11.1",
       "dependencies": {
         "@sentry/bun": "^10.25.0",
         "@sentry/profiling-node": "^10.25.0",
@@ -169,7 +169,7 @@
     },
     "api-health": {
       "name": "@terreno/api-health",
-      "version": "0.10.0",
+      "version": "0.11.1",
       "dependencies": {
         "@terreno/api": "workspace:*",
         "express": "^5.2.1",
@@ -397,7 +397,7 @@
     },
     "rtk": {
       "name": "@terreno/rtk",
-      "version": "0.10.0",
+      "version": "0.11.1",
       "dependencies": {
         "@better-auth/expo": "^1.2.8",
         "@react-native-async-storage/async-storage": "catalog:",
@@ -436,7 +436,7 @@
     },
     "ui": {
       "name": "@terreno/ui",
-      "version": "0.10.0",
+      "version": "0.11.1",
       "dependencies": {
         "@expo-google-fonts/nunito": "^0.4.2",
         "@expo-google-fonts/titillium-web": "^0.4.1",

--- a/example-backend/src/api/todos.ts
+++ b/example-backend/src/api/todos.ts
@@ -22,7 +22,7 @@ export const addTodoRoutes = (
       preCreate: (body, req) => {
         return {
           ...body,
-          ownerId: (req.user as UserDocument)?._id,
+          ownerId: (req.user as unknown as UserDocument)?._id,
         } as TodoDocument;
       },
       queryFields: ["completed", "ownerId"],

--- a/example-backend/src/types/models/todoTypes.ts
+++ b/example-backend/src/types/models/todoTypes.ts
@@ -6,15 +6,16 @@ import type {BaseDocument} from "../../modelInterfaces";
 // biome-ignore lint/complexity/noBannedTypes: No methods.
 export type TodoMethods = {};
 
-export type TodoStatics = FindExactlyOnePlugin<TodoDocument> & FindOneOrNonePlugin<TodoDocument>;
+export interface TodoStatics
+  extends FindExactlyOnePlugin<TodoDocument>,
+    FindOneOrNonePlugin<TodoDocument> {}
 
-export type TodoModel = mongoose.Model<TodoDocument, object, TodoMethods> & TodoStatics;
+export interface TodoModel extends mongoose.Model<TodoDocument, object, TodoMethods>, TodoStatics {}
 
-export type TodoDocument = BaseDocument &
-  TodoMethods & {
-    title: string;
-    completed: boolean;
-    ownerId: mongoose.Types.ObjectId;
-    tags: string[];
-    priority?: "low" | "medium" | "high";
-  };
+export interface TodoDocument extends BaseDocument, TodoMethods {
+  title: string;
+  completed: boolean;
+  ownerId: mongoose.Types.ObjectId;
+  tags: string[];
+  priority?: "low" | "medium" | "high";
+}


### PR DESCRIPTION
## Summary
Minimal rule-compliance changes for 3 randomly selected backend files:

**`api/src/openApiBuilder.ts`**
- Converted `OpenApiSchemaProperty`, `OpenApiParameter`, and `OpenApiResponse` from `type` to `interface` (rule: prefer interfaces over types)
- `OpenApiSchema` kept as `type` because it's passed to `Record<string, unknown>` parameters — interfaces lack implicit index signatures
- Converted `createOpenApiBuilder` from `function` declaration to const arrow function (rule: prefer const arrow functions)

**`example-backend/src/api/todos.ts`**
- Fixed user cast in `preCreate` from `req.user as UserDocument` to `req.user as unknown as UserDocument` (rule: in @terreno/api callbacks, cast via `as unknown as UserDocument`)

**`example-backend/src/types/models/todoTypes.ts`**
- Converted `TodoStatics`, `TodoModel`, and `TodoDocument` from `type` intersection to `interface extends` (rule: prefer interfaces over types)
- `TodoMethods` kept as `type` since empty interfaces trigger biome's `noEmptyInterface` rule

## Review & Testing Checklist for Human
- [ ] Verify the `interface` conversions don't break downstream consumers that import these types
- [ ] Confirm the `as unknown as UserDocument` cast in todos.ts preCreate still works correctly at runtime

### Notes
- All changes are type-level only — no runtime behavior changes
- Linter and TypeScript compiler pass locally on the changed files and their respective packages

Link to Devin session: https://app.devin.ai/sessions/61c6090651204d9693443440761412da
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ce2a5a7f3a29d70fbfcda640771ba45717007492. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->