### PR TITLE
Add explicit import/require conditions to @terreno/ai exports map

### DIFF
--- a/ai/package.json
+++ b/ai/package.json
@@ -30,16 +30,22 @@
   },
   "exports": {
     ".": {
-      "default": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./langfuseClient": {
-      "default": "./dist/langfuseClient.js",
-      "types": "./dist/langfuseClient.d.ts"
+      "types": "./dist/langfuseClient.d.ts",
+      "import": "./dist/langfuseClient.js",
+      "require": "./dist/langfuseClient.js",
+      "default": "./dist/langfuseClient.js"
     },
     "./langfuseApp": {
-      "default": "./dist/langfuseApp.js",
-      "types": "./dist/langfuseApp.d.ts"
+      "types": "./dist/langfuseApp.d.ts",
+      "import": "./dist/langfuseApp.js",
+      "require": "./dist/langfuseApp.js",
+      "default": "./dist/langfuseApp.js"
     }
   },
   "homepage": "https://github.com/FlourishHealth/terreno#readme",


### PR DESCRIPTION
## Summary

Bun resolves package subpath imports via the \`exports\` map, but currently picks the wrong condition for \`@terreno/ai/langfuseClient\` and \`@terreno/ai/langfuseApp\` — it loads the \`.d.ts\` file at runtime, producing an empty module.

\`\`\`
$ bun -e 'console.log(Object.keys(require("@terreno/ai/langfuseClient")))'
[]
$ node -e 'console.log(Object.keys(require("@terreno/ai/langfuseClient")))'
[ 'getLangfuseClient', 'initLangfuseClient', 'isLangfuseInitialized', 'shutdownLangfuseClient' ]
\`\`\`

This breaks any consumer running on Bun that imports those subpaths.

## Fix

For each entry in \`ai/package.json\` exports:
- Move \`types\` first (so TypeScript matches it before falling through)
- Add explicit \`import\` and \`require\` conditions so Bun (and any other runtime) selects a JS file rather than the type declaration

Verified locally: with this change, \`bun -e 'require("@terreno/ai/langfuseClient")'\` returns the expected runtime exports.

## Human Testing Steps
- [ ] Publish a prerelease and confirm \`bun -e 'require("@terreno/ai/langfuseClient")'\` returns non-empty exports
- [ ] Confirm \`tsc\` still resolves types from the same paths

## Automated Tests
- None changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only packaging change limited to `exports` resolution; no runtime logic changes, with main risk being unintended module resolution differences for consumers.
> 
> **Overview**
> Updates `@terreno/ai`’s `package.json` `exports` map to add explicit `import`/`require` conditions (while keeping `types`) for the root entry and the `./langfuseClient`/`./langfuseApp` subpaths.
> 
> This prevents runtimes like Bun from mistakenly resolving the `.d.ts` files at runtime for these subpath imports, ensuring JS modules are loaded while TypeScript still resolves declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 729bb9e0d48dd9643739decd937c4b76a4d644d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->