### PR TITLE
fix(ui): avoid raw text nodes in View on react-native-web

### DIFF
--- a/ui/src/CustomSelectField.tsx
+++ b/ui/src/CustomSelectField.tsx
@@ -109,7 +109,7 @@ export const CustomSelectField: FC<CustomSelectFieldProps> = ({
           />
         </View>
       )}
-      {helperText && <FieldHelperText text={helperText} />}
+      {Boolean(helperText) && <FieldHelperText text={helperText!} />}
     </View>
   );
 };

--- a/ui/src/DataTable.tsx
+++ b/ui/src/DataTable.tsx
@@ -263,37 +263,41 @@ const DataTableHeaderCell: FC<DataTableHeaderCellProps> = ({
         }),
       }}
     >
-      {Boolean(column.title) && <TableTitle align="left" title={column.title!} />}
-      <View style={{alignItems: "center", flexDirection: "row"}}>
-        {column.infoModalText && (
-          <InfoModalIcon infoModalChildren={<Markdown>{column.infoModalText}</Markdown>} />
-        )}
-        {column.sortable && (
-          <Pressable hitSlop={16} onPress={() => onSort(index)}>
-            <View
-              style={{
-                alignItems: "center",
-                backgroundColor: sort ? theme.surface.primary : theme.surface.neutralLight,
-                borderRadius: theme.radius.rounded,
-                height: 16,
-                justifyContent: "center",
-                marginLeft: 8,
-                width: 16,
-              }}
-            >
-              <FontAwesome6
-                color={theme.text.inverted}
-                name={
-                  sort === "asc" ? "arrow-down" : sort === "desc" ? "arrow-up" : "arrows-up-down"
-                }
-                selectable={undefined}
-                size={10}
-                solid
-              />
-            </View>
-          </Pressable>
-        )}
-      </View>
+      {[
+        Boolean(column.title) ? (
+          <TableTitle align="left" key="data-table-header-title" title={column.title!} />
+        ) : null,
+        <View key="data-table-header-tools" style={{alignItems: "center", flexDirection: "row"}}>
+          {column.infoModalText && (
+            <InfoModalIcon infoModalChildren={<Markdown>{column.infoModalText}</Markdown>} />
+          )}
+          {column.sortable && (
+            <Pressable hitSlop={16} onPress={() => onSort(index)}>
+              <View
+                style={{
+                  alignItems: "center",
+                  backgroundColor: sort ? theme.surface.primary : theme.surface.neutralLight,
+                  borderRadius: theme.radius.rounded,
+                  height: 16,
+                  justifyContent: "center",
+                  marginLeft: 8,
+                  width: 16,
+                }}
+              >
+                <FontAwesome6
+                  color={theme.text.inverted}
+                  name={
+                    sort === "asc" ? "arrow-down" : sort === "desc" ? "arrow-up" : "arrows-up-down"
+                  }
+                  selectable={undefined}
+                  size={10}
+                  solid
+                />
+              </View>
+            </Pressable>
+          )}
+        </View>,
+      ]}
     </View>
   );
 };

--- a/ui/src/MarkdownEditorField.tsx
+++ b/ui/src/MarkdownEditorField.tsx
@@ -58,7 +58,7 @@ export const MarkdownEditorField: React.FC<MarkdownEditorFieldProps> = ({
 
   return (
     <View testID={testID}>
-      {title && <FieldTitle text={title} />}
+      {Boolean(title) && <FieldTitle text={title!} />}
       <Box
         border={errorText ? "error" : "default"}
         direction={isWeb ? "row" : "column"}
@@ -151,8 +151,8 @@ export const MarkdownEditorField: React.FC<MarkdownEditorFieldProps> = ({
           </Box>
         </ScrollView>
       </Box>
-      {errorText && <FieldError text={errorText} />}
-      {helperText && <FieldHelperText text={helperText} />}
+      {Boolean(errorText) && <FieldError text={errorText!} />}
+      {Boolean(helperText) && <FieldHelperText text={helperText!} />}
     </View>
   );
 };

--- a/ui/src/Modal.tsx
+++ b/ui/src/Modal.tsx
@@ -102,7 +102,7 @@ const ModalContent: FC<{
           <Icon iconName="x" size="sm" />
         </Pressable>
       </View>
-      {title && (
+      {Boolean(title) && (
         <View
           accessibilityHint="Modal title"
           aria-label={title}
@@ -112,7 +112,7 @@ const ModalContent: FC<{
           <Heading size="lg">{title}</Heading>
         </View>
       )}
-      {subtitle && (
+      {Boolean(subtitle) && (
         <View
           accessibilityHint="Modal Sub Heading Text"
           aria-label={subtitle}
@@ -122,7 +122,7 @@ const ModalContent: FC<{
           <Text size="lg">{subtitle}</Text>
         </View>
       )}
-      {text && (
+      {Boolean(text) && (
         <View
           accessibilityHint="Modal body text"
           aria-label={text}

--- a/ui/src/SelectField.tsx
+++ b/ui/src/SelectField.tsx
@@ -20,7 +20,7 @@ export const SelectField: FC<SelectFieldProps> = ({
 
   return (
     <View>
-      {title && <FieldTitle text={title} />}
+      {Boolean(title) && <FieldTitle text={title!} />}
       {Boolean(errorText) && <FieldError text={errorText!} />}
       <RNPickerSelect
         disabled={disabled}
@@ -35,7 +35,7 @@ export const SelectField: FC<SelectFieldProps> = ({
         placeholder={!requireValue ? clearOption : {}}
         value={value ?? ""}
       />
-      {helperText && <FieldHelperText text={helperText} />}
+      {Boolean(helperText) && <FieldHelperText text={helperText!} />}
     </View>
   );
 };


### PR DESCRIPTION
- SelectField, MarkdownEditorField, CustomSelectField: use Boolean() for optional strings so "" is not rendered as a View child; assert non-null when passing to FieldTitle/FieldHelperText/FieldError.
- Modal: Boolean() guards for title/subtitle/text blocks.
- DataTable: render header title + tools as an explicit keyed array to avoid whitespace text siblings between nodes.

Fixes LogBox "Unexpected text node" warnings on web when optional titles or helpers are empty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only conditional rendering changes; behavior should be identical except for suppressing web warnings, with minimal chance of layout regressions.
> 
> **Overview**
> Eliminates React Native Web LogBox warnings caused by rendering empty-string `title`/`helperText`/`errorText` values as raw text children in `View`.
> 
> Updates `SelectField`, `MarkdownEditorField`, `CustomSelectField`, and `Modal` to guard optional string blocks with `Boolean(...)` and pass non-null assertions to `Field*` components. Adjusts `DataTable` header rendering to return a keyed array of title + tool elements to avoid whitespace text siblings between nodes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb9d9917575369043df48988a5c83433b2085e28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->