### PR TITLE
[alignRules] mcp-server/src/resources.ts, mcp-server/src/tools.ts, mcp-server/src/prompts.ts

### DIFF
--- a/mcp-server/src/prompts.ts
+++ b/mcp-server/src/prompts.ts
@@ -481,9 +481,10 @@ const ${name}Screen: React.FC = () => {
     try {
       await ${endpoint}({ /* fields */ }).unwrap();
       // Success handling
-    } catch (err: any) {
-      if (err.data?.fields) {
-        setErrors(err.data.fields);
+    } catch (err: unknown) {
+      const apiError = err as {data?: {fields?: FormErrors}};
+      if (apiError.data?.fields) {
+        setErrors(apiError.data.fields);
       }
     }
   }, [validate, ${endpoint}]);

--- a/mcp-server/src/resources.ts
+++ b/mcp-server/src/resources.ts
@@ -30,6 +30,16 @@ const loadMarkdown = (filename: string): string => {
   return readFileSync(filePath, "utf-8");
 };
 
+interface TypeDocType {
+  type: string;
+  name?: string;
+  value?: unknown;
+  types?: TypeDocType[];
+  elementType?: TypeDocType;
+  typeArguments?: TypeDocType[];
+  declaration?: {signatures?: unknown[]};
+}
+
 interface TypeDocProp {
   id: number;
   name: string;
@@ -40,7 +50,7 @@ interface TypeDocProp {
     summary?: {kind: string; text: string}[];
     blockTags?: {tag: string; content: {kind: string; text: string}[]}[];
   };
-  type?: any;
+  type?: TypeDocType;
 }
 
 interface TypeDocInterface {
@@ -81,21 +91,21 @@ export const loadTypeDocJson = (): TypeDocRoot | null => {
   return JSON.parse(readFileSync(filePath, "utf-8"));
 };
 
-export const extractTypeString = (typeObj: any): string => {
+export const extractTypeString = (typeObj: TypeDocType | null | undefined): string => {
   if (!typeObj) {
     return "unknown";
   }
 
   if (typeObj.type === "intrinsic") {
-    return typeObj.name;
+    return typeObj.name ?? "unknown";
   }
 
   if (typeObj.type === "literal") {
-    return JSON.stringify(typeObj.value);
+    return JSON.stringify(typeObj.value) ?? "unknown";
   }
 
   if (typeObj.type === "union") {
-    return typeObj.types?.map((t: any) => extractTypeString(t)).join(" | ") ?? "unknown";
+    return typeObj.types?.map((t: TypeDocType) => extractTypeString(t)).join(" | ") ?? "unknown";
   }
 
   if (typeObj.type === "array") {
@@ -104,8 +114,8 @@ export const extractTypeString = (typeObj: any): string => {
 
   if (typeObj.type === "reference") {
     if (typeObj.typeArguments) {
-      const args = typeObj.typeArguments.map((t: any) => extractTypeString(t)).join(", ");
-      return `${typeObj.name}<${args}>`;
+      const args = typeObj.typeArguments.map((t: TypeDocType) => extractTypeString(t)).join(", ");
+      return `${typeObj.name ?? "unknown"}<${args}>`;
     }
     return typeObj.name ?? "unknown";
   }

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -508,9 +508,10 @@ ${fieldStates}
     try {
       await create${modelName}({ ${bodyFields} }).unwrap();
       // Success - navigate or show message
-    } catch (err: any) {
-      if (err.data?.fields) {
-        setErrors(err.data.fields);
+    } catch (err: unknown) {
+      const apiError = err as {data?: {fields?: FormErrors}};
+      if (apiError.data?.fields) {
+        setErrors(apiError.data.fields);
       }
     }
   }, [${bodyFields}, create${modelName}]);


### PR DESCRIPTION
## Summary
Replace all `any` types in three mcp-server files with explicit, properly-typed alternatives:

- **`mcp-server/src/resources.ts`** (4 instances): Introduced a `TypeDocType` interface to represent TypeDoc's recursive type structure. Replaced `type?: any` in `TypeDocProp`, the `typeObj: any` parameter in `extractTypeString`, and inline `(t: any)` callback params with the new interface. Added `?? "unknown"` fallbacks for optional `name` fields.
- **`mcp-server/src/tools.ts`** (1 instance): Replaced `catch (err: any)` in generated code template with `catch (err: unknown)` and proper type narrowing via an inline type assertion.
- **`mcp-server/src/prompts.ts`** (1 instance): Same pattern as tools.ts — `catch (err: unknown)` with narrowing.

No logic, behavior, or variable renaming changes.

## Review & Testing Checklist for Human
- [ ] Verify `TypeDocType` interface covers all shapes encountered in real `ui-types-documentation.json`
- [ ] Confirm generated code templates (tools.ts, prompts.ts) produce valid TypeScript when consumed downstream

### Notes
- All other compile errors in the `bun run compile` output are pre-existing (missing `@terreno/api` module declarations in other packages unrelated to this change).
- mcp-server compiles and lints cleanly with these changes.


Link to Devin session: https://app.devin.ai/sessions/23e0608045c340f79da8427100abb021
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only changes plus safer error narrowing in code-generation templates; behavior should be unchanged aside from more defensive handling of missing TypeDoc fields.
> 
> **Overview**
> Improves TypeScript safety across `mcp-server` by removing `any` usage in three files.
> 
> In `resources.ts`, introduces a recursive `TypeDocType` interface and updates `extractTypeString`/TypeDoc prop typing to use it, adding `"unknown"` fallbacks for missing optional fields. In `tools.ts` and `prompts.ts`, updates generated template code to use `catch (err: unknown)` and narrows to the expected `{data?: {fields?: FormErrors}}` shape before reading `fields` errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cc925b43dfb1d26945b37b29abd16a13f827904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->