### PR TITLE
[alignRules] api/src/notifiers/zoomNotifier.ts, api/src/notifiers/googleChatNotifier.ts, example-backend/src/utils/requestMonitor.ts

### DIFF
--- a/api/src/notifiers/googleChatNotifier.ts
+++ b/api/src/notifiers/googleChatNotifier.ts
@@ -4,10 +4,10 @@ import axios from "axios";
 import {APIError} from "../errors";
 import {logger} from "../logger";
 
-export async function sendToGoogleChat(
+export const sendToGoogleChat = async (
   messageText: string,
   {channel, shouldThrow = false, env}: {channel?: string; shouldThrow?: boolean; env?: string} = {}
-) {
+) => {
   const chatWebhooksString = process.env.GOOGLE_CHAT_WEBHOOKS;
   if (!chatWebhooksString) {
     const msg = "GOOGLE_CHAT_WEBHOOKS not set. Google Chat message not sent";
@@ -44,4 +44,4 @@ export async function sendToGoogleChat(
       });
     }
   }
-}
+};

--- a/api/src/notifiers/zoomNotifier.ts
+++ b/api/src/notifiers/zoomNotifier.ts
@@ -29,10 +29,10 @@ import {logger} from "../logger";
  * Logs errors to Sentry and logger when webhook is missing or request fails.
  * Uses Zoom's rich message format (format=full) with structured header and body.
  */
-export async function sendToZoom(
+export const sendToZoom = async (
   {header, body, subheader}: {header: string; body: string; subheader?: string},
   {channel, shouldThrow = false, env}: {channel: string; shouldThrow?: boolean; env?: string}
-) {
+) => {
   const zoomWebhooksString = process.env.ZOOM_CHAT_WEBHOOKS;
   if (!zoomWebhooksString) {
     const msg = "ZOOM_CHAT_WEBHOOKS not set. Zoom message not sent";
@@ -45,7 +45,6 @@ export async function sendToZoom(
   );
 
   const zoomChannel = channel ?? "default";
-  // Use format full
   const zoomWebhookUrl = zoomWebhooks[zoomChannel]?.channel ?? zoomWebhooks.default?.channel;
 
   if (!zoomWebhookUrl) {
@@ -64,7 +63,6 @@ export async function sendToZoom(
     return;
   }
 
-  // Build the message structure
   const messageBody: {
     head: {text: string; sub_head?: {text: string}};
     body: Array<{type: string; text: string}>;
@@ -80,7 +78,6 @@ export async function sendToZoom(
     },
   };
 
-  // Add subheader if provided
   if (subheader) {
     messageBody.head.sub_head = {
       text: subheader,
@@ -108,4 +105,4 @@ export async function sendToZoom(
       });
     }
   }
-}
+};

--- a/example-backend/src/utils/requestMonitor.ts
+++ b/example-backend/src/utils/requestMonitor.ts
@@ -17,13 +17,10 @@ interface RequestTiming {
   }>;
 }
 
-// Store timing data per request
 const requestTimings = new WeakMap<Request, RequestTiming>();
 
-// AsyncLocalStorage for request-scoped context (prevents race conditions)
 const requestContext = new AsyncLocalStorage<Request>();
 
-// Only log slow requests to avoid noise
 const SLOW_REQUEST_THRESHOLD_MS = process.env.SLOW_REQUEST_THRESHOLD_MS
   ? Number.parseInt(process.env.SLOW_REQUEST_THRESHOLD_MS, 10)
   : 1000;
@@ -34,8 +31,43 @@ const SLOW_DB_QUERY_THRESHOLD_MS = process.env.SLOW_DB_QUERY_THRESHOLD_MS
   ? Number.parseInt(process.env.SLOW_DB_QUERY_THRESHOLD_MS, 10)
   : 250;
 
+const getCurrentRequest = (): Request | null => {
+  return requestContext.getStore() || null;
+};
+
+const logSlowRequest = (
+  req: Request,
+  res: Response,
+  timing: RequestTiming,
+  totalMs: number
+): void => {
+  const reqUser = req.user as {id?: string} | undefined;
+  const userId = reqUser?.id || "anonymous";
+
+  const memoryDelta =
+    timing.memorySnapshots.length > 1
+      ? timing.memorySnapshots[timing.memorySnapshots.length - 1].heapUsed -
+        timing.memorySnapshots[0].heapUsed
+      : 0;
+
+  const logData = {
+    dbQueries: timing.dbQueries,
+    dbQueryCount: timing.dbQueries.length,
+    memoryDeltaMB: memoryDelta,
+    method: req.method,
+    middlewareTimes: timing.middlewareTimes,
+    statusCode: res.statusCode,
+    totalDbTime: timing.dbQueries.reduce((sum, q) => sum + q.duration, 0),
+    totalMs,
+    url: req.url,
+    userAgent: req.get("user-agent")?.substring(0, 100),
+    userId,
+  };
+
+  logger.warn(`[lag] SLOW_REQUEST: ${JSON.stringify(logData)}`);
+};
+
 export const requestMonitorMiddleware = (req: Request, res: Response, next: NextFunction): void => {
-  // Skip health check requests
   if (req.path === "/health") {
     next();
     return;
@@ -51,9 +83,7 @@ export const requestMonitorMiddleware = (req: Request, res: Response, next: Next
 
   requestTimings.set(req, timing);
 
-  // Run the rest of the request in the AsyncLocalStorage context
   requestContext.run(req, () => {
-    // Sample memory usage periodically during request
     const memoryInterval = setInterval(() => {
       const memUsage = process.memoryUsage();
       timing.memorySnapshots.push({
@@ -63,7 +93,6 @@ export const requestMonitorMiddleware = (req: Request, res: Response, next: Next
       });
     }, MEMORY_SAMPLE_INTERVAL_MS);
 
-    // Override res.end to capture final timing
     const originalEnd = res.end;
     // biome-ignore lint/suspicious/noExplicitAny: Express Response.end has multiple overload signatures with varying types
     res.end = function (chunk?: any, encoding?: any): Response {
@@ -72,7 +101,6 @@ export const requestMonitorMiddleware = (req: Request, res: Response, next: Next
       const diff = process.hrtime(startTime);
       const totalMs = Math.round(diff[0] * 1000 + diff[1] * 0.000001);
 
-      // Only log if request was slow
       if (totalMs > SLOW_REQUEST_THRESHOLD_MS) {
         logSlowRequest(req, res, timing, totalMs);
       }
@@ -116,54 +144,17 @@ export const trackDbQuery = (req: Request, query: string, startTime: [number, nu
 
   timing.dbQueries.push({
     duration,
-    query: query.substring(0, 100) + (query.length > 100 ? "..." : ""), // Truncate long queries
+    query: query.substring(0, 100) + (query.length > 100 ? "..." : ""),
     timestamp: Date.now(),
   });
 };
 
-// Helper function to get current request from AsyncLocalStorage
-const getCurrentRequest = (): Request | null => {
-  return requestContext.getStore() || null;
-};
-
-function logSlowRequest(req: Request, res: Response, timing: RequestTiming, totalMs: number): void {
-  // User type from Express.Request.user - may have id property
-  const reqUser = req.user as {id?: string} | undefined;
-  const userId = reqUser?.id || "anonymous";
-
-  // Calculate memory delta
-  const memoryDelta =
-    timing.memorySnapshots.length > 1
-      ? timing.memorySnapshots[timing.memorySnapshots.length - 1].heapUsed -
-        timing.memorySnapshots[0].heapUsed
-      : 0;
-
-  const logData = {
-    dbQueries: timing.dbQueries,
-    dbQueryCount: timing.dbQueries.length,
-    memoryDeltaMB: memoryDelta,
-    method: req.method,
-    middlewareTimes: timing.middlewareTimes,
-    statusCode: res.statusCode,
-    totalDbTime: timing.dbQueries.reduce((sum, q) => sum + q.duration, 0),
-    totalMs,
-    url: req.url,
-    userAgent: req.get("user-agent")?.substring(0, 100),
-    userId,
-  };
-
-  logger.warn(`[lag] SLOW_REQUEST: ${JSON.stringify(logData)}`);
-}
-
-// Mongoose query monitoring using a simpler approach
 export const setupMongooseMonitoring = (): void => {
   const mongoose = require("mongoose");
 
-  // Store original methods
   const originalExec = mongoose.Query.prototype.exec;
   const originalAggregate = mongoose.Model.aggregate;
 
-  // Override exec method to catch all query executions
   // biome-ignore lint/suspicious/noExplicitAny: Mongoose callback can be undefined or have various signatures
   mongoose.Query.prototype.exec = function (callback: any): any {
     const startTime = process.hrtime();
@@ -180,7 +171,6 @@ export const setupMongooseMonitoring = (): void => {
             const diff = process.hrtime(startTime);
             const duration = Math.round(diff[0] * 1000 + diff[1] * 0.000001);
 
-            // Track query in current request if available
             const currentRequest = getCurrentRequest();
             if (currentRequest) {
               trackDbQuery(currentRequest, `${operation}: ${queryString}`, startTime);
@@ -196,7 +186,6 @@ export const setupMongooseMonitoring = (): void => {
             const diff = process.hrtime(startTime);
             const duration = Math.round(diff[0] * 1000 + diff[1] * 0.000001);
 
-            // Track query in current request if available
             const currentRequest = getCurrentRequest();
             if (currentRequest) {
               trackDbQuery(currentRequest, `${operation}: ${queryString}`, startTime);
@@ -214,7 +203,6 @@ export const setupMongooseMonitoring = (): void => {
     return result;
   };
 
-  // Override aggregate method
   // biome-ignore lint/suspicious/noExplicitAny: Aggregate pipeline and options have complex dynamic structure
   mongoose.Model.aggregate = function (pipeline: any, options: any): any {
     const startTime = process.hrtime();
@@ -228,7 +216,6 @@ export const setupMongooseMonitoring = (): void => {
           const diff = process.hrtime(startTime);
           const duration = Math.round(diff[0] * 1000 + diff[1] * 0.000001);
 
-          // Track query in current request if available
           const currentRequest = getCurrentRequest();
           if (currentRequest) {
             trackDbQuery(currentRequest, `aggregate: ${queryString}`, startTime);
@@ -244,7 +231,6 @@ export const setupMongooseMonitoring = (): void => {
           const diff = process.hrtime(startTime);
           const duration = Math.round(diff[0] * 1000 + diff[1] * 0.000001);
 
-          // Track query in current request if available
           const currentRequest = getCurrentRequest();
           if (currentRequest) {
             trackDbQuery(currentRequest, `aggregate: ${queryString}`, startTime);


### PR DESCRIPTION
## Summary

Minimal rule-compliance changes for 3 randomly selected backend files.

### Changes per file

**`api/src/notifiers/zoomNotifier.ts`**
- Converted `function` declaration to const arrow function (rule: "Prefer const arrow functions over `function` keyword")
- Removed effect-describing comments (`// Use format full`, `// Build the message structure`, `// Add subheader if provided`) — per rule: "Comments should describe purpose, not effect"
- Added trailing semicolon for const arrow function assignment

**`api/src/notifiers/googleChatNotifier.ts`**
- Converted `function` declaration to const arrow function (same rule)
- Added trailing semicolon for const arrow function assignment

**`example-backend/src/utils/requestMonitor.ts`**
- Converted `function logSlowRequest` to const arrow function and moved it above its call site (const declarations are not hoisted like function declarations)
- Moved `getCurrentRequest` helper above `requestMonitorMiddleware` for consistent declaration ordering
- Removed effect-describing comments throughout (e.g. `// Store timing data per request`, `// Skip health check requests`, `// Calculate memory delta`, `// Track query in current request if available`, etc.)
- No logic, variable, or behavioral changes

## Review & Testing Checklist for Human
- [ ] Verify the notifier functions (`sendToZoom`, `sendToGoogleChat`) still export correctly and are imported the same way in consumers
- [ ] Confirm `requestMonitor.ts` ordering change doesn't affect runtime behavior (moved `logSlowRequest`/`getCurrentRequest` above their callers)

### Notes
- All changes are style-only — no logic, behavior, or API changes
- `bun lint` and `bun tsc` pass for both `api/` and `example-backend/`
- `require("mongoose")` in `setupMongooseMonitoring` was intentionally kept — converting to ES module `import()` would require broader type changes beyond minimal compliance scope


Link to Devin session: https://app.devin.ai/sessions/3b2eca83af7442b99eb379343c882900
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactors and comment removals with no intended behavior changes; main risk is accidental export/import or hoisting/ordering regressions.
> 
> **Overview**
> This PR makes *style-only* rule-alignment updates in backend utilities.
> 
> It converts `sendToGoogleChat` and `sendToZoom` from `function` declarations to `const` async arrow functions (adding trailing semicolons) and removes a few effect-describing comments.
> 
> In `requestMonitor.ts`, it similarly converts `logSlowRequest` to a `const` arrow function and reorders `getCurrentRequest`/`logSlowRequest` above their call sites to avoid hoisting issues, while trimming non-essential comments; request/query tracking logic is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0af9e4dd840922656b217ac8ce071332895532e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->