### PR TITLE
[alignRules] middleware.ts, openApiEtag.ts, secretProviders.ts

### DIFF
--- a/api/src/middleware.ts
+++ b/api/src/middleware.ts
@@ -9,10 +9,14 @@ import type {NextFunction, Request, Response} from "express";
  *
  * Expected header: `App-Version`
  */
-export function sentryAppVersionMiddleware(req: Request, _res: Response, next: NextFunction): void {
+export const sentryAppVersionMiddleware = (
+  req: Request,
+  _res: Response,
+  next: NextFunction
+): void => {
   const appVersion = req.get("App-Version");
   if (appVersion) {
     Sentry.getCurrentScope().setTag("app_version", appVersion);
   }
   next();
-}
+};

--- a/api/src/openApiEtag.ts
+++ b/api/src/openApiEtag.ts
@@ -6,7 +6,7 @@ import type {NextFunction, Request, Response} from "express";
  * This middleware should be added before the @wesleytodd/openapi middleware
  * to intercept requests to /openapi.json and add conditional request support.
  */
-export function openApiEtagMiddleware(req: Request, res: Response, next: NextFunction): void {
+export const openApiEtagMiddleware = (req: Request, res: Response, next: NextFunction): void => {
   // Only handle GET requests to /openapi.json
   if (req.method !== "GET" || req.path !== "/openapi.json") {
     next();
@@ -37,4 +37,4 @@ export function openApiEtagMiddleware(req: Request, res: Response, next: NextFun
   };
 
   next();
-}
+};

--- a/api/src/secretProviders.ts
+++ b/api/src/secretProviders.ts
@@ -1,4 +1,5 @@
 import type {SecretProvider} from "./configurationPlugin";
+import {APIError} from "./errors";
 import {logger} from "./logger";
 
 /**
@@ -69,9 +70,11 @@ export class GcpSecretProvider implements SecretProvider {
           mod.SecretManagerServiceClient ?? mod.default?.SecretManagerServiceClient;
         this.client = new SecretManagerServiceClient();
       } catch {
-        throw new Error(
-          "GcpSecretProvider requires @google-cloud/secret-manager. Install it with: bun add @google-cloud/secret-manager"
-        );
+        throw new APIError({
+          status: 500,
+          title:
+            "GcpSecretProvider requires @google-cloud/secret-manager. Install it with: bun add @google-cloud/secret-manager",
+        });
       }
     }
     return this.client;


### PR DESCRIPTION
## Summary

Minimal rule-compliance fixes for three backend files in `api/src/`:

1. **`middleware.ts`** — Converted `sentryAppVersionMiddleware` from `function` declaration to `const` arrow function per repo rule: _"Prefer const arrow functions over `function` keyword"_.

2. **`openApiEtag.ts`** — Converted `openApiEtagMiddleware` from `function` declaration to `const` arrow function (same rule).

3. **`secretProviders.ts`** — Replaced `throw new Error(...)` with `throw new APIError({status: 500, ...})` per repo rule: _"Throw `APIError` with appropriate status codes"_ / _"never plain `Error`"_. Added corresponding `APIError` import.

No logic, variable naming, or behavioral changes.

## Review & Testing Checklist for Human
- [ ] Verify `sentryAppVersionMiddleware` still works correctly as an arrow function export (callers reference it by name, not by `function.name`)
- [ ] Verify `openApiEtagMiddleware` still works correctly as an arrow function export
- [ ] Verify the `APIError` throw in `GcpSecretProvider.getClient()` is appropriate (500 status for missing dependency)

### Notes
- Linter (`biome check`) and TypeScript compiler (`tsc`) both pass locally for the `api` package.
- All changes are backend-only (`api/` package).


Link to Devin session: https://app.devin.ai/sessions/68defb6524da4402a94599f87b44b043
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk stylistic/error-shaping changes: middleware exports are refactored without behavior changes, and a missing optional dependency now throws `APIError(500)` instead of a plain `Error`, which only affects error formatting/handling paths.
> 
> **Overview**
> Updates `sentryAppVersionMiddleware` and `openApiEtagMiddleware` exports from `function` declarations to `const` arrow functions without changing behavior.
> 
> Changes `GcpSecretProvider.getClient()` to throw a structured `APIError` (HTTP 500) when `@google-cloud/secret-manager` is not installed, instead of throwing a plain `Error`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06dfe5b453e82f4776f9608bebc7740c58cfa2a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->