### PR TITLE
[coverage] plugins.ts, gpt.ts

### DIFF
--- a/ai/src/routes/routes.test.ts
+++ b/ai/src/routes/routes.test.ts
@@ -321,6 +321,27 @@ describe("AI Routes", () => {
       expect(createServerModelFn).toHaveBeenCalledWith("gemini-2.5-pro");
     });
 
+    it("falls back to default aiService when createServerModelFn returns null", async () => {
+      const createServerModelFn = mock((_modelId?: string) => null);
+      const customApp = setupServer({
+        addRoutes: (router, options) => {
+          addGptRoutes(router, {aiService, createServerModelFn, openApiOptions: options});
+        },
+        skipListen: true,
+        userModel: UserModel,
+      });
+      const agent = await authAsUser(customApp, "notAdmin");
+      const res = await agent
+        .post("/gpt/prompt")
+        .send({model: "unsupported-model", prompt: "Hi"})
+        .buffer(true)
+        .parse(sseCollect);
+      expect(res.status).toBe(200);
+      expect(createServerModelFn).toHaveBeenCalledWith("unsupported-model");
+      const body = (res as SseResponse).body;
+      expect(body).toContain("done");
+    });
+
     it("rejects history from another user", async () => {
       const otherUserId = new mongoose.Types.ObjectId();
       const other = await GptHistory.create({

--- a/api/src/plugins.test.ts
+++ b/api/src/plugins.test.ts
@@ -8,10 +8,12 @@ import {addAuthRoutes, setupAuth} from "./auth";
 import type {APIErrorConstructor} from "./errors";
 import {Permissions} from "./permissions";
 import {
+  baseUserPlugin,
   createdUpdatedPlugin,
   DateOnly,
   findExactlyOne,
   findOneOrNone,
+  firebaseJWTPlugin,
   type IsDeleted,
   isDeletedPlugin,
   upsertPlugin,
@@ -51,6 +53,33 @@ stuffSchema.plugin(upsertPlugin);
 stuffSchema.plugin(createdUpdatedPlugin);
 
 const StuffModel = model<Stuff>("Stuff", stuffSchema) as unknown as StuffModelType;
+
+describe("baseUserPlugin", () => {
+  it("adds admin and email fields to the schema", () => {
+    const testSchema = new Schema({});
+    // biome-ignore lint/suspicious/noExplicitAny: test schema
+    baseUserPlugin(testSchema as Schema<any, any, any, any>);
+
+    const adminPath = testSchema.path("admin");
+    expect(adminPath).toBeDefined();
+    expect((adminPath as unknown as {options: {default: boolean}}).options.default).toBe(false);
+
+    const emailPath = testSchema.path("email");
+    expect(emailPath).toBeDefined();
+    expect((emailPath as unknown as {options: {index: boolean}}).options.index).toBe(true);
+  });
+});
+
+describe("firebaseJWTPlugin", () => {
+  it("adds firebaseId field to the schema", () => {
+    const testSchema = new Schema({});
+    firebaseJWTPlugin(testSchema);
+
+    const firebaseIdPath = testSchema.path("firebaseId");
+    expect(firebaseIdPath).toBeDefined();
+    expect((firebaseIdPath as unknown as {options: {index: boolean}}).options.index).toBe(true);
+  });
+});
 
 describe("createdUpdate", () => {
   it("sets created and updated on save", async () => {


### PR DESCRIPTION
## Summary
Improve test coverage for two backend files:

**api/src/plugins.ts** — Added tests for `baseUserPlugin` and `firebaseJWTPlugin`, verifying that schema fields (`admin`, `email`, `firebaseId`) are added with correct defaults and indexes.
- Function coverage: 83.33% → 95.83%
- Line coverage: 98.88% → 99.44%

**ai/src/routes/gpt.ts** — Added test for `createServerModelFn` returning null, exercising the fallback to the default `aiService`.
- Function coverage: 100% (maintained)
- Line coverage: 95.02% → 95.18%

## Review & Testing Checklist for Human
- [ ] Verify new tests actually run and pass: `cd api && bun test --preload ./src/tests/bunSetup.ts src/plugins.test.ts` and `cd ai && bun test --preload ./src/tests/bunSetup.ts src/routes/routes.test.ts`
- [ ] Confirm no behavioral changes to source code — only test files modified

### Notes
- The `baseUserPlugin` function signature in plugins.ts uses `Schema<any, any, any, any>` in source; test uses biome-ignore for that line but avoids `any` elsewhere via `unknown` casts.
- Existing pre-existing lint warnings in api/ and ai/ are unchanged.

Link to Devin session: https://app.devin.ai/sessions/4ce5752e6e8f4be890772549dc8eb16b
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to new/updated tests and do not modify runtime logic; main risk is potential test brittleness around Mongoose schema internals and SSE parsing.
> 
> **Overview**
> Improves backend test coverage by adding assertions for `baseUserPlugin` and `firebaseJWTPlugin` to verify the expected schema fields, defaults, and indexes are registered.
> 
> Adds a GPT prompt route test case that exercises the `createServerModelFn` returning `null` path and confirms the request falls back to the default `aiService` and still completes the SSE stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f0c69f1455a59580ad99d195fc0bc0447a457dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->