### PR TITLE
[coverage] TerrenoProvider.tsx, useUpgradeCheck.ts

### DIFF
--- a/rtk/src/useUpgradeCheck.mobile.test.ts
+++ b/rtk/src/useUpgradeCheck.mobile.test.ts
@@ -1,0 +1,213 @@
+import {afterEach, beforeEach, describe, expect, it, mock} from "bun:test";
+import {act, renderHook, waitFor} from "@testing-library/react-native";
+
+// ---------------------------------------------------------------------------
+// Mutable refs
+// ---------------------------------------------------------------------------
+let mockBuildNumber: number | undefined = 42;
+
+interface MockVersionCheckResponse {
+  message?: string;
+  status: "ok" | "warning" | "required";
+  updateUrl?: string;
+}
+const mockUnwrap = mock((): Promise<MockVersionCheckResponse> => Promise.resolve({status: "ok"}));
+const mockTrigger = mock((..._args: unknown[]) => ({unwrap: mockUnwrap}));
+
+mock.module("./emptyApi", () => ({
+  useLazyGetVersionCheckQuery: () => [mockTrigger],
+}));
+
+// IsWeb is false to exercise native code paths
+mock.module("./platform", () => ({
+  IsWeb: false,
+}));
+
+let appStateListeners: Array<(state: string) => void> = [];
+const mockRemove = mock(() => {});
+const mockAddEventListener = mock((_event: string, handler: (state: string) => void) => {
+  appStateListeners.push(handler);
+  return {remove: mockRemove};
+});
+
+const mockOpenURL = mock(() => Promise.resolve(true));
+
+mock.module("react-native", () => ({
+  AppState: {
+    addEventListener: mockAddEventListener,
+    currentState: "active",
+  },
+  Linking: {openURL: mockOpenURL},
+  Platform: {OS: "ios"},
+  StyleSheet: {create: (s: unknown) => s},
+}));
+
+mock.module("expo-constants", () => ({
+  default: {
+    get expoConfig() {
+      return {extra: {buildNumber: mockBuildNumber}};
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Timer mocks
+// ---------------------------------------------------------------------------
+const originalSetInterval = globalThis.setInterval;
+const originalClearInterval = globalThis.clearInterval;
+let intervalIdCounter = 0;
+const mockSetInterval = mock((_cb: () => void, _ms: number) => {
+  return ++intervalIdCounter as unknown as ReturnType<typeof setInterval>;
+});
+const mockClearInterval = mock((_id: unknown) => {});
+
+// ---------------------------------------------------------------------------
+// Console capture
+// ---------------------------------------------------------------------------
+const warnCalls: unknown[][] = [];
+const originalDebug = console.debug;
+const originalWarn = console.warn;
+
+import {useUpgradeCheck} from "./useUpgradeCheck";
+
+const flushPromises = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  mockBuildNumber = 42;
+  appStateListeners = [];
+
+  mockUnwrap.mockClear();
+  mockUnwrap.mockImplementation(() => Promise.resolve({status: "ok" as const}));
+  mockTrigger.mockClear();
+  mockTrigger.mockImplementation((..._args: unknown[]) => ({unwrap: mockUnwrap}));
+  mockRemove.mockClear();
+  mockAddEventListener.mockClear();
+  mockAddEventListener.mockImplementation((_event: string, handler: (state: string) => void) => {
+    appStateListeners.push(handler);
+    return {remove: mockRemove};
+  });
+  mockOpenURL.mockClear();
+  mockOpenURL.mockImplementation(() => Promise.resolve(true));
+
+  globalThis.setInterval = mockSetInterval as unknown as typeof setInterval;
+  globalThis.clearInterval = mockClearInterval as unknown as typeof clearInterval;
+  mockSetInterval.mockClear();
+  mockClearInterval.mockClear();
+
+  warnCalls.length = 0;
+  console.debug = () => {};
+  console.warn = (...args: unknown[]): void => {
+    warnCalls.push(args);
+  };
+});
+
+afterEach(() => {
+  console.debug = originalDebug;
+  console.warn = originalWarn;
+  globalThis.setInterval = originalSetInterval;
+  globalThis.clearInterval = originalClearInterval;
+});
+
+describe("useUpgradeCheck (mobile)", () => {
+  describe("onUpdate", () => {
+    it("calls Linking.openURL when updateUrl is available", async () => {
+      mockUnwrap.mockImplementation(() =>
+        Promise.resolve({
+          status: "warning" as const,
+          updateUrl: "https://apps.apple.com/app/123",
+        })
+      );
+      const {result} = renderHook(() => useUpgradeCheck());
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isWarning).toBe(true);
+      });
+
+      act(() => {
+        result.current.onUpdate();
+      });
+
+      expect(mockOpenURL).toHaveBeenCalledWith("https://apps.apple.com/app/123");
+    });
+
+    it("logs warning when no updateUrl is available on mobile", async () => {
+      mockUnwrap.mockImplementation(() => Promise.resolve({status: "warning" as const}));
+      const {result} = renderHook(() => useUpgradeCheck());
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isWarning).toBe(true);
+      });
+
+      act(() => {
+        result.current.onUpdate();
+      });
+
+      const noUrlWarn = warnCalls.find(
+        (args) => typeof args[0] === "string" && args[0].includes("no update URL")
+      );
+      expect(noUrlWarn).toBeDefined();
+    });
+
+    it("logs warning when Linking.openURL rejects", async () => {
+      mockOpenURL.mockImplementation(() => Promise.reject(new Error("Cannot open URL")));
+      mockUnwrap.mockImplementation(() =>
+        Promise.resolve({
+          status: "warning" as const,
+          updateUrl: "https://apps.apple.com/app/123",
+        })
+      );
+      const {result} = renderHook(() => useUpgradeCheck());
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isWarning).toBe(true);
+      });
+
+      await act(async () => {
+        result.current.onUpdate();
+        await flushPromises();
+      });
+
+      const failWarn = warnCalls.find(
+        (args) => typeof args[0] === "string" && args[0].includes("Failed to open update URL")
+      );
+      expect(failWarn).toBeDefined();
+    });
+  });
+
+  describe("canUpdate", () => {
+    it("is false on mobile when updateUrl is not set", () => {
+      const {result} = renderHook(() => useUpgradeCheck());
+      expect(result.current.canUpdate).toBe(false);
+    });
+
+    it("is true on mobile when updateUrl is set", async () => {
+      mockUnwrap.mockImplementation(() =>
+        Promise.resolve({
+          status: "warning" as const,
+          updateUrl: "https://apps.apple.com/app/123",
+        })
+      );
+      const {result} = renderHook(() => useUpgradeCheck());
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      await waitFor(() => {
+        expect(result.current.canUpdate).toBe(true);
+      });
+    });
+  });
+});

--- a/ui/src/TerrenoProvider.test.tsx
+++ b/ui/src/TerrenoProvider.test.tsx
@@ -1,5 +1,5 @@
 import {beforeAll, describe, expect, it, mock} from "bun:test";
-import {act, render} from "@testing-library/react-native";
+import {act, fireEvent, render} from "@testing-library/react-native";
 import {Text, View} from "react-native";
 
 import {TerrenoProvider} from "./TerrenoProvider";
@@ -72,5 +72,41 @@ describe("TerrenoProvider", () => {
     });
 
     expect(queryByText("Hello from toast")).toBeTruthy();
+  });
+
+  it("invokes data onDismiss via handleDismiss when persistent toast is dismissed", async () => {
+    const dismissSpy = mock(() => {});
+    let toastApi: ReturnType<typeof useToast> | null = null;
+
+    const ToastCaller = () => {
+      toastApi = useToast();
+      return <Text>App</Text>;
+    };
+
+    const {UNSAFE_getAllByProps} = render(
+      <TerrenoProvider>
+        <ToastCaller />
+      </TerrenoProvider>
+    );
+
+    expect(toastApi).not.toBeNull();
+
+    await act(async () => {
+      toastApi?.info("Dismissible toast", {onDismiss: dismissSpy, persistent: true});
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Find the dismiss Pressable via its aria-role="button" that wraps the xmark icon.
+    const buttons = UNSAFE_getAllByProps({"aria-role": "button"});
+    // The dismiss button is the one without an accessibilityLabel
+    const dismissBtn = buttons.find((b) => !b.props.accessibilityLabel && b.props.onPress);
+    expect(dismissBtn).toBeDefined();
+
+    await act(async () => {
+      fireEvent.press(dismissBtn!);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(dismissSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
Improve test coverage for two frontend files:

**ui/src/TerrenoProvider.tsx** — Added test that shows a persistent toast and dismisses it, exercising the `handleDismiss` callback inside `renderToast`.
- Function coverage: 66.67% → 100%
- Line coverage: 92.86% → 100%

**rtk/src/useUpgradeCheck.ts** — Added new test file `useUpgradeCheck.mobile.test.ts` with `IsWeb=false` to exercise mobile-only code paths: `Linking.openURL` with update URL, missing update URL warning, and `openURL` rejection handling.
- Function coverage: 92.31% → 100%
- Line coverage: 94.38% → 100%

## Review & Testing Checklist for Human
- [ ] Verify new tests pass: `cd ui && TZ=America/New_York bun test src/TerrenoProvider.test.tsx` and `cd rtk && bun test src/useUpgradeCheck.test.ts src/useUpgradeCheck.mobile.test.ts`
- [ ] Confirm no behavioral changes to source code — only test files modified

### Notes
- A separate test file was needed for rtk because `IsWeb` is mocked at module level and bun snapshots module exports, preventing per-test changes.
- Existing pre-existing lint warnings in ui/ and rtk/ are unchanged.

Link to Devin session: https://app.devin.ai/sessions/4ce5752e6e8f4be890772549dc8eb16b
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are test-only and don’t alter production logic; main risk is potential test flakiness due to timers/module mocks.
> 
> **Overview**
> Improves frontend test coverage for two areas without changing runtime behavior.
> 
> Adds `useUpgradeCheck.mobile.test.ts` to exercise native-only paths with `IsWeb=false`, covering `onUpdate` opening the store URL, warning logs when the URL is missing, and handling `Linking.openURL` failures, plus `canUpdate` behavior.
> 
> Extends `TerrenoProvider.test.tsx` to verify that dismissing a *persistent* toast triggers the toast data’s `onDismiss` via the provider’s `handleDismiss` (using a press event on the dismiss button).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c30323c8d62ba12c35dbf905db65c56489d0edd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->