### PR TITLE
[alignRules] ToastNotifications.tsx, Tooltip.test.tsx, Utilities.test.tsx

### DIFF
--- a/ui/src/ToastNotifications.tsx
+++ b/ui/src/ToastNotifications.tsx
@@ -177,6 +177,10 @@ export interface ToastOptions {
   /**
    * Payload data for custom toasts. You can pass whatever you want
    */
+  // noExplicitAny: Vendored from react-native-toast-notifications; this is a public extension point
+  // for arbitrary user-supplied payload data (`renderToast` consumers spread it directly), so a
+  // narrower type would force every consumer to add casts and would break the library's contract.
+  // biome-ignore lint/suspicious/noExplicitAny: see noExplicitAny comment above.
   data?: any;
 
   swipeEnabled?: boolean;

--- a/ui/src/Tooltip.test.tsx
+++ b/ui/src/Tooltip.test.tsx
@@ -1,6 +1,7 @@
 import {beforeAll, describe, expect, it, mock} from "bun:test";
 import {act} from "@testing-library/react-native";
 import {View} from "react-native";
+import type {ReactTestRendererJSON} from "react-test-renderer";
 
 import {Text} from "./Text";
 import {Tooltip} from "./Tooltip";
@@ -13,10 +14,10 @@ mock.module("react-native-portalize", () => ({
 }));
 
 beforeAll(() => {
-  (global as any).requestAnimationFrame = (callback: FrameRequestCallback) => {
+  global.requestAnimationFrame = (callback: FrameRequestCallback) => {
     return setTimeout(() => callback(Date.now()), 0) as unknown as number;
   };
-  (global as any).cancelAnimationFrame = (id: number) => {
+  global.cancelAnimationFrame = (id: number) => {
     clearTimeout(id);
   };
 });
@@ -111,14 +112,14 @@ describe("Tooltip", () => {
       </Tooltip>
     );
 
-    const wrapper = toJSON() as any;
+    const wrapper = toJSON() as ReactTestRendererJSON;
     expect(wrapper).toBeTruthy();
     expect(queryByTestId("tooltip-container")).toBeNull();
 
     const tree = toJSON();
     await act(async () => {
       // Trigger pointer enter on the wrapper
-      const root = (tree as any).children?.[0];
+      const root = (tree as ReactTestRendererJSON).children?.[0] as ReactTestRendererJSON;
       if (root?.props?.onPointerEnter) {
         root.props.onPointerEnter();
       }
@@ -138,8 +139,8 @@ describe("Tooltip", () => {
       </Tooltip>
     );
 
-    const tree = toJSON() as any;
-    const root = tree.children?.[0];
+    const tree = toJSON() as ReactTestRendererJSON;
+    const root = tree.children?.[0] as ReactTestRendererJSON;
 
     await act(async () => {
       root.props.onTouchStart?.({nativeEvent: {}});
@@ -151,8 +152,10 @@ describe("Tooltip", () => {
     expect(queryByTestId("tooltip-container")).toBeTruthy();
 
     // Second touch should hide
-    const treeAfterShow = toJSON() as any;
-    const updatedRoot = treeAfterShow.children?.[treeAfterShow.children.length - 1];
+    const treeAfterShow = toJSON() as ReactTestRendererJSON;
+    const updatedRoot = treeAfterShow.children?.[
+      treeAfterShow.children.length - 1
+    ] as ReactTestRendererJSON;
     await act(async () => {
       updatedRoot.props.onTouchStart?.({nativeEvent: {}});
     });
@@ -167,8 +170,8 @@ describe("Tooltip", () => {
       </Tooltip>
     );
 
-    const tree = toJSON() as any;
-    const root = tree.children?.[0];
+    const tree = toJSON() as ReactTestRendererJSON;
+    const root = tree.children?.[0] as ReactTestRendererJSON;
 
     await act(async () => {
       root.props.onPointerEnter?.();
@@ -179,8 +182,8 @@ describe("Tooltip", () => {
 
     expect(queryByTestId("tooltip-container")).toBeTruthy();
 
-    const treeAfter = toJSON() as any;
-    const wrapper = treeAfter.children?.[treeAfter.children.length - 1];
+    const treeAfter = toJSON() as ReactTestRendererJSON;
+    const wrapper = treeAfter.children?.[treeAfter.children.length - 1] as ReactTestRendererJSON;
     await act(async () => {
       wrapper.props.onPointerLeave?.();
     });
@@ -206,8 +209,8 @@ describe("Tooltip", () => {
       </Tooltip>
     );
 
-    const tree = toJSON() as any;
-    const root = tree.children?.[0];
+    const tree = toJSON() as ReactTestRendererJSON;
+    const root = tree.children?.[0] as ReactTestRendererJSON;
 
     await act(async () => {
       root.props.onPointerEnter?.();
@@ -227,8 +230,8 @@ describe("Tooltip", () => {
       </Tooltip>
     );
 
-    const tree = toJSON() as any;
-    const root = tree.children?.[0];
+    const tree = toJSON() as ReactTestRendererJSON;
+    const root = tree.children?.[0] as ReactTestRendererJSON;
 
     // Show the tooltip
     await act(async () => {
@@ -240,12 +243,11 @@ describe("Tooltip", () => {
     expect(queryByTestId("tooltip-container")).toBeTruthy();
 
     // Find any views with onLayout to simulate layout event
-    const {View: ViewComp} = await import("react-native");
-    const allViews = UNSAFE_getAllByType(ViewComp as any);
+    const allViews = UNSAFE_getAllByType(View);
     for (const v of allViews) {
-      if ((v.props as any).onLayout) {
+      if (v.props.onLayout) {
         await act(async () => {
-          (v.props as any).onLayout({
+          v.props.onLayout({
             nativeEvent: {
               layout: {height: 100, width: 200, x: 0, y: 0},
             },
@@ -280,8 +282,8 @@ describe("Tooltip", () => {
       </Tooltip>
     );
 
-    const tree = toJSON() as any;
-    const root = tree.children?.[0];
+    const tree = toJSON() as ReactTestRendererJSON;
+    const root = tree.children?.[0] as ReactTestRendererJSON;
     await act(async () => {
       root.props.onPointerEnter?.();
     });

--- a/ui/src/Utilities.test.tsx
+++ b/ui/src/Utilities.test.tsx
@@ -1,5 +1,6 @@
 import {describe, expect, it} from "bun:test";
 
+import type {APIError, BaseProfile} from "./Common";
 import {
   bind,
   concat,
@@ -25,6 +26,15 @@ import {
   union,
 } from "./Utilities";
 
+interface AddressResultWithCounty {
+  address1: string;
+  city: string;
+  state: string;
+  zipcode: string;
+  countyCode?: string;
+  countyName?: string;
+}
+
 describe("Utilities", () => {
   describe("mergeInlineStyles", () => {
     it("merges inline styles", () => {
@@ -47,15 +57,15 @@ describe("Utilities", () => {
 
   describe("isTestUser", () => {
     it("returns true for nang.io email", () => {
-      expect(isTestUser({email: "test@nang.io"} as any)).toBe(true);
+      expect(isTestUser({email: "test@nang.io"} as unknown as BaseProfile)).toBe(true);
     });
 
     it("returns true for example.com email", () => {
-      expect(isTestUser({email: "test@example.com"} as any)).toBe(true);
+      expect(isTestUser({email: "test@example.com"} as unknown as BaseProfile)).toBe(true);
     });
 
     it("returns false for regular email", () => {
-      expect(isTestUser({email: "user@company.com"} as any)).toBe(false);
+      expect(isTestUser({email: "user@company.com"} as unknown as BaseProfile)).toBe(false);
     });
 
     it("returns falsy for undefined profile", () => {
@@ -63,7 +73,7 @@ describe("Utilities", () => {
     });
 
     it("returns falsy for profile without email", () => {
-      expect(isTestUser({} as any)).toBeFalsy();
+      expect(isTestUser({} as unknown as BaseProfile)).toBeFalsy();
     });
   });
 
@@ -321,13 +331,15 @@ describe("Utilities", () => {
     });
 
     it("handles empty components with includeCounty", () => {
-      const result = processAddressComponents([], {includeCounty: true}) as any;
+      const result = processAddressComponents([], {includeCounty: true}) as AddressResultWithCounty;
       expect(result.countyName).toBe("");
       expect(result.countyCode).toBe("");
     });
 
     it("handles components with includeCounty when county is present", () => {
-      const result = processAddressComponents(components, {includeCounty: true}) as any;
+      const result = processAddressComponents(components, {
+        includeCounty: true,
+      }) as AddressResultWithCounty;
       expect(result.countyName).toBe("Suffolk County");
     });
 
@@ -337,7 +349,7 @@ describe("Utilities", () => {
       );
       const result = processAddressComponents(componentsWithoutCounty, {
         includeCounty: true,
-      }) as any;
+      }) as AddressResultWithCounty;
       expect(result.countyName).toBe("");
     });
   });
@@ -364,7 +376,7 @@ describe("Utilities", () => {
     });
 
     it("returns false when passed a non-string value", () => {
-      expect(isValidGoogleApiKey(123 as any)).toBe(false);
+      expect(isValidGoogleApiKey(123 as unknown as string)).toBe(false);
     });
 
     it("returns false for whitespace-only key", () => {
@@ -404,22 +416,24 @@ describe("Utilities", () => {
   describe("printAPIError", () => {
     it("prints error title", () => {
       const error = {data: {title: "Not Found"}};
-      expect(printAPIError(error as any)).toBe("Not Found");
+      expect(printAPIError(error as unknown as APIError)).toBe("Not Found");
     });
 
     it("prints error title and detail", () => {
       const error = {data: {detail: "Resource does not exist", title: "Not Found"}};
-      expect(printAPIError(error as any)).toBe("Not Found: Resource does not exist");
+      expect(printAPIError(error as unknown as APIError)).toBe(
+        "Not Found: Resource does not exist"
+      );
     });
 
     it("omits detail when details is false", () => {
       const error = {data: {detail: "Resource does not exist", title: "Not Found"}};
-      expect(printAPIError(error as any, false)).toBe("Not Found");
+      expect(printAPIError(error as unknown as APIError, false)).toBe("Not Found");
     });
 
     it("prints title when detail is missing", () => {
       const error = {data: {title: "Not Found"}};
-      expect(printAPIError(error as any, true)).toBe("Not Found");
+      expect(printAPIError(error as unknown as APIError, true)).toBe("Not Found");
     });
   });
 });


### PR DESCRIPTION
## Summary
Replace `as any` / `: any` usages with explicit types in three UI package files as part of the `noExplicitAny` align-rules cleanup.

- `ui/src/ToastNotifications.tsx`: The single `data?: any` is on the public extension point of a vendored library type (`ToastOptions`) where consumers (e.g. `TerrenoProvider`) spread the payload directly into their custom `renderToast`. Narrowing it (e.g. to `unknown`) would break the contract and force casts at every call site, so it's annotated with a `noExplicitAny:` comment plus a matching `biome-ignore` and left as `any`.
- `ui/src/Utilities.test.tsx`: Replaced `as any` casts with the actual types from `./Common` — `BaseProfile` for `isTestUser` test inputs, `APIError` for `printAPIError` test inputs, a local `AddressResultWithCounty` interface for `processAddressComponents` results that include county fields, and `as unknown as string` for the deliberately-invalid `123` input to `isValidGoogleApiKey`.
- `ui/src/Tooltip.test.tsx`: Replaced `as any` casts on `toJSON()` results with `ReactTestRendererJSON` from `react-test-renderer`, dropped the redundant dynamic `import("react-native")` (the static `View` import is already in scope, eliminating the need for the cast), and replaced `(global as any).requestAnimationFrame` / `(global as any).cancelAnimationFrame` with direct `global.requestAnimationFrame` / `global.cancelAnimationFrame` assignments (matching the pattern already used in `ToastNotifications.test.tsx`).

No behavior changes; only type annotations and explicit casts.

## Review & Testing Checklist for Human
- [ ] Confirm `noExplicitAny:` justification on `ToastOptions.data` is acceptable, vs. e.g. typing it as `unknown` and updating `TerrenoProvider` consumers.
- [ ] Confirm `Tooltip.test.tsx` still exercises the same code paths after dropping the dynamic `import("react-native")` (it now uses the top-level `View` import for `UNSAFE_getAllByType(View)`).

### Notes
- `bun lint` passes.
- `bun compile` passes.
- `bun test` for `Tooltip.test.tsx`, `Utilities.test.tsx`, and `ToastNotifications.test.tsx` passes (121 tests).
- All three files are in the `ui/` (frontend) package — no backend files mixed in.


Link to Devin session: https://app.devin.ai/sessions/25ea570cc0ab4709b894e41fa034f68a
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-annotation/test-only changes; production code behavior is unchanged aside from adding a documented lint suppression for a public `any` extension point.
> 
> **Overview**
> **Aligns `noExplicitAny` lint rules in the UI package** by replacing `as any` casts in `Tooltip.test.tsx` and `Utilities.test.tsx` with concrete types (`ReactTestRendererJSON`, `BaseProfile`, `APIError`) and a small local `AddressResultWithCounty` helper type.
> 
> Keeps `ToastOptions.data` as `any` but documents it as a deliberate public extension point and adds a targeted `biome-ignore` lint suppression to prevent future churn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ce1c7335a63ef9e2209cc3797d0519ca4e7db66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->