### PR TITLE
[alignRules] errors.ts, openApiCompat.ts, seed-feature-flags.ts

### DIFF
--- a/api/src/errors.ts
+++ b/api/src/errors.ts
@@ -137,7 +137,7 @@ export class APIError extends Error {
 
 // Create an errors field for storing error information in a JSONAPI compatible form directly on a
 // model.
-export function errorsPlugin(schema: Schema): void {
+export const errorsPlugin = (schema: Schema): void => {
   const errorSchema = new Schema({
     code: {description: "Application-specific error code", type: String},
     detail: {description: "Human-readable explanation of the error", type: String},
@@ -160,18 +160,18 @@ export function errorsPlugin(schema: Schema): void {
   });
 
   schema.add({apiErrors: errorSchema});
-}
+};
 
-export function isAPIError(error: Error): error is APIError {
+export const isAPIError = (error: Error): error is APIError => {
   return error.name === "APIError";
-}
+};
 
 /**
  * Safely extracts the disableExternalErrorTracking property from an error.
  * Works with both APIError instances and regular Error objects that may have
  * this property attached.
  */
-export function getDisableExternalErrorTracking(error: unknown): boolean | undefined {
+export const getDisableExternalErrorTracking = (error: unknown): boolean | undefined => {
   if (error instanceof Error) {
     if (isAPIError(error)) {
       return error.disableExternalErrorTracking;
@@ -181,12 +181,12 @@ export function getDisableExternalErrorTracking(error: unknown): boolean | undef
     return (error as {disableExternalErrorTracking?: boolean}).disableExternalErrorTracking;
   }
   return undefined;
-}
+};
 
 // Creates an APIError body to send to clients as JSON. Errors don't have a toJSON defined,
 // and we want to strip out things like message, name, and stack for the client.
 // There is almost certainly a more elegant solution to this.
-export function getAPIErrorBody(error: APIError): {[id: string]: any} {
+export const getAPIErrorBody = (error: APIError): {[id: string]: any} => {
   const errorData = {status: error.status, title: error.title};
   for (const key of [
     "id",
@@ -203,23 +203,28 @@ export function getAPIErrorBody(error: APIError): {[id: string]: any} {
     }
   }
   return errorData;
-}
+};
 
-export function apiUnauthorizedMiddleware(
+export const apiUnauthorizedMiddleware = (
   err: Error,
   _req: Request,
   res: Response,
   next: NextFunction
-) {
+) => {
   if (err.message === "Unauthorized") {
     // not using the actual APIError class here because we don't want to log it as an error.
     res.status(401).json({status: 401, title: "Unauthorized"}).send();
   } else {
     next(err);
   }
-}
+};
 
-export function apiErrorMiddleware(err: Error, _req: Request, res: Response, next: NextFunction) {
+export const apiErrorMiddleware = (
+  err: Error,
+  _req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   if (isAPIError(err)) {
     if (!err.disableExternalErrorTracking) {
       Sentry.captureException(err);
@@ -228,4 +233,4 @@ export function apiErrorMiddleware(err: Error, _req: Request, res: Response, nex
   } else {
     next(err);
   }
-}
+};

--- a/api/src/openApiCompat.ts
+++ b/api/src/openApiCompat.ts
@@ -110,7 +110,7 @@ const patchRouterStack = (stack: any[]): void => {
  */
 export const patchAppUse = (app: any): void => {
   const originalUse = app.use.bind(app);
-  app.use = function patchedUse(...args: any[]) {
+  const patchedUse = (...args: any[]): unknown => {
     // Track stack length before the call
     const router = app._router || app.router;
     const stackBefore = router?.stack?.length ?? 0;
@@ -132,6 +132,7 @@ export const patchAppUse = (app: any): void => {
 
     return result;
   };
+  app.use = patchedUse;
 };
 
 /**

--- a/example-backend/src/scripts/seed-feature-flags.ts
+++ b/example-backend/src/scripts/seed-feature-flags.ts
@@ -79,7 +79,7 @@ export const seedFeatureFlags = async (): Promise<{results: string[]; success: b
   const results: string[] = [];
 
   for (const flag of SEED_FLAGS) {
-    const existing = await FeatureFlag.findOne({key: flag.key});
+    const existing = await FeatureFlag.findOneOrNone({key: flag.key});
     if (existing) {
       results.push(`Skipped (already exists): ${flag.key}`);
       skipped++;


### PR DESCRIPTION
## Summary

Bring three randomly selected backend files into compliance with the configured `.rulesync` rules. Each change is the minimum necessary to satisfy a rule — no logic refactors, variable renames, or behavior changes.

### Files & rule alignments

1. **`api/src/errors.ts`** — Rule: *"Prefer const arrow functions over `function` keyword"* (`.rulesync/rules/00-root.md`).
   - Converted six top-level `export function` declarations to `export const ... = (...) =>`:
     `errorsPlugin`, `isAPIError`, `getDisableExternalErrorTracking`, `getAPIErrorBody`, `apiUnauthorizedMiddleware`, `apiErrorMiddleware`.
   - The `APIError` class itself is unchanged (class constructor stays as `function`-style, which is the only valid form).

2. **`api/src/openApiCompat.ts`** — Same arrow-function rule.
   - The inline `app.use = function patchedUse(...args) { … }` was the last remaining `function` keyword in the file. Converted to a const arrow function (`const patchedUse = (...args: any[]): unknown => { … }; app.use = patchedUse;`). `this` is not referenced inside the body, so the conversion is semantically safe.

3. **`example-backend/src/scripts/seed-feature-flags.ts`** — Rule: *"Do not use `Model.findOne` — use `Model.findExactlyOne` or `Model.findOneOrNone`"* (`.rulesync/rules/api/00-api.md`, root rules, repo knowledge).
   - Replaced `await FeatureFlag.findOne({key: flag.key})` with `await FeatureFlag.findOneOrNone({key: flag.key})`. `FeatureFlag` already registers the `findOneOrNone` plugin (see `feature-flags/src/featureFlagModel.ts`), so this is a drop-in replacement with the same `null | doc` return type.

### Verification

- `bun run lint` — no new warnings introduced. Pre-existing warnings in `expressServer.test.ts`, `admin-backend/src/adminApp.models.test.ts`, etc. are unchanged.
- `bun run compile` — all packages compile cleanly.

## Review & Testing Checklist for Human

- [ ] Confirm the `function` → arrow conversion in `api/src/errors.ts` is acceptable for the exported middleware (`apiUnauthorizedMiddleware`, `apiErrorMiddleware`). No call sites rely on hoisting or `.name` of the function.
- [ ] Spot-check that `FeatureFlag.findOneOrNone` behaves identically to `findOne` for the seed script's "skip if exists" flow (matching by unique `key`).

### Notes

- Files were selected via `find … | shuf -n 3` over the backend tree (`api/`, `admin-backend/`, `example-backend/`); all three are backend files so no frontend/backend mixing.
- PR opened as draft; will be marked ready for review once CI is green.

Link to Devin session: https://app.devin.ai/sessions/48751545739c401585c10e243d6fa30b
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk formatting/consistency changes: converts exported functions to `const` arrow functions and swaps `FeatureFlag.findOne` for `findOneOrNone` in a seed script, with no intended behavior changes.
> 
> **Overview**
> Updates `api/src/errors.ts` and `api/src/openApiCompat.ts` to satisfy the *prefer const arrow functions* rule by converting exported/inline `function` declarations to `export const ... = (...) =>` equivalents.
> 
> Updates `example-backend/src/scripts/seed-feature-flags.ts` to comply with the *no `Model.findOne`* rule by replacing `FeatureFlag.findOne` with `FeatureFlag.findOneOrNone` when checking for existing flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5846a2df1cd5b0c80c6c275c1911015c34d394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->