### PR TITLE
[alignRules] SplitPage.test.tsx, TextFieldNumberActionSheet.tsx, ToastNotifications.tsx

### DIFF
--- a/ui/src/SplitPage.test.tsx
+++ b/ui/src/SplitPage.test.tsx
@@ -1,6 +1,6 @@
 import {afterAll, beforeAll, describe, expect, it, mock} from "bun:test";
 import {act} from "@testing-library/react-native";
-import {Dimensions, View} from "react-native";
+import {Dimensions, type ScaledSize, View} from "react-native";
 
 import {SplitPage} from "./SplitPage";
 import {renderWithTheme} from "./test-utils";
@@ -178,22 +178,25 @@ describe("SplitPage", () => {
   });
 
   describe("desktop viewport (mediaQueryLargerThan('sm') true)", () => {
-    const desktopImpl = () => ({fontScale: 1, height: 1000, scale: 2, width: 1400}) as any;
-    const mobileImpl = () => ({fontScale: 1, height: 812, scale: 2, width: 375}) as any;
+    type DimensionsGetMock = {mockImplementation?: (impl: () => ScaledSize) => void};
+    const desktopImpl = (): ScaledSize => ({fontScale: 1, height: 1000, scale: 2, width: 1400});
+    const mobileImpl = (): ScaledSize => ({fontScale: 1, height: 812, scale: 2, width: 375});
     let originalGet: typeof Dimensions.get;
     beforeAll(() => {
       originalGet = Dimensions.get;
-      if (typeof (Dimensions.get as any).mockImplementation === "function") {
-        (Dimensions.get as any).mockImplementation(desktopImpl);
+      const mockable = Dimensions.get as DimensionsGetMock;
+      if (typeof mockable.mockImplementation === "function") {
+        mockable.mockImplementation(desktopImpl);
       } else {
-        (Dimensions.get as any) = desktopImpl;
+        (Dimensions as {get: typeof Dimensions.get}).get = desktopImpl as typeof Dimensions.get;
       }
     });
     afterAll(() => {
-      if (typeof (Dimensions.get as any).mockImplementation === "function") {
-        (Dimensions.get as any).mockImplementation(mobileImpl);
+      const mockable = Dimensions.get as DimensionsGetMock;
+      if (typeof mockable.mockImplementation === "function") {
+        mockable.mockImplementation(mobileImpl);
       } else {
-        (Dimensions.get as any) = originalGet;
+        (Dimensions as {get: typeof Dimensions.get}).get = originalGet;
       }
     });
 

--- a/ui/src/TextFieldNumberActionSheet.tsx
+++ b/ui/src/TextFieldNumberActionSheet.tsx
@@ -1,4 +1,4 @@
-import DateTimePicker from "@react-native-community/datetimepicker";
+import DateTimePicker, {type DateTimePickerEvent} from "@react-native-community/datetimepicker";
 import React from "react";
 
 import {ActionSheet} from "./ActionSheet";
@@ -30,7 +30,7 @@ export class NumberPickerActionSheet extends React.Component<
             display="spinner"
             is24Hour
             mode={this.props.mode}
-            onChange={(_event: any, date?: Date) => {
+            onChange={(_event: DateTimePickerEvent, date?: Date) => {
               if (!date) {
                 return;
               }

--- a/ui/src/ToastNotifications.tsx
+++ b/ui/src/ToastNotifications.tsx
@@ -177,6 +177,10 @@ export interface ToastOptions {
   /**
    * Payload data for custom toasts. You can pass whatever you want
    */
+  // noExplicitAny: Generic payload field for vendored toast library; consumers
+  // pass arbitrary shapes (e.g. ToastProps) and spread them into custom render
+  // functions. Narrowing to unknown breaks downstream spreads/property access.
+  // biome-ignore lint/suspicious/noExplicitAny: Vendored generic payload type.
   data?: any;
 
   swipeEnabled?: boolean;


### PR DESCRIPTION
## Summary
Replace `as any` / `: any` usages in three `@terreno/ui` files with explicit types. Minimal, type-only changes — no logic, naming, or behavior changes.

- `ui/src/SplitPage.test.tsx`: typed the `Dimensions.get` mock helpers with `ScaledSize` and a small `DimensionsGetMock` interface so the mock-detection branch and the direct-assignment branch both type-check without `any`.
- `ui/src/TextFieldNumberActionSheet.tsx`: imported `DateTimePickerEvent` from `@react-native-community/datetimepicker` and used it for the `DateTimePicker.onChange` callback's first argument.
- `ui/src/ToastNotifications.tsx`: this file is vendored from `react-native-toast-notifications`. The `ToastOptions.data` field is intentionally a generic payload that consumers spread into custom `renderToast` functions (TerrenoProvider spreads it into a `Toast`). Narrowing to `unknown` breaks downstream spreads/property access, so left it as `any` with a `noExplicitAny:` rationale and a `biome-ignore` directive.

## Review & Testing Checklist for Human
- [ ] Confirm the `noExplicitAny:` rationale on `ToastOptions.data` is acceptable, or suggest an alternative (e.g., making `ToastOptions`/`ToastProps` generic over the payload shape).
- [ ] Sanity-check the `Dimensions.get` mock approach in `SplitPage.test.tsx` — the runtime behavior is identical, but the cast site moved from `(Dimensions.get as any) = …` to `(Dimensions as {get: typeof Dimensions.get}).get = …`.
- [ ] Verify `DateTimePickerEvent` is the correct event type for the `onChange` callback in `TextFieldNumberActionSheet.tsx`.

### Notes
- `bun lint`, `bun compile`, and `bun ui:test` (1333 tests, 0 failures) all pass locally.
- No frontend/backend mixing — all three files are in `@terreno/ui`.
- Drafted PR; will mark ready for review once CI is green.

Link to Devin session: https://app.devin.ai/sessions/806fb991e3714c638797641e72dccac6
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are type-only (replacing `any`/casts with explicit types and a lint exception) and should not affect runtime behavior. Main risk is minor TypeScript typing/compatibility issues in tests or in downstream toast `data` consumers.
> 
> **Overview**
> **Type-safety cleanup across `@terreno/ui`** by replacing `as any`/`any` usages with explicit types.
> 
> Updates `SplitPage.test.tsx` to type `Dimensions.get` mock helpers using `ScaledSize` and a small mock interface, and updates `TextFieldNumberActionSheet.tsx` to type the DateTimePicker `onChange` event with `DateTimePickerEvent`.
> 
> Keeps `ToastNotifications.tsx` `ToastOptions.data` as `any`, adding a rationale comment and `biome-ignore` to document that it’s an intentionally untyped payload for custom toast rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95e988bd383e7d251a741c531ebfa8ee62d97566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->