### PR TITLE
Skip version bump PR for beta and alpha releases

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -851,9 +851,11 @@ jobs:
 
   create-version-pr:
     needs: [check-changes, publish-api, publish-ui, publish-rtk, publish-admin-backend, publish-admin-frontend, publish-ai, publish-api-health]
-    # Run if any package was published (always() ensures this runs even if some publish jobs were skipped)
+    # Run if any package was published and this is not a prerelease (beta/alpha) tag
     if: |
       always() &&
+      !contains(needs.check-changes.outputs.version, '-beta') &&
+      !contains(needs.check-changes.outputs.version, '-alpha') &&
       (needs.publish-api.result == 'success' || needs.publish-ui.result == 'success' || needs.publish-rtk.result == 'success' || needs.publish-admin-backend.result == 'success' || needs.publish-admin-frontend.result == 'success' || needs.publish-ai.result == 'success' || needs.publish-api-health.result == 'success')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
When tagging a `-beta` or `-alpha` prerelease, the `create-version-pr` job in the publish-on-tag workflow now skips creating the version bump PR. This prevents unnecessary PRs for prerelease versions that shouldn't update the tracked version in `package.json` on master.

The condition uses `!contains(needs.check-changes.outputs.version, '-beta')` and `!contains(needs.check-changes.outputs.version, '-alpha')` to detect prerelease tags.

## Review & Testing Checklist for Human
- [ ] Verify the `if` condition syntax is correct for GitHub Actions expressions
- [ ] Confirm that stable releases (e.g. `1.2.0`) still trigger the version bump PR as expected

### Notes
Only the `create-version-pr` job is affected — packages still publish to npm normally for prerelease tags.

Link to Devin session: https://app.devin.ai/sessions/c92a0ccb7bd54306a75ea3693f6dfd48
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release workflow gating for updating versions on `master`; a mistake could prevent expected version bumps or unexpectedly allow them during prereleases.
> 
> **Overview**
> Prevents the `update-version-on-master` job in `publish-on-tag.yml` from running for prerelease tags by adding checks that the tag version does **not** contain `-beta` or `-alpha`.
> 
> Stable tags still update `master` only when at least one publish job succeeded; prerelease tags can publish packages but won’t trigger the post-release version bump commit to `master`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 664cb4a80d0b6c9835c799af31cf3a36e0bf1cf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->