### PR TITLE
[alignRules] SplitPage.test.tsx, TextFieldNumberActionSheet.tsx, ToastNotifications.tsx

### DIFF
--- a/ui/src/SplitPage.test.tsx
+++ b/ui/src/SplitPage.test.tsx
@@ -1,9 +1,15 @@
 import {afterAll, beforeAll, describe, expect, it, mock} from "bun:test";
 import {act} from "@testing-library/react-native";
+import type {ScaledSize} from "react-native";
 import {Dimensions, View} from "react-native";
 
 import {SplitPage} from "./SplitPage";
 import {renderWithTheme} from "./test-utils";
+
+type DimensionsGetImpl = (dim: "window" | "screen") => ScaledSize;
+type MockableDimensionsGet = DimensionsGetImpl & {
+  mockImplementation?: (impl: DimensionsGetImpl) => void;
+};
 
 // Mock react-native-swiper-flatlist
 mock.module("react-native-swiper-flatlist", () => ({
@@ -178,22 +184,34 @@ describe("SplitPage", () => {
   });
 
   describe("desktop viewport (mediaQueryLargerThan('sm') true)", () => {
-    const desktopImpl = () => ({fontScale: 1, height: 1000, scale: 2, width: 1400}) as any;
-    const mobileImpl = () => ({fontScale: 1, height: 812, scale: 2, width: 375}) as any;
+    const desktopImpl: DimensionsGetImpl = () => ({
+      fontScale: 1,
+      height: 1000,
+      scale: 2,
+      width: 1400,
+    });
+    const mobileImpl: DimensionsGetImpl = () => ({
+      fontScale: 1,
+      height: 812,
+      scale: 2,
+      width: 375,
+    });
     let originalGet: typeof Dimensions.get;
     beforeAll(() => {
       originalGet = Dimensions.get;
-      if (typeof (Dimensions.get as any).mockImplementation === "function") {
-        (Dimensions.get as any).mockImplementation(desktopImpl);
+      const dimGet = Dimensions.get as MockableDimensionsGet;
+      if (typeof dimGet.mockImplementation === "function") {
+        dimGet.mockImplementation(desktopImpl);
       } else {
-        (Dimensions.get as any) = desktopImpl;
+        (Dimensions as {get: DimensionsGetImpl}).get = desktopImpl;
       }
     });
     afterAll(() => {
-      if (typeof (Dimensions.get as any).mockImplementation === "function") {
-        (Dimensions.get as any).mockImplementation(mobileImpl);
+      const dimGet = Dimensions.get as MockableDimensionsGet;
+      if (typeof dimGet.mockImplementation === "function") {
+        dimGet.mockImplementation(mobileImpl);
       } else {
-        (Dimensions.get as any) = originalGet;
+        (Dimensions as {get: DimensionsGetImpl}).get = originalGet;
       }
     });
 

--- a/ui/src/TextFieldNumberActionSheet.tsx
+++ b/ui/src/TextFieldNumberActionSheet.tsx
@@ -1,4 +1,4 @@
-import DateTimePicker from "@react-native-community/datetimepicker";
+import DateTimePicker, {type DateTimePickerEvent} from "@react-native-community/datetimepicker";
 import React from "react";
 
 import {ActionSheet} from "./ActionSheet";
@@ -30,7 +30,7 @@ export class NumberPickerActionSheet extends React.Component<
             display="spinner"
             is24Hour
             mode={this.props.mode}
-            onChange={(_event: any, date?: Date) => {
+            onChange={(_event: DateTimePickerEvent, date?: Date) => {
               if (!date) {
                 return;
               }

--- a/ui/src/ToastNotifications.tsx
+++ b/ui/src/ToastNotifications.tsx
@@ -177,6 +177,10 @@ export interface ToastOptions {
   /**
    * Payload data for custom toasts. You can pass whatever you want
    */
+  // noExplicitAny: This is the public API of a vendored 3rd-party library
+  // (react-native-toast-notifications); the `data` field is an opaque
+  // user-provided payload. Tightening to `unknown` breaks downstream consumers
+  // that spread `data` into `Toast` (e.g. TerrenoProvider) without refactor.
   data?: any;
 
   swipeEnabled?: boolean;


### PR DESCRIPTION
## Summary
Replace `any` usages with explicit types in three `@terreno/ui` files, per the no-explicit-any alignment effort. Minimal-scope changes — no logic/behavior refactors.

- `ui/src/SplitPage.test.tsx`: typed the `Dimensions.get` mock implementations as `(dim: "window" | "screen") => ScaledSize` and introduced a small `MockableDimensionsGet` helper type so the existing "is it a bun mock?" branch no longer relies on `as any`.
- `ui/src/TextFieldNumberActionSheet.tsx`: replaced `_event: any` in the `DateTimePicker` `onChange` with the upstream `DateTimePickerEvent` type from `@react-native-community/datetimepicker`.
- `ui/src/ToastNotifications.tsx`: this file is vendored from `react-native-toast-notifications` (see license header at the top of the file). The `data?: any` field is the library's documented opaque user payload, and `TerrenoProvider` spreads it directly into the `Toast` component (`{...toastOptions?.data}`). Tightening to `unknown` would force a downstream refactor of `TerrenoProvider`, which contradicts the "minimal necessary changes — don't refactor logic or change behavior" instruction. Added a `noExplicitAny:` comment explaining the rationale instead.

## Review & Testing Checklist for Human
- [ ] Confirm the `noExplicitAny:` justification on `ToastNotifications.tsx#data` is acceptable (vendored 3rd-party API + downstream `TerrenoProvider` consumer), or request the follow-up refactor that types `data` as `unknown` and casts in `TerrenoProvider`.
- [ ] Spot-check the `SplitPage.test.tsx` desktop-viewport branch — the bun-mock detection (`mockImplementation` runtime check) is preserved; the only change is the type annotations.

### Notes
- `bun lint` ✅ (no new warnings/errors from these files; pre-existing `Boolean()`-redundancy info in `DataTable.tsx` is unrelated).
- `bun compile` ✅ across all packages.
- `bun test src/SplitPage.test.tsx` ✅ — 23/23 pass.

Link to Devin session: https://app.devin.ai/sessions/8550d896c3904c9c9c596df698db2725
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are type-only in tests and component event typing, plus a comment clarifying an intentional `any` in a vendored public API with no runtime behavior changes.
> 
> **Overview**
> Aligns with `no-explicit-any` by replacing a few `any` usages with explicit types.
> 
> `SplitPage.test.tsx` now types the `Dimensions.get` desktop/mobile mock implementations and adds a small helper type to support both Bun-mocked and direct override branches without `as any`. `TextFieldNumberActionSheet.tsx` types the DateTimePicker `onChange` event as `DateTimePickerEvent`. `ToastNotifications.tsx` keeps `data?: any` (vendored third-party public API) and adds an inline justification comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb1d7ad519793dc2614fa0833c7289f358344b4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->