### PR TITLE
[alignRules] openApiValidator.ts, scriptRunner.ts, configurationPlugin.ts

### DIFF
--- a/api/src/configurationPlugin.ts
+++ b/api/src/configurationPlugin.ts
@@ -177,15 +177,18 @@ export const configurationPlugin = (schema: Schema, options?: ConfigurationPlugi
 
   // Static: get the singleton configuration document or a value at a path (race-safe via upsert)
   schema.statics.getConfig = async function (key?: string): Promise<unknown> {
-    const findSingleton = (): Promise<any> =>
-      (this as unknown as FindOneOrNonePlugin<unknown>).findOneOrNone({});
-    let config = await findSingleton();
+    const findSingleton = (): Promise<Document | null> =>
+      (this as unknown as FindOneOrNonePlugin<unknown>).findOneOrNone({}) as Promise<
+        Document | null
+      >;
+    let config: Document | null = await findSingleton();
     if (!config) {
       try {
         // Use `new` + `save` instead of `create({})` so Mongoose initializes
         // nested subdocument defaults (create({}) skips them).
-        config = new this();
-        await config.save();
+        const created = new this();
+        await created.save();
+        config = created;
       } catch (err: unknown) {
         // If another process created the document between the lookup and create,
         // the pre-save hook will throw a 409. Just fetch the existing one.
@@ -203,7 +206,7 @@ export const configurationPlugin = (schema: Schema, options?: ConfigurationPlugi
 
     // Resolve dot-notation key into the document
     const parts = key.split(".");
-    let value: unknown = config.toObject();
+    let value: unknown = config?.toObject();
     for (const part of parts) {
       if (value == null || typeof value !== "object") {
         return undefined;

--- a/api/src/configurationPlugin.ts
+++ b/api/src/configurationPlugin.ts
@@ -2,6 +2,7 @@ import type {Document, Model, Schema} from "mongoose";
 
 import {APIError} from "./errors";
 import {logger} from "./logger";
+import {type FindOneOrNonePlugin, findOneOrNone} from "./plugins";
 
 /**
  * Metadata for a secret field discovered by the configuration plugin.
@@ -100,7 +101,7 @@ export interface ConfigurationStatics<T extends object> {
  * const full = await AppConfig.getConfig(); // typed as AppConfigDocument
  * ```
  */
-export type ConfigurationModel<T extends object> = Model<T> & ConfigurationStatics<T>;
+export interface ConfigurationModel<T extends object> extends Model<T>, ConfigurationStatics<T> {}
 
 // ---------------------------------------------------------------------------
 // Plugin
@@ -132,6 +133,9 @@ export type ConfigurationModel<T extends object> = Model<T> & ConfigurationStati
 export const configurationPlugin = (schema: Schema, options?: ConfigurationPluginOptions): void => {
   const pluginOptions = options ?? {};
 
+  // Apply findOneOrNone so the singleton lookup avoids bare Model.findOne (idempotent).
+  findOneOrNone(schema);
+
   // Add a sentinel field with a unique index to enforce singleton at the DB level.
   // All config documents get _singleton: "config", and the unique index prevents duplicates.
   schema.add({
@@ -142,8 +146,8 @@ export const configurationPlugin = (schema: Schema, options?: ConfigurationPlugi
   // Enforce singleton: only one document allowed (application-level guard)
   schema.pre("save", async function () {
     if (this.isNew) {
-      // Intentional unfiltered findOne — checking if any singleton document exists
-      const existing = await (this.constructor as Model<unknown>).findOne({});
+      // Cheap existence check — no document needs to be returned.
+      const existing = await (this.constructor as Model<unknown>).exists({});
       if (existing) {
         throw new APIError({
           status: 409,
@@ -173,7 +177,9 @@ export const configurationPlugin = (schema: Schema, options?: ConfigurationPlugi
 
   // Static: get the singleton configuration document or a value at a path (race-safe via upsert)
   schema.statics.getConfig = async function (key?: string): Promise<unknown> {
-    let config = await this.findOne({});
+    const findSingleton = (): Promise<any> =>
+      (this as unknown as FindOneOrNonePlugin<unknown>).findOneOrNone({});
+    let config = await findSingleton();
     if (!config) {
       try {
         // Use `new` + `save` instead of `create({})` so Mongoose initializes
@@ -181,10 +187,10 @@ export const configurationPlugin = (schema: Schema, options?: ConfigurationPlugi
         config = new this();
         await config.save();
       } catch (err: unknown) {
-        // If another process created the document between findOne and create,
+        // If another process created the document between the lookup and create,
         // the pre-save hook will throw a 409. Just fetch the existing one.
         if ((err as {status?: number})?.status === 409) {
-          config = await this.findOne({});
+          config = await findSingleton();
         } else {
           throw err;
         }

--- a/api/src/configurationPlugin.ts
+++ b/api/src/configurationPlugin.ts
@@ -178,9 +178,9 @@ export const configurationPlugin = (schema: Schema, options?: ConfigurationPlugi
   // Static: get the singleton configuration document or a value at a path (race-safe via upsert)
   schema.statics.getConfig = async function (key?: string): Promise<unknown> {
     const findSingleton = (): Promise<Document | null> =>
-      (this as unknown as FindOneOrNonePlugin<unknown>).findOneOrNone({}) as Promise<
-        Document | null
-      >;
+      (this as unknown as FindOneOrNonePlugin<unknown>).findOneOrNone(
+        {}
+      ) as Promise<Document | null>;
     let config: Document | null = await findSingleton();
     if (!config) {
       try {

--- a/api/src/openApiValidator.ts
+++ b/api/src/openApiValidator.ts
@@ -110,9 +110,9 @@ let globalConfig: OpenApiValidatorConfig = {
  * Check whether `configureOpenApiValidator()` has been called.
  * Validation middleware is a no-op when this returns false.
  */
-export function isOpenApiValidatorConfigured(): boolean {
+export const isOpenApiValidatorConfigured = (): boolean => {
   return isConfigured;
-}
+};
 
 /**
  * Configure the global OpenAPI validator settings.
@@ -131,28 +131,28 @@ export function isOpenApiValidatorConfigured(): boolean {
  * });
  * ```
  */
-export function configureOpenApiValidator(config: Partial<OpenApiValidatorConfig> = {}): void {
+export const configureOpenApiValidator = (config: Partial<OpenApiValidatorConfig> = {}): void => {
   isConfigured = true;
   globalConfig = {...globalConfig, ...config};
   // Clear cached AJV instances so new config takes effect
   ajvCache.clear();
   validatorCache.clear();
   logger.debug(`OpenAPI validator configured: ${JSON.stringify(globalConfig)}`);
-}
+};
 
 /**
  * Get the current global validator configuration.
  */
-export function getOpenApiValidatorConfig(): OpenApiValidatorConfig {
+export const getOpenApiValidatorConfig = (): OpenApiValidatorConfig => {
   return {...globalConfig};
-}
+};
 
 /**
  * Reset the global validator configuration to defaults.
  * Also resets `isConfigured` to false.
  * Useful for testing.
  */
-export function resetOpenApiValidatorConfig(): void {
+export const resetOpenApiValidatorConfig = (): void => {
   isConfigured = false;
   globalConfig = {
     coerceTypes: true,
@@ -163,7 +163,7 @@ export function resetOpenApiValidatorConfig(): void {
   };
   ajvCache.clear();
   validatorCache.clear();
-}
+};
 
 // Lazy AJV instance cache keyed by coerceTypes + removeAdditional
 const ajvCache = new Map<string, Ajv>();
@@ -171,7 +171,7 @@ const ajvCache = new Map<string, Ajv>();
 /**
  * Get or create an AJV instance with the current config settings.
  */
-function getAjvInstance(): Ajv {
+const getAjvInstance = (): Ajv => {
   const key = `coerce:${globalConfig.coerceTypes ?? true},remove:${globalConfig.removeAdditional ?? true}`;
   let instance = ajvCache.get(key);
 
@@ -189,7 +189,7 @@ function getAjvInstance(): Ajv {
   }
 
   return instance;
-}
+};
 
 // Cache compiled validators by schema hash + config key
 const validatorCache = new Map<string, ValidateFunction>();
@@ -197,9 +197,9 @@ const validatorCache = new Map<string, ValidateFunction>();
 /**
  * Generate a simple hash for a schema to use as a cache key.
  */
-function hashSchema(schema: OpenApiSchema): string {
+const hashSchema = (schema: OpenApiSchema): string => {
   return JSON.stringify(schema);
-}
+};
 
 const VALID_JSON_SCHEMA_TYPES = new Set([
   "string",
@@ -221,7 +221,7 @@ const MONGOOSE_TYPE_MAP: Record<string, {type: string; format?: string}> = {
  * Recursively replace non-standard mongoose-to-swagger types with valid JSON Schema types
  * so AJV can compile the schema.
  */
-function sanitizeSchemaForAjv(schema: Record<string, unknown>): Record<string, unknown> {
+const sanitizeSchemaForAjv = (schema: Record<string, unknown>): Record<string, unknown> => {
   if (!schema || typeof schema !== "object") {
     return schema;
   }
@@ -262,7 +262,7 @@ function sanitizeSchemaForAjv(schema: Record<string, unknown>): Record<string, u
   }
 
   return result;
-}
+};
 
 /**
  * Get or create a compiled validator for a schema.
@@ -270,7 +270,7 @@ function sanitizeSchemaForAjv(schema: Record<string, unknown>): Record<string, u
  * Sanitizes non-standard mongoose-to-swagger types before compilation.
  * Returns null if the schema still cannot be compiled after sanitization.
  */
-function getValidator(schema: OpenApiSchema): ValidateFunction | null {
+const getValidator = (schema: OpenApiSchema): ValidateFunction | null => {
   const ajv = getAjvInstance();
   const configKey = `coerce:${globalConfig.coerceTypes ?? true},remove:${globalConfig.removeAdditional ?? true}`;
   const hash = `${configKey}:${hashSchema(schema)}`;
@@ -293,12 +293,12 @@ function getValidator(schema: OpenApiSchema): ValidateFunction | null {
     validatorCache.set(hash, null as unknown as ValidateFunction);
     return null;
   }
-}
+};
 
 /**
  * Format AJV errors into a human-readable string.
  */
-function formatValidationErrors(errors: ErrorObject[]): string {
+const formatValidationErrors = (errors: ErrorObject[]): string => {
   return errors
     .map((err) => {
       const path = err.instancePath || "/";
@@ -306,17 +306,17 @@ function formatValidationErrors(errors: ErrorObject[]): string {
       return `${path}: ${message}`;
     })
     .join("; ");
-}
+};
 
 /**
  * Convert OpenApiSchemaProperty to a full OpenApiSchema suitable for AJV.
  * Strips `required` from individual properties (OpenAPI-style) and moves it
  * to the schema-level `required` array (JSON Schema-style) for AJV compatibility.
  */
-function propertiesToSchema(
+const propertiesToSchema = (
   properties: Record<string, OpenApiSchemaProperty>,
   requiredFields?: string[]
-): OpenApiSchema {
+): OpenApiSchema => {
   // Extract required fields from properties that have required: true
   const autoRequired = Object.entries(properties)
     .filter(([_, prop]) => prop.required)
@@ -344,7 +344,7 @@ function propertiesToSchema(
   }
 
   return schema;
-}
+};
 
 /**
  * Options for the request body validator middleware.
@@ -388,10 +388,10 @@ export interface RequestBodyValidatorOptions {
  * @param options - Optional configuration for this validator
  * @returns Express middleware function
  */
-export function validateRequestBody(
+export const validateRequestBody = (
   schema: Record<string, OpenApiSchemaProperty>,
   options?: RequestBodyValidatorOptions
-): (req: Request, res: Response, next: NextFunction) => void {
+): ((req: Request, res: Response, next: NextFunction) => void) => {
   const fullSchema = propertiesToSchema(schema, options?.required);
 
   return (req: Request, _res: Response, next: NextFunction): void => {
@@ -491,7 +491,7 @@ export function validateRequestBody(
 
     next();
   };
-}
+};
 
 /**
  * Options for the query parameter validator middleware.
@@ -515,10 +515,10 @@ export interface QueryValidatorOptions {
  * @param options - Optional configuration for this validator
  * @returns Express middleware function
  */
-export function validateQueryParams(
+export const validateQueryParams = (
   schema: Record<string, OpenApiSchemaProperty>,
   options?: QueryValidatorOptions
-): (req: Request, res: Response, next: NextFunction) => void {
+): ((req: Request, res: Response, next: NextFunction) => void) => {
   const fullSchema = propertiesToSchema(schema);
 
   return (req: Request, _res: Response, next: NextFunction): void => {
@@ -591,7 +591,7 @@ export function validateQueryParams(
 
     next();
   };
-}
+};
 
 /**
  * Options for creating a combined validation middleware.
@@ -630,9 +630,9 @@ export interface CreateValidatorOptions {
  * ], handler);
  * ```
  */
-export function createValidator(
+export const createValidator = (
   options: CreateValidatorOptions
-): (req: Request, res: Response, next: NextFunction) => void {
+): ((req: Request, res: Response, next: NextFunction) => void) => {
   const bodyValidator = options.body
     ? validateRequestBody(options.body, {enabled: options.enabled})
     : null;
@@ -663,7 +663,7 @@ export function createValidator(
       next();
     }
   };
-}
+};
 
 /**
  * Validates response data against a schema.
@@ -673,10 +673,10 @@ export function createValidator(
  * @param schema - The expected schema
  * @returns Object with valid flag and any errors
  */
-export function validateResponseData(
+export const validateResponseData = (
   data: unknown,
   schema: Record<string, OpenApiSchemaProperty>
-): {valid: boolean; errors?: ErrorObject[]} {
+): {valid: boolean; errors?: ErrorObject[]} => {
   if (!globalConfig.validateResponses) {
     return {valid: true};
   }
@@ -698,7 +698,7 @@ export function validateResponseData(
   }
 
   return {valid: true};
-}
+};
 
 const m2sOptions = {
   props: ["readOnly", "required", "enum", "default"],
@@ -712,19 +712,19 @@ const m2sOptions = {
  * @param model - A Mongoose model
  * @returns Schema properties suitable for validation
  */
-export function getSchemaFromModel<T>(model: Model<T>): Record<string, OpenApiSchemaProperty> {
+export const getSchemaFromModel = <T>(model: Model<T>): Record<string, OpenApiSchemaProperty> => {
   const modelSwagger = m2s(model, m2sOptions);
   fixMixedFields((model as any).schema, modelSwagger.properties);
   return modelSwagger.properties as Record<string, OpenApiSchemaProperty>;
-}
+};
 
 /**
  * Extract required field names from a Mongoose model's swagger schema.
  */
-function getRequiredFieldsFromModel<T>(model: Model<T>): string[] {
+const getRequiredFieldsFromModel = <T>(model: Model<T>): string[] => {
   const modelSwagger = m2s(model, m2sOptions);
   return (modelSwagger.required as string[]) ?? [];
-}
+};
 
 /**
  * Creates a request body validator middleware from a Mongoose model.
@@ -734,10 +734,10 @@ function getRequiredFieldsFromModel<T>(model: Model<T>): string[] {
  * @param options - Optional configuration for the validator
  * @returns Express middleware function
  */
-export function validateModelRequestBody<T>(
+export const validateModelRequestBody = <T>(
   model: Model<T>,
   options?: RequestBodyValidatorOptions
-): (req: Request, res: Response, next: NextFunction) => void {
+): ((req: Request, res: Response, next: NextFunction) => void) => {
   let schema = getSchemaFromModel(model);
   let requiredFields = getRequiredFieldsFromModel(model);
 
@@ -751,7 +751,7 @@ export function validateModelRequestBody<T>(
     ...options,
     required: [...(options?.required ?? []), ...requiredFields],
   });
-}
+};
 
 /**
  * Options for creating validation middleware for a modelRouter.
@@ -805,13 +805,13 @@ export interface ModelRouterValidationOptions {
  * @param options - Configuration options
  * @returns Object with create and update validation middleware
  */
-export function createModelValidators<T>(
+export const createModelValidators = <T>(
   model: Model<T>,
   options?: ModelRouterValidationOptions
 ): {
   create: (req: Request, res: Response, next: NextFunction) => void;
   update: (req: Request, res: Response, next: NextFunction) => void;
-} {
+} => {
   const schema = getSchemaFromModel(model);
 
   return {
@@ -826,7 +826,7 @@ export function createModelValidators<T>(
       onError: options?.onError,
     }),
   };
-}
+};
 
 /**
  * Build a query parameter schema from a model's Mongoose schema and queryFields array.
@@ -836,10 +836,10 @@ export function createModelValidators<T>(
  * @param queryFields - Array of field names allowed for querying
  * @returns Schema properties suitable for query validation
  */
-export function buildQuerySchemaFromFields<T>(
+export const buildQuerySchemaFromFields = <T>(
   model: Model<T>,
   queryFields: string[] = []
-): Record<string, OpenApiSchemaProperty> {
+): Record<string, OpenApiSchemaProperty> => {
   const modelSchema = getSchemaFromModel(model);
   const querySchema: Record<string, OpenApiSchemaProperty> = {
     limit: {type: "number"},
@@ -859,4 +859,4 @@ export function buildQuerySchemaFromFields<T>(
   }
 
   return querySchema;
-}
+};

--- a/api/src/scriptRunner.ts
+++ b/api/src/scriptRunner.ts
@@ -42,7 +42,7 @@ interface BackgroundTaskLog {
   message: string;
 }
 
-export type BackgroundTaskMethods = {
+export interface BackgroundTaskMethods {
   addLog: (
     this: BackgroundTaskDocument,
     level: "info" | "warn" | "error",
@@ -54,35 +54,31 @@ export type BackgroundTaskMethods = {
     stage?: string,
     message?: string
   ) => Promise<void>;
-};
+}
 
-export type BackgroundTaskDocument = Document &
-  BackgroundTaskMethods & {
-    taskType: string;
-    status: "pending" | "running" | "completed" | "failed" | "cancelled";
-    progress?: BackgroundTaskProgress;
-    createdBy?: mongoose.Types.ObjectId;
-    isDryRun: boolean;
-    result?: string[];
-    error?: string;
-    logs: BackgroundTaskLog[];
-    startedAt?: Date;
-    completedAt?: Date;
-    created: Date;
-    updated: Date;
-    deleted: boolean;
-  };
+export interface BackgroundTaskDocument extends Document, BackgroundTaskMethods {
+  taskType: string;
+  status: "pending" | "running" | "completed" | "failed" | "cancelled";
+  progress?: BackgroundTaskProgress;
+  createdBy?: mongoose.Types.ObjectId;
+  isDryRun: boolean;
+  result?: string[];
+  error?: string;
+  logs: BackgroundTaskLog[];
+  startedAt?: Date;
+  completedAt?: Date;
+  created: Date;
+  updated: Date;
+  deleted: boolean;
+}
 
-export type BackgroundTaskStatics = {
+export interface BackgroundTaskStatics {
   checkCancellation: (taskId: string) => Promise<void>;
-};
+}
 
-export type BackgroundTaskModel = Model<
-  BackgroundTaskDocument,
-  Record<string, never>,
-  BackgroundTaskMethods
-> &
-  BackgroundTaskStatics;
+export interface BackgroundTaskModel
+  extends Model<BackgroundTaskDocument, Record<string, never>, BackgroundTaskMethods>,
+    BackgroundTaskStatics {}
 
 const progressSchema = new Schema(
   {


### PR DESCRIPTION
## Summary
Minimal rule-compliance changes for 3 randomly selected backend files. All edits target the rules in `.rulesync/rules/` and `AGENTS.md` ("Prefer interfaces over types", "Prefer const arrow functions", "Do not use `Model.findOne` — use `findExactlyOne` or `findOneOrNone`"). No logic, behavior, or naming changes.

**`api/src/openApiValidator.ts`**
- Converted all 19 top-level `function` declarations (5 exported, 6 internal helpers, plus middleware factories like `validateRequestBody`, `validateQueryParams`, `createValidator`, `validateResponseData`, `getSchemaFromModel`, `getRequiredFieldsFromModel`, `validateModelRequestBody`, `createModelValidators`, `buildQuerySchemaFromFields`) to const arrow functions (rule: prefer const arrow functions over `function` keyword).
- Pure syntactic conversion — return types, signatures, and bodies unchanged.

**`api/src/scriptRunner.ts`**
- Converted `BackgroundTaskMethods`, `BackgroundTaskStatics`, `BackgroundTaskDocument`, and `BackgroundTaskModel` from `type` aliases (some using intersection) to `interface` declarations using `extends` (rule: prefer interfaces over types).
- Document/Model interfaces extend `Document` / `Model<...>` and the corresponding methods/statics interfaces, mirroring the pattern used in PR #496 for `TodoDocument` / `TodoModel`.

**`api/src/configurationPlugin.ts`**
- Converted `ConfigurationModel<T>` from `type` intersection to `interface` extends (rule: prefer interfaces over types).
- Replaced bare `Model.findOne({})` calls per the "Never use `Model.findOne`" rule:
  - In the singleton pre-save guard, replaced `findOne({})` with `exists({})` since only a boolean check is needed.
  - In `getConfig()`, replaced `findOne({})` with `findOneOrNone({})`. Applied `findOneOrNone(schema)` inside the plugin (idempotent) so consumers of `configurationPlugin` automatically gain the safer static, then routed the singleton lookup through it via the existing `FindOneOrNonePlugin<unknown>` type from `./plugins`.
- All existing `configurationPlugin` tests (20/20) and `configuration.test.ts` continue to pass.

## Review & Testing Checklist for Human
- [ ] Confirm the `findOneOrNone(schema)` call inside `configurationPlugin` is acceptable as an internal dependency (it's safe to apply twice; consumers like `example-backend/src/models/appConfiguration.ts` are unaffected since they don't use the static directly).
- [ ] Spot-check that the `interface` conversions in `scriptRunner.ts` don't break downstream consumers that import these types (`BackgroundTask` is the model export; tests reference it).
- [ ] Verify behavior of `getConfig()` end-to-end on a fresh DB (singleton create on first call) and on an existing DB (singleton fetch).

### Notes
- All changes are scoped to the 3 selected files. No tests, configs, or generated files were modified.
- Linter (`bunx biome check`) and TypeScript compiler (`bun tsc`) pass locally for the api package and across the full workspace (`bun run lint`, `bun run compile`).
- 19 function-to-arrow conversions in `openApiValidator.ts` are mechanical syntactic changes; biome's formatter was used to normalize a single resulting line wrap.

Link to Devin session: https://app.devin.ai/sessions/db27bb74a5564cfd958cc9029e3a0ab2
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mechanical TypeScript style refactors (arrow functions, `interface` conversions) plus small Mongoose query API swaps (`findOne` -> `exists`/`findOneOrNone`) intended to preserve behavior; limited surface area but touches configuration singleton persistence.
> 
> **Overview**
> **Aligns three backend modules with repo rules** by converting type intersections to `interface`/`extends` (in `configurationPlugin.ts` and `scriptRunner.ts`) and rewriting `openApiValidator.ts` top-level `function` declarations into `const` arrow functions.
> 
> In `configurationPlugin.ts`, removes direct `Model.findOne` usage for singleton config lookups: the pre-save guard now uses `Model.exists`, and `getConfig()` now uses `findOneOrNone` (applied via `findOneOrNone(schema)` inside the plugin) to avoid ambiguous singleton reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c2a3c8ab00140319b4bc562817942478acb4e9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->