### PR TITLE
[coverage] files.ts

### DIFF
--- a/ai/src/routes/files.test.ts
+++ b/ai/src/routes/files.test.ts
@@ -7,6 +7,7 @@ import supertest from "supertest";
 
 import {FileAttachment} from "../models/fileAttachment";
 import type {FileStorageService, UploadFileParams, UploadFileResult} from "../service/fileStorage";
+import type {FileAttachmentDocument} from "../types";
 import {addFileRoutes} from "./files";
 
 type PasswordedUser = {setPassword: (password: string) => Promise<void>};
@@ -109,6 +110,27 @@ describe("File Routes", () => {
       const res = await supertest(app).get("/files/missing/key.txt");
       expect(res.status).toBe(404);
     });
+
+    it("returns the signed URL when the file exists", async () => {
+      const owner = (await UserModel.findOne({email: "notAdmin@example.com"})) as
+        | (mongoose.Document & {_id: mongoose.Types.ObjectId})
+        | null;
+      if (!owner) {
+        throw new Error("Owner user not found in test setup");
+      }
+      const attachment: FileAttachmentDocument = await FileAttachment.create({
+        filename: "report.pdf",
+        gcsKey: "report.pdf",
+        mimeType: "application/pdf",
+        size: 4,
+        url: "https://example.com/report.pdf",
+        userId: owner._id,
+      });
+      const res = await supertest(app).get(`/files/${attachment.gcsKey}`);
+      expect(res.status).toBe(200);
+      expect(res.body.data.url).toBe("https://example.com/signed");
+      expect(fileStorageService.getSignedUrl as ReturnType<typeof mock>).toHaveBeenCalled();
+    });
   });
 
   describe("DELETE /files/*gcsKey", () => {
@@ -121,6 +143,49 @@ describe("File Routes", () => {
     it("requires authentication", async () => {
       const res = await supertest(app).delete("/files/any/thing.txt");
       expect(res.status).toBe(401);
+    });
+
+    it("returns 403 when the file belongs to another user", async () => {
+      const otherOwner = (await UserModel.findOne({email: "admin@example.com"})) as
+        | (mongoose.Document & {_id: mongoose.Types.ObjectId})
+        | null;
+      if (!otherOwner) {
+        throw new Error("Other owner user not found in test setup");
+      }
+      await FileAttachment.create({
+        filename: "secret.txt",
+        gcsKey: "secret.txt",
+        mimeType: "text/plain",
+        size: 1,
+        url: "https://example.com/secret.txt",
+        userId: otherOwner._id,
+      });
+      const agent = await authAsUser(app, "notAdmin");
+      const res = await agent.delete("/files/secret.txt");
+      expect(res.status).toBe(403);
+      expect(fileStorageService.delete as ReturnType<typeof mock>).not.toHaveBeenCalled();
+    });
+
+    it("deletes a file owned by the authenticated user", async () => {
+      const owner = (await UserModel.findOne({email: "notAdmin@example.com"})) as
+        | (mongoose.Document & {_id: mongoose.Types.ObjectId})
+        | null;
+      if (!owner) {
+        throw new Error("Owner user not found in test setup");
+      }
+      await FileAttachment.create({
+        filename: "owned.txt",
+        gcsKey: "owned.txt",
+        mimeType: "text/plain",
+        size: 1,
+        url: "https://example.com/owned.txt",
+        userId: owner._id,
+      });
+      const agent = await authAsUser(app, "notAdmin");
+      const res = await agent.delete("/files/owned.txt");
+      expect(res.status).toBe(200);
+      expect(res.body.data.success).toBe(true);
+      expect(fileStorageService.delete as ReturnType<typeof mock>).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Improves test coverage of `ai/src/routes/files.ts` from `100%` functions / `93.33%` lines (uncovered: 93, 95, 118, 120-122) to `100%` / `100%`. The source file is untouched — this is purely additive test coverage.

What is exercised by the new tests in `ai/src/routes/files.test.ts`:

- `GET /files/*gcsKey`: returns the signed URL when a matching, non-deleted `FileAttachment` exists (covers the success path and the `getSignedUrl` call).
- `DELETE /files/*gcsKey`:
  - returns `403` when the attachment belongs to a different user (covers the ownership-check branch and verifies `fileStorageService.delete` is **not** called).
  - returns `200` and removes the file when the attachment is owned by the authenticated user (covers `fileStorageService.delete` and the `success: true` response).

## Review & Testing Checklist for Human
- [ ] Confirm the test approach for the GET / DELETE success cases is acceptable: tests insert a `FileAttachment` directly via the model (not via the upload route) so the read/delete handlers can find it. The mock `FileStorageService.upload` was left as-is and intentionally does not persist a `FileAttachment` row.
- [ ] Confirm using single-segment `gcsKey` values (e.g. `"report.pdf"`, `"owned.txt"`) in tests is acceptable. This was chosen because Express 5.2.1 parses `*gcsKey` splat params as arrays — a multi-segment URL would produce `req.params.gcsKey = ["a","b","c"]`, which only matches stored documents whose `gcsKey` equals one of those segments. Single-segment keys keep the test intent clear without hiding that quirk.

### Notes
- No behavior changes — only new tests.
- No new `any` introduced; existing `(req as any).user?._id` casts in `files.ts` were left untouched (they are an established cross-package convention documented in `AGENTS.md` and changing them would touch every backend route).
- Local `bun run lint` and `bun run compile` both pass for `ai/`. The single pre-existing biome warning in `ai/src/routes/routes.test.ts:1020` is unrelated.

Link to Devin session: https://app.devin.ai/sessions/f3281cf65fea4ffca6ba7297bfd78f23
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only new tests around file retrieval and deletion paths; no production code changes, so risk is limited to potential test brittleness/mocking assumptions.
> 
> **Overview**
> Adds missing coverage in `ai/src/routes/files.test.ts` for the file routes.
> 
> The test suite now exercises the `GET /files/*gcsKey` success path (returns a signed URL and calls `getSignedUrl`) and expands `DELETE /files/*gcsKey` coverage to include ownership enforcement (`403` for other users) and successful deletion (`200` with `success: true`, calling `delete`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ad5a8ce51049a7dc8d35162ac44c99b58a103a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->