### PR TITLE
[coverage] buildNumber.ts

### DIFF
--- a/rtk/src/isolated/buildNumber.isolated.ts
+++ b/rtk/src/isolated/buildNumber.isolated.ts
@@ -1,0 +1,31 @@
+/**
+ * Isolated tests for buildNumber.ts paths that require mock.module.
+ *
+ * These live in isolated/ so that mock.module calls do not interfere
+ * with coverage tracking in the main buildNumber.test.ts file.
+ */
+import {describe, expect, it, mock} from "bun:test";
+
+describe("resolveBuildNumber catch path", () => {
+  it("returns undefined when execSync throws (no git available)", async () => {
+    const originalEnvValue = process.env.EXPO_PUBLIC_BUILD_NUMBER;
+    delete process.env.EXPO_PUBLIC_BUILD_NUMBER;
+    mock.module("node:child_process", () => ({
+      execSync: (): never => {
+        throw new Error("git command not found");
+      },
+    }));
+    try {
+      const testId = `${Date.now()}-${Math.random()}`;
+      const loaded = (await import(
+        `../buildNumber?case=${testId}`
+      )) as typeof import("../buildNumber");
+      const result = loaded.resolveBuildNumber();
+      expect(result).toBeUndefined();
+    } finally {
+      if (originalEnvValue !== undefined) {
+        process.env.EXPO_PUBLIC_BUILD_NUMBER = originalEnvValue;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Improves test coverage of `rtk/src/buildNumber.ts` from `100%` functions / `96.43%` lines to `100%` / `100%`. The source file is untouched — this is purely additive test coverage.

The previously-uncovered branch (`} catch { return undefined; }` at the end of `resolveBuildNumber`, line 65) requires `execSync("git rev-list --count HEAD")` to throw, which can't happen inside this repo's normal `bun test` run. A new isolated test mocks `node:child_process` so `execSync` throws and asserts `resolveBuildNumber()` returns `undefined`.

The test lives in `rtk/src/isolated/buildNumber.isolated.ts`, mirroring the existing `constants.isolated.ts` / `useUpgradeCheck.isolated.ts` pattern. `scripts/check-coverage.ts` automatically discovers files matching `src/isolated/*.isolated.{ts,tsx}` and merges their LCOV coverage with the main pass.

## Review & Testing Checklist for Human
- [ ] Confirm the isolated-test placement is correct (`rtk/src/isolated/buildNumber.isolated.ts`) — it follows the same pattern as `constants.isolated.ts`, and `scripts/check-coverage.ts` automatically picks it up.
- [ ] Confirm the package-level `EXPO_PUBLIC_BUILD_NUMBER` env var is restored after the test in case other tests in the same merged coverage pass relied on it (the test deletes and restores it inside a `try`/`finally`).

### Notes
- No behavior changes — only a new isolated test file.
- No `any` introduced; no nearby `any` to clean up in `buildNumber.ts` or the new isolated test.
- Local `bun run lint` and `bun run compile` both pass for `rtk/`. Merged `bun run test:coverage` reports `functions=98.10%`, `lines=98.70%` (was `98.10%` / `98.56%`).

Link to Devin session: https://app.devin.ai/sessions/f3281cf65fea4ffca6ba7297bfd78f23
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new isolated test that mocks `execSync` to cover an error-handling branch, with no runtime code changes.
> 
> **Overview**
> Improves coverage for `resolveBuildNumber` by adding an *isolated* Bun test that mocks `node:child_process.execSync` to throw and asserts the function returns `undefined` when git is unavailable.
> 
> The test also temporarily clears and restores `EXPO_PUBLIC_BUILD_NUMBER` to ensure the catch-path is exercised without leaking env changes across tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 289bfe22e5b1e1038b9378c5e869817b4d407971. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->