### PR TITLE
Consent form polish: decline privacy policy, side-by-side buttons, centered layout

### DIFF
--- a/example-backend/src/consentDefinitions.ts
+++ b/example-backend/src/consentDefinitions.ts
@@ -2,6 +2,7 @@ import type {ConsentFormDefinition} from "@terreno/api";
 
 export const consentDefinitions: Record<string, ConsentFormDefinition> = {
   "privacy-policy": {
+    allowDecline: true,
     content: {
       en: `# Privacy Policy
 

--- a/example-backend/src/scripts/seed-test-data.ts
+++ b/example-backend/src/scripts/seed-test-data.ts
@@ -4,16 +4,47 @@
  * Run with: bun run src/scripts/seed-test-data.ts
  */
 
-import "dotenv/config";
 import {logger} from "@terreno/api";
 import mongoose from "mongoose";
 import {User} from "../models/user";
 import {connectToMongoDB} from "../utils/database";
 
-const TEST_USER = {
-  email: "test@example.com",
-  name: "Test User",
-  password: "testpassword123",
+interface SeedUser {
+  admin?: boolean;
+  email: string;
+  name: string;
+  password: string;
+}
+
+const TEST_USERS: SeedUser[] = [
+  {
+    email: "test@example.com",
+    name: "Test User",
+    password: "testpassword123",
+  },
+  {
+    admin: true,
+    email: "superuser@example.com",
+    name: "Super User",
+    password: "testpassword123",
+  },
+];
+
+const seedUser = async (testUser: SeedUser): Promise<void> => {
+  const existingUser = await User.findByEmail(testUser.email);
+  if (existingUser) {
+    logger.info(`Test user already exists: ${testUser.email}`);
+    return;
+  }
+
+  // Create test user using passport-local-mongoose's register method
+  // biome-ignore lint/suspicious/noExplicitAny: passport-local-mongoose register is not typed on the model
+  const user = await (User as any).register(
+    {admin: testUser.admin ?? false, email: testUser.email, name: testUser.name},
+    testUser.password
+  );
+
+  logger.info(`Test user created: ${user.email} (id: ${user._id})`);
 };
 
 const main = async (): Promise<void> => {
@@ -21,22 +52,9 @@ const main = async (): Promise<void> => {
     logger.info("Connecting to MongoDB...");
     await connectToMongoDB();
 
-    // Check if test user already exists
-    const existingUser = await User.findByEmail(TEST_USER.email);
-    if (existingUser) {
-      logger.info(`Test user already exists: ${TEST_USER.email}`);
-      await mongoose.disconnect();
-      return;
+    for (const testUser of TEST_USERS) {
+      await seedUser(testUser);
     }
-
-    // Create test user using passport-local-mongoose's register method
-    // biome-ignore lint/suspicious/noExplicitAny: passport-local-mongoose register is not typed on the model
-    const user = await (User as any).register(
-      {email: TEST_USER.email, name: TEST_USER.name},
-      TEST_USER.password
-    );
-
-    logger.info(`Test user created: ${user.email} (id: ${user._id})`);
 
     await mongoose.disconnect();
     logger.info("Done.");

--- a/example-backend/src/scripts/syncConsents.ts
+++ b/example-backend/src/scripts/syncConsents.ts
@@ -8,7 +8,6 @@
  * Dry run:  DRY_RUN=true bun run src/scripts/syncConsents.ts
  */
 
-import "dotenv/config";
 import {logger, syncConsents} from "@terreno/api";
 import mongoose from "mongoose";
 import {consentDefinitions} from "../consentDefinitions";

--- a/mcp-server/src/bootstrap.ts
+++ b/mcp-server/src/bootstrap.ts
@@ -209,7 +209,6 @@ const generateBackendPackageJson = (args: BootstrapArgs): string => {
       dependencies: {
         "@terreno/admin-backend": "latest",
         "@terreno/api": "latest",
-        dotenv: "^16.4.7",
         luxon: "^3.7.2",
         mongoose: "^8.18.1",
         "passport-local-mongoose": "^9.0.1",

--- a/ui/src/ConsentFormScreen.tsx
+++ b/ui/src/ConsentFormScreen.tsx
@@ -116,27 +116,29 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
     confirmModalCheckboxIndex !== null ? form.checkboxes[confirmModalCheckboxIndex] : null;
 
   const footer = (
-    <Box direction="row" gap={2} paddingY={2} testID="consent-form-footer" width="100%">
-      {Boolean(form.allowDecline && onDecline) && (
+    <Box alignSelf="center" maxWidth={800} testID="consent-form-footer" width="100%">
+      <Box direction="row" gap={4} paddingY={2} width="100%">
+        {Boolean(form.allowDecline && onDecline) && (
+          <Box flex="grow">
+            <Button
+              fullWidth
+              onClick={onDecline!}
+              testID="consent-form-decline-button"
+              text={form.declineButtonText}
+              variant="muted"
+            />
+          </Box>
+        )}
         <Box flex="grow">
           <Button
+            disabled={!canAgree}
             fullWidth
-            onClick={onDecline!}
-            testID="consent-form-decline-button"
-            text={form.declineButtonText}
-            variant="muted"
+            loading={isSubmitting}
+            onClick={handleAgree}
+            testID="consent-form-agree-button"
+            text={form.agreeButtonText}
           />
         </Box>
-      )}
-      <Box flex="grow">
-        <Button
-          disabled={!canAgree}
-          fullWidth
-          loading={isSubmitting}
-          onClick={handleAgree}
-          testID="consent-form-agree-button"
-          text={form.agreeButtonText}
-        />
       </Box>
     </Box>
   );
@@ -149,7 +151,7 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
         onScroll={handleScroll}
         scrollEnabled={scrollEnabled}
         scrollEventThrottle={16}
-        style={{flex: 1}}
+        style={{alignSelf: "center", flex: 1, maxWidth: 800}}
         testID="consent-form-scroll-view"
       >
         <Box direction="column" gap={3} paddingY={2}>

--- a/ui/src/ConsentFormScreen.tsx
+++ b/ui/src/ConsentFormScreen.tsx
@@ -151,7 +151,7 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
         onScroll={handleScroll}
         scrollEnabled={scrollEnabled}
         scrollEventThrottle={16}
-        style={{alignSelf: "center", flex: 1, maxWidth: 800}}
+        style={{alignSelf: "center", flex: 1, maxWidth: 800, width: "100%"}}
         testID="consent-form-scroll-view"
       >
         <Box direction="column" gap={3} paddingY={2}>

--- a/ui/src/ConsentFormScreen.tsx
+++ b/ui/src/ConsentFormScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {useRef, useState} from "react";
 import {Pressable, ScrollView} from "react-native";
 
 import {Box} from "./Box";
@@ -36,6 +36,7 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
   const [scrollEnabled, setScrollEnabled] = useState(true);
   const [contentHeight, setContentHeight] = useState(0);
   const [layoutHeight, setLayoutHeight] = useState(0);
+  const scrollViewRef = useRef<ScrollView>(null);
 
   const rawContent = form.content[locale] ?? form.content[form.defaultLocale] ?? "";
   const content = variables
@@ -51,7 +52,7 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
 
   const signatureProvided = !form.captureSignature || Boolean(signatureValue);
 
-  const canAgree = hasScrolledToBottom && allRequiredCheckboxesChecked && signatureProvided;
+  const canAgree = allRequiredCheckboxesChecked && signatureProvided;
 
   // Auto-satisfy scroll requirement when content fits within the viewport
   const handleContentSizeChange = (_w: number, h: number) => {
@@ -109,6 +110,10 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
   };
 
   const handleAgree = () => {
+    if (!hasScrolledToBottom) {
+      scrollViewRef.current?.scrollToEnd({animated: true});
+      return;
+    }
     onAgree({checkboxValues, signature: signatureValue});
   };
 
@@ -116,9 +121,9 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
     confirmModalCheckboxIndex !== null ? form.checkboxes[confirmModalCheckboxIndex] : null;
 
   const footer = (
-    <Box direction="column" gap={2} paddingY={2} testID="consent-form-footer" width="100%">
+    <Box direction="row" gap={2} paddingY={2} testID="consent-form-footer" width="100%">
       {Boolean(form.allowDecline && onDecline) && (
-        <Box width="100%">
+        <Box flex="grow">
           <Button
             fullWidth
             onClick={onDecline!}
@@ -128,7 +133,7 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
           />
         </Box>
       )}
-      <Box width="100%">
+      <Box flex="grow">
         <Button
           disabled={!canAgree}
           fullWidth
@@ -147,6 +152,7 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
         onContentSizeChange={handleContentSizeChange}
         onLayout={handleLayout}
         onScroll={handleScroll}
+        ref={scrollViewRef}
         scrollEnabled={scrollEnabled}
         scrollEventThrottle={16}
         style={{flex: 1}}

--- a/ui/src/ConsentFormScreen.tsx
+++ b/ui/src/ConsentFormScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState} from "react";
+import React, {useState} from "react";
 import {Pressable, ScrollView} from "react-native";
 
 import {Box} from "./Box";
@@ -36,7 +36,6 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
   const [scrollEnabled, setScrollEnabled] = useState(true);
   const [contentHeight, setContentHeight] = useState(0);
   const [layoutHeight, setLayoutHeight] = useState(0);
-  const scrollViewRef = useRef<ScrollView>(null);
 
   const rawContent = form.content[locale] ?? form.content[form.defaultLocale] ?? "";
   const content = variables
@@ -52,7 +51,7 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
 
   const signatureProvided = !form.captureSignature || Boolean(signatureValue);
 
-  const canAgree = allRequiredCheckboxesChecked && signatureProvided;
+  const canAgree = hasScrolledToBottom && allRequiredCheckboxesChecked && signatureProvided;
 
   // Auto-satisfy scroll requirement when content fits within the viewport
   const handleContentSizeChange = (_w: number, h: number) => {
@@ -110,10 +109,6 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
   };
 
   const handleAgree = () => {
-    if (!hasScrolledToBottom) {
-      scrollViewRef.current?.scrollToEnd({animated: true});
-      return;
-    }
     onAgree({checkboxValues, signature: signatureValue});
   };
 
@@ -147,12 +142,11 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
   );
 
   return (
-    <Page footer={footer} scroll={false} title={form.title}>
+    <Page color="base" footer={footer} maxWidth="100%" scroll={false} title={form.title}>
       <ScrollView
         onContentSizeChange={handleContentSizeChange}
         onLayout={handleLayout}
         onScroll={handleScroll}
-        ref={scrollViewRef}
         scrollEnabled={scrollEnabled}
         scrollEventThrottle={16}
         style={{flex: 1}}


### PR DESCRIPTION
## Summary
Polishes the consent form UX: privacy policy is now declinable, footer buttons sit side-by-side on a centered, max-width container, and the scroll body shares the same centered, max-width layout. Also adds a superuser seed user and drops the now-unused `dotenv` dependency from a couple of script entry points.

## Human Testing Steps
- [ ] Open the privacy policy consent form — verify a "Decline" button appears beside "Agree"
- [ ] Tap "Decline" — verify `onDecline` fires
- [ ] Open a consent form with `requireScrollToBottom: true` — verify the agree button is disabled until the user scrolls to the bottom, then enables and submits when tapped
- [ ] Open a consent form without `allowDecline` — verify the agree button still spans the full footer width
- [ ] Verify the body content and footer are centered with a max width on wide viewports (and stretch full-width on narrow viewports)
- [ ] Run `bun run seed` in `example-backend` — verify both `test@example.com` and `superuser@example.com` (admin) are created (or already exist)
- [ ] Run `bun run sync-consents` in `example-backend` — verify the privacy policy is updated to a new version with `allowDecline: true`

## Changes
- `ui/src/ConsentFormScreen.tsx`
  - Footer wrapped in a centered `Box` with `maxWidth={800}`; inner row holds decline (left) + agree (right) using `flex="grow"` so they share width
  - Scroll body uses `alignSelf: "center"`, `maxWidth: 800`, and `width: "100%"` for consistent centered layout that fills available space up to the cap
  - `Page` is rendered with `color="base"` and `maxWidth="100%"`
- `example-backend/src/consentDefinitions.ts` — `allowDecline: true` added to the privacy-policy definition
- `example-backend/src/scripts/seed-test-data.ts` — refactored to seed an array of users; added `superuser@example.com` admin user
- `example-backend/src/scripts/syncConsents.ts` — removed unused `dotenv/config` import (env is loaded by `connectToMongoDB`)
- `mcp-server/src/bootstrap.ts` — removed `dotenv` from the generated backend template's `package.json` dependencies

## Automated Tests
- `ui/src/ConsentFormScreen.test.tsx` — 7 pass
- `ui/src/useConsentForms.test.ts` — 7 pass
- `example-backend/src/models/user.test.ts` — 14 pass
- `example-backend/src/services/userService.test.ts` — 6 pass