### PR TITLE
Fix React error #310 in consent admin editors

### DIFF
--- a/admin-frontend/src/ConsentFormEditor.test.tsx
+++ b/admin-frontend/src/ConsentFormEditor.test.tsx
@@ -143,6 +143,52 @@ describe("ConsentFormEditor", () => {
     expect(toJSON()).toBeDefined();
   });
 
+  // Regression: hooks (useMemo) used to run after the early-return spinner branch,
+  // which produced React error #310 ("Rendered more hooks than during the previous
+  // render") the moment loading flipped to loaded. This test exercises both renders.
+  // Pass a stable supportedLocales reference so the data-hydration useEffect's deps
+  // don't churn between renders.
+  it("survives the loading → loaded transition without a hook-order error", async () => {
+    const supportedLocales = ["en"];
+    state.isFormLoading = true;
+    const {rerender, getByTestId} = renderWithTheme(
+      <ConsentFormEditor
+        api={makeApi() as any}
+        baseUrl="/admin"
+        id="f1"
+        supportedLocales={supportedLocales}
+      />
+    );
+    await act(async () => {
+      state.isFormLoading = false;
+      state.formData = {
+        active: true,
+        agreeButtonText: "I Agree",
+        allowDecline: false,
+        captureSignature: false,
+        checkboxes: [],
+        content: {en: "Body"},
+        defaultLocale: "en",
+        order: 0,
+        required: false,
+        requireScrollToBottom: false,
+        slug: "loaded-form",
+        title: "Loaded Form",
+        type: "agreement",
+        version: 1,
+      };
+      rerender(
+        <ConsentFormEditor
+          api={makeApi() as any}
+          baseUrl="/admin"
+          id="f1"
+          supportedLocales={supportedLocales}
+        />
+      );
+    });
+    expect(getByTestId("consent-form-title-input")).toBeDefined();
+  });
+
   it("renders create mode with default values", () => {
     const {getByTestId} = renderWithTheme(
       <ConsentFormEditor api={makeApi() as any} baseUrl="/admin" />

--- a/admin-frontend/src/ConsentFormEditor.tsx
+++ b/admin-frontend/src/ConsentFormEditor.tsx
@@ -367,6 +367,22 @@ export const ConsentFormEditor: React.FC<ConsentFormEditorProps> = ({
     [defaultLocale, handleLocaleContentChange, localeContent, toast, translateContent]
   );
 
+  // Hooks must run before any early returns to keep React's hook order stable across
+  // the loading → loaded transition (otherwise: "Rendered more hooks than during the
+  // previous render", React error #310).
+  const contentLocales = useMemo(
+    () => Object.keys(localeContent).filter((k) => localeContent[k] !== undefined),
+    [localeContent]
+  );
+  const defaultLocaleOptions = useMemo(
+    () =>
+      contentLocales.map((locale) => ({
+        label: locale.toUpperCase(),
+        value: locale,
+      })),
+    [contentLocales]
+  );
+
   if (isEditMode && isFormLoading) {
     return (
       <Page maxWidth="100%">
@@ -380,20 +396,7 @@ export const ConsentFormEditor: React.FC<ConsentFormEditorProps> = ({
   const isSaving = isCreating || isUpdating;
   const activeLocale = supportedLocales[activeLocaleIndex] ?? "en";
   const isNonDefaultLocale = activeLocale !== defaultLocale;
-
-  const contentLocales = useMemo(
-    () => Object.keys(localeContent).filter((k) => localeContent[k] !== undefined),
-    [localeContent]
-  );
   const hasLocales = contentLocales.length > 0;
-  const defaultLocaleOptions = useMemo(
-    () =>
-      contentLocales.map((locale) => ({
-        label: locale.toUpperCase(),
-        value: locale,
-      })),
-    [contentLocales]
-  );
 
   return (
     <Page

--- a/admin-frontend/src/ConsentResponseViewer.test.tsx
+++ b/admin-frontend/src/ConsentResponseViewer.test.tsx
@@ -47,6 +47,23 @@ describe("ConsentResponseViewer", () => {
     expect(toJSON()).toBeDefined();
   });
 
+  // Regression: useState/useCallback used to run after the early-return spinner
+  // branch, which produced React error #310 ("Rendered more hooks than during the
+  // previous render") the moment loading flipped to loaded. This test exercises
+  // both renders.
+  it("survives the loading → loaded transition without a hook-order error", async () => {
+    readState.isLoading = true;
+    const {rerender, getByText} = renderWithTheme(
+      <ConsentResponseViewer api={{} as any} baseUrl="/admin" id="r1" />
+    );
+    await act(async () => {
+      readState.isLoading = false;
+      readState.data = {agreed: true, consentFormId: "raw-id", userId: "u1"};
+      rerender(<ConsentResponseViewer api={{} as any} baseUrl="/admin" id="r1" />);
+    });
+    expect(getByText("Download PDF")).toBeDefined();
+  });
+
   it("shows not-found state when there is no id / data", () => {
     const {getByText} = renderWithTheme(
       <ConsentResponseViewer api={{} as any} baseUrl="/admin" id="" />

--- a/admin-frontend/src/ConsentResponseViewer.tsx
+++ b/admin-frontend/src/ConsentResponseViewer.tsx
@@ -28,6 +28,25 @@ export const ConsentResponseViewer: React.FC<ConsentResponseViewerProps> = ({bas
 
   const {data: response, isLoading} = useReadQuery(id, {skip: !id});
 
+  // Hooks must run before any early returns to keep React's hook order stable across
+  // the loading → loaded transition (otherwise: "Rendered more hooks than during the
+  // previous render", React error #310).
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const handleDownloadPdf = useCallback(async () => {
+    if (!response) {
+      return;
+    }
+    setIsDownloading(true);
+    try {
+      await generateConsentPdf(response);
+    } catch (err) {
+      console.error("Failed to generate PDF", err);
+    } finally {
+      setIsDownloading(false);
+    }
+  }, [response]);
+
   if (isLoading) {
     return (
       <Page maxWidth="100%">
@@ -74,19 +93,6 @@ export const ConsentResponseViewer: React.FC<ConsentResponseViewerProps> = ({bas
     response.userAgent ||
     response.contentSnapshot ||
     response.formVersionSnapshot;
-
-  const [isDownloading, setIsDownloading] = useState(false);
-
-  const handleDownloadPdf = useCallback(async () => {
-    setIsDownloading(true);
-    try {
-      await generateConsentPdf(response);
-    } catch (err) {
-      console.error("Failed to generate PDF", err);
-    } finally {
-      setIsDownloading(false);
-    }
-  }, [response]);
 
   return (
     <Page maxWidth="100%" scroll>


### PR DESCRIPTION
## Summary

\`ConsentFormEditor\` and \`ConsentResponseViewer\` both called hooks after early-return spinner branches. When the underlying RTK Query \`useReadQuery\` flipped from loading to loaded, React saw more hooks rendered than on the previous render and threw [error #310](https://react.dev/errors/310) (\"Rendered more hooks than during the previous render\") — which crashed the entire admin screen.

This was hit in Flourish staging when editing a consent form via the admin UI ([Flourish PR #5363](https://github.com/FlourishHealth/flourish/pull/5363)).

## Fix

- \`ConsentFormEditor.tsx\`: hoist the two \`useMemo\` calls (\`contentLocales\`, \`defaultLocaleOptions\`) above the \`if (isEditMode && isFormLoading)\` early return.
- \`ConsentResponseViewer.tsx\`: hoist \`useState(false)\` and the \`handleDownloadPdf\` \`useCallback\` above the \`isLoading\` and \`!response\` early returns. The callback now guards against an undefined \`response\` (it can't actually fire before the loaded branch renders the button, but the explicit guard keeps the hook deps honest).

## Tests

Added a regression test in each of \`ConsentFormEditor.test.tsx\` and \`ConsentResponseViewer.test.tsx\` that exercises the loading → loaded transition with a \`rerender\`. The existing \"renders loading state\" tests rendered only once and so didn't catch the bug.

\`bun test src/ConsentFormEditor.test.tsx src/ConsentResponseViewer.test.tsx\` → 30 pass.

## Test plan

- [ ] In a downstream app, open an existing consent form in admin → editor renders without React error #310 in the console
- [ ] Open a consent response → viewer renders, \"Download PDF\" button works
- [ ] Existing consent admin tests still pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small refactor that only reorders hooks to satisfy React’s rules and adds regression tests; behavior should be unchanged aside from avoiding a crash during loading→loaded transitions.
> 
> **Overview**
> Fixes React error #310 crashes in the consent admin UI by ensuring hooks run *before* any early-return loading/not-found branches.
> 
> In `ConsentFormEditor`, `useMemo` derivations for locale options are hoisted above the edit-mode spinner return; in `ConsentResponseViewer`, the PDF download `useState`/`useCallback` are hoisted similarly (with a guard for missing `response`).
> 
> Adds regression tests for both components that `rerender` from loading to loaded to catch hook-order violations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c56fad49a9c6a9cd134eec7512db96cee6a6611d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->