### PR TITLE
Fix consent form UX: required hint, signature clear, inject warnings

### DIFF
--- a/ui/src/ConsentFormScreen.test.tsx
+++ b/ui/src/ConsentFormScreen.test.tsx
@@ -185,4 +185,51 @@ describe("ConsentFormScreen", () => {
     expect(getByTestId("consent-footer-scroll-hint")).toBeTruthy();
     expect(getByTestId("consent-footer-signature-hint")).toBeTruthy();
   });
+
+  it("shows the required-items legend when any checkbox is required", () => {
+    const form: ConsentFormPublic = {
+      ...baseForm,
+      checkboxes: [{label: "Required box", required: true}],
+    };
+    const {getByTestId} = renderWithTheme(
+      <ConsentFormScreen form={form} locale="en" onAgree={() => {}} />
+    );
+    expect(getByTestId("consent-form-required-legend")).toBeTruthy();
+  });
+
+  it("hides the required-items legend when no checkbox is required", () => {
+    const form: ConsentFormPublic = {
+      ...baseForm,
+      checkboxes: [{label: "Optional box", required: false}],
+    };
+    const {queryByTestId} = renderWithTheme(
+      <ConsentFormScreen form={form} locale="en" onAgree={() => {}} />
+    );
+    expect(queryByTestId("consent-form-required-legend")).toBeNull();
+  });
+
+  it("shows the checkbox footer hint when a required checkbox is unchecked", () => {
+    const form: ConsentFormPublic = {
+      ...baseForm,
+      checkboxes: [{label: "Required box", required: true}],
+    };
+    const {getByTestId} = renderWithTheme(
+      <ConsentFormScreen form={form} locale="en" onAgree={() => {}} />
+    );
+    expect(getByTestId("consent-footer-checkboxes-hint")).toBeTruthy();
+  });
+
+  it("hides the checkbox footer hint once required checkboxes are checked", () => {
+    const form: ConsentFormPublic = {
+      ...baseForm,
+      checkboxes: [{label: "Required box", required: true}],
+    };
+    const {getByTestId, queryByTestId} = renderWithTheme(
+      <ConsentFormScreen form={form} locale="en" onAgree={() => {}} />
+    );
+    act(() => {
+      fireEvent.press(getByTestId("consent-form-checkbox-0"));
+    });
+    expect(queryByTestId("consent-footer-checkboxes-hint")).toBeNull();
+  });
 });

--- a/ui/src/ConsentFormScreen.tsx
+++ b/ui/src/ConsentFormScreen.tsx
@@ -50,6 +50,7 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
   });
 
   const signatureProvided = !form.captureSignature || Boolean(signatureValue);
+  const hasRequiredCheckboxes = form.checkboxes.some((checkbox) => checkbox.required);
 
   const canAgree = hasScrolledToBottom && allRequiredCheckboxesChecked && signatureProvided;
 
@@ -145,6 +146,11 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
           Please scroll to the bottom to continue
         </Text>
       )}
+      {Boolean(hasRequiredCheckboxes && !allRequiredCheckboxesChecked) && (
+        <Text align="center" color="error" size="sm" testID="consent-footer-checkboxes-hint">
+          Please check all required items marked with *
+        </Text>
+      )}
       {Boolean(form.captureSignature && !signatureValue) && (
         <Text align="center" color="error" size="sm" testID="consent-footer-signature-hint">
           Please provide your signature to continue
@@ -169,6 +175,11 @@ export const ConsentFormScreen: React.FC<ConsentFormScreenProps> = ({
 
           {form.checkboxes.length > 0 && (
             <Box direction="column" gap={2} testID="consent-form-checkboxes">
+              {hasRequiredCheckboxes && (
+                <Text color="secondaryDark" size="sm" testID="consent-form-required-legend">
+                  * indicates a required item
+                </Text>
+              )}
               {form.checkboxes.map((checkbox, index) => {
                 const key = index.toString();
                 const isChecked = checkboxValues[key] ?? false;

--- a/ui/src/Signature.native.tsx
+++ b/ui/src/Signature.native.tsx
@@ -18,6 +18,10 @@ export const Signature: FC<Props> = ({onChange, onStart, onEnd}: Props) => {
 
   const handleClear = () => {
     ref.current?.clearSignature();
+    // `clearSignature` on the underlying canvas does not fire `onOK`, so the
+    // parent never learns the signature is gone. Push an empty value so any
+    // "signature required" gating reflects the cleared state immediately.
+    onChange("");
   };
 
   const onBegin = () => {

--- a/ui/src/Signature.test.tsx
+++ b/ui/src/Signature.test.tsx
@@ -49,6 +49,16 @@ describe("Signature", () => {
     expect(clearMock).toHaveBeenCalledTimes(1);
   });
 
+  it("notifies the parent with an empty value when Clear is pressed", () => {
+    clearMock.mockClear();
+    const mockOnChange = mock(() => {});
+    const {getByText} = renderWithTheme(<Signature onChange={mockOnChange} />);
+    fireEvent.press(getByText("Clear"));
+    // Without this, "signature required" gating in parents would never reset
+    // because the underlying canvas clear() does not fire onEnd/onOK.
+    expect(mockOnChange).toHaveBeenCalledWith("");
+  });
+
   it("calls onChange with the data URL when a stroke ends", () => {
     toDataURLReturn = "data:image/png;base64,abc";
     const mockOnChange = mock(() => {});

--- a/ui/src/Signature.tsx
+++ b/ui/src/Signature.tsx
@@ -17,6 +17,10 @@ export const Signature = ({onChange}: SignatureProps): ReactElement | null => {
 
   const onClear = () => {
     ref.current?.clear();
+    // `clear()` on the underlying canvas does not fire `onEnd`, so the parent
+    // never learns the signature is gone. Push an empty value so any
+    // "signature required" gating reflects the cleared state immediately.
+    onChange("");
   };
 
   const onUpdatedSignature = () => {

--- a/ui/src/useConsentForms.test.ts
+++ b/ui/src/useConsentForms.test.ts
@@ -149,4 +149,29 @@ describe("useConsentForms", () => {
     const {result} = renderHook(() => useConsentForms(api as unknown as ConsentFormsApi));
     expect(result.current.error).toBe("error");
   });
+
+  it("injects the pending-consents endpoint only once per (api, baseUrl)", () => {
+    let injectCallCount = 0;
+    const refetch = mock(() => {});
+    const useGetPendingConsentsQuery = mock(() => ({
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+      refetch,
+    }));
+    const api = {
+      enhanceEndpoints: () => ({
+        injectEndpoints: () => {
+          injectCallCount += 1;
+          return {useGetPendingConsentsQuery};
+        },
+      }),
+    };
+    const {rerender} = renderHook(() => useConsentForms(api as unknown as ConsentFormsApi));
+    rerender(undefined);
+    rerender(undefined);
+    // The hook reuses the cached enhanced api after the first render so the
+    // dev-mode RTK warning about re-injecting endpoints never fires.
+    expect(injectCallCount).toBe(1);
+  });
 });

--- a/ui/src/useConsentForms.ts
+++ b/ui/src/useConsentForms.ts
@@ -41,13 +41,15 @@ interface ConsentFormsHookState {
   refetch: () => void | Promise<void>;
 }
 
+interface ConsentFormsEnhancedApi {
+  useGetPendingConsentsQuery: () => ConsentFormsHookState;
+}
+
 interface ConsentFormsApiWithTags {
   injectEndpoints: (options: {
     endpoints: (build: ConsentFormsQueryBuilder) => {getPendingConsents: unknown};
     overrideExisting: boolean;
-  }) => {
-    useGetPendingConsentsQuery: () => ConsentFormsHookState;
-  };
+  }) => ConsentFormsEnhancedApi;
 }
 
 interface ConsentFormsApi {
@@ -73,11 +75,27 @@ export const detectLocale = (): string => {
   return "en";
 };
 
-export const useConsentForms = (api: ConsentFormsApi, baseUrl?: string) => {
-  const base = baseUrl || "";
-  const apiWithConsentTags = api.enhanceEndpoints({addTagTypes: ["PendingConsents"]});
+/**
+ * Cache the enhanced api per (api, baseUrl). `injectEndpoints` logs a console
+ * error in development whenever an endpoint with the same name is re-injected
+ * (with `overrideExisting: false`), so calling it on every render of every
+ * consumer would flood the console. WeakMap-by-api lets the GC reclaim entries
+ * when the api object is unreachable.
+ */
+const enhancedApiCache = new WeakMap<ConsentFormsApi, Map<string, ConsentFormsEnhancedApi>>();
 
-  const enhancedApi = apiWithConsentTags.injectEndpoints({
+const getEnhancedApi = (api: ConsentFormsApi, base: string): ConsentFormsEnhancedApi => {
+  let byBase = enhancedApiCache.get(api);
+  if (!byBase) {
+    byBase = new Map();
+    enhancedApiCache.set(api, byBase);
+  }
+  const cached = byBase.get(base);
+  if (cached) {
+    return cached;
+  }
+  const apiWithConsentTags = api.enhanceEndpoints({addTagTypes: ["PendingConsents"]});
+  const enhanced = apiWithConsentTags.injectEndpoints({
     endpoints: (build) => ({
       getPendingConsents: build.query({
         async onQueryStarted(_arg: unknown, {queryFulfilled}) {
@@ -97,6 +115,13 @@ export const useConsentForms = (api: ConsentFormsApi, baseUrl?: string) => {
     }),
     overrideExisting: false,
   });
+  byBase.set(base, enhanced);
+  return enhanced;
+};
+
+export const useConsentForms = (api: ConsentFormsApi, baseUrl?: string) => {
+  const base = baseUrl || "";
+  const enhancedApi = getEnhancedApi(api, base);
 
   const {data, isLoading, error, refetch} = enhancedApi.useGetPendingConsentsQuery();
   const forms: ConsentFormPublic[] = Array.isArray(data) ? data : (data?.data ?? []);

--- a/ui/src/useConsentHistory.test.ts
+++ b/ui/src/useConsentHistory.test.ts
@@ -1,0 +1,99 @@
+import {describe, expect, it, mock} from "bun:test";
+import {renderHook} from "@testing-library/react-native";
+
+import type {ConsentHistoryEntry} from "./useConsentHistory";
+import {useConsentHistory} from "./useConsentHistory";
+
+type ConsentHistoryApi = Parameters<typeof useConsentHistory>[0];
+
+interface MockQueryDef {
+  query: () => string;
+  providesTags: string[];
+}
+
+interface MockInjectOpts {
+  endpoints: (build: {query: (def: MockQueryDef) => string}) => Record<string, unknown>;
+}
+
+describe("useConsentHistory", () => {
+  const buildApi = (queryResult: {data?: unknown; error?: unknown; isLoading?: boolean}) => {
+    const refetch = mock(() => {});
+    const useGetMyConsentsQuery = mock(() => ({
+      data: queryResult.data,
+      error: queryResult.error,
+      isLoading: queryResult.isLoading ?? false,
+      refetch,
+    }));
+    const api = {
+      injectEndpoints: mock((opts: MockInjectOpts) => {
+        const build = {
+          query: mock((def: MockQueryDef) => {
+            // Exercise the URL builder so the closure captures `base`
+            const url = def.query();
+            expect(url).toContain("/consents/my");
+            return "my-consents-query";
+          }),
+        };
+        opts.endpoints(build);
+        return {useGetMyConsentsQuery};
+      }),
+    };
+    return {api, refetch};
+  };
+
+  it("returns an array of entries when response is an array", () => {
+    const {api} = buildApi({
+      data: [{_id: "1", agreed: true} as unknown as ConsentHistoryEntry],
+    });
+    const {result} = renderHook(() => useConsentHistory(api as unknown as ConsentHistoryApi));
+    expect(Array.isArray(result.current.entries)).toBe(true);
+    expect(result.current.entries).toHaveLength(1);
+  });
+
+  it("unwraps .data property when response is object shape", () => {
+    const {api} = buildApi({
+      data: {data: [{_id: "2", agreed: false} as unknown as ConsentHistoryEntry]},
+    });
+    const {result} = renderHook(() =>
+      useConsentHistory(api as unknown as ConsentHistoryApi, "/api")
+    );
+    expect(Array.isArray(result.current.entries)).toBe(true);
+    expect(result.current.entries).toHaveLength(1);
+  });
+
+  it("returns empty array when no data is present", () => {
+    const {api} = buildApi({data: undefined, isLoading: true});
+    const {result} = renderHook(() => useConsentHistory(api as unknown as ConsentHistoryApi));
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("surfaces error from the query hook", () => {
+    const {api} = buildApi({data: undefined, error: "boom"});
+    const {result} = renderHook(() => useConsentHistory(api as unknown as ConsentHistoryApi));
+    expect(result.current.error).toBe("boom");
+  });
+
+  it("injects the my-consents endpoint only once per (api, baseUrl)", () => {
+    let injectCallCount = 0;
+    const refetch = mock(() => {});
+    const useGetMyConsentsQuery = mock(() => ({
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+      refetch,
+    }));
+    const api = {
+      injectEndpoints: () => {
+        injectCallCount += 1;
+        return {useGetMyConsentsQuery};
+      },
+    };
+    const {rerender} = renderHook(() => useConsentHistory(api as unknown as ConsentHistoryApi));
+    rerender(undefined);
+    rerender(undefined);
+    // The hook reuses the cached enhanced api after the first render so the
+    // dev-mode RTK warning about re-injecting endpoints never fires.
+    expect(injectCallCount).toBe(1);
+  });
+});

--- a/ui/src/useConsentHistory.ts
+++ b/ui/src/useConsentHistory.ts
@@ -35,19 +35,37 @@ interface ConsentHistoryHookState {
   refetch: () => void | Promise<void>;
 }
 
+interface ConsentHistoryEnhancedApi {
+  useGetMyConsentsQuery: () => ConsentHistoryHookState;
+}
+
 interface ConsentHistoryApi {
   injectEndpoints: (options: {
     endpoints: (build: ConsentHistoryQueryBuilder) => {getMyConsents: unknown};
     overrideExisting: boolean;
-  }) => {
-    useGetMyConsentsQuery: () => ConsentHistoryHookState;
-  };
+  }) => ConsentHistoryEnhancedApi;
 }
 
-export const useConsentHistory = (api: ConsentHistoryApi, baseUrl?: string) => {
-  const base = baseUrl || "";
+/**
+ * Cache the enhanced api per (api, baseUrl). `injectEndpoints` logs a console
+ * error in development whenever an endpoint with the same name is re-injected
+ * (with `overrideExisting: false`), so calling it on every render of every
+ * consumer would flood the console. WeakMap-by-api lets the GC reclaim entries
+ * when the api object is unreachable.
+ */
+const enhancedApiCache = new WeakMap<ConsentHistoryApi, Map<string, ConsentHistoryEnhancedApi>>();
 
-  const enhancedApi = api.injectEndpoints({
+const getEnhancedApi = (api: ConsentHistoryApi, base: string): ConsentHistoryEnhancedApi => {
+  let byBase = enhancedApiCache.get(api);
+  if (!byBase) {
+    byBase = new Map();
+    enhancedApiCache.set(api, byBase);
+  }
+  const cached = byBase.get(base);
+  if (cached) {
+    return cached;
+  }
+  const enhanced = api.injectEndpoints({
     endpoints: (build) => ({
       getMyConsents: build.query({
         providesTags: ["MyConsents"],
@@ -56,6 +74,13 @@ export const useConsentHistory = (api: ConsentHistoryApi, baseUrl?: string) => {
     }),
     overrideExisting: false,
   });
+  byBase.set(base, enhanced);
+  return enhanced;
+};
+
+export const useConsentHistory = (api: ConsentHistoryApi, baseUrl?: string) => {
+  const base = baseUrl || "";
+  const enhancedApi = getEnhancedApi(api, base);
 
   const {data, isLoading, error, refetch} = enhancedApi.useGetMyConsentsQuery();
   const entries: ConsentHistoryEntry[] = Array.isArray(data) ? data : (data?.data ?? []);

--- a/ui/src/useSubmitConsent.test.ts
+++ b/ui/src/useSubmitConsent.test.ts
@@ -72,4 +72,28 @@ describe("useSubmitConsent", () => {
     const {result} = renderHook(() => useSubmitConsent(api as unknown as SubmitConsentApi));
     expect(result.current.submit).toBeDefined();
   });
+
+  it("injects the submit endpoint only once per (api, baseUrl)", () => {
+    let injectCallCount = 0;
+    const unwrap = mock(async () => ({}));
+    const submitMutation = mock(() => ({unwrap}));
+    const useSubmitConsentResponseMutation = mock(() => [
+      submitMutation,
+      {error: undefined, isLoading: false},
+    ]);
+    const api = {
+      enhanceEndpoints: () => ({
+        injectEndpoints: () => {
+          injectCallCount += 1;
+          return {useSubmitConsentResponseMutation};
+        },
+      }),
+    };
+    const {rerender} = renderHook(() => useSubmitConsent(api as unknown as SubmitConsentApi));
+    rerender(undefined);
+    rerender(undefined);
+    // The hook reuses the cached enhanced api after the first render so the
+    // dev-mode RTK warning about re-injecting endpoints never fires.
+    expect(injectCallCount).toBe(1);
+  });
 });

--- a/ui/src/useSubmitConsent.ts
+++ b/ui/src/useSubmitConsent.ts
@@ -26,27 +26,45 @@ interface SubmitConsentMutationBuilder {
   }) => unknown;
 }
 
+interface SubmitConsentEnhancedApi {
+  useSubmitConsentResponseMutation: () => [
+    (body: SubmitConsentBody) => SubmitConsentMutationResult,
+    SubmitConsentMutationHookState,
+  ];
+}
+
 interface SubmitConsentApiWithTags {
   injectEndpoints: (options: {
     endpoints: (build: SubmitConsentMutationBuilder) => {submitConsentResponse: unknown};
     overrideExisting: boolean;
-  }) => {
-    useSubmitConsentResponseMutation: () => [
-      (body: SubmitConsentBody) => SubmitConsentMutationResult,
-      SubmitConsentMutationHookState,
-    ];
-  };
+  }) => SubmitConsentEnhancedApi;
 }
 
 interface SubmitConsentApi {
   enhanceEndpoints: (options: {addTagTypes: string[]}) => SubmitConsentApiWithTags;
 }
 
-export const useSubmitConsent = (api: SubmitConsentApi, baseUrl?: string) => {
-  const base = baseUrl || "";
-  const apiWithConsentTags = api.enhanceEndpoints({addTagTypes: ["PendingConsents"]});
+/**
+ * Cache the enhanced api per (api, baseUrl). `injectEndpoints` logs a console
+ * error in development whenever an endpoint with the same name is re-injected
+ * (with `overrideExisting: false`), so calling it on every render of every
+ * consumer would flood the console. WeakMap-by-api lets the GC reclaim entries
+ * when the api object is unreachable.
+ */
+const enhancedApiCache = new WeakMap<SubmitConsentApi, Map<string, SubmitConsentEnhancedApi>>();
 
-  const enhancedApi = apiWithConsentTags.injectEndpoints({
+const getEnhancedApi = (api: SubmitConsentApi, base: string): SubmitConsentEnhancedApi => {
+  let byBase = enhancedApiCache.get(api);
+  if (!byBase) {
+    byBase = new Map();
+    enhancedApiCache.set(api, byBase);
+  }
+  const cached = byBase.get(base);
+  if (cached) {
+    return cached;
+  }
+  const apiWithConsentTags = api.enhanceEndpoints({addTagTypes: ["PendingConsents"]});
+  const enhanced = apiWithConsentTags.injectEndpoints({
     endpoints: (build) => ({
       submitConsentResponse: build.mutation({
         invalidatesTags: ["PendingConsents"],
@@ -59,6 +77,13 @@ export const useSubmitConsent = (api: SubmitConsentApi, baseUrl?: string) => {
     }),
     overrideExisting: false,
   });
+  byBase.set(base, enhanced);
+  return enhanced;
+};
+
+export const useSubmitConsent = (api: SubmitConsentApi, baseUrl?: string) => {
+  const base = baseUrl || "";
+  const enhancedApi = getEnhancedApi(api, base);
 
   const [submitMutation, {isLoading: isSubmitting, error}] =
     enhancedApi.useSubmitConsentResponseMutation();


### PR DESCRIPTION
Surfaced while testing the Flourish consent rollout (FlourishHealth/flourish#5363).

## Changes

### `ConsentFormScreen`
Add an inline `* indicates a required item` legend above the checkbox list and a footer hint when required checkboxes are unchecked, so users can tell why the Agree button is disabled. Previously the asterisks were unexplained and there was no message in the gating logic.

### `Signature` / `Signature.native`
When the user presses **Clear**, push an empty value through `onChange` so parents that gate on \"signature required\" can detect the cleared state. The underlying canvas's `clear()` / `clearSignature()` does not fire `onEnd`/`onOK`, so previously the parent kept the last drawn value and let the user submit an empty signature.

### `useSubmitConsent` / `useConsentForms` / `useConsentHistory`
Cache the enhanced api per `(api, baseUrl)` in a module-level WeakMap so we only inject endpoints once. Previously each render of every consumer re-ran `injectEndpoints({overrideExisting: false})`, which RTK Query logs as a `console.error` in development whenever the endpoint already exists — producing a stream of errors on mobile.

## Test plan
- [x] `bun test src/ConsentFormScreen.test.tsx src/Signature.test.tsx src/useSubmitConsent.test.ts src/useConsentForms.test.ts src/useConsentHistory.test.ts` — new tests added for each behavior
- [x] `bun run lint`
- [x] `bun run compile`
- [ ] Verify on mobile: agree button stays disabled after clearing signature, required-checkbox hint appears, no `injectEndpoints` console errors on patient consent flow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes consent gating UX and signature-clear behavior, and adds caching around RTK Query endpoint injection which could affect data fetching if cache keys/baseUrl usage are incorrect.
> 
> **Overview**
> Improves consent form UX by explaining required checkbox asterisks (adds a required-items legend) and showing a new footer error when required checkboxes are still unchecked, clarifying why the Agree button is disabled.
> 
> Fixes signature clearing on both web and native `Signature` components by calling `onChange("")` when Clear is pressed so parent “signature required” gating resets immediately.
> 
> Updates `useConsentForms`, `useConsentHistory`, and `useSubmitConsent` to cache the RTK Query enhanced API per `(api, baseUrl)` via a module-level `WeakMap`, preventing repeated `injectEndpoints({overrideExisting: false})` calls and associated dev-mode console errors; adds/extends tests to cover these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feb531551b6c44b13abd3c1cfa946705c9ba86ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->