### PR TITLE
Fix test isolation failures in publish-ui and publish-ai

### DIFF
--- a/ai/src/langfuseClient.test.ts
+++ b/ai/src/langfuseClient.test.ts
@@ -1,4 +1,4 @@
-import {afterEach, describe, expect, it, mock} from "bun:test";
+import {afterEach, describe, expect, it} from "bun:test";
 
 import {
   getLangfuseClient,
@@ -7,23 +7,7 @@ import {
   shutdownLangfuseClient,
 } from "./langfuseClient";
 
-mock.module("@langfuse/client", () => {
-  return {
-    LangfuseClient: class MockLangfuseClient {
-      baseUrl: string;
-      publicKey: string;
-      secretKey: string;
-
-      constructor(opts: {baseUrl: string; publicKey: string; secretKey: string}) {
-        this.baseUrl = opts.baseUrl;
-        this.publicKey = opts.publicKey;
-        this.secretKey = opts.secretKey;
-      }
-
-      shutdown = mock(async () => {});
-    },
-  };
-});
+// @langfuse/client is mocked globally in tests/bunSetup.ts.
 
 describe("langfuseClient", () => {
   afterEach(async () => {

--- a/ai/src/langfusePrompts.test.ts
+++ b/ai/src/langfusePrompts.test.ts
@@ -1,6 +1,8 @@
 import {beforeEach, describe, expect, it, mock} from "bun:test";
 
 import {LangfuseCache} from "./langfuseCache";
+import {getLangfuseClient, initLangfuseClient} from "./langfuseClient";
+import {compilePrompt, createPrompt, getPrompt, invalidatePromptCache} from "./langfusePrompts";
 import type {LangfuseCachedPrompt} from "./langfuseTypes";
 
 const mockPromptCreate = mock(async (_params: Record<string, unknown>) => {});
@@ -13,16 +15,6 @@ const mockPromptGet = mock(async (_name: string, _options?: Record<string, unkno
   type: "text" as const,
   version: 1,
 }));
-
-const realLangfuseClient = await import("./langfuseClient");
-mock.module("./langfuseClient", () => ({
-  ...realLangfuseClient,
-  getLangfuseClient: () => ({prompt: {create: mockPromptCreate, get: mockPromptGet}}),
-}));
-
-const {compilePrompt, createPrompt, getPrompt, invalidatePromptCache} = await import(
-  "./langfusePrompts"
-);
 
 const textPrompt: LangfuseCachedPrompt = {
   config: {},
@@ -60,6 +52,15 @@ beforeEach(async () => {
     type: "text" as const,
     version: 1,
   }));
+  // Init the (fake) langfuse client and wire our local mocks onto its prompt
+  // methods so the real `langfusePrompts` code exercises customizable
+  // responses without hitting the network.
+  initLangfuseClient({publicKey: "pk-test", secretKey: "sk-test"});
+  const client = getLangfuseClient() as unknown as {
+    prompt: {create: typeof mockPromptCreate; get: typeof mockPromptGet};
+  };
+  client.prompt.get = mockPromptGet;
+  client.prompt.create = mockPromptCreate;
 });
 
 describe("compilePrompt", () => {

--- a/ai/src/langfuseRoutes.test.ts
+++ b/ai/src/langfuseRoutes.test.ts
@@ -4,6 +4,12 @@ import mongoose from "mongoose";
 import passportLocalMongoose from "passport-local-mongoose";
 import supertest from "supertest";
 
+import {getLangfuseClient, initLangfuseClient} from "./langfuseClient";
+import {addEvaluationRoutes} from "./langfuseRoutesEvaluations";
+import {addPlaygroundRoutes} from "./langfuseRoutesPlayground";
+import {addPromptRoutes} from "./langfuseRoutesPrompts";
+import {addTraceRoutes} from "./langfuseRoutesTraces";
+
 const scoreCreate = mock(() => {});
 const promptCreate = mock(async (_params: Record<string, unknown>) => ({}));
 const promptGet = mock(async (name: string) => ({
@@ -25,25 +31,6 @@ const traceList = mock(async () => ({
 }));
 const traceGet = mock(async (traceId: string) => ({id: traceId, name: "Trace"}));
 const flush = mock(async () => {});
-
-const realLangfuseClient = await import("./langfuseClient");
-mock.module("./langfuseClient", () => ({
-  ...realLangfuseClient,
-  getLangfuseClient: () => ({
-    api: {
-      prompts: {list: promptsList},
-      trace: {get: traceGet, list: traceList},
-    },
-    flush,
-    prompt: {create: promptCreate, get: promptGet},
-    score: {create: scoreCreate},
-  }),
-}));
-
-const {addPromptRoutes} = await import("./langfuseRoutesPrompts");
-const {addTraceRoutes} = await import("./langfuseRoutesTraces");
-const {addPlaygroundRoutes} = await import("./langfuseRoutesPlayground");
-const {addEvaluationRoutes} = await import("./langfuseRoutesEvaluations");
 
 const userSchema = new mongoose.Schema({
   admin: {default: false, type: Boolean},
@@ -89,6 +76,27 @@ describe("Langfuse routes", () => {
   });
 
   beforeEach(() => {
+    // Init the (fake) langfuse client and wire our local mocks onto its
+    // methods so the route handlers exercise customizable responses without
+    // making real SDK calls.
+    initLangfuseClient({publicKey: "pk-test", secretKey: "sk-test"});
+    const client = getLangfuseClient() as unknown as {
+      api: {
+        prompts: {list: typeof promptsList};
+        trace: {get: typeof traceGet; list: typeof traceList};
+      };
+      flush: typeof flush;
+      prompt: {create: typeof promptCreate; get: typeof promptGet};
+      score: {create: typeof scoreCreate};
+    };
+    client.api.prompts.list = promptsList;
+    client.api.trace.get = traceGet;
+    client.api.trace.list = traceList;
+    client.flush = flush;
+    client.prompt.create = promptCreate;
+    client.prompt.get = promptGet;
+    client.score.create = scoreCreate;
+
     app = setupServer({
       addRoutes: (router) => {
         addPromptRoutes(router, "/admin/langfuse");

--- a/ai/src/langfuseVercelAi.test.ts
+++ b/ai/src/langfuseVercelAi.test.ts
@@ -1,6 +1,8 @@
 import {beforeEach, describe, expect, it, mock} from "bun:test";
 
 import {LangfuseCache} from "./langfuseCache";
+import {getLangfuseClient, initLangfuseClient} from "./langfuseClient";
+import {createTelemetryConfig, preparePromptForAI} from "./langfuseVercelAi";
 
 const mockPromptGet = mock(async (_name: string, _options?: Record<string, unknown>) => ({
   config: {temperature: 0.5},
@@ -12,22 +14,16 @@ const mockPromptGet = mock(async (_name: string, _options?: Record<string, unkno
   version: 3,
 }));
 
-// Mock the langfuse SDK client so the real `getPrompt`/`compilePrompt` from
-// `./langfusePrompts` can be exercised without network access. We intentionally
-// do NOT mock `./langfusePrompts` directly because that would leak into other
-// test suites that share the module cache in the same bun process.
-const realLangfuseClient = await import("./langfuseClient");
-mock.module("./langfuseClient", () => ({
-  ...realLangfuseClient,
-  getLangfuseClient: () => ({prompt: {get: mockPromptGet}}),
-}));
-
-const {createTelemetryConfig, preparePromptForAI} = await import("./langfuseVercelAi");
-
 describe("langfuseVercelAi", () => {
   beforeEach(async () => {
     mockPromptGet.mockClear();
     await LangfuseCache.deleteMany({});
+    // Re-init the (fake) langfuse client and wire the prompt.get mock so the
+    // real `getPrompt`/`compilePrompt` from `./langfusePrompts` runs against
+    // a customizable response without network access.
+    initLangfuseClient({publicKey: "pk-test", secretKey: "sk-test"});
+    (getLangfuseClient() as unknown as {prompt: {get: typeof mockPromptGet}}).prompt.get =
+      mockPromptGet;
   });
 
   describe("preparePromptForAI", () => {

--- a/ai/src/tests/bunSetup.ts
+++ b/ai/src/tests/bunSetup.ts
@@ -99,6 +99,65 @@ afterEach(() => {
   logs = [];
 });
 
+// Mock @langfuse/client globally so the real `./langfuseClient` module runs
+// without making network calls. Each `new LangfuseClient(...)` gets its own
+// mock functions so tests can customize per-instance behavior (via
+// `getLangfuseClient()` after `initLangfuseClient(...)`). Mocking the SDK
+// here, rather than mocking `./langfuseClient` per-test-file, prevents the
+// `mock.module()` global cache from leaking different shapes across files.
+mock.module("@langfuse/client", () => {
+  return {
+    LangfuseClient: class FakeLangfuseClient {
+      baseUrl: string;
+      publicKey: string;
+      secretKey: string;
+      api = {
+        prompts: {
+          list: mock(async () => ({
+            data: [],
+            meta: {limit: 20, page: 1, total: 0, totalPages: 0},
+          })),
+        },
+        trace: {
+          get: mock(async (id: string) => ({id, name: "Trace"})),
+          list: mock(async () => ({
+            data: [],
+            meta: {limit: 20, page: 1, total: 0, totalPages: 0},
+          })),
+        },
+      };
+      prompt = {
+        create: mock(async (_params: Record<string, unknown>) => undefined),
+        get: mock(async (name: string) => ({
+          config: {},
+          labels: [],
+          name,
+          prompt: "",
+          tags: [],
+          type: "text" as const,
+          version: 1,
+        })),
+      };
+      score = {create: mock(() => {})};
+      flush = mock(async () => {});
+      shutdown = mock(async () => {});
+
+      constructor(opts: {baseUrl: string; publicKey: string; secretKey: string}) {
+        this.baseUrl = opts.baseUrl;
+        this.publicKey = opts.publicKey;
+        this.secretKey = opts.secretKey;
+      }
+    },
+  };
+});
+
+// Ensure no langfuse client instance leaks across tests in different files.
+// The real langfuseInstance module variable is reset to null between tests.
+beforeEach(async () => {
+  const {shutdownLangfuseClient} = await import("../langfuseClient");
+  await shutdownLangfuseClient();
+});
+
 // Mock @sentry/bun module
 mock.module("@sentry/bun", () => {
   const mockFn = (): ReturnType<typeof mock> => mock(() => {});

--- a/ui/src/__snapshots__/TerrenoProvider.test.tsx.snap
+++ b/ui/src/__snapshots__/TerrenoProvider.test.tsx.snap
@@ -27,15 +27,8 @@ exports[`TerrenoProvider renders correctly with default props 1`] = `
       },
     ],
     "props": {
-      "collapsable": false,
-      "pointerEvents": "box-none",
-      "style": [
-        {
-          "flex": 1,
-        },
-        undefined,
-      ],
-      "testID": undefined,
+      "style": undefined,
+      "testID": "portal-host",
     },
     "type": "View",
   },
@@ -123,15 +116,8 @@ exports[`TerrenoProvider renders with openAPISpecUrl 1`] = `
       },
     ],
     "props": {
-      "collapsable": false,
-      "pointerEvents": "box-none",
-      "style": [
-        {
-          "flex": 1,
-        },
-        undefined,
-      ],
-      "testID": undefined,
+      "style": undefined,
+      "testID": "portal-host",
     },
     "type": "View",
   },

--- a/ui/src/bunSetup.ts
+++ b/ui/src/bunSetup.ts
@@ -530,6 +530,28 @@ mock.module("react-native-signature-canvas", () => ({
   Signature: mock(() => null),
 }));
 
+// Mock react-signature-canvas (web). The real module references `window` at
+// import time, which doesn't exist under bun test.
+mock.module("react-signature-canvas", () => {
+  const SignatureCanvasMock = React.forwardRef(
+    ({backgroundColor}: {backgroundColor?: string}, _ref) =>
+      React.createElement("View", {style: {backgroundColor}, testID: "signature-canvas"})
+  );
+  return {__esModule: true, default: SignatureCanvasMock};
+});
+
+// Mock react-native-portalize. The real `Host` wraps children in an extra View
+// whose presence makes snapshots brittle, and individual tests already mock
+// this to render inline; hoisting the mock to setup keeps test ordering from
+// leaking different shapes into other test files. Shape matches the per-file
+// mock used by Tooltip.test.tsx so the two don't disagree.
+mock.module("react-native-portalize", () => ({
+  Host: ({children}: MockComponentProps) =>
+    React.createElement("View", {style: undefined, testID: "portal-host"}, children),
+  Portal: ({children}: MockComponentProps) =>
+    React.createElement("View", {style: undefined, testID: "portal"}, children),
+}));
+
 // Mock IconButton component
 mock.module("./IconButton", () => ({
   IconButton: mock(() => null),


### PR DESCRIPTION
## Summary

Bun's `mock.module()` is process-global and persists for the full test run. Multiple test files mocked internal modules in ways that leaked into unrelated test suites, causing the publish-on-tag workflow to fail for both `publish-ui` and `publish-ai` since 0.13.1.

## Changes

**UI (publish-ui):**
- `ui/src/bunSetup.ts` — Add global mocks for `react-native-portalize` and `react-signature-canvas` so test ordering doesn't affect snapshot/testID assertions. The real mocks in `Tooltip.test.tsx` and `Signature.test.tsx` still work (they override the global with compatible shapes).
- `ui/src/__snapshots__/TerrenoProvider.test.tsx.snap` — Regenerated against the now-stable mocked Host output (`testID: "portal-host"` instead of the real portalize View props).

**AI (publish-ai):**
- `ai/src/tests/bunSetup.ts` — Add a global `@langfuse/client` mock with a `FakeLangfuseClient` class (all methods are `mock()` instances, customizable per test). Add a global `beforeEach` that calls `shutdownLangfuseClient` to reset the module-level `langfuseInstance` between tests.
- `ai/src/langfuse{VercelAi,Prompts,Routes}.test.ts` — Remove their `mock.module("./langfuseClient", ...)` calls (which were leaking globally). Now call `initLangfuseClient()` in `beforeEach` and patch methods directly on the returned fake instance.
- `ai/src/langfuseClient.test.ts` — Remove the local `@langfuse/client` mock (now handled by bunSetup).

## Human Testing Steps
- [ ] Trigger or observe the next `publish-on-tag` workflow run — `publish-ui` and `publish-ai` jobs should both pass tests.
- [ ] Verify `bun run test:ci` in `ui/` passes locally with 0 failures.
- [ ] Verify `bun run test` in `ai/` passes locally with 0 failures.

## Automated Tests
- UI: 1367 pass, 0 fail
- AI: 210 pass, 0 fail (including `langfuseClient` which previously failed due to leaked mocks)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test setup/mocking and a regenerated snapshot, intended to improve isolation and determinism without affecting runtime behavior.
> 
> **Overview**
> Stabilizes Bun test runs by moving process-global `mock.module()` usage into shared `bunSetup` files to prevent cross-file mock shape leakage and reduce order-dependent failures.
> 
> In `ai`, `@langfuse/client` is now mocked globally (with per-instance mocked methods) and tests are updated to initialize a fake client via `initLangfuseClient()` and patch method mocks on the returned instance, plus a setup `beforeEach` resets the module-level Langfuse singleton between tests.
> 
> In `ui`, adds global mocks for `react-signature-canvas` and `react-native-portalize` (to avoid `window` access and brittle portal wrappers), and updates the `TerrenoProvider` snapshot to match the new stable portal host output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d7f68a47b673c79457ecd8bfa495214f8fd0fa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->