### PR TITLE
Sync skills to .agents via rulesync 8.x

### DIFF
--- a/.agents/skills/generate-sdk/SKILL.md
+++ b/.agents/skills/generate-sdk/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: generate-sdk
+description: >-
+  Regenerate the example-frontend RTK Query SDK (store/openApiSdk.ts) from the
+  example-backend's OpenAPI spec. Handles dependency install, backend startup,
+  SDK codegen, and cleanup from a fresh checkout. Use whenever the backend's API
+  surface changes — new modelRouter routes, custom routes registered via
+  createOpenApiBuilder, new/modified Mongoose models or field descriptions in
+  example-backend, changes to
+  permissions/queryFields/populatePaths/responseHandler, edits to @terreno/api
+  routing or OpenAPI generation, or any time a route is added/removed/renamed.
+  Also use when the user asks to "regenerate the SDK", "update openApiSdk.ts",
+  "run bun run sdk", or reports stale/missing generated hooks.
+---
+# Generate Frontend SDK
+
+The `example-frontend` consumes the `example-backend` API via auto-generated RTK Query hooks in `store/openApiSdk.ts`. The codegen pulls from the live backend at `http://localhost:4000/openapi.json`, so the backend must be running while `bun run sdk` executes.
+
+**Never edit `example-frontend/store/openApiSdk.ts` by hand — it is fully overwritten by this skill.**
+
+## When to run this skill
+
+Run it whenever the backend's OpenAPI surface changes. Common triggers:
+
+- New or removed `modelRouter` registration
+- Edits to `permissions`, `queryFields`, `populatePaths`, `defaultQueryParams`, `sort`, `responseHandler`, or `openApiOverwrite` on an existing `modelRouter`
+- New custom routes built with `createOpenApiBuilder` (path params, query params, request body, response schema changes)
+- Mongoose schema changes that affect the public shape: added/removed fields, type changes, required/enum/default changes, `description` updates, ref changes
+- Changes to auth routes (e.g. `addAuthRoutes`, `addMeRoutes`, GitHub OAuth, Better Auth)
+- Edits to `@terreno/api` files that produce the OpenAPI spec (`openApi.ts`, `openApiBuilder.ts`, `api.ts`, `populate.ts`)
+- User asks: "regenerate SDK", "update the SDK", "run bun run sdk", "openApiSdk.ts is out of date"
+
+If the change is purely backend-internal (logging, refactor that doesn't alter routes/models, test-only edits), the SDK does **not** need regeneration — skip this skill.
+
+## Prerequisites
+
+- Bun is on PATH (run `bun` directly; do not modify PATH)
+- MongoDB reachable at `mongodb://localhost:27017` (the example backend connects on boot)
+- Ports 4000 (backend) must be free
+
+If MongoDB is not running, tell the user and stop — do not try to install or start it automatically.
+
+## Procedure
+
+Run the steps in order. Stop and report on the first failure.
+
+### 1. Verify the worktree is bootstrapped
+
+Detect whether dependencies are installed. The repo uses Bun workspaces, so a single root `node_modules` is sufficient.
+
+```bash
+test -d node_modules && test -d example-backend/node_modules && test -d example-frontend/node_modules && echo "installed" || echo "missing"
+```
+
+If `missing`, run the full bootstrap from the repo root. This installs deps **and** compiles every workspace package (needed because `example-frontend` imports built artifacts from `@terreno/rtk` and other workspaces):
+
+```bash
+bun run bootstrap
+```
+
+Bootstrap can take a few minutes — run it in the background and wait for it to finish before continuing.
+
+### 2. Ensure backend env vars are set
+
+The backend reads `example-backend/.env`. If that file is missing, copy the example:
+
+```bash
+test -f example-backend/.env || cp example-backend/.env.example example-backend/.env
+```
+
+The default `.env.example` values are fine for local SDK generation. Do not invent secrets or overwrite an existing `.env`.
+
+### 3. Start the example backend on port 4000
+
+The dev script watches files, which is fine for a one-shot codegen run. Start it in the background from the repo root:
+
+```bash
+bun run backend:dev
+```
+
+Use the Bash tool's `run_in_background: true` so the process keeps running while you continue.
+
+### 4. Wait for the OpenAPI spec to be served
+
+Poll `http://localhost:4000/openapi.json` until it returns HTTP 200. The backend has to connect to MongoDB and register all routes before the spec is available, which can take 5–20 seconds on a cold start. Do not skip this wait — running `bun run sdk` before the spec is ready produces an empty/broken `openApiSdk.ts`.
+
+```bash
+until curl -sf -o /dev/null -w "%{http_code}" http://localhost:4000/openapi.json | grep -q 200; do sleep 2; done
+```
+
+If the backend logs an error (Mongo connection refused, port already in use, compile error), stop and surface the error to the user. Do not retry blindly.
+
+### 5. Generate the SDK
+
+Run the codegen from `example-frontend`. The script also runs Biome formatting on the output and strips an empty re-export line, so no follow-up formatting is needed.
+
+```bash
+cd example-frontend && bun run sdk
+```
+
+If the script fails with a missing module error (e.g. `@rtk-query/codegen-openapi`), dependencies are stale — re-run `bun run bootstrap` from the repo root and try again.
+
+### 6. Stop the backend
+
+Kill the background backend process you started in step 3. Use the PID from the background shell, or:
+
+```bash
+pkill -f "example-backend.*src/index.ts" || true
+```
+
+### 7. Verify and report
+
+Confirm `example-frontend/store/openApiSdk.ts` exists and was modified. Show the user a short summary:
+
+- Which routes/models triggered the regeneration
+- A `git diff --stat example-frontend/store/openApiSdk.ts` to show the size of the change
+- Any warnings or errors emitted by the backend or codegen
+
+Do **not** commit `openApiSdk.ts` automatically — leave that to the user's normal commit flow.
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `ECONNREFUSED 127.0.0.1:27017` | MongoDB not running | Ask the user to start Mongo; do not auto-start |
+| `EADDRINUSE :::4000` | Stale backend process | `pkill -f "example-backend.*src/index.ts"` then retry |
+| `Cannot find module '@rtk-query/codegen-openapi'` | Missing/stale deps | Re-run `bun run bootstrap` |
+| `openApiSdk.ts` has no endpoints | Backend wasn't ready when codegen ran | Step 4 wait was skipped — start over with a proper poll |
+| Codegen errors on `$ref` | Backend OpenAPI spec is malformed | Inspect `/openapi.json` manually; check recent changes to `openApi.ts` or model schemas |
+
+## Notes
+
+- The codegen config lives at `example-frontend/openapi-config.ts`. The schema URL respects `OPENAPI_URL` if set, otherwise defaults to `http://localhost:4000/openapi.json`.
+- The script entry point is `example-frontend/scripts/generate-sdk.ts` — it shells out to the `@rtk-query/codegen-openapi` CLI, then post-processes the output with Biome.
+- Custom endpoints and cache tag types are layered on top in `example-frontend/store/sdk.ts` via `injectEndpoints`/`enhanceEndpoints`; that file is hand-maintained and is **not** overwritten by codegen.

--- a/.cursor/rules/ai/00-ai.mdc
+++ b/.cursor/rules/ai/00-ai.mdc
@@ -1,0 +1,226 @@
+---
+description: @terreno/ai - AI service layer for Terreno apps
+globs: **/*
+---
+
+# @terreno/ai
+
+AI service layer for Terreno apps providing GPT chat, request logging, and admin tools. Provider-agnostic via Vercel AI SDK. This is a **backend-only** package — no React, no UI components, no frontend code.
+
+## Commands
+
+```bash
+bun run compile          # Compile TypeScript
+bun run dev              # Watch mode
+bun run test             # Run tests
+bun run lint             # Lint code
+bun run lint:fix         # Fix lint issues
+```
+
+## Architecture
+
+### File Structure
+
+```
+src/
+  index.ts               # All package exports
+  models/
+    aiRequest.ts         # AI request logging model
+    gptHistory.ts        # Conversation history model
+    index.ts             # Model exports
+  routes/
+    gpt.ts               # GPT chat streaming and remix endpoints
+    gptHistories.ts      # GPT history CRUD via modelRouter
+    aiRequestsExplorer.ts # Admin-only AI request explorer
+    index.ts             # Route exports
+  service/
+    aiService.ts         # Provider-agnostic AI service class
+    prompts.ts           # System prompt constants
+    index.ts             # Service exports
+  types/
+    index.ts             # All type definitions
+  tests/
+    bunSetup.ts          # Test environment setup
+```
+
+## AIService
+
+Provider-agnostic AI service using Vercel AI SDK's `LanguageModel` interface. Consuming apps provide their own model instance.
+
+### Usage
+
+```typescript
+import {AIService} from "@terreno/ai";
+import {google} from "@ai-sdk/google";
+
+const aiService = new AIService({
+  model: google("gemini-2.5-flash"),
+  defaultTemperature: 1.0,  // optional
+});
+```
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `generateText(options)` | Generate text (non-streaming) |
+| `generateTextStream(options)` | Stream text chunks (AsyncGenerator) |
+| `generateRemix({text, userId?})` | Reword text naturally |
+| `generateSummary({text, userId?})` | Summarize text |
+| `translateText({text, targetLanguage, sourceLanguage?, userId?})` | Translate text |
+| `generateChatStream({messages, systemPrompt?, userId?})` | Stream chat response |
+
+All methods automatically log requests to the AIRequest model.
+
+### Temperature Presets
+
+```typescript
+import {TemperaturePresets} from "@terreno/ai";
+
+TemperaturePresets.DETERMINISTIC  // 0
+TemperaturePresets.LOW            // 0.3
+TemperaturePresets.BALANCED       // 0.7
+TemperaturePresets.DEFAULT        // 1.0
+TemperaturePresets.HIGH           // 1.5
+TemperaturePresets.MAXIMUM        // 2.0
+```
+
+## Models
+
+### AIRequest
+
+Logs all AI requests with metrics for monitoring and debugging.
+
+```typescript
+// Fields
+aiModel: string          // Model identifier (e.g., "gemini-2.5-flash")
+prompt: string           // Input prompt
+requestType: "general" | "remix" | "summarization" | "translation"
+response?: string        // AI response text
+responseTime?: number    // Response time in ms
+tokensUsed?: number      // Total tokens consumed
+userId?: ObjectId        // User who made the request
+error?: string           // Error message if failed
+metadata?: Mixed         // Additional data
+
+// Static method
+await AIRequest.logRequest({aiModel, prompt, requestType, ...});
+```
+
+Plugins: `createdUpdatedPlugin`, `isDeletedPlugin`, `findOneOrNone`, `findExactlyOne`
+
+### GptHistory
+
+Persists conversation history with auto-generated titles.
+
+```typescript
+// Fields
+title?: string                    // Auto-generated from first assistant response
+userId: ObjectId                  // Owner (required)
+prompts: Array<{                  // Conversation messages
+  text: string,
+  type: "user" | "assistant" | "system",
+  model?: string
+}>
+
+// Virtual
+ownerId                           // Alias for userId (Permissions.IsOwner compatibility)
+```
+
+Pre-save hook auto-generates title from first assistant response (first 50 chars).
+
+## Routes
+
+### addGptRoutes(router, options)
+
+```typescript
+import {addGptRoutes} from "@terreno/ai";
+
+addGptRoutes(router, {aiService, openApiOptions: options});
+```
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/gpt/prompt` | POST | SSE streaming chat with history persistence |
+| `/gpt/remix` | POST | Non-streaming text remix |
+
+Both require authentication. `/gpt/prompt` accepts `{prompt, historyId?, systemPrompt?}` and streams via Server-Sent Events.
+
+### addGptHistoryRoutes(router, options)
+
+Standard modelRouter CRUD at `/gpt/histories`:
+- **Create/List**: `IsAuthenticated`
+- **Read/Update/Delete**: `IsOwner`
+- Query filtered by `userId`
+- Sorted by `-updated`
+
+### addAiRequestsExplorerRoutes(router, options)
+
+Admin-only endpoint at `GET /aiRequestsExplorer`:
+- Paginated with `?page=1&limit=20`
+- Filters: `requestType`, `model`, `startDate`, `endDate`
+- Aggregation pipeline with user lookup
+- Returns `{data, total, page, limit, more}`
+
+## Integration
+
+Consuming apps wire up routes in their `setupServer` call:
+
+```typescript
+import {AIService, addGptRoutes, addGptHistoryRoutes, addAiRequestsExplorerRoutes} from "@terreno/ai";
+import {google} from "@ai-sdk/google";
+
+const aiService = new AIService({model: google("gemini-2.5-flash")});
+
+setupServer({
+  addRoutes: (router, options) => {
+    addGptHistoryRoutes(router, options);
+    addGptRoutes(router, {aiService, openApiOptions: options});
+    addAiRequestsExplorerRoutes(router, {openApiOptions: options});
+  },
+});
+```
+
+## Conventions
+
+- Uses `aiModel` field name (not `model`) to avoid Mongoose internal property conflicts
+- GptHistory uses `userId` field with `ownerId` virtual for `Permissions.IsOwner` compatibility
+- Custom query filter `(user) => ({userId: user?.id})` instead of `OwnerQueryFilter`
+- All AI calls are logged via private `logRequest()` — logging failures never break the main flow
+- Express user accessed via `(req as any).user` casting pattern
+- Error handling: `throw new APIError({status: 400, title: "..."})` — check conditions early
+
+## Testing
+
+- Framework: bun test with expect
+- HTTP testing: supertest
+- Mock AI model: Create mock with `doGenerate`/`doStream` methods returning `ReadableStream`
+- Test DB: `mongodb://127.0.0.1/terreno-ai-test`
+- Preload: `./src/tests/bunSetup.ts` (MongoDB connection, log silencing, Sentry mock)
+- **Never mock @terreno/api or models** — test against real functionality
+
+### Mock Model Pattern
+
+```typescript
+const createMockModel = () => ({
+  doGenerate: mock(async () => ({
+    finishReason: "stop" as const,
+    rawCall: {rawPrompt: "", rawSettings: {}},
+    text: "response text",
+    usage: {completionTokens: 10, promptTokens: 5},
+  })),
+  doStream: mock(async () => ({
+    rawCall: {rawPrompt: "", rawSettings: {}},
+    stream: new ReadableStream({
+      start(controller) {
+        controller.enqueue({type: "text-delta" as const, textDelta: "chunk "});
+        controller.enqueue({type: "finish" as const, finishReason: "stop" as const, usage: {completionTokens: 10, promptTokens: 5}});
+        controller.close();
+      },
+    }),
+  })),
+  modelId: "mock-model",
+  provider: "mock-provider",
+  specificationVersion: "v1" as const,
+});
+```

--- a/.cursor/skills/generate-sdk/SKILL.md
+++ b/.cursor/skills/generate-sdk/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: generate-sdk
+description: Regenerate the example-frontend RTK Query SDK (store/openApiSdk.ts) from the example-backend's OpenAPI spec. Handles dependency install, backend startup, SDK codegen, and cleanup from a fresh checkout. Use whenever the backend's API surface changes — new modelRouter routes, custom routes registered via createOpenApiBuilder, new/modified Mongoose models or field descriptions in example-backend, changes to permissions/queryFields/populatePaths/responseHandler, edits to @terreno/api routing or OpenAPI generation, or any time a route is added/removed/renamed. Also use when the user asks to "regenerate the SDK", "update openApiSdk.ts", "run bun run sdk", or reports stale/missing generated hooks.
+---
+# Generate Frontend SDK
+
+The `example-frontend` consumes the `example-backend` API via auto-generated RTK Query hooks in `store/openApiSdk.ts`. The codegen pulls from the live backend at `http://localhost:4000/openapi.json`, so the backend must be running while `bun run sdk` executes.
+
+**Never edit `example-frontend/store/openApiSdk.ts` by hand — it is fully overwritten by this skill.**
+
+## When to run this skill
+
+Run it whenever the backend's OpenAPI surface changes. Common triggers:
+
+- New or removed `modelRouter` registration
+- Edits to `permissions`, `queryFields`, `populatePaths`, `defaultQueryParams`, `sort`, `responseHandler`, or `openApiOverwrite` on an existing `modelRouter`
+- New custom routes built with `createOpenApiBuilder` (path params, query params, request body, response schema changes)
+- Mongoose schema changes that affect the public shape: added/removed fields, type changes, required/enum/default changes, `description` updates, ref changes
+- Changes to auth routes (e.g. `addAuthRoutes`, `addMeRoutes`, GitHub OAuth, Better Auth)
+- Edits to `@terreno/api` files that produce the OpenAPI spec (`openApi.ts`, `openApiBuilder.ts`, `api.ts`, `populate.ts`)
+- User asks: "regenerate SDK", "update the SDK", "run bun run sdk", "openApiSdk.ts is out of date"
+
+If the change is purely backend-internal (logging, refactor that doesn't alter routes/models, test-only edits), the SDK does **not** need regeneration — skip this skill.
+
+## Prerequisites
+
+- Bun is on PATH (run `bun` directly; do not modify PATH)
+- MongoDB reachable at `mongodb://localhost:27017` (the example backend connects on boot)
+- Ports 4000 (backend) must be free
+
+If MongoDB is not running, tell the user and stop — do not try to install or start it automatically.
+
+## Procedure
+
+Run the steps in order. Stop and report on the first failure.
+
+### 1. Verify the worktree is bootstrapped
+
+Detect whether dependencies are installed. The repo uses Bun workspaces, so a single root `node_modules` is sufficient.
+
+```bash
+test -d node_modules && test -d example-backend/node_modules && test -d example-frontend/node_modules && echo "installed" || echo "missing"
+```
+
+If `missing`, run the full bootstrap from the repo root. This installs deps **and** compiles every workspace package (needed because `example-frontend` imports built artifacts from `@terreno/rtk` and other workspaces):
+
+```bash
+bun run bootstrap
+```
+
+Bootstrap can take a few minutes — run it in the background and wait for it to finish before continuing.
+
+### 2. Ensure backend env vars are set
+
+The backend reads `example-backend/.env`. If that file is missing, copy the example:
+
+```bash
+test -f example-backend/.env || cp example-backend/.env.example example-backend/.env
+```
+
+The default `.env.example` values are fine for local SDK generation. Do not invent secrets or overwrite an existing `.env`.
+
+### 3. Start the example backend on port 4000
+
+The dev script watches files, which is fine for a one-shot codegen run. Start it in the background from the repo root:
+
+```bash
+bun run backend:dev
+```
+
+Use the Bash tool's `run_in_background: true` so the process keeps running while you continue.
+
+### 4. Wait for the OpenAPI spec to be served
+
+Poll `http://localhost:4000/openapi.json` until it returns HTTP 200. The backend has to connect to MongoDB and register all routes before the spec is available, which can take 5–20 seconds on a cold start. Do not skip this wait — running `bun run sdk` before the spec is ready produces an empty/broken `openApiSdk.ts`.
+
+```bash
+until curl -sf -o /dev/null -w "%{http_code}" http://localhost:4000/openapi.json | grep -q 200; do sleep 2; done
+```
+
+If the backend logs an error (Mongo connection refused, port already in use, compile error), stop and surface the error to the user. Do not retry blindly.
+
+### 5. Generate the SDK
+
+Run the codegen from `example-frontend`. The script also runs Biome formatting on the output and strips an empty re-export line, so no follow-up formatting is needed.
+
+```bash
+cd example-frontend && bun run sdk
+```
+
+If the script fails with a missing module error (e.g. `@rtk-query/codegen-openapi`), dependencies are stale — re-run `bun run bootstrap` from the repo root and try again.
+
+### 6. Stop the backend
+
+Kill the background backend process you started in step 3. Use the PID from the background shell, or:
+
+```bash
+pkill -f "example-backend.*src/index.ts" || true
+```
+
+### 7. Verify and report
+
+Confirm `example-frontend/store/openApiSdk.ts` exists and was modified. Show the user a short summary:
+
+- Which routes/models triggered the regeneration
+- A `git diff --stat example-frontend/store/openApiSdk.ts` to show the size of the change
+- Any warnings or errors emitted by the backend or codegen
+
+Do **not** commit `openApiSdk.ts` automatically — leave that to the user's normal commit flow.
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `ECONNREFUSED 127.0.0.1:27017` | MongoDB not running | Ask the user to start Mongo; do not auto-start |
+| `EADDRINUSE :::4000` | Stale backend process | `pkill -f "example-backend.*src/index.ts"` then retry |
+| `Cannot find module '@rtk-query/codegen-openapi'` | Missing/stale deps | Re-run `bun run bootstrap` |
+| `openApiSdk.ts` has no endpoints | Backend wasn't ready when codegen ran | Step 4 wait was skipped — start over with a proper poll |
+| Codegen errors on `$ref` | Backend OpenAPI spec is malformed | Inspect `/openapi.json` manually; check recent changes to `openApi.ts` or model schemas |
+
+## Notes
+
+- The codegen config lives at `example-frontend/openapi-config.ts`. The schema URL respects `OPENAPI_URL` if set, otherwise defaults to `http://localhost:4000/openapi.json`.
+- The script entry point is `example-frontend/scripts/generate-sdk.ts` — it shells out to the `@rtk-query/codegen-openapi` CLI, then post-processes the output with Biome.
+- Custom endpoints and cache tag types are layered on top in `example-frontend/store/sdk.ts` via `injectEndpoints`/`enhanceEndpoints`; that file is hand-maintained and is **not** overwritten by codegen.

--- a/.github/instructions/ai/00-ai.instructions.md
+++ b/.github/instructions/ai/00-ai.instructions.md
@@ -1,0 +1,225 @@
+---
+description: '@terreno/ai - AI service layer for Terreno apps'
+applyTo: '**/*'
+---
+# @terreno/ai
+
+AI service layer for Terreno apps providing GPT chat, request logging, and admin tools. Provider-agnostic via Vercel AI SDK. This is a **backend-only** package — no React, no UI components, no frontend code.
+
+## Commands
+
+```bash
+bun run compile          # Compile TypeScript
+bun run dev              # Watch mode
+bun run test             # Run tests
+bun run lint             # Lint code
+bun run lint:fix         # Fix lint issues
+```
+
+## Architecture
+
+### File Structure
+
+```
+src/
+  index.ts               # All package exports
+  models/
+    aiRequest.ts         # AI request logging model
+    gptHistory.ts        # Conversation history model
+    index.ts             # Model exports
+  routes/
+    gpt.ts               # GPT chat streaming and remix endpoints
+    gptHistories.ts      # GPT history CRUD via modelRouter
+    aiRequestsExplorer.ts # Admin-only AI request explorer
+    index.ts             # Route exports
+  service/
+    aiService.ts         # Provider-agnostic AI service class
+    prompts.ts           # System prompt constants
+    index.ts             # Service exports
+  types/
+    index.ts             # All type definitions
+  tests/
+    bunSetup.ts          # Test environment setup
+```
+
+## AIService
+
+Provider-agnostic AI service using Vercel AI SDK's `LanguageModel` interface. Consuming apps provide their own model instance.
+
+### Usage
+
+```typescript
+import {AIService} from "@terreno/ai";
+import {google} from "@ai-sdk/google";
+
+const aiService = new AIService({
+  model: google("gemini-2.5-flash"),
+  defaultTemperature: 1.0,  // optional
+});
+```
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `generateText(options)` | Generate text (non-streaming) |
+| `generateTextStream(options)` | Stream text chunks (AsyncGenerator) |
+| `generateRemix({text, userId?})` | Reword text naturally |
+| `generateSummary({text, userId?})` | Summarize text |
+| `translateText({text, targetLanguage, sourceLanguage?, userId?})` | Translate text |
+| `generateChatStream({messages, systemPrompt?, userId?})` | Stream chat response |
+
+All methods automatically log requests to the AIRequest model.
+
+### Temperature Presets
+
+```typescript
+import {TemperaturePresets} from "@terreno/ai";
+
+TemperaturePresets.DETERMINISTIC  // 0
+TemperaturePresets.LOW            // 0.3
+TemperaturePresets.BALANCED       // 0.7
+TemperaturePresets.DEFAULT        // 1.0
+TemperaturePresets.HIGH           // 1.5
+TemperaturePresets.MAXIMUM        // 2.0
+```
+
+## Models
+
+### AIRequest
+
+Logs all AI requests with metrics for monitoring and debugging.
+
+```typescript
+// Fields
+aiModel: string          // Model identifier (e.g., "gemini-2.5-flash")
+prompt: string           // Input prompt
+requestType: "general" | "remix" | "summarization" | "translation"
+response?: string        // AI response text
+responseTime?: number    // Response time in ms
+tokensUsed?: number      // Total tokens consumed
+userId?: ObjectId        // User who made the request
+error?: string           // Error message if failed
+metadata?: Mixed         // Additional data
+
+// Static method
+await AIRequest.logRequest({aiModel, prompt, requestType, ...});
+```
+
+Plugins: `createdUpdatedPlugin`, `isDeletedPlugin`, `findOneOrNone`, `findExactlyOne`
+
+### GptHistory
+
+Persists conversation history with auto-generated titles.
+
+```typescript
+// Fields
+title?: string                    // Auto-generated from first assistant response
+userId: ObjectId                  // Owner (required)
+prompts: Array<{                  // Conversation messages
+  text: string,
+  type: "user" | "assistant" | "system",
+  model?: string
+}>
+
+// Virtual
+ownerId                           // Alias for userId (Permissions.IsOwner compatibility)
+```
+
+Pre-save hook auto-generates title from first assistant response (first 50 chars).
+
+## Routes
+
+### addGptRoutes(router, options)
+
+```typescript
+import {addGptRoutes} from "@terreno/ai";
+
+addGptRoutes(router, {aiService, openApiOptions: options});
+```
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/gpt/prompt` | POST | SSE streaming chat with history persistence |
+| `/gpt/remix` | POST | Non-streaming text remix |
+
+Both require authentication. `/gpt/prompt` accepts `{prompt, historyId?, systemPrompt?}` and streams via Server-Sent Events.
+
+### addGptHistoryRoutes(router, options)
+
+Standard modelRouter CRUD at `/gpt/histories`:
+- **Create/List**: `IsAuthenticated`
+- **Read/Update/Delete**: `IsOwner`
+- Query filtered by `userId`
+- Sorted by `-updated`
+
+### addAiRequestsExplorerRoutes(router, options)
+
+Admin-only endpoint at `GET /aiRequestsExplorer`:
+- Paginated with `?page=1&limit=20`
+- Filters: `requestType`, `model`, `startDate`, `endDate`
+- Aggregation pipeline with user lookup
+- Returns `{data, total, page, limit, more}`
+
+## Integration
+
+Consuming apps wire up routes in their `setupServer` call:
+
+```typescript
+import {AIService, addGptRoutes, addGptHistoryRoutes, addAiRequestsExplorerRoutes} from "@terreno/ai";
+import {google} from "@ai-sdk/google";
+
+const aiService = new AIService({model: google("gemini-2.5-flash")});
+
+setupServer({
+  addRoutes: (router, options) => {
+    addGptHistoryRoutes(router, options);
+    addGptRoutes(router, {aiService, openApiOptions: options});
+    addAiRequestsExplorerRoutes(router, {openApiOptions: options});
+  },
+});
+```
+
+## Conventions
+
+- Uses `aiModel` field name (not `model`) to avoid Mongoose internal property conflicts
+- GptHistory uses `userId` field with `ownerId` virtual for `Permissions.IsOwner` compatibility
+- Custom query filter `(user) => ({userId: user?.id})` instead of `OwnerQueryFilter`
+- All AI calls are logged via private `logRequest()` — logging failures never break the main flow
+- Express user accessed via `(req as any).user` casting pattern
+- Error handling: `throw new APIError({status: 400, title: "..."})` — check conditions early
+
+## Testing
+
+- Framework: bun test with expect
+- HTTP testing: supertest
+- Mock AI model: Create mock with `doGenerate`/`doStream` methods returning `ReadableStream`
+- Test DB: `mongodb://127.0.0.1/terreno-ai-test`
+- Preload: `./src/tests/bunSetup.ts` (MongoDB connection, log silencing, Sentry mock)
+- **Never mock @terreno/api or models** — test against real functionality
+
+### Mock Model Pattern
+
+```typescript
+const createMockModel = () => ({
+  doGenerate: mock(async () => ({
+    finishReason: "stop" as const,
+    rawCall: {rawPrompt: "", rawSettings: {}},
+    text: "response text",
+    usage: {completionTokens: 10, promptTokens: 5},
+  })),
+  doStream: mock(async () => ({
+    rawCall: {rawPrompt: "", rawSettings: {}},
+    stream: new ReadableStream({
+      start(controller) {
+        controller.enqueue({type: "text-delta" as const, textDelta: "chunk "});
+        controller.enqueue({type: "finish" as const, finishReason: "stop" as const, usage: {completionTokens: 10, promptTokens: 5}});
+        controller.close();
+      },
+    }),
+  })),
+  modelId: "mock-model",
+  provider: "mock-provider",
+  specificationVersion: "v1" as const,
+});
+```

--- a/.github/skills/generate-sdk/SKILL.md
+++ b/.github/skills/generate-sdk/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: generate-sdk
+description: >-
+  Regenerate the example-frontend RTK Query SDK (store/openApiSdk.ts) from the
+  example-backend's OpenAPI spec. Handles dependency install, backend startup,
+  SDK codegen, and cleanup from a fresh checkout. Use whenever the backend's API
+  surface changes — new modelRouter routes, custom routes registered via
+  createOpenApiBuilder, new/modified Mongoose models or field descriptions in
+  example-backend, changes to
+  permissions/queryFields/populatePaths/responseHandler, edits to @terreno/api
+  routing or OpenAPI generation, or any time a route is added/removed/renamed.
+  Also use when the user asks to "regenerate the SDK", "update openApiSdk.ts",
+  "run bun run sdk", or reports stale/missing generated hooks.
+---
+# Generate Frontend SDK
+
+The `example-frontend` consumes the `example-backend` API via auto-generated RTK Query hooks in `store/openApiSdk.ts`. The codegen pulls from the live backend at `http://localhost:4000/openapi.json`, so the backend must be running while `bun run sdk` executes.
+
+**Never edit `example-frontend/store/openApiSdk.ts` by hand — it is fully overwritten by this skill.**
+
+## When to run this skill
+
+Run it whenever the backend's OpenAPI surface changes. Common triggers:
+
+- New or removed `modelRouter` registration
+- Edits to `permissions`, `queryFields`, `populatePaths`, `defaultQueryParams`, `sort`, `responseHandler`, or `openApiOverwrite` on an existing `modelRouter`
+- New custom routes built with `createOpenApiBuilder` (path params, query params, request body, response schema changes)
+- Mongoose schema changes that affect the public shape: added/removed fields, type changes, required/enum/default changes, `description` updates, ref changes
+- Changes to auth routes (e.g. `addAuthRoutes`, `addMeRoutes`, GitHub OAuth, Better Auth)
+- Edits to `@terreno/api` files that produce the OpenAPI spec (`openApi.ts`, `openApiBuilder.ts`, `api.ts`, `populate.ts`)
+- User asks: "regenerate SDK", "update the SDK", "run bun run sdk", "openApiSdk.ts is out of date"
+
+If the change is purely backend-internal (logging, refactor that doesn't alter routes/models, test-only edits), the SDK does **not** need regeneration — skip this skill.
+
+## Prerequisites
+
+- Bun is on PATH (run `bun` directly; do not modify PATH)
+- MongoDB reachable at `mongodb://localhost:27017` (the example backend connects on boot)
+- Ports 4000 (backend) must be free
+
+If MongoDB is not running, tell the user and stop — do not try to install or start it automatically.
+
+## Procedure
+
+Run the steps in order. Stop and report on the first failure.
+
+### 1. Verify the worktree is bootstrapped
+
+Detect whether dependencies are installed. The repo uses Bun workspaces, so a single root `node_modules` is sufficient.
+
+```bash
+test -d node_modules && test -d example-backend/node_modules && test -d example-frontend/node_modules && echo "installed" || echo "missing"
+```
+
+If `missing`, run the full bootstrap from the repo root. This installs deps **and** compiles every workspace package (needed because `example-frontend` imports built artifacts from `@terreno/rtk` and other workspaces):
+
+```bash
+bun run bootstrap
+```
+
+Bootstrap can take a few minutes — run it in the background and wait for it to finish before continuing.
+
+### 2. Ensure backend env vars are set
+
+The backend reads `example-backend/.env`. If that file is missing, copy the example:
+
+```bash
+test -f example-backend/.env || cp example-backend/.env.example example-backend/.env
+```
+
+The default `.env.example` values are fine for local SDK generation. Do not invent secrets or overwrite an existing `.env`.
+
+### 3. Start the example backend on port 4000
+
+The dev script watches files, which is fine for a one-shot codegen run. Start it in the background from the repo root:
+
+```bash
+bun run backend:dev
+```
+
+Use the Bash tool's `run_in_background: true` so the process keeps running while you continue.
+
+### 4. Wait for the OpenAPI spec to be served
+
+Poll `http://localhost:4000/openapi.json` until it returns HTTP 200. The backend has to connect to MongoDB and register all routes before the spec is available, which can take 5–20 seconds on a cold start. Do not skip this wait — running `bun run sdk` before the spec is ready produces an empty/broken `openApiSdk.ts`.
+
+```bash
+until curl -sf -o /dev/null -w "%{http_code}" http://localhost:4000/openapi.json | grep -q 200; do sleep 2; done
+```
+
+If the backend logs an error (Mongo connection refused, port already in use, compile error), stop and surface the error to the user. Do not retry blindly.
+
+### 5. Generate the SDK
+
+Run the codegen from `example-frontend`. The script also runs Biome formatting on the output and strips an empty re-export line, so no follow-up formatting is needed.
+
+```bash
+cd example-frontend && bun run sdk
+```
+
+If the script fails with a missing module error (e.g. `@rtk-query/codegen-openapi`), dependencies are stale — re-run `bun run bootstrap` from the repo root and try again.
+
+### 6. Stop the backend
+
+Kill the background backend process you started in step 3. Use the PID from the background shell, or:
+
+```bash
+pkill -f "example-backend.*src/index.ts" || true
+```
+
+### 7. Verify and report
+
+Confirm `example-frontend/store/openApiSdk.ts` exists and was modified. Show the user a short summary:
+
+- Which routes/models triggered the regeneration
+- A `git diff --stat example-frontend/store/openApiSdk.ts` to show the size of the change
+- Any warnings or errors emitted by the backend or codegen
+
+Do **not** commit `openApiSdk.ts` automatically — leave that to the user's normal commit flow.
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `ECONNREFUSED 127.0.0.1:27017` | MongoDB not running | Ask the user to start Mongo; do not auto-start |
+| `EADDRINUSE :::4000` | Stale backend process | `pkill -f "example-backend.*src/index.ts"` then retry |
+| `Cannot find module '@rtk-query/codegen-openapi'` | Missing/stale deps | Re-run `bun run bootstrap` |
+| `openApiSdk.ts` has no endpoints | Backend wasn't ready when codegen ran | Step 4 wait was skipped — start over with a proper poll |
+| Codegen errors on `$ref` | Backend OpenAPI spec is malformed | Inspect `/openapi.json` manually; check recent changes to `openApi.ts` or model schemas |
+
+## Notes
+
+- The codegen config lives at `example-frontend/openapi-config.ts`. The schema URL respects `OPENAPI_URL` if set, otherwise defaults to `http://localhost:4000/openapi.json`.
+- The script entry point is `example-frontend/scripts/generate-sdk.ts` — it shells out to the `@rtk-query/codegen-openapi` CLI, then post-processes the output with Biome.
+- Custom endpoints and cache tag types are layered on top in `example-frontend/store/sdk.ts` via `injectEndpoints`/`enhanceEndpoints`; that file is hand-maintained and is **not** overwritten by codegen.

--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -1,6 +1,6 @@
 ---
 root: true
-targets: ["cursor", "windsurf", "copilot"]
+targets: ["cursor", "windsurf", "copilot", "claudecode"]
 description: "Terreno monorepo root guidelines"
 globs: ["**/*"]
 ---

--- a/.rulesync/skills/generate-sdk/SKILL.md
+++ b/.rulesync/skills/generate-sdk/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: generate-sdk
+description: >-
+  Regenerate the example-frontend RTK Query SDK (store/openApiSdk.ts) from the
+  example-backend's OpenAPI spec. Handles dependency install, backend startup,
+  SDK codegen, and cleanup from a fresh checkout. Use whenever the backend's API
+  surface changes — new modelRouter routes, custom routes registered via
+  createOpenApiBuilder, new/modified Mongoose models or field descriptions in
+  example-backend, changes to
+  permissions/queryFields/populatePaths/responseHandler, edits to @terreno/api
+  routing or OpenAPI generation, or any time a route is added/removed/renamed.
+  Also use when the user asks to "regenerate the SDK", "update openApiSdk.ts",
+  "run bun run sdk", or reports stale/missing generated hooks.
+targets:
+  - '*'
+---
+# Generate Frontend SDK
+
+The `example-frontend` consumes the `example-backend` API via auto-generated RTK Query hooks in `store/openApiSdk.ts`. The codegen pulls from the live backend at `http://localhost:4000/openapi.json`, so the backend must be running while `bun run sdk` executes.
+
+**Never edit `example-frontend/store/openApiSdk.ts` by hand — it is fully overwritten by this skill.**
+
+## When to run this skill
+
+Run it whenever the backend's OpenAPI surface changes. Common triggers:
+
+- New or removed `modelRouter` registration
+- Edits to `permissions`, `queryFields`, `populatePaths`, `defaultQueryParams`, `sort`, `responseHandler`, or `openApiOverwrite` on an existing `modelRouter`
+- New custom routes built with `createOpenApiBuilder` (path params, query params, request body, response schema changes)
+- Mongoose schema changes that affect the public shape: added/removed fields, type changes, required/enum/default changes, `description` updates, ref changes
+- Changes to auth routes (e.g. `addAuthRoutes`, `addMeRoutes`, GitHub OAuth, Better Auth)
+- Edits to `@terreno/api` files that produce the OpenAPI spec (`openApi.ts`, `openApiBuilder.ts`, `api.ts`, `populate.ts`)
+- User asks: "regenerate SDK", "update the SDK", "run bun run sdk", "openApiSdk.ts is out of date"
+
+If the change is purely backend-internal (logging, refactor that doesn't alter routes/models, test-only edits), the SDK does **not** need regeneration — skip this skill.
+
+## Prerequisites
+
+- Bun is on PATH (run `bun` directly; do not modify PATH)
+- MongoDB reachable at `mongodb://localhost:27017` (the example backend connects on boot)
+- Ports 4000 (backend) must be free
+
+If MongoDB is not running, tell the user and stop — do not try to install or start it automatically.
+
+## Procedure
+
+Run the steps in order. Stop and report on the first failure.
+
+### 1. Verify the worktree is bootstrapped
+
+Detect whether dependencies are installed. The repo uses Bun workspaces, so a single root `node_modules` is sufficient.
+
+```bash
+test -d node_modules && test -d example-backend/node_modules && test -d example-frontend/node_modules && echo "installed" || echo "missing"
+```
+
+If `missing`, run the full bootstrap from the repo root. This installs deps **and** compiles every workspace package (needed because `example-frontend` imports built artifacts from `@terreno/rtk` and other workspaces):
+
+```bash
+bun run bootstrap
+```
+
+Bootstrap can take a few minutes — run it in the background and wait for it to finish before continuing.
+
+### 2. Ensure backend env vars are set
+
+The backend reads `example-backend/.env`. If that file is missing, copy the example:
+
+```bash
+test -f example-backend/.env || cp example-backend/.env.example example-backend/.env
+```
+
+The default `.env.example` values are fine for local SDK generation. Do not invent secrets or overwrite an existing `.env`.
+
+### 3. Start the example backend on port 4000
+
+The dev script watches files, which is fine for a one-shot codegen run. Start it in the background from the repo root:
+
+```bash
+bun run backend:dev
+```
+
+Use the Bash tool's `run_in_background: true` so the process keeps running while you continue.
+
+### 4. Wait for the OpenAPI spec to be served
+
+Poll `http://localhost:4000/openapi.json` until it returns HTTP 200. The backend has to connect to MongoDB and register all routes before the spec is available, which can take 5–20 seconds on a cold start. Do not skip this wait — running `bun run sdk` before the spec is ready produces an empty/broken `openApiSdk.ts`.
+
+```bash
+until curl -sf -o /dev/null -w "%{http_code}" http://localhost:4000/openapi.json | grep -q 200; do sleep 2; done
+```
+
+If the backend logs an error (Mongo connection refused, port already in use, compile error), stop and surface the error to the user. Do not retry blindly.
+
+### 5. Generate the SDK
+
+Run the codegen from `example-frontend`. The script also runs Biome formatting on the output and strips an empty re-export line, so no follow-up formatting is needed.
+
+```bash
+cd example-frontend && bun run sdk
+```
+
+If the script fails with a missing module error (e.g. `@rtk-query/codegen-openapi`), dependencies are stale — re-run `bun run bootstrap` from the repo root and try again.
+
+### 6. Stop the backend
+
+Kill the background backend process you started in step 3. Use the PID from the background shell, or:
+
+```bash
+pkill -f "example-backend.*src/index.ts" || true
+```
+
+### 7. Verify and report
+
+Confirm `example-frontend/store/openApiSdk.ts` exists and was modified. Show the user a short summary:
+
+- Which routes/models triggered the regeneration
+- A `git diff --stat example-frontend/store/openApiSdk.ts` to show the size of the change
+- Any warnings or errors emitted by the backend or codegen
+
+Do **not** commit `openApiSdk.ts` automatically — leave that to the user's normal commit flow.
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `ECONNREFUSED 127.0.0.1:27017` | MongoDB not running | Ask the user to start Mongo; do not auto-start |
+| `EADDRINUSE :::4000` | Stale backend process | `pkill -f "example-backend.*src/index.ts"` then retry |
+| `Cannot find module '@rtk-query/codegen-openapi'` | Missing/stale deps | Re-run `bun run bootstrap` |
+| `openApiSdk.ts` has no endpoints | Backend wasn't ready when codegen ran | Step 4 wait was skipped — start over with a proper poll |
+| Codegen errors on `$ref` | Backend OpenAPI spec is malformed | Inspect `/openapi.json` manually; check recent changes to `openApi.ts` or model schemas |
+
+## Notes
+
+- The codegen config lives at `example-frontend/openapi-config.ts`. The schema URL respects `OPENAPI_URL` if set, otherwise defaults to `http://localhost:4000/openapi.json`.
+- The script entry point is `example-frontend/scripts/generate-sdk.ts` — it shells out to the `@rtk-query/codegen-openapi` CLI, then post-processes the output with Biome.
+- Custom endpoints and cache tag types are layered on top in `example-frontend/store/sdk.ts` via `injectEndpoints`/`enhanceEndpoints`; that file is hand-maintained and is **not** overwritten by codegen.

--- a/.windsurf/rules/admin-backend/00-admin-backend.md
+++ b/.windsurf/rules/admin-backend/00-admin-backend.md
@@ -1,3 +1,7 @@
+---
+title: '@terreno/admin-backend - Admin panel backend plugin for @terreno/api'
+trigger: always_on
+---
 # @terreno/admin-backend
 
 Admin panel backend plugin for @terreno/api that auto-generates admin CRUD endpoints for Mongoose models. This is a **backend-only** package — no React, no UI components, no frontend code.

--- a/.windsurf/rules/admin-frontend/00-admin-frontend.md
+++ b/.windsurf/rules/admin-frontend/00-admin-frontend.md
@@ -1,3 +1,9 @@
+---
+title: >-
+  @terreno/admin-frontend - Admin panel frontend screens for @terreno/api
+  backends
+trigger: always_on
+---
 # @terreno/admin-frontend
 
 Admin panel frontend screens for @terreno/api backends. Provides reusable React Native components for building admin interfaces with CRUD operations. This is a **frontend-only** package — no Express, no Mongoose, no backend code.

--- a/.windsurf/rules/ai/00-ai.md
+++ b/.windsurf/rules/ai/00-ai.md
@@ -1,0 +1,225 @@
+---
+title: '@terreno/ai - AI service layer for Terreno apps'
+trigger: always_on
+---
+# @terreno/ai
+
+AI service layer for Terreno apps providing GPT chat, request logging, and admin tools. Provider-agnostic via Vercel AI SDK. This is a **backend-only** package — no React, no UI components, no frontend code.
+
+## Commands
+
+```bash
+bun run compile          # Compile TypeScript
+bun run dev              # Watch mode
+bun run test             # Run tests
+bun run lint             # Lint code
+bun run lint:fix         # Fix lint issues
+```
+
+## Architecture
+
+### File Structure
+
+```
+src/
+  index.ts               # All package exports
+  models/
+    aiRequest.ts         # AI request logging model
+    gptHistory.ts        # Conversation history model
+    index.ts             # Model exports
+  routes/
+    gpt.ts               # GPT chat streaming and remix endpoints
+    gptHistories.ts      # GPT history CRUD via modelRouter
+    aiRequestsExplorer.ts # Admin-only AI request explorer
+    index.ts             # Route exports
+  service/
+    aiService.ts         # Provider-agnostic AI service class
+    prompts.ts           # System prompt constants
+    index.ts             # Service exports
+  types/
+    index.ts             # All type definitions
+  tests/
+    bunSetup.ts          # Test environment setup
+```
+
+## AIService
+
+Provider-agnostic AI service using Vercel AI SDK's `LanguageModel` interface. Consuming apps provide their own model instance.
+
+### Usage
+
+```typescript
+import {AIService} from "@terreno/ai";
+import {google} from "@ai-sdk/google";
+
+const aiService = new AIService({
+  model: google("gemini-2.5-flash"),
+  defaultTemperature: 1.0,  // optional
+});
+```
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `generateText(options)` | Generate text (non-streaming) |
+| `generateTextStream(options)` | Stream text chunks (AsyncGenerator) |
+| `generateRemix({text, userId?})` | Reword text naturally |
+| `generateSummary({text, userId?})` | Summarize text |
+| `translateText({text, targetLanguage, sourceLanguage?, userId?})` | Translate text |
+| `generateChatStream({messages, systemPrompt?, userId?})` | Stream chat response |
+
+All methods automatically log requests to the AIRequest model.
+
+### Temperature Presets
+
+```typescript
+import {TemperaturePresets} from "@terreno/ai";
+
+TemperaturePresets.DETERMINISTIC  // 0
+TemperaturePresets.LOW            // 0.3
+TemperaturePresets.BALANCED       // 0.7
+TemperaturePresets.DEFAULT        // 1.0
+TemperaturePresets.HIGH           // 1.5
+TemperaturePresets.MAXIMUM        // 2.0
+```
+
+## Models
+
+### AIRequest
+
+Logs all AI requests with metrics for monitoring and debugging.
+
+```typescript
+// Fields
+aiModel: string          // Model identifier (e.g., "gemini-2.5-flash")
+prompt: string           // Input prompt
+requestType: "general" | "remix" | "summarization" | "translation"
+response?: string        // AI response text
+responseTime?: number    // Response time in ms
+tokensUsed?: number      // Total tokens consumed
+userId?: ObjectId        // User who made the request
+error?: string           // Error message if failed
+metadata?: Mixed         // Additional data
+
+// Static method
+await AIRequest.logRequest({aiModel, prompt, requestType, ...});
+```
+
+Plugins: `createdUpdatedPlugin`, `isDeletedPlugin`, `findOneOrNone`, `findExactlyOne`
+
+### GptHistory
+
+Persists conversation history with auto-generated titles.
+
+```typescript
+// Fields
+title?: string                    // Auto-generated from first assistant response
+userId: ObjectId                  // Owner (required)
+prompts: Array<{                  // Conversation messages
+  text: string,
+  type: "user" | "assistant" | "system",
+  model?: string
+}>
+
+// Virtual
+ownerId                           // Alias for userId (Permissions.IsOwner compatibility)
+```
+
+Pre-save hook auto-generates title from first assistant response (first 50 chars).
+
+## Routes
+
+### addGptRoutes(router, options)
+
+```typescript
+import {addGptRoutes} from "@terreno/ai";
+
+addGptRoutes(router, {aiService, openApiOptions: options});
+```
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/gpt/prompt` | POST | SSE streaming chat with history persistence |
+| `/gpt/remix` | POST | Non-streaming text remix |
+
+Both require authentication. `/gpt/prompt` accepts `{prompt, historyId?, systemPrompt?}` and streams via Server-Sent Events.
+
+### addGptHistoryRoutes(router, options)
+
+Standard modelRouter CRUD at `/gpt/histories`:
+- **Create/List**: `IsAuthenticated`
+- **Read/Update/Delete**: `IsOwner`
+- Query filtered by `userId`
+- Sorted by `-updated`
+
+### addAiRequestsExplorerRoutes(router, options)
+
+Admin-only endpoint at `GET /aiRequestsExplorer`:
+- Paginated with `?page=1&limit=20`
+- Filters: `requestType`, `model`, `startDate`, `endDate`
+- Aggregation pipeline with user lookup
+- Returns `{data, total, page, limit, more}`
+
+## Integration
+
+Consuming apps wire up routes in their `setupServer` call:
+
+```typescript
+import {AIService, addGptRoutes, addGptHistoryRoutes, addAiRequestsExplorerRoutes} from "@terreno/ai";
+import {google} from "@ai-sdk/google";
+
+const aiService = new AIService({model: google("gemini-2.5-flash")});
+
+setupServer({
+  addRoutes: (router, options) => {
+    addGptHistoryRoutes(router, options);
+    addGptRoutes(router, {aiService, openApiOptions: options});
+    addAiRequestsExplorerRoutes(router, {openApiOptions: options});
+  },
+});
+```
+
+## Conventions
+
+- Uses `aiModel` field name (not `model`) to avoid Mongoose internal property conflicts
+- GptHistory uses `userId` field with `ownerId` virtual for `Permissions.IsOwner` compatibility
+- Custom query filter `(user) => ({userId: user?.id})` instead of `OwnerQueryFilter`
+- All AI calls are logged via private `logRequest()` — logging failures never break the main flow
+- Express user accessed via `(req as any).user` casting pattern
+- Error handling: `throw new APIError({status: 400, title: "..."})` — check conditions early
+
+## Testing
+
+- Framework: bun test with expect
+- HTTP testing: supertest
+- Mock AI model: Create mock with `doGenerate`/`doStream` methods returning `ReadableStream`
+- Test DB: `mongodb://127.0.0.1/terreno-ai-test`
+- Preload: `./src/tests/bunSetup.ts` (MongoDB connection, log silencing, Sentry mock)
+- **Never mock @terreno/api or models** — test against real functionality
+
+### Mock Model Pattern
+
+```typescript
+const createMockModel = () => ({
+  doGenerate: mock(async () => ({
+    finishReason: "stop" as const,
+    rawCall: {rawPrompt: "", rawSettings: {}},
+    text: "response text",
+    usage: {completionTokens: 10, promptTokens: 5},
+  })),
+  doStream: mock(async () => ({
+    rawCall: {rawPrompt: "", rawSettings: {}},
+    stream: new ReadableStream({
+      start(controller) {
+        controller.enqueue({type: "text-delta" as const, textDelta: "chunk "});
+        controller.enqueue({type: "finish" as const, finishReason: "stop" as const, usage: {completionTokens: 10, promptTokens: 5}});
+        controller.close();
+      },
+    }),
+  })),
+  modelId: "mock-model",
+  provider: "mock-provider",
+  specificationVersion: "v1" as const,
+});
+```

--- a/.windsurf/rules/api/00-api.md
+++ b/.windsurf/rules/api/00-api.md
@@ -1,3 +1,7 @@
+---
+title: '@terreno/api - Express/Mongoose REST API framework'
+trigger: always_on
+---
 # @terreno/api
 
 Express/Mongoose REST API framework styled after Django REST Framework. This is a **backend-only** package — no React, no UI components, no frontend code.

--- a/.windsurf/rules/api/01-model-field-descriptions.md
+++ b/.windsurf/rules/api/01-model-field-descriptions.md
@@ -1,3 +1,7 @@
+---
+title: Require description on all Mongoose model fields
+trigger: always_on
+---
 # Model Field Descriptions
 
 Every field in a Mongoose schema **must** have a `description` property. Descriptions flow through to the OpenAPI spec via `mongoose-to-swagger`, making the generated API documentation and SDK more useful.

--- a/.windsurf/rules/demo/00-demo.md
+++ b/.windsurf/rules/demo/00-demo.md
@@ -1,3 +1,7 @@
+---
+title: terreno-demo - Interactive showcase for @terreno/ui components
+trigger: always_on
+---
 # terreno-demo
 
 Interactive demo app for developing, testing, and showcasing @terreno/ui components. Built with Expo Router. This is a **frontend-only** app — no backend, no API integration.

--- a/.windsurf/rules/example-backend/00-example-backend.md
+++ b/.windsurf/rules/example-backend/00-example-backend.md
@@ -1,3 +1,7 @@
+---
+title: example-backend - Express backend demonstrating @terreno/api usage
+trigger: always_on
+---
 # example-backend
 
 Example Express backend demonstrating @terreno/api usage with Mongoose models, permissions, and OpenAPI generation. This is a **backend-only** app — no React, no UI components, no frontend code.

--- a/.windsurf/rules/example-frontend/00-example-frontend.md
+++ b/.windsurf/rules/example-frontend/00-example-frontend.md
@@ -1,3 +1,7 @@
+---
+title: example-frontend - Expo app demonstrating full-stack Terreno usage
+trigger: always_on
+---
 # example-frontend
 
 Example Expo app demonstrating full-stack usage with @terreno/api backend, @terreno/rtk for state, and @terreno/ui for components. This is a **frontend-only** app — no Express, no Mongoose, no backend code.

--- a/.windsurf/rules/mcp-server/00-mcp-server.md
+++ b/.windsurf/rules/mcp-server/00-mcp-server.md
@@ -1,3 +1,7 @@
+---
+title: '@terreno/mcp-server - MCP server for AI assistant integration'
+trigger: always_on
+---
 # @terreno/mcp-server
 
 Model Context Protocol (MCP) server that provides tools, prompts, and resources for AI coding assistants to generate Terreno-compatible code. Built with Express and JSON-RPC 2.0.

--- a/.windsurf/rules/rtk/00-rtk.md
+++ b/.windsurf/rules/rtk/00-rtk.md
@@ -1,3 +1,7 @@
+---
+title: '@terreno/rtk - Redux Toolkit Query utilities for Terreno frontends'
+trigger: always_on
+---
 # @terreno/rtk
 
 Redux Toolkit Query utilities for frontends connecting to @terreno/api backends. Provides JWT authentication, token management, SDK code generation support, and Socket.io integration. This is a **frontend state management** package — no Express, no Mongoose, no backend code.

--- a/.windsurf/rules/ui/00-ui.md
+++ b/.windsurf/rules/ui/00-ui.md
@@ -1,3 +1,7 @@
+---
+title: '@terreno/ui - React Native component library'
+trigger: always_on
+---
 # @terreno/ui
 
 React Native UI component library with 90+ components and a three-layer theming system. This is a **frontend-only** package — no Express, no Mongoose, no backend code.

--- a/.windsurf/skills/generate-sdk/SKILL.md
+++ b/.windsurf/skills/generate-sdk/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: generate-sdk
+description: >-
+  Regenerate the example-frontend RTK Query SDK (store/openApiSdk.ts) from the
+  example-backend's OpenAPI spec. Handles dependency install, backend startup,
+  SDK codegen, and cleanup from a fresh checkout. Use whenever the backend's API
+  surface changes — new modelRouter routes, custom routes registered via
+  createOpenApiBuilder, new/modified Mongoose models or field descriptions in
+  example-backend, changes to
+  permissions/queryFields/populatePaths/responseHandler, edits to @terreno/api
+  routing or OpenAPI generation, or any time a route is added/removed/renamed.
+  Also use when the user asks to "regenerate the SDK", "update openApiSdk.ts",
+  "run bun run sdk", or reports stale/missing generated hooks.
+---
+# Generate Frontend SDK
+
+The `example-frontend` consumes the `example-backend` API via auto-generated RTK Query hooks in `store/openApiSdk.ts`. The codegen pulls from the live backend at `http://localhost:4000/openapi.json`, so the backend must be running while `bun run sdk` executes.
+
+**Never edit `example-frontend/store/openApiSdk.ts` by hand — it is fully overwritten by this skill.**
+
+## When to run this skill
+
+Run it whenever the backend's OpenAPI surface changes. Common triggers:
+
+- New or removed `modelRouter` registration
+- Edits to `permissions`, `queryFields`, `populatePaths`, `defaultQueryParams`, `sort`, `responseHandler`, or `openApiOverwrite` on an existing `modelRouter`
+- New custom routes built with `createOpenApiBuilder` (path params, query params, request body, response schema changes)
+- Mongoose schema changes that affect the public shape: added/removed fields, type changes, required/enum/default changes, `description` updates, ref changes
+- Changes to auth routes (e.g. `addAuthRoutes`, `addMeRoutes`, GitHub OAuth, Better Auth)
+- Edits to `@terreno/api` files that produce the OpenAPI spec (`openApi.ts`, `openApiBuilder.ts`, `api.ts`, `populate.ts`)
+- User asks: "regenerate SDK", "update the SDK", "run bun run sdk", "openApiSdk.ts is out of date"
+
+If the change is purely backend-internal (logging, refactor that doesn't alter routes/models, test-only edits), the SDK does **not** need regeneration — skip this skill.
+
+## Prerequisites
+
+- Bun is on PATH (run `bun` directly; do not modify PATH)
+- MongoDB reachable at `mongodb://localhost:27017` (the example backend connects on boot)
+- Ports 4000 (backend) must be free
+
+If MongoDB is not running, tell the user and stop — do not try to install or start it automatically.
+
+## Procedure
+
+Run the steps in order. Stop and report on the first failure.
+
+### 1. Verify the worktree is bootstrapped
+
+Detect whether dependencies are installed. The repo uses Bun workspaces, so a single root `node_modules` is sufficient.
+
+```bash
+test -d node_modules && test -d example-backend/node_modules && test -d example-frontend/node_modules && echo "installed" || echo "missing"
+```
+
+If `missing`, run the full bootstrap from the repo root. This installs deps **and** compiles every workspace package (needed because `example-frontend` imports built artifacts from `@terreno/rtk` and other workspaces):
+
+```bash
+bun run bootstrap
+```
+
+Bootstrap can take a few minutes — run it in the background and wait for it to finish before continuing.
+
+### 2. Ensure backend env vars are set
+
+The backend reads `example-backend/.env`. If that file is missing, copy the example:
+
+```bash
+test -f example-backend/.env || cp example-backend/.env.example example-backend/.env
+```
+
+The default `.env.example` values are fine for local SDK generation. Do not invent secrets or overwrite an existing `.env`.
+
+### 3. Start the example backend on port 4000
+
+The dev script watches files, which is fine for a one-shot codegen run. Start it in the background from the repo root:
+
+```bash
+bun run backend:dev
+```
+
+Use the Bash tool's `run_in_background: true` so the process keeps running while you continue.
+
+### 4. Wait for the OpenAPI spec to be served
+
+Poll `http://localhost:4000/openapi.json` until it returns HTTP 200. The backend has to connect to MongoDB and register all routes before the spec is available, which can take 5–20 seconds on a cold start. Do not skip this wait — running `bun run sdk` before the spec is ready produces an empty/broken `openApiSdk.ts`.
+
+```bash
+until curl -sf -o /dev/null -w "%{http_code}" http://localhost:4000/openapi.json | grep -q 200; do sleep 2; done
+```
+
+If the backend logs an error (Mongo connection refused, port already in use, compile error), stop and surface the error to the user. Do not retry blindly.
+
+### 5. Generate the SDK
+
+Run the codegen from `example-frontend`. The script also runs Biome formatting on the output and strips an empty re-export line, so no follow-up formatting is needed.
+
+```bash
+cd example-frontend && bun run sdk
+```
+
+If the script fails with a missing module error (e.g. `@rtk-query/codegen-openapi`), dependencies are stale — re-run `bun run bootstrap` from the repo root and try again.
+
+### 6. Stop the backend
+
+Kill the background backend process you started in step 3. Use the PID from the background shell, or:
+
+```bash
+pkill -f "example-backend.*src/index.ts" || true
+```
+
+### 7. Verify and report
+
+Confirm `example-frontend/store/openApiSdk.ts` exists and was modified. Show the user a short summary:
+
+- Which routes/models triggered the regeneration
+- A `git diff --stat example-frontend/store/openApiSdk.ts` to show the size of the change
+- Any warnings or errors emitted by the backend or codegen
+
+Do **not** commit `openApiSdk.ts` automatically — leave that to the user's normal commit flow.
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `ECONNREFUSED 127.0.0.1:27017` | MongoDB not running | Ask the user to start Mongo; do not auto-start |
+| `EADDRINUSE :::4000` | Stale backend process | `pkill -f "example-backend.*src/index.ts"` then retry |
+| `Cannot find module '@rtk-query/codegen-openapi'` | Missing/stale deps | Re-run `bun run bootstrap` |
+| `openApiSdk.ts` has no endpoints | Backend wasn't ready when codegen ran | Step 4 wait was skipped — start over with a proper poll |
+| Codegen errors on `$ref` | Backend OpenAPI spec is malformed | Inspect `/openapi.json` manually; check recent changes to `openApi.ts` or model schemas |
+
+## Notes
+
+- The codegen config lives at `example-frontend/openapi-config.ts`. The schema URL respects `OPENAPI_URL` if set, otherwise defaults to `http://localhost:4000/openapi.json`.
+- The script entry point is `example-frontend/scripts/generate-sdk.ts` — it shells out to the `@rtk-query/codegen-openapi` CLI, then post-processes the output with Biome.
+- Custom endpoints and cache tag types are layered on top in `example-frontend/store/sdk.ts` via `injectEndpoints`/`enhanceEndpoints`; that file is hand-maintained and is **not** overwritten by codegen.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,7 @@
+---
+title: Terreno monorepo root guidelines
+trigger: always_on
+---
 # Terreno
 
 A monorepo containing shared packages for building full-stack applications with React Native and Express/Mongoose.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,3 @@
----
-localRoot: true
-targets: ["claudecode"]
-description: "Terreno monorepo Claude Code guidelines"
-globs: ["**/*"]
----
-
 # Terreno
 
 A monorepo containing shared packages for building full-stack applications with React Native and Express/Mongoose.
@@ -16,6 +9,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
 - **admin-backend/** - Admin panel backend plugin for @terreno/api (`@terreno/admin-backend`)
 - **admin-frontend/** - Admin panel frontend screens for @terreno/api backends (`@terreno/admin-frontend`)
+- **mcp-server/** - MCP server for AI assistant integration (`@terreno/mcp-server`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
 - **example-backend/** - Example Express backend using @terreno/api
@@ -23,20 +17,6 @@ A monorepo containing shared packages for building full-stack applications with 
 ## Development
 
 Uses [Bun](https://bun.sh/) as the package manager.
-
-### Bootstrap
-
-Run these commands when setting up or updating the project:
-
-```bash
-bun run bootstrap        # Initial setup: install deps + compile all packages
-bun run bootstrap:update # Update after changes: install deps + recompile all packages
-```
-
-- **`bootstrap`**: Run when first cloning the repo or creating a new dev environment (e.g. a container image). Installs all dependencies and compiles every package.
-- **`bootstrap:update`**: Run when resuming work after pulling changes, switching branches, or when dependencies have changed. Reinstalls dependencies and recompiles to pick up any changes.
-
-### Common Commands
 
 ```bash
 bun install              # Install dependencies
@@ -54,6 +34,8 @@ bun run ui:test          # Test UI package
 bun run demo:start       # Start demo app
 bun run frontend:web     # Start frontend example
 bun run backend:dev      # Start backend example
+bun run mcp:build        # Build MCP server
+bun run mcp:start        # Start MCP server
 bun run admin-backend:compile   # Compile admin backend
 bun run admin-frontend:compile  # Compile admin frontend
 ```
@@ -170,6 +152,53 @@ import {
 } from "@terreno/api";
 ```
 
+#### modelRouter Usage
+
+```typescript
+import {modelRouter, modelRouterOptions, Permissions} from "@terreno/api";
+
+const router = modelRouter(YourModel, {
+  permissions: {
+    list: [Permissions.IsAuthenticated],
+    create: [Permissions.IsAuthenticated],
+    read: [Permissions.IsOwner],
+    update: [Permissions.IsOwner],
+    delete: [],  // Disabled
+  },
+  sort: "-created",
+  queryFields: ["_id", "type", "name"],
+});
+```
+
+#### Custom Routes
+
+For non-CRUD endpoints, use the OpenAPI builder:
+
+```typescript
+import {asyncHandler, authenticateMiddleware, createOpenApiBuilder} from "@terreno/api";
+
+router.get("/yourRoute/:id", [
+  authenticateMiddleware(),
+  createOpenApiBuilder(options)
+    .withTags(["yourTag"])
+    .withSummary("Brief summary")
+    .withPathParameter("id", {type: "string"})
+    .withResponse(200, {data: {type: "object"}})
+    .build(),
+], asyncHandler(async (req, res) => {
+  return res.json({data: result});
+}));
+```
+
+#### API Conventions
+
+- Throw `APIError` with appropriate status codes: `throw new APIError({status: 400, title: "Message"})`
+- Do not use `Model.findOne` - use `Model.findExactlyOne` or `Model.findOneOrThrow`
+- Define statics/methods by direct assignment: `schema.methods = {bar() {}}`
+- All model types live in `src/modelInterfaces.ts`
+- In routes: `req.user` is `UserDocument | undefined`
+- In @terreno/api callbacks: cast with `const user = u as unknown as UserDocument`
+
 ### @terreno/ui
 
 React Native component library with 88+ components:
@@ -194,6 +223,60 @@ import {
 } from "@terreno/ui";
 ```
 
+#### UI Component Examples
+
+Layout with Box:
+```typescript
+<Box direction="row" padding={4} gap={2} alignItems="center">
+  <Text>Content</Text>
+  <Button text="Action" />
+</Box>
+```
+
+Buttons:
+```typescript
+<Button
+  text="Submit"
+  variant="primary"  // 'primary' | 'secondary' | 'outline' | 'ghost'
+  onClick={handleSubmit}
+  loading={isLoading}
+  iconName="check"
+/>
+```
+
+Forms:
+```typescript
+<TextField
+  label="Email"
+  value={email}
+  onChangeText={setEmail}
+  error={emailError}
+  helperText="Enter a valid email"
+/>
+```
+
+Modals:
+```typescript
+<Modal
+  title="Confirm Action"
+  visible={isVisible}
+  primaryButtonText="Confirm"
+  secondaryButtonText="Cancel"
+  onDismiss={() => setIsVisible(false)}
+  onPrimaryAction={handleConfirm}
+>
+  <Text>Are you sure?</Text>
+</Modal>
+```
+
+#### UI Common Pitfalls
+
+- Don't use inline styles when theme values are available
+- Don't use raw `View`/`Text` when `Box`/@terreno/ui `Text` are available
+- Don't forget loading and error states
+- Don't use `style` prop when equivalent props exist (`padding`, `margin`)
+- Never modify `openApiSdk.ts` manually
+
 ### @terreno/rtk
 
 Redux Toolkit Query integration:
@@ -206,6 +289,31 @@ Key imports:
 ```typescript
 import {generateAuthSlice} from "@terreno/rtk";
 ```
+
+Always use generated SDK hooks - never use `axios` or `request` directly:
+
+```typescript
+// Correct
+import {useGetYourRouteQuery} from "@/store/openApiSdk";
+const {data, isLoading, error} = useGetYourRouteQuery({id: "value"});
+
+// Wrong - don't use axios directly
+// const result = await axios.get("/api/yourRoute/value");
+```
+
+## React Best Practices (Frontend Packages)
+
+- Use functional components with `React.FC` type
+- Import hooks directly: `import {useEffect, useMemo} from 'react'`
+- Always provide return types for functions
+- Add explanatory comment above each `useEffect`
+- Wrap callbacks in `useCallback`
+- Prefer const arrow functions
+- Use inline styles over `StyleSheet.create`
+- Use Luxon for date operations
+- Place static content and interfaces at beginning of file
+- Minimize `use client`, `useEffect`, and `setState`
+- Always support React-Native Web
 
 ## CI/CD Workflows
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,12 +6,12 @@
       "name": "@terreno/root",
       "devDependencies": {
         "@biomejs/biome": "catalog:",
-        "rulesync": "^5.9.0",
+        "rulesync": "^8.18.0",
       },
     },
     "admin-backend": {
       "name": "@terreno/admin-backend",
-      "version": "0.13.1",
+      "version": "0.13.3",
       "dependencies": {
         "@google-cloud/storage": "^7.15.0",
         "@terreno/api": "workspace:*",
@@ -36,7 +36,7 @@
     },
     "admin-frontend": {
       "name": "@terreno/admin-frontend",
-      "version": "0.13.0",
+      "version": "0.13.3",
       "dependencies": {
         "@terreno/ui": "workspace:*",
         "expo-router": "catalog:",
@@ -67,7 +67,7 @@
     },
     "ai": {
       "name": "@terreno/ai",
-      "version": "0.13.1",
+      "version": "0.13.3",
       "dependencies": {
         "@ai-sdk/mcp": "^1.0.21",
         "@google-cloud/storage": "^7.15.0",
@@ -100,7 +100,7 @@
     },
     "api": {
       "name": "@terreno/api",
-      "version": "0.13.1",
+      "version": "0.13.3",
       "dependencies": {
         "@sentry/bun": "^10.25.0",
         "@sentry/profiling-node": "^10.25.0",
@@ -170,7 +170,7 @@
     },
     "api-health": {
       "name": "@terreno/api-health",
-      "version": "0.13.1",
+      "version": "0.13.3",
       "dependencies": {
         "@terreno/api": "workspace:*",
         "express": "^5.2.1",
@@ -358,7 +358,7 @@
     },
     "feature-flags": {
       "name": "@terreno/feature-flags",
-      "version": "0.13.1",
+      "version": "0.13.3",
       "dependencies": {
         "@terreno/api": "workspace:*",
         "express": "^5.2.1",
@@ -398,7 +398,7 @@
     },
     "rtk": {
       "name": "@terreno/rtk",
-      "version": "0.13.0",
+      "version": "0.13.3",
       "dependencies": {
         "@better-auth/expo": "^1.2.8",
         "@react-native-async-storage/async-storage": "catalog:",
@@ -437,7 +437,7 @@
     },
     "ui": {
       "name": "@terreno/ui",
-      "version": "0.13.0",
+      "version": "0.13.3",
       "dependencies": {
         "@expo-google-fonts/nunito": "^0.4.2",
         "@expo-google-fonts/titillium-web": "^0.4.1",
@@ -1157,6 +1157,30 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
+    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
+
+    "@octokit/core": ["@octokit/core@7.0.6", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.3", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
+
+    "@octokit/graphql": ["@octokit/graphql@9.0.3", "", { "dependencies": { "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
+
+    "@octokit/plugin-request-log": ["@octokit/plugin-request-log@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q=="],
+
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
+
+    "@octokit/request": ["@octokit/request@10.0.9", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "content-type": "^2.0.0", "fast-content-type-parse": "^3.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-o8Bi3f608eyM+7BmBiUWxFsdjLb3/ym1cQek5LZOv9KkZcxRrHCPhhRzm6xjO6HVZ85ItD6+sTsjxo821SVa/A=="],
+
+    "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
+
+    "@octokit/rest": ["@octokit/rest@22.0.1", "", { "dependencies": { "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-request-log": "^6.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0" } }, "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw=="],
+
+    "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
     "@opencensus/core": ["@opencensus/core@0.1.0", "", { "dependencies": { "continuation-local-storage": "^3.2.1", "log-driver": "^1.2.7", "semver": "^7.0.0", "shimmer": "^1.2.0", "uuid": "^8.0.0" } }, "sha512-Bdbi5vi44a1fwyHNyKh6bwzuFZJeZJPhzdwogk/Kw5juoEeRGPworK1sgtB3loeR8cqLyi5us0mz9h0xqINiSQ=="],
 
     "@opencensus/propagation-stackdriver": ["@opencensus/propagation-stackdriver@0.1.0", "", { "dependencies": { "@opencensus/core": "^0.1.0", "hex2dec": "^1.0.1", "uuid": "^8.0.0" } }, "sha512-YLklu8jnnYKaJ8gUFz3rM0FVdsWXEJAMLzeeU4JRac6LI34raENy4kvRezZtNEFS5KthaJUsYg04sPc/Ag0w4w=="],
@@ -1753,7 +1777,7 @@
 
     "@urql/exchange-retry": ["@urql/exchange-retry@1.3.2", "", { "dependencies": { "@urql/core": "^5.1.2", "wonka": "^6.3.2" } }, "sha512-TQMCz2pFJMfpNxmSfX1VSfTjwUIFx/mL+p1bnfM1xjjdla7Z+KnGMW/EhFbpckp3LyWAH4PgOsMwOMnIN+MBFg=="],
 
-    "@valibot/to-json-schema": ["@valibot/to-json-schema@1.5.0", "", { "peerDependencies": { "valibot": "^1.2.0" } }, "sha512-GE7DmSr1C2UCWPiV0upRH6mv0cCPsqYGs819fb6srCS1tWhyXrkGGe+zxUiwzn/L1BOfADH4sNjY/YHCuP8phQ=="],
+    "@valibot/to-json-schema": ["@valibot/to-json-schema@1.6.0", "", { "peerDependencies": { "valibot": "^1.3.0" } }, "sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
 
@@ -1939,6 +1963,8 @@
 
     "batch": ["batch@0.6.1", "", {}, "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="],
 
+    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
+
     "better-auth": ["better-auth@1.5.5", "", { "dependencies": { "@better-auth/core": "1.5.5", "@better-auth/drizzle-adapter": "1.5.5", "@better-auth/kysely-adapter": "1.5.5", "@better-auth/memory-adapter": "1.5.5", "@better-auth/mongo-adapter": "1.5.5", "@better-auth/prisma-adapter": "1.5.5", "@better-auth/telemetry": "1.5.5", "@better-auth/utils": "0.3.1", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.2", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.11", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": ">=0.41.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-GpVPaV1eqr3mOovKfghJXXk6QvlcVeFbS3z+n+FPDid5rK/2PchnDtiaVCzWyXA9jH2KkirOfl+JhAUvnja0Eg=="],
 
     "better-call": ["better-call@1.3.2", "", { "dependencies": { "@better-auth/utils": "^0.3.1", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw=="],
@@ -2079,7 +2105,7 @@
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
-    "commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
 
@@ -2097,8 +2123,6 @@
 
     "connect-history-api-fallback": ["connect-history-api-fallback@2.0.0", "", {}, "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA=="],
 
-    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
-
     "console-log-level": ["console-log-level@1.4.1", "", {}, "sha512-VZzbIORbP+PPcN/gg3DXClTLPLg5Slwd5fL2MIc+o1qZ4BXBvWyc6QxPk6T/Mkr6IVjRpoAGf32XxP3ZWMVRcQ=="],
 
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
@@ -2114,6 +2138,8 @@
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "cookiejar": ["cookiejar@2.1.4", "", {}, "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="],
+
+    "cookies": ["cookies@0.9.1", "", { "dependencies": { "depd": "~2.0.0", "keygrip": "~1.1.0" } }, "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw=="],
 
     "copy-webpack-plugin": ["copy-webpack-plugin@10.2.4", "", { "dependencies": { "fast-glob": "^3.2.7", "glob-parent": "^6.0.1", "globby": "^12.0.2", "normalize-path": "^3.0.0", "schema-utils": "^4.0.0", "serialize-javascript": "^6.0.0" }, "peerDependencies": { "webpack": "^5.1.0" } }, "sha512-xFVltahqlsRcyyJqQbDY6EYTtyQZF9rf+JPjwHObLdPFMEISqkFkr7mFoVOC6BfYS/dNThyoQKvziugm+OnwBg=="],
 
@@ -2181,6 +2207,8 @@
 
     "decode-uri-component": ["decode-uri-component@0.2.2", "", {}, "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="],
 
+    "deep-equal": ["deep-equal@1.0.1", "", {}, "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw=="],
+
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
@@ -2200,6 +2228,8 @@
     "del": ["del@4.1.1", "", { "dependencies": { "@types/glob": "^7.1.1", "globby": "^6.1.0", "is-path-cwd": "^2.0.0", "is-path-in-cwd": "^2.0.0", "p-map": "^2.0.0", "pify": "^4.0.1", "rimraf": "^2.6.3" } }, "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "delegates": ["delegates@1.0.0", "", {}, "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="],
 
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
@@ -2261,7 +2291,7 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "effect": ["effect@3.19.14", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-3vwdq0zlvQOxXzXNKRIPKTqZNMyGCdaFUBfMPqpsyzZDre67kgC1EEHDV4EoQTovJ4w5fmJW756f86kkuz7WFA=="],
+    "effect": ["effect@3.20.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.313", "", {}, "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA=="],
 
@@ -2309,7 +2339,7 @@
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
-    "es-toolkit": ["es-toolkit@1.44.0", "", {}, "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg=="],
+    "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -2439,6 +2469,8 @@
 
     "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
+    "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
@@ -2457,7 +2489,7 @@
 
     "fast-xml-parser": ["fast-xml-parser@5.5.5", "", { "dependencies": { "fast-xml-builder": "^1.1.3", "path-expression-matcher": "^1.1.3", "strnum": "^2.1.2" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-NLY+V5NNbdmiEszx9n14mZBseJTC50bRq1VHsaxOmR72JDuZt+5J1Co+dC/4JPnyq+WrIHNM69r0sqf7BMb3Mg=="],
 
-    "fastmcp": ["fastmcp@3.28.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.24.3", "@standard-schema/spec": "^1.0.0", "execa": "^9.6.1", "file-type": "^21.1.1", "fuse.js": "^7.1.0", "mcp-proxy": "^5.12.5", "strict-event-emitter-types": "^2.0.0", "undici": "^7.16.0", "uri-templates": "^0.2.0", "xsschema": "0.4.0-beta.5", "yargs": "^18.0.0", "zod": "^4.1.13", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "jose": "^5.0.0" }, "optionalPeers": ["jose"], "bin": { "fastmcp": "dist/bin/fastmcp.js" } }, "sha512-/WPXZiTYUoghdfxLwWdUYxwF1B78waX6FFsq+nIyVUL8whnJ83KzO+s4XDJ886mRZnD5EoPrroEvWDTmCkdAdQ=="],
+    "fastmcp": ["fastmcp@3.34.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.24.3", "@standard-schema/spec": "^1.0.0", "execa": "^9.6.1", "file-type": "^21.1.1", "fuse.js": "^7.1.0", "hono": "^4.11.5", "mcp-proxy": "^6.4.0", "strict-event-emitter-types": "^2.0.0", "undici": "^7.16.0", "uri-templates": "^0.2.0", "xsschema": "^0.4.3", "yargs": "^18.0.0", "zod": "^4.1.13", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "jose": "^5.0.0" }, "optionalPeers": ["jose"], "bin": { "fastmcp": "dist/bin/fastmcp.js" } }, "sha512-xKOXjU+MK7OZy91BY3FS5aenSiclJBCRMaZtXb3HYaKZVFbq4qYvAlFu6xYI3UU1NGLtv+h8izoStnOQ1By0BA=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -2575,7 +2607,7 @@
 
     "global-prefix": ["global-prefix@3.0.0", "", { "dependencies": { "ini": "^1.3.5", "kind-of": "^6.0.2", "which": "^1.3.1" } }, "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg=="],
 
-    "globby": ["globby@16.1.0", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "fast-glob": "^3.3.3", "ignore": "^7.0.5", "is-path-inside": "^4.0.0", "slash": "^5.1.0", "unicorn-magic": "^0.4.0" } }, "sha512-+A4Hq7m7Ze592k9gZRy4gJ27DrXRNnC1vPjxTt1qQxEY8RxagBkBxivkCwg7FxSTG0iLLEMaUx13oOr0R2/qcQ=="],
+    "globby": ["globby@16.1.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "fast-glob": "^3.3.3", "ignore": "^7.0.5", "is-path-inside": "^4.0.0", "slash": "^5.1.0", "unicorn-magic": "^0.4.0" } }, "sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg=="],
 
     "google-auth-library": ["google-auth-library@9.15.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^6.1.1", "gcp-metadata": "^6.1.0", "gtoken": "^7.0.0", "jws": "^4.0.0" } }, "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng=="],
 
@@ -2639,6 +2671,8 @@
 
     "htmlparser2": ["htmlparser2@6.1.0", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.0.0", "domutils": "^2.5.2", "entities": "^2.0.0" } }, "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A=="],
 
+    "http-assert": ["http-assert@1.5.0", "", { "dependencies": { "deep-equal": "~1.0.1", "http-errors": "~1.8.0" } }, "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w=="],
+
     "http-deceiver": ["http-deceiver@1.2.7", "", {}, "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
@@ -2652,6 +2686,8 @@
     "http-proxy-middleware": ["http-proxy-middleware@2.0.9", "", { "dependencies": { "@types/http-proxy": "^1.17.8", "http-proxy": "^1.18.1", "is-glob": "^4.0.1", "is-plain-obj": "^3.0.0", "micromatch": "^4.0.2" }, "peerDependencies": { "@types/express": "^4.17.13" }, "optionalPeers": ["@types/express"] }, "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "human-readable-ids": ["human-readable-ids@1.0.4", "", { "dependencies": { "knuth-shuffle": "^1.0.0" } }, "sha512-h1zwThTims8A/SpqFGWyTx+jG1+WRMJaEeZgbtPGrIpj2AZjsOgy8Y+iNzJ0yAyN669Q6F02EK66WMWcst+2FA=="],
 
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
 
@@ -2803,6 +2839,8 @@
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
+    "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
+
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
@@ -2821,9 +2859,19 @@
 
     "kareem": ["kareem@2.6.3", "", {}, "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q=="],
 
+    "keygrip": ["keygrip@1.1.0", "", { "dependencies": { "tsscmp": "1.0.6" } }, "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ=="],
+
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
     "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "knuth-shuffle": ["knuth-shuffle@1.0.8", "", {}, "sha512-IdC4Hpp+mx53zTt6VAGsAtbGM0g4BV9fP8tTcviCosSwocHcRDw9uG5Rnv6wLWckF4r72qeXFoK9NkvV1gUJCQ=="],
+
+    "koa": ["koa@3.2.0", "", { "dependencies": { "accepts": "^1.3.8", "content-disposition": "~1.0.1", "content-type": "^1.0.5", "cookies": "~0.9.1", "delegates": "^1.0.0", "destroy": "^1.2.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "fresh": "~0.5.2", "http-assert": "^1.5.0", "http-errors": "^2.0.0", "koa-compose": "^4.1.0", "mime-types": "^3.0.1", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-TrM4/tnNY7uJ1aW55sIIa+dqBvc4V14WRIAlGcWat9wV5pRS9Wr5Zk2ZTjQP1jtfIHDoHiSbPuV08P0fUZo2pg=="],
+
+    "koa-compose": ["koa-compose@4.1.0", "", {}, "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw=="],
+
+    "koa-router": ["koa-router@14.0.0", "", { "dependencies": { "debug": "^4.4.1", "http-errors": "^2.0.0", "koa-compose": "^4.1.0", "path-to-regexp": "^8.2.0" } }, "sha512-Ue8f/PRsLLNm6b7y+eS6xkqvsG2xH11d2VB1HPcfdfW6p5736kCHf2pXaq8q9XPQ01x0Dk7V/P5Il9pe+tGTxA=="],
 
     "kuler": ["kuler@2.0.0", "", {}, "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="],
 
@@ -2945,7 +2993,7 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
-    "mcp-proxy": ["mcp-proxy@5.12.5", "", { "bin": { "mcp-proxy": "dist/bin/mcp-proxy.mjs" } }, "sha512-Vawdc8vi36fXxKCaDpluRvbGcmrUXJdvXcDhkh30HYsws8XqX2rWPBflZpavzeS+6SwijRFV7g+9ypQRJZlrEQ=="],
+    "mcp-proxy": ["mcp-proxy@6.5.0", "", { "dependencies": { "pipenet": "^1.3.0" }, "bin": { "mcp-proxy": "dist/bin/mcp-proxy.mjs" } }, "sha512-lYqbGxiMkEc/QOhCfU0cqtvm0f8Usaq3KDV/8/xOnSUTv9exiDG/xk8rAuYkE/PuzP4xIGtyoKDw7BKa8LHJYw=="],
 
     "md5.js": ["md5.js@1.3.5", "", { "dependencies": { "hash-base": "^3.0.0", "inherits": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg=="],
 
@@ -3234,6 +3282,8 @@
     "pinkie": ["pinkie@2.0.4", "", {}, "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg=="],
 
     "pinkie-promise": ["pinkie-promise@2.0.1", "", { "dependencies": { "pinkie": "^2.0.0" } }, "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw=="],
+
+    "pipenet": ["pipenet@1.4.2", "", { "dependencies": { "axios": "^1.7.3", "debug": "^4.3.6", "human-readable-ids": "^1.0.4", "koa": "^3.1.1", "koa-router": "^14.0.0", "pump": "^3.0.3", "tldjs": "^2.3.2", "yargs": "^18.0.0" }, "bin": { "pipenet": "dist/cli.js" } }, "sha512-mPPqygXr7ccwImeaa8zReY9GubH/1r+kBNfqPVfKREQ1s8bKE3XlOqBMONxJAW4d3ZBNGzP9AZp9Axnhi5uOyw=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 
@@ -3581,7 +3631,7 @@
 
     "rtl-detect": ["rtl-detect@1.1.2", "", {}, "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ=="],
 
-    "rulesync": ["rulesync@5.9.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@toon-format/toon": "2.1.0", "@valibot/to-json-schema": "1.5.0", "commander": "14.0.2", "consola": "3.4.2", "effect": "3.19.14", "es-toolkit": "1.44.0", "fastmcp": "3.28.0", "globby": "16.1.0", "gray-matter": "4.0.3", "js-yaml": "4.1.1", "jsonc-parser": "3.3.1", "smol-toml": "1.6.0", "sury": "11.0.0-alpha.4", "zod": "4.3.5" }, "bin": { "rulesync": "dist/index.js" } }, "sha512-97kyhoihhCVEk0eKu04aYxjThChHakz8JgvnniLdrFDjR02OX37m/7sSKotzeTfTqs9ME7HVdIJWoCE0a0d2/g=="],
+    "rulesync": ["rulesync@8.18.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@octokit/request-error": "7.1.0", "@octokit/rest": "22.0.1", "@toon-format/toon": "2.1.0", "@valibot/to-json-schema": "1.6.0", "commander": "14.0.3", "effect": "3.20.0", "es-toolkit": "1.45.1", "fastmcp": "3.34.0", "globby": "16.1.1", "gray-matter": "4.0.3", "js-yaml": "4.1.1", "jsonc-parser": "3.3.1", "smol-toml": "1.6.1", "sury": "10.0.4", "zod": "4.3.6" }, "bin": { "rulesync": "dist/cli/index.js" } }, "sha512-fyDWLB47HkpERiy74LjsXoY51RJdeofPMK80p5kFAFWxYAJAjDJS7xmP5L4ifgxJLigEA6oXY+kZp+lXQD16Yg=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
@@ -3671,7 +3721,7 @@
 
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
-    "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
+    "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
     "socket.io": ["socket.io@4.8.3", "", { "dependencies": { "accepts": "~1.3.4", "base64id": "~2.0.0", "cors": "~2.8.5", "debug": "~4.4.1", "engine.io": "~6.6.0", "socket.io-adapter": "~2.5.2", "socket.io-parser": "~4.2.4" } }, "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A=="],
 
@@ -3787,7 +3837,7 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "sury": ["sury@11.0.0-alpha.4", "", { "peerDependencies": { "rescript": "12.x" }, "optionalPeers": ["rescript"] }, "sha512-oeG/GJWZvQCKtGPpLbu0yCZudfr5LxycDo5kh7SJmKHDPCsEPJssIZL2Eb4Tl7g9aPEvIDuRrkS+L0pybsMEMA=="],
+    "sury": ["sury@10.0.4", "", { "peerDependencies": { "rescript": "11.x" }, "optionalPeers": ["rescript"] }, "sha512-dWKqOv+6D4AwGCjeKyaWr157RVBtvnPUp1I6RxReYD1dYuBl4k6oUd/t5INh1mBhUuAEC9SP+rZmIunCyNjXzQ=="],
 
     "svg-pathdata": ["svg-pathdata@6.0.3", "", {}, "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw=="],
 
@@ -3843,6 +3893,8 @@
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
+    "tldjs": ["tldjs@2.3.2", "", { "dependencies": { "punycode": "^2.0.0" } }, "sha512-EORDwFMSZKrHPUVDhejCMDeAovRS5d8jZKiqALFiPp3cjKjEldPkxBY39ZSx3c45awz3RpKwJD1cCgGxEfy8/A=="],
+
     "tmpl": ["tmpl@1.0.5", "", {}, "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="],
 
     "to-buffer": ["to-buffer@1.2.2", "", { "dependencies": { "isarray": "^2.0.5", "safe-buffer": "^5.2.1", "typed-array-buffer": "^1.0.3" } }, "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw=="],
@@ -3866,6 +3918,8 @@
     "tsc-watch": ["tsc-watch@7.2.0", "", { "dependencies": { "cross-spawn": "^7.0.6", "node-cleanup": "^2.1.2", "ps-tree": "^1.2.0", "string-argv": "^0.3.2" }, "peerDependencies": { "typescript": "*" }, "bin": { "tsc-watch": "dist/lib/tsc-watch.js" } }, "sha512-4gRFawQD1cVSaILvG7wl2x6NtteKbS2dGBMbL7Q6n1ldLIOKXCJUoEwUXdGuee4dp+zcnA6tukBBLz1lZrNI9w=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsscmp": ["tsscmp@1.0.6", "", {}, "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="],
 
     "type-detect": ["type-detect@4.0.8", "", {}, "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="],
 
@@ -3904,6 +3958,8 @@
     "unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
 
     "unique-string": ["unique-string@1.0.0", "", { "dependencies": { "crypto-random-string": "^1.0.0" } }, "sha512-ODgiYu03y5g76A1I9Gt0/chLCzQjvzDy7DsZGsLOE/1MrF6wriEskSncj1+/C58Xk/kPZDppSctDybCwOSaGAg=="],
+
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
@@ -4017,7 +4073,7 @@
 
     "xmlhttprequest-ssl": ["xmlhttprequest-ssl@2.1.2", "", {}, "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="],
 
-    "xsschema": ["xsschema@0.4.0-beta.5", "", { "peerDependencies": { "@valibot/to-json-schema": "^1.0.0", "arktype": "^2.1.20", "effect": "^3.16.0", "sury": "^10.0.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.5" }, "optionalPeers": ["@valibot/to-json-schema", "arktype", "effect", "sury", "zod", "zod-to-json-schema"] }, "sha512-73pYwf1hMy++7SnOkghJdgdPaGi+Y5I0SaO6rIlxb1ouV6tEyDbEcXP82kyr32KQVTlUbFj6qewi9eUVEiXm+g=="],
+    "xsschema": ["xsschema@0.4.4", "", { "peerDependencies": { "@valibot/to-json-schema": "^1.0.0", "arktype": "^2.1.20", "effect": "^3.16.0", "sury": "^10.0.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "optionalPeers": ["@valibot/to-json-schema", "arktype", "effect", "sury", "zod", "zod-to-json-schema"] }, "sha512-TMhbk8AhxO+YuDOn3rXBjGXQ+Vja3T13UPQkHx/FemhusaOzRfCSj2seykt0mdnFPsOtO9l3ANf4adcp+4NRGw=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
@@ -4146,6 +4202,8 @@
     "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@10.3.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.0" } }, "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA=="],
+
+    "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "@opentelemetry/exporter-logs-otlp-grpc/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.213.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/otlp-transformer": "0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MegxAP1/n09Ob2dQvY5NBDVjAFkZRuKtWKxYev1R2M8hrsgXzQGkaMgoEKeUOyQ0FUyYcO29UOnYdQWmWa0PXg=="],
 
@@ -4423,6 +4481,8 @@
 
     "htmlparser2/entities": ["entities@2.0.3", "", {}, "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="],
 
+    "http-assert/http-errors": ["http-errors@1.8.1", "", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": ">= 1.5.0 < 2", "toidentifier": "1.0.1" } }, "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g=="],
+
     "http-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "http-proxy-middleware/is-plain-obj": ["is-plain-obj@3.0.0", "", {}, "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA=="],
@@ -4442,6 +4502,12 @@
     "jest-util/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
+
+    "koa/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
+    "koa/fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
+    "koa-router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "lighthouse-logger/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -4519,6 +4585,8 @@
 
     "pdf-lib/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
+    "pipenet/yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
+
     "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "pkg-up/find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
@@ -4572,10 +4640,6 @@
     "ripemd160/hash-base": ["hash-base@3.1.2", "", { "dependencies": { "inherits": "^2.0.4", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.1" } }, "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
-
-    "rulesync/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "rulesync/zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
 
     "schema-utils/ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "^6.9.1" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
 
@@ -5055,6 +5119,10 @@
 
     "htmlparser2/domutils/dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
 
+    "http-assert/http-errors/depd": ["depd@1.1.2", "", {}, "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="],
+
+    "http-assert/http-errors/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
+
     "jest-diff/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
 
     "jest-diff/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
@@ -5064,6 +5132,10 @@
     "jest-matcher-utils/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
 
     "jest-matcher-utils/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "koa/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "koa/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -5133,6 +5205,12 @@
 
     "ora/strip-ansi/ansi-regex": ["ansi-regex@4.1.1", "", {}, "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="],
 
+    "pipenet/yargs/cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+
+    "pipenet/yargs/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "pipenet/yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+
     "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "pkg-up/find-up/locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
@@ -5158,10 +5236,6 @@
     "rimraf/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "ripemd160/hash-base/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
-
-    "rulesync/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
-
-    "rulesync/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "serve-index/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
@@ -5335,6 +5409,8 @@
 
     "jest-matcher-utils/pretty-format/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
 
+    "koa/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "log-symbols/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 
     "log-symbols/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
@@ -5360,6 +5436,14 @@
     "ora/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 
     "ora/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
+
+    "pipenet/yargs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "pipenet/yargs/cliui/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "pipenet/yargs/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "pipenet/yargs/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
@@ -5454,6 +5538,12 @@
     "node-html-parser/css-select/domutils/dom-serializer/entities": ["entities@2.0.3", "", {}, "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="],
 
     "ora/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
+
+    "pipenet/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "pipenet/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "pipenet/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",
-    "rulesync": "^5.9.0"
+    "rulesync": "^8.18.0"
   },
   "name": "@terreno/root",
   "overrides": {

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dyoshikawa/rulesync/refs/heads/main/config-schema.json",
-  "targets": ["cursor", "windsurf", "claudecode", "copilot"],
-  "features": ["rules"],
+  "targets": ["cursor", "windsurf", "claudecode", "copilot", "agentsskills"],
+  "features": ["rules", "skills"],
   "baseDirs": ["."],
   "delete": true,
   "verbose": false


### PR DESCRIPTION
## Summary

Upgrades rulesync from 5.9.1 to 8.18.0 and adds the `agentsskills` target so skills are synced to `.agents/skills/` where Codex and other agent tools can discover them. Also adds `skills` as a rulesync feature so the generate-sdk skill propagates to cursor, windsurf, and GitHub alongside the new agents location.

The upgrade to 8.x required fixing a `localRoot`/`root` rule configuration issue, and brought in new windsurf frontmatter format (title/trigger fields on all rules).

## Human Testing Steps
- [ ] Run `bun run rules` and confirm it exits cleanly with no errors
- [ ] Confirm `.agents/skills/generate-sdk/SKILL.md` exists and has the full skill content
- [ ] Run `bun run rules:check` after committing to confirm no drift

## Changes
- `rulesync.jsonc`: add `agentsskills` to targets, add `skills` to features
- `package.json` + `bun.lock`: upgrade rulesync from ^5.9.0 to ^8.18.0
- `.rulesync/skills/generate-sdk/SKILL.md`: source of truth for the generate-sdk skill (imported from `.claude/skills`)
- `.agents/skills/generate-sdk/SKILL.md`: generated output for Codex
- `.cursor/skills/`, `.windsurf/skills/`, `.github/skills/`: synced to other targets
- `.rulesync/rules/00-root.md`: add claudecode to root targets (required by rulesync 8.x for localRoot rules to work)
- `.rulesync/rules/01-claudecode-root.md`: restore Bootstrap section that had been manually edited into `CLAUDE.local.md` without updating the rulesync source
- `.windsurf/rules/*`, `AGENTS.md`: rulesync 8.x adds title/trigger frontmatter to windsurf rules
- `CLAUDE.md`: new file generated by rulesync 8.x for the claudecode root rule (alongside existing `CLAUDE.local.md`)

## Automated Tests
- Lint: passed
- Compile: passed
- rulesync generate: idempotent (re-running shows "all files up to date")

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades the repo’s rulesync tooling and regenerates a large set of synced rule/skill files, which can affect developer workflows and CI checks if the new version behaves differently.
> 
> **Overview**
> **Updates rulesync to v8.18.0** (via `package.json`/`bun.lock`) and adjusts `rulesync.jsonc` to sync both *rules* and *skills* while adding a new `agentsskills` target.
> 
> **Expands generated assistant metadata** by introducing `.agents/skills/generate-sdk/SKILL.md` and syncing the `generate-sdk` skill into `.cursor/skills/`, `.windsurf/skills/`, and `.github/skills/`.
> 
> Regenerates/updates a number of rules/instructions files (including new `CLAUDE.md` and updated WindSurf rule frontmatter) and tweaks `.rulesync` root targeting (adds `claudecode`) to satisfy v8 configuration expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e29f17fd35ce5c3a5732b42a62e3655a650be8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->