### PR TITLE
Align MCP server docs and tests with terreno_* names

### DIFF
--- a/.claude/rules/mcp-server/00-mcp-server.md
+++ b/.claude/rules/mcp-server/00-mcp-server.md
@@ -31,11 +31,14 @@ src/
 
 | Tool | Description |
 |------|-------------|
-| `generate_model` | Creates Mongoose schemas with Terreno conventions (plugins, types, methods/statics) |
-| `generate_route` | Creates modelRouter configurations with permission setup |
-| `generate_screen` | Creates React Native screens (list, detail, form, empty types) |
-| `generate_form_fields` | Generates form field components with validation |
-| `validate_model_schema` | Validates schemas against Terreno conventions |
+| `terreno_bootstrap_app` | Scaffold a new full-stack Terreno app (frontend, backend, rules, MCP) |
+| `terreno_bootstrap_ai_rules` | Scaffold AI assistant rules for Cursor, Claude Code, Copilot, etc. |
+| `terreno_generate_model` | Creates Mongoose schemas with Terreno conventions (plugins, types, methods/statics) |
+| `terreno_generate_route` | Creates modelRouter configurations with permission setup |
+| `terreno_generate_screen` | Creates React Native screens (list, detail, form, empty types) |
+| `terreno_generate_form_fields` | Generates form field components with validation |
+| `terreno_validate_model_schema` | Validates schemas against Terreno conventions |
+| `terreno_install_admin` | Generates admin panel integration files and instructions |
 
 Each tool returns generated code wrapped with file path instructions and additional setup steps.
 
@@ -43,11 +46,13 @@ Each tool returns generated code wrapped with file path instructions and additio
 
 | Prompt | Description |
 |--------|-------------|
-| `create_crud_feature` | Full CRUD generation: model + routes + screens |
-| `create_api_endpoint` | Custom API endpoint with OpenAPI docs |
-| `create_ui_component` | Reusable UI component (display, interactive, form, layout) |
-| `create_form_screen` | Form screen with validation |
-| `add_authentication` | Auth setup with feature selection |
+| `terreno_bootstrap` | Workflow for scaffolding a new Terreno application |
+| `terreno_create_crud_feature` | Full CRUD generation: model + routes + screens |
+| `terreno_create_api_endpoint` | Custom API endpoint with OpenAPI docs |
+| `terreno_create_ui_component` | Reusable UI component (display, interactive, form, layout) |
+| `terreno_create_form_screen` | Form screen with validation |
+| `terreno_add_authentication` | Auth setup with feature selection |
+| `terreno_migrate_to_terreno_app` | Migrate from setupServer to TerrenoApp pattern |
 | `terreno_style_guide` | Code style guide from project markdown |
 
 Prompts provide detailed requirements, example code patterns, and step-by-step setup instructions.
@@ -74,7 +79,7 @@ Resources are loaded from markdown files with dynamic path resolution.
 ```typescript
 // In src/tools.ts
 {
-  name: "my_tool",
+  name: "terreno_my_tool",
   description: "What it does",
   inputSchema: {
     type: "object",

--- a/.cursor/rules/mcp-server/00-mcp-server.mdc
+++ b/.cursor/rules/mcp-server/00-mcp-server.mdc
@@ -32,11 +32,14 @@ src/
 
 | Tool | Description |
 |------|-------------|
-| `generate_model` | Creates Mongoose schemas with Terreno conventions (plugins, types, methods/statics) |
-| `generate_route` | Creates modelRouter configurations with permission setup |
-| `generate_screen` | Creates React Native screens (list, detail, form, empty types) |
-| `generate_form_fields` | Generates form field components with validation |
-| `validate_model_schema` | Validates schemas against Terreno conventions |
+| `terreno_bootstrap_app` | Scaffold a new full-stack Terreno app (frontend, backend, rules, MCP) |
+| `terreno_bootstrap_ai_rules` | Scaffold AI assistant rules for Cursor, Claude Code, Copilot, etc. |
+| `terreno_generate_model` | Creates Mongoose schemas with Terreno conventions (plugins, types, methods/statics) |
+| `terreno_generate_route` | Creates modelRouter configurations with permission setup |
+| `terreno_generate_screen` | Creates React Native screens (list, detail, form, empty types) |
+| `terreno_generate_form_fields` | Generates form field components with validation |
+| `terreno_validate_model_schema` | Validates schemas against Terreno conventions |
+| `terreno_install_admin` | Generates admin panel integration files and instructions |
 
 Each tool returns generated code wrapped with file path instructions and additional setup steps.
 
@@ -44,11 +47,13 @@ Each tool returns generated code wrapped with file path instructions and additio
 
 | Prompt | Description |
 |--------|-------------|
-| `create_crud_feature` | Full CRUD generation: model + routes + screens |
-| `create_api_endpoint` | Custom API endpoint with OpenAPI docs |
-| `create_ui_component` | Reusable UI component (display, interactive, form, layout) |
-| `create_form_screen` | Form screen with validation |
-| `add_authentication` | Auth setup with feature selection |
+| `terreno_bootstrap` | Workflow for scaffolding a new Terreno application |
+| `terreno_create_crud_feature` | Full CRUD generation: model + routes + screens |
+| `terreno_create_api_endpoint` | Custom API endpoint with OpenAPI docs |
+| `terreno_create_ui_component` | Reusable UI component (display, interactive, form, layout) |
+| `terreno_create_form_screen` | Form screen with validation |
+| `terreno_add_authentication` | Auth setup with feature selection |
+| `terreno_migrate_to_terreno_app` | Migrate from setupServer to TerrenoApp pattern |
 | `terreno_style_guide` | Code style guide from project markdown |
 
 Prompts provide detailed requirements, example code patterns, and step-by-step setup instructions.
@@ -75,7 +80,7 @@ Resources are loaded from markdown files with dynamic path resolution.
 ```typescript
 // In src/tools.ts
 {
-  name: "my_tool",
+  name: "terreno_my_tool",
   description: "What it does",
   inputSchema: {
     type: "object",

--- a/.github/instructions/mcp-server/00-mcp-server.instructions.md
+++ b/.github/instructions/mcp-server/00-mcp-server.instructions.md
@@ -31,11 +31,14 @@ src/
 
 | Tool | Description |
 |------|-------------|
-| `generate_model` | Creates Mongoose schemas with Terreno conventions (plugins, types, methods/statics) |
-| `generate_route` | Creates modelRouter configurations with permission setup |
-| `generate_screen` | Creates React Native screens (list, detail, form, empty types) |
-| `generate_form_fields` | Generates form field components with validation |
-| `validate_model_schema` | Validates schemas against Terreno conventions |
+| `terreno_bootstrap_app` | Scaffold a new full-stack Terreno app (frontend, backend, rules, MCP) |
+| `terreno_bootstrap_ai_rules` | Scaffold AI assistant rules for Cursor, Claude Code, Copilot, etc. |
+| `terreno_generate_model` | Creates Mongoose schemas with Terreno conventions (plugins, types, methods/statics) |
+| `terreno_generate_route` | Creates modelRouter configurations with permission setup |
+| `terreno_generate_screen` | Creates React Native screens (list, detail, form, empty types) |
+| `terreno_generate_form_fields` | Generates form field components with validation |
+| `terreno_validate_model_schema` | Validates schemas against Terreno conventions |
+| `terreno_install_admin` | Generates admin panel integration files and instructions |
 
 Each tool returns generated code wrapped with file path instructions and additional setup steps.
 
@@ -43,11 +46,13 @@ Each tool returns generated code wrapped with file path instructions and additio
 
 | Prompt | Description |
 |--------|-------------|
-| `create_crud_feature` | Full CRUD generation: model + routes + screens |
-| `create_api_endpoint` | Custom API endpoint with OpenAPI docs |
-| `create_ui_component` | Reusable UI component (display, interactive, form, layout) |
-| `create_form_screen` | Form screen with validation |
-| `add_authentication` | Auth setup with feature selection |
+| `terreno_bootstrap` | Workflow for scaffolding a new Terreno application |
+| `terreno_create_crud_feature` | Full CRUD generation: model + routes + screens |
+| `terreno_create_api_endpoint` | Custom API endpoint with OpenAPI docs |
+| `terreno_create_ui_component` | Reusable UI component (display, interactive, form, layout) |
+| `terreno_create_form_screen` | Form screen with validation |
+| `terreno_add_authentication` | Auth setup with feature selection |
+| `terreno_migrate_to_terreno_app` | Migrate from setupServer to TerrenoApp pattern |
 | `terreno_style_guide` | Code style guide from project markdown |
 
 Prompts provide detailed requirements, example code patterns, and step-by-step setup instructions.
@@ -74,7 +79,7 @@ Resources are loaded from markdown files with dynamic path resolution.
 ```typescript
 // In src/tools.ts
 {
-  name: "my_tool",
+  name: "terreno_my_tool",
   description: "What it does",
   inputSchema: {
     type: "object",

--- a/.rulesync/rules/mcp-server/00-mcp-server.md
+++ b/.rulesync/rules/mcp-server/00-mcp-server.md
@@ -33,11 +33,14 @@ src/
 
 | Tool | Description |
 |------|-------------|
-| `generate_model` | Creates Mongoose schemas with Terreno conventions (plugins, types, methods/statics) |
-| `generate_route` | Creates modelRouter configurations with permission setup |
-| `generate_screen` | Creates React Native screens (list, detail, form, empty types) |
-| `generate_form_fields` | Generates form field components with validation |
-| `validate_model_schema` | Validates schemas against Terreno conventions |
+| `terreno_bootstrap_app` | Scaffold a new full-stack Terreno app (frontend, backend, rules, MCP) |
+| `terreno_bootstrap_ai_rules` | Scaffold AI assistant rules for Cursor, Claude Code, Copilot, etc. |
+| `terreno_generate_model` | Creates Mongoose schemas with Terreno conventions (plugins, types, methods/statics) |
+| `terreno_generate_route` | Creates modelRouter configurations with permission setup |
+| `terreno_generate_screen` | Creates React Native screens (list, detail, form, empty types) |
+| `terreno_generate_form_fields` | Generates form field components with validation |
+| `terreno_validate_model_schema` | Validates schemas against Terreno conventions |
+| `terreno_install_admin` | Generates admin panel integration files and instructions |
 
 Each tool returns generated code wrapped with file path instructions and additional setup steps.
 
@@ -45,11 +48,13 @@ Each tool returns generated code wrapped with file path instructions and additio
 
 | Prompt | Description |
 |--------|-------------|
-| `create_crud_feature` | Full CRUD generation: model + routes + screens |
-| `create_api_endpoint` | Custom API endpoint with OpenAPI docs |
-| `create_ui_component` | Reusable UI component (display, interactive, form, layout) |
-| `create_form_screen` | Form screen with validation |
-| `add_authentication` | Auth setup with feature selection |
+| `terreno_bootstrap` | Workflow for scaffolding a new Terreno application |
+| `terreno_create_crud_feature` | Full CRUD generation: model + routes + screens |
+| `terreno_create_api_endpoint` | Custom API endpoint with OpenAPI docs |
+| `terreno_create_ui_component` | Reusable UI component (display, interactive, form, layout) |
+| `terreno_create_form_screen` | Form screen with validation |
+| `terreno_add_authentication` | Auth setup with feature selection |
+| `terreno_migrate_to_terreno_app` | Migrate from setupServer to TerrenoApp pattern |
 | `terreno_style_guide` | Code style guide from project markdown |
 
 Prompts provide detailed requirements, example code patterns, and step-by-step setup instructions.
@@ -76,7 +81,7 @@ Resources are loaded from markdown files with dynamic path resolution.
 ```typescript
 // In src/tools.ts
 {
-  name: "my_tool",
+  name: "terreno_my_tool",
   description: "What it does",
   inputSchema: {
     type: "object",

--- a/.windsurf/rules/mcp-server/00-mcp-server.md
+++ b/.windsurf/rules/mcp-server/00-mcp-server.md
@@ -31,11 +31,14 @@ src/
 
 | Tool | Description |
 |------|-------------|
-| `generate_model` | Creates Mongoose schemas with Terreno conventions (plugins, types, methods/statics) |
-| `generate_route` | Creates modelRouter configurations with permission setup |
-| `generate_screen` | Creates React Native screens (list, detail, form, empty types) |
-| `generate_form_fields` | Generates form field components with validation |
-| `validate_model_schema` | Validates schemas against Terreno conventions |
+| `terreno_bootstrap_app` | Scaffold a new full-stack Terreno app (frontend, backend, rules, MCP) |
+| `terreno_bootstrap_ai_rules` | Scaffold AI assistant rules for Cursor, Claude Code, Copilot, etc. |
+| `terreno_generate_model` | Creates Mongoose schemas with Terreno conventions (plugins, types, methods/statics) |
+| `terreno_generate_route` | Creates modelRouter configurations with permission setup |
+| `terreno_generate_screen` | Creates React Native screens (list, detail, form, empty types) |
+| `terreno_generate_form_fields` | Generates form field components with validation |
+| `terreno_validate_model_schema` | Validates schemas against Terreno conventions |
+| `terreno_install_admin` | Generates admin panel integration files and instructions |
 
 Each tool returns generated code wrapped with file path instructions and additional setup steps.
 
@@ -43,11 +46,13 @@ Each tool returns generated code wrapped with file path instructions and additio
 
 | Prompt | Description |
 |--------|-------------|
-| `create_crud_feature` | Full CRUD generation: model + routes + screens |
-| `create_api_endpoint` | Custom API endpoint with OpenAPI docs |
-| `create_ui_component` | Reusable UI component (display, interactive, form, layout) |
-| `create_form_screen` | Form screen with validation |
-| `add_authentication` | Auth setup with feature selection |
+| `terreno_bootstrap` | Workflow for scaffolding a new Terreno application |
+| `terreno_create_crud_feature` | Full CRUD generation: model + routes + screens |
+| `terreno_create_api_endpoint` | Custom API endpoint with OpenAPI docs |
+| `terreno_create_ui_component` | Reusable UI component (display, interactive, form, layout) |
+| `terreno_create_form_screen` | Form screen with validation |
+| `terreno_add_authentication` | Auth setup with feature selection |
+| `terreno_migrate_to_terreno_app` | Migrate from setupServer to TerrenoApp pattern |
 | `terreno_style_guide` | Code style guide from project markdown |
 
 Prompts provide detailed requirements, example code patterns, and step-by-step setup instructions.
@@ -74,7 +79,7 @@ Resources are loaded from markdown files with dynamic path resolution.
 ```typescript
 // In src/tools.ts
 {
-  name: "my_tool",
+  name: "terreno_my_tool",
   description: "What it does",
   inputSchema: {
     type: "object",

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Most apps need the same foundational pieces: authentication, user management, CR
 
 ### The best way to build with AI
 
-Terreno is designed to be the best framework for AI-assisted app development. The [MCP server](#mcp-server) gives AI coding assistants deep knowledge of Terreno's conventions, enabling them to generate models, routes, screens, and full CRUD features that follow the framework's patterns exactly. The `bootstrap_app` tool can scaffold a complete, launchable app from a description — not a toy demo, but a real app with auth, data models, and screens ready to ship.
+Terreno is designed to be the best framework for AI-assisted app development. The [MCP server](#mcp-server) gives AI coding assistants deep knowledge of Terreno's conventions, enabling them to generate models, routes, screens, and full CRUD features that follow the framework's patterns exactly. The `terreno_bootstrap_app` tool can scaffold a complete, launchable app from a description — not a toy demo, but a real app with auth, data models, and screens ready to ship.
 
 ### Philosophy
 

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -97,7 +97,7 @@ Set `TERRENO_MCP_DOCS_DIR` environment variable to override default path.
 
 Code generation tools that return TypeScript/JavaScript code as text. **Tools do not write files** — the AI assistant receives the code and writes it to appropriate locations.
 
-### generate_model
+### terreno_generate_model
 
 Generate a Mongoose model with Terreno conventions (timestamps, soft delete, owner tracking, type definitions).
 
@@ -142,7 +142,7 @@ Generate a Mongoose model with Terreno conventions (timestamps, soft delete, own
 - Plugin configuration
 - Export statements
 
-### generate_route
+### terreno_generate_route
 
 Generate modelRouter configuration with permissions and query options.
 
@@ -192,7 +192,7 @@ Generate modelRouter configuration with permissions and query options.
 - Lifecycle hooks structure
 - Instructions for registering route
 
-### generate_screen
+### terreno_generate_screen
 
 Generate React Native screen component with Terreno UI components.
 
@@ -229,7 +229,7 @@ Generate React Native screen component with Terreno UI components.
 - @terreno/ui components (Box, Text, Button, Card, etc.)
 - Loading/error/empty states
 
-### generate_form_fields
+### terreno_generate_form_fields
 
 Generate form field components for a model.
 
@@ -266,7 +266,7 @@ Generate form field components for a model.
 - Validation logic structure
 - Form state management pattern
 
-### validate_model_schema
+### terreno_validate_model_schema
 
 Validate a Mongoose schema against Terreno conventions.
 
@@ -284,11 +284,53 @@ Validate a Mongoose schema against Terreno conventions.
 - Recommendations for fixes
 - Severity levels (error, warning, info)
 
+### terreno_bootstrap_app
+
+Scaffold a new full-stack Terreno application (Expo frontend, Express/Mongoose backend, Cursor rules, MCP settings).
+
+**Parameters:**
+
+``````typescript
+{
+  appName: string;           // kebab-case (e.g., "my-app")
+  appDisplayName: string;    // Human-readable name
+  description?: string;
+  mcpServerUrl?: string;     // Default: https://mcp.terreno.flourish.health
+}
+``````
+
+**Returns:** File list, setup instructions, and full file contents for backend, frontend, CI workflows, and MCP configuration.
+
+### terreno_bootstrap_ai_rules
+
+Scaffold AI coding assistant rules (AGENTS.md, Cursor/Windsurf rules, Copilot instructions, rulesync config).
+
+**Parameters:** Same as `terreno_bootstrap_app` (`appName`, `appDisplayName` required).
+
+**Returns:** Rules files and instructions for installing/syncing with rulesync.
+
+### terreno_install_admin
+
+Generate admin panel integration for `@terreno/admin-backend` and `@terreno/admin-frontend`.
+
+**Parameters:** Model configurations with `modelName`, `routePath`, `displayName`, `listFields`, etc.
+
+**Returns:** Frontend screen files and backend/frontend setup snippets.
+
 ## Prompts
 
 Multi-step workflow prompts that guide AI assistants through complex tasks.
 
-### create_crud_feature
+### terreno_bootstrap
+
+Workflow prompt for scaffolding a new Terreno app. Delegates to `terreno_bootstrap_app` and `terreno_bootstrap_ai_rules` tools.
+
+**Arguments:**
+
+- `appName` (string) — Application name in kebab-case
+- `appDisplayName` (string) — Human-readable display name
+
+### terreno_create_crud_feature
 
 Generate complete CRUD feature: backend model + routes + frontend screens.
 
@@ -310,7 +352,7 @@ Generate complete CRUD feature: backend model + routes + frontend screens.
    - Regenerating SDK: `bun run sdk`
    - Adding navigation
 
-### create_api_endpoint
+### terreno_create_api_endpoint
 
 Generate custom (non-CRUD) API endpoint with OpenAPI documentation.
 
@@ -328,7 +370,7 @@ Generate custom (non-CRUD) API endpoint with OpenAPI documentation.
 4. Provide authentication setup instructions
 5. Provide SDK regeneration instructions
 
-### create_ui_component
+### terreno_create_ui_component
 
 Generate reusable UI component following @terreno/ui patterns.
 
@@ -346,7 +388,7 @@ Generate reusable UI component following @terreno/ui patterns.
 4. Include usage example
 5. Provide testing setup
 
-### create_form_screen
+### terreno_create_form_screen
 
 Generate form screen with validation and error handling.
 
@@ -365,7 +407,7 @@ Generate form screen with validation and error handling.
 5. Add loading/error/success states
 6. Provide navigation setup
 
-### add_authentication
+### terreno_add_authentication
 
 Generate authentication setup for new projects.
 
@@ -383,6 +425,14 @@ Generate authentication setup for new projects.
 5. Generate signup screen
 6. Set up token storage
 7. Provide environment variable list
+
+### terreno_migrate_to_terreno_app
+
+Guide for migrating from `setupServer` to the `TerrenoApp` fluent API pattern.
+
+**Arguments:**
+
+- `serverFile` (string, optional) — Path to server file to migrate (e.g., `src/server.ts`)
 
 ### terreno_style_guide
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -18,21 +18,26 @@ Documentation resources accessible via MCP:
 
 Code generation tools:
 
-- `generate_model` - Generate a Mongoose model with proper Terreno conventions
-- `generate_route` - Generate a modelRouter route configuration
-- `generate_screen` - Generate a React Native screen component
-- `generate_form_fields` - Generate form field components
-- `validate_model_schema` - Validate a Mongoose schema follows conventions
+- `terreno_bootstrap_app` - Scaffold a new full-stack Terreno app (frontend, backend, rules, MCP)
+- `terreno_bootstrap_ai_rules` - Scaffold AI assistant rules files for Cursor, Claude Code, etc.
+- `terreno_generate_model` - Generate a Mongoose model with proper Terreno conventions
+- `terreno_generate_route` - Generate a modelRouter route configuration
+- `terreno_generate_screen` - Generate a React Native screen component
+- `terreno_generate_form_fields` - Generate form field components
+- `terreno_validate_model_schema` - Validate a Mongoose schema follows conventions
+- `terreno_install_admin` - Generate admin panel integration files and instructions
 
 ### Prompts
 
 Code generation prompts:
 
-- `create_crud_feature` - Generate complete CRUD feature (model, routes, screens)
-- `create_api_endpoint` - Generate custom API endpoint with OpenAPI docs
-- `create_ui_component` - Generate reusable UI component
-- `create_form_screen` - Generate form screen with validation
-- `add_authentication` - Generate authentication setup
+- `terreno_bootstrap` - Prompt workflow for scaffolding a new Terreno application
+- `terreno_create_crud_feature` - Generate complete CRUD feature (model, routes, screens)
+- `terreno_create_api_endpoint` - Generate custom API endpoint with OpenAPI docs
+- `terreno_create_ui_component` - Generate reusable UI component
+- `terreno_create_form_screen` - Generate form screen with validation
+- `terreno_add_authentication` - Generate authentication setup
+- `terreno_migrate_to_terreno_app` - Migrate from setupServer to TerrenoApp pattern
 - `terreno_style_guide` - Get the Terreno code style guide
 
 ## Installation
@@ -188,7 +193,7 @@ This design allows the AI assistant to:
 
 ```json
 {
-  "name": "generate_model",
+  "name": "terreno_generate_model",
   "arguments": {
     "name": "Product",
     "fields": [
@@ -208,7 +213,7 @@ The tool returns TypeScript code that should be written to `backend/src/models/p
 
 ```json
 {
-  "name": "generate_route",
+  "name": "terreno_generate_route",
   "arguments": {
     "modelName": "Product",
     "routePath": "/products",
@@ -232,7 +237,7 @@ The tool returns route configuration code that should be written to `backend/src
 
 ```json
 {
-  "name": "generate_screen",
+  "name": "terreno_generate_screen",
   "arguments": {
     "name": "ProductList",
     "type": "list",
@@ -249,7 +254,7 @@ The tool returns React Native screen code that should be written to `frontend/sr
 ### Create CRUD Feature
 
 ```
-Prompt: create_crud_feature
+Prompt: terreno_create_crud_feature
 Arguments:
   - name: "Product"
   - fields: "title:string,price:number,description:string,active:boolean"

--- a/mcp-server/src/__tests__/bootstrap.test.ts
+++ b/mcp-server/src/__tests__/bootstrap.test.ts
@@ -8,10 +8,10 @@ import {
 
 describe("bootstrap", () => {
   describe("bootstrapTools", () => {
-    test("should export bootstrap_app and bootstrap_ai_rules", () => {
+    test("should export terreno_bootstrap_app and terreno_bootstrap_ai_rules", () => {
       const names = bootstrapTools.map((t) => t.name);
-      expect(names).toContain("bootstrap_app");
-      expect(names).toContain("bootstrap_ai_rules");
+      expect(names).toContain("terreno_bootstrap_app");
+      expect(names).toContain("terreno_bootstrap_ai_rules");
     });
 
     test("should have valid input schema structure", () => {
@@ -24,13 +24,13 @@ describe("bootstrap", () => {
   });
 
   describe("bootstrapPrompts", () => {
-    test("should export bootstrap_terreno_app prompt", () => {
+    test("should export terreno_bootstrap prompt", () => {
       const names = bootstrapPrompts.map((p) => p.name);
-      expect(names).toContain("bootstrap_terreno_app");
+      expect(names).toContain("terreno_bootstrap");
     });
 
     test("should have required arguments", () => {
-      const prompt = bootstrapPrompts.find((p) => p.name === "bootstrap_terreno_app");
+      const prompt = bootstrapPrompts.find((p) => p.name === "terreno_bootstrap");
       expect(prompt).toBeDefined();
       const argNames = prompt?.arguments.map((a) => a.name);
       expect(argNames).toContain("appName");
@@ -38,9 +38,9 @@ describe("bootstrap", () => {
     });
   });
 
-  describe("handleBootstrapToolCall - bootstrap_app", () => {
+  describe("handleBootstrapToolCall - terreno_bootstrap_app", () => {
     test("should return error when appName is missing", () => {
-      const result = handleBootstrapToolCall("bootstrap_app", {
+      const result = handleBootstrapToolCall("terreno_bootstrap_app", {
         appDisplayName: "My App",
       });
       expect(result.content[0].text).toContain("Error");
@@ -48,14 +48,14 @@ describe("bootstrap", () => {
     });
 
     test("should return error when appDisplayName is missing", () => {
-      const result = handleBootstrapToolCall("bootstrap_app", {
+      const result = handleBootstrapToolCall("terreno_bootstrap_app", {
         appName: "my-app",
       });
       expect(result.content[0].text).toContain("Error");
     });
 
     test("should return all expected files with required args", () => {
-      const result = handleBootstrapToolCall("bootstrap_app", {
+      const result = handleBootstrapToolCall("terreno_bootstrap_app", {
         appDisplayName: "My App",
         appName: "my-app",
       });
@@ -113,7 +113,7 @@ describe("bootstrap", () => {
     });
 
     test("should include setup instructions", () => {
-      const result = handleBootstrapToolCall("bootstrap_app", {
+      const result = handleBootstrapToolCall("terreno_bootstrap_app", {
         appDisplayName: "Test App",
         appName: "test-app",
       });
@@ -130,7 +130,7 @@ describe("bootstrap", () => {
     });
 
     test("should use custom MCP server URL when provided", () => {
-      const result = handleBootstrapToolCall("bootstrap_app", {
+      const result = handleBootstrapToolCall("terreno_bootstrap_app", {
         appDisplayName: "Custom App",
         appName: "custom-app",
         mcpServerUrl: "https://custom.mcp.example.com",
@@ -139,7 +139,7 @@ describe("bootstrap", () => {
     });
 
     test("should use default MCP server URL when not provided", () => {
-      const result = handleBootstrapToolCall("bootstrap_app", {
+      const result = handleBootstrapToolCall("terreno_bootstrap_app", {
         appDisplayName: "Default App",
         appName: "default-app",
       });
@@ -147,7 +147,7 @@ describe("bootstrap", () => {
     });
 
     test("should include generated backend server code", () => {
-      const result = handleBootstrapToolCall("bootstrap_app", {
+      const result = handleBootstrapToolCall("terreno_bootstrap_app", {
         appDisplayName: "Code App",
         appName: "code-app",
       });
@@ -160,7 +160,7 @@ describe("bootstrap", () => {
     });
 
     test("should include generated frontend code", () => {
-      const result = handleBootstrapToolCall("bootstrap_app", {
+      const result = handleBootstrapToolCall("terreno_bootstrap_app", {
         appDisplayName: "FE App",
         appName: "fe-app",
       });
@@ -179,7 +179,7 @@ describe("bootstrap", () => {
     });
 
     test("should generate valid JSON in mcp.json settings", () => {
-      const result = handleBootstrapToolCall("bootstrap_app", {
+      const result = handleBootstrapToolCall("terreno_bootstrap_app", {
         appDisplayName: "JSON App",
         appName: "json-app",
       });
@@ -194,7 +194,7 @@ describe("bootstrap", () => {
     });
 
     test("should use app name in workflow files", () => {
-      const result = handleBootstrapToolCall("bootstrap_app", {
+      const result = handleBootstrapToolCall("terreno_bootstrap_app", {
         appDisplayName: "Workflow App",
         appName: "workflow-app",
       });
@@ -204,23 +204,23 @@ describe("bootstrap", () => {
     });
   });
 
-  describe("handleBootstrapToolCall - bootstrap_ai_rules", () => {
+  describe("handleBootstrapToolCall - terreno_bootstrap_ai_rules", () => {
     test("should return error when appName is missing", () => {
-      const result = handleBootstrapToolCall("bootstrap_ai_rules", {
+      const result = handleBootstrapToolCall("terreno_bootstrap_ai_rules", {
         appDisplayName: "My App",
       });
       expect(result.content[0].text).toContain("Error");
     });
 
     test("should return error when appDisplayName is missing", () => {
-      const result = handleBootstrapToolCall("bootstrap_ai_rules", {
+      const result = handleBootstrapToolCall("terreno_bootstrap_ai_rules", {
         appName: "my-app",
       });
       expect(result.content[0].text).toContain("Error");
     });
 
     test("should generate all AI rules files with required args", () => {
-      const result = handleBootstrapToolCall("bootstrap_ai_rules", {
+      const result = handleBootstrapToolCall("terreno_bootstrap_ai_rules", {
         appDisplayName: "Rules App",
         appName: "rules-app",
       });
@@ -237,7 +237,7 @@ describe("bootstrap", () => {
     });
 
     test("should include setup instructions for rulesync", () => {
-      const result = handleBootstrapToolCall("bootstrap_ai_rules", {
+      const result = handleBootstrapToolCall("terreno_bootstrap_ai_rules", {
         appDisplayName: "R App",
         appName: "r-app",
       });
@@ -246,7 +246,7 @@ describe("bootstrap", () => {
     });
 
     test("should strip frontmatter from backend/frontend AGENTS files", () => {
-      const result = handleBootstrapToolCall("bootstrap_ai_rules", {
+      const result = handleBootstrapToolCall("terreno_bootstrap_ai_rules", {
         appDisplayName: "Strip App",
         appName: "strip-app",
       });
@@ -273,7 +273,7 @@ describe("bootstrap", () => {
 
   describe("handleBootstrapPromptRequest", () => {
     test("should generate bootstrap prompt", () => {
-      const result = handleBootstrapPromptRequest("bootstrap_terreno_app", {
+      const result = handleBootstrapPromptRequest("terreno_bootstrap", {
         appDisplayName: "Prompt App",
         appName: "prompt-app",
       });
@@ -281,8 +281,8 @@ describe("bootstrap", () => {
 
       expect(text).toContain("prompt-app");
       expect(text).toContain("Prompt App");
-      expect(text).toContain("bootstrap_app");
-      expect(text).toContain("bootstrap_ai_rules");
+      expect(text).toContain("terreno_bootstrap_app");
+      expect(text).toContain("terreno_bootstrap_ai_rules");
       expect(text).toContain("rulesync");
     });
 

--- a/mcp-server/src/__tests__/prompts.test.ts
+++ b/mcp-server/src/__tests__/prompts.test.ts
@@ -5,12 +5,14 @@ describe("prompts", () => {
   test("should export all required prompts", () => {
     const promptNames = prompts.map((p) => p.name);
 
-    expect(promptNames).toContain("create_crud_feature");
-    expect(promptNames).toContain("create_api_endpoint");
-    expect(promptNames).toContain("create_ui_component");
-    expect(promptNames).toContain("create_form_screen");
-    expect(promptNames).toContain("add_authentication");
+    expect(promptNames).toContain("terreno_create_crud_feature");
+    expect(promptNames).toContain("terreno_create_api_endpoint");
+    expect(promptNames).toContain("terreno_create_ui_component");
+    expect(promptNames).toContain("terreno_create_form_screen");
+    expect(promptNames).toContain("terreno_add_authentication");
     expect(promptNames).toContain("terreno_style_guide");
+    expect(promptNames).toContain("terreno_migrate_to_terreno_app");
+    expect(promptNames).toContain("terreno_bootstrap");
   });
 
   test("should have valid prompt structure", () => {
@@ -27,9 +29,9 @@ describe("prompts", () => {
     }
   });
 
-  describe("create_crud_feature", () => {
+  describe("terreno_create_crud_feature", () => {
     test("should generate CRUD feature prompt", () => {
-      const result = handlePromptRequest("create_crud_feature", {
+      const result = handlePromptRequest("terreno_create_crud_feature", {
         fields: "title:string,price:number",
         name: "Product",
       });
@@ -47,7 +49,7 @@ describe("prompts", () => {
     });
 
     test("should include owner documentation when hasOwner is yes", () => {
-      const result = handlePromptRequest("create_crud_feature", {
+      const result = handlePromptRequest("terreno_create_crud_feature", {
         fields: "title:string",
         hasOwner: "yes",
         name: "Todo",
@@ -62,7 +64,7 @@ describe("prompts", () => {
     });
 
     test("should include code style requirements", () => {
-      const result = handlePromptRequest("create_crud_feature", {
+      const result = handlePromptRequest("terreno_create_crud_feature", {
         fields: "name:string",
         name: "Item",
       });
@@ -76,9 +78,9 @@ describe("prompts", () => {
     });
   });
 
-  describe("create_api_endpoint", () => {
+  describe("terreno_create_api_endpoint", () => {
     test("should generate API endpoint prompt", () => {
-      const result = handlePromptRequest("create_api_endpoint", {
+      const result = handlePromptRequest("terreno_create_api_endpoint", {
         description: "Verify user email address",
         method: "POST",
         path: "/users/:id/verify",
@@ -95,7 +97,7 @@ describe("prompts", () => {
     });
 
     test("should include OpenAPI documentation requirements", () => {
-      const result = handlePromptRequest("create_api_endpoint", {
+      const result = handlePromptRequest("terreno_create_api_endpoint", {
         description: "Test endpoint",
         method: "GET",
         path: "/test",
@@ -109,9 +111,9 @@ describe("prompts", () => {
     });
   });
 
-  describe("create_ui_component", () => {
+  describe("terreno_create_ui_component", () => {
     test("should generate display component prompt", () => {
-      const result = handlePromptRequest("create_ui_component", {
+      const result = handlePromptRequest("terreno_create_ui_component", {
         name: "UserCard",
         type: "display",
       });
@@ -125,7 +127,7 @@ describe("prompts", () => {
     });
 
     test("should generate interactive component prompt", () => {
-      const result = handlePromptRequest("create_ui_component", {
+      const result = handlePromptRequest("terreno_create_ui_component", {
         name: "ToggleSwitch",
         type: "interactive",
       });
@@ -137,7 +139,7 @@ describe("prompts", () => {
     });
 
     test("should generate form component prompt", () => {
-      const result = handlePromptRequest("create_ui_component", {
+      const result = handlePromptRequest("terreno_create_ui_component", {
         name: "SearchInput",
         type: "form",
       });
@@ -149,7 +151,7 @@ describe("prompts", () => {
     });
 
     test("should generate layout component prompt", () => {
-      const result = handlePromptRequest("create_ui_component", {
+      const result = handlePromptRequest("terreno_create_ui_component", {
         name: "GridContainer",
         type: "layout",
       });
@@ -161,7 +163,7 @@ describe("prompts", () => {
     });
 
     test("should include component best practices", () => {
-      const result = handlePromptRequest("create_ui_component", {
+      const result = handlePromptRequest("terreno_create_ui_component", {
         name: "Test",
         type: "display",
       });
@@ -174,9 +176,9 @@ describe("prompts", () => {
     });
   });
 
-  describe("create_form_screen", () => {
+  describe("terreno_create_form_screen", () => {
     test("should generate form screen prompt", () => {
-      const result = handlePromptRequest("create_form_screen", {
+      const result = handlePromptRequest("terreno_create_form_screen", {
         endpoint: "createProduct",
         fields: "title:text,price:number,description:textarea",
         name: "CreateProduct",
@@ -192,7 +194,7 @@ describe("prompts", () => {
     });
 
     test("should include required imports", () => {
-      const result = handlePromptRequest("create_form_screen", {
+      const result = handlePromptRequest("terreno_create_form_screen", {
         endpoint: "updateUser",
         fields: "name:text,email:email",
         name: "EditUser",
@@ -207,7 +209,7 @@ describe("prompts", () => {
     });
 
     test("should include validation requirements", () => {
-      const result = handlePromptRequest("create_form_screen", {
+      const result = handlePromptRequest("terreno_create_form_screen", {
         endpoint: "createTest",
         fields: "name:text",
         name: "Test",
@@ -222,9 +224,9 @@ describe("prompts", () => {
     });
   });
 
-  describe("add_authentication", () => {
+  describe("terreno_add_authentication", () => {
     test("should generate authentication prompt with email", () => {
-      const result = handlePromptRequest("add_authentication", {
+      const result = handlePromptRequest("terreno_add_authentication", {
         features: "email",
       });
 
@@ -238,7 +240,7 @@ describe("prompts", () => {
     });
 
     test("should include password reset when requested", () => {
-      const result = handlePromptRequest("add_authentication", {
+      const result = handlePromptRequest("terreno_add_authentication", {
         features: "email,passwordReset",
       });
 
@@ -250,7 +252,7 @@ describe("prompts", () => {
     });
 
     test("should include auth state management", () => {
-      const result = handlePromptRequest("add_authentication", {});
+      const result = handlePromptRequest("terreno_add_authentication", {});
 
       const content = result.messages[0].content.text;
 
@@ -318,9 +320,9 @@ describe("prompts", () => {
     });
   });
 
-  describe("migrate_to_terreno_app", () => {
+  describe("terreno_migrate_to_terreno_app", () => {
     test("should return generic guide without serverFile", () => {
-      const result = handlePromptRequest("migrate_to_terreno_app", {});
+      const result = handlePromptRequest("terreno_migrate_to_terreno_app", {});
       const content = result.messages[0].content.text;
 
       expect(content.length).toBeGreaterThan(0);
@@ -328,7 +330,7 @@ describe("prompts", () => {
     });
 
     test("should include task-specific instructions when serverFile is provided", () => {
-      const result = handlePromptRequest("migrate_to_terreno_app", {
+      const result = handlePromptRequest("terreno_migrate_to_terreno_app", {
         serverFile: "src/myServer.ts",
       });
       const content = result.messages[0].content.text;
@@ -340,9 +342,9 @@ describe("prompts", () => {
     });
   });
 
-  describe("bootstrap_terreno_app", () => {
+  describe("terreno_bootstrap", () => {
     test("should delegate to bootstrap prompt handler", () => {
-      const result = handlePromptRequest("bootstrap_terreno_app", {
+      const result = handlePromptRequest("terreno_bootstrap", {
         appDisplayName: "My Bootstrap App",
         appName: "my-bootstrap-app",
       });
@@ -350,7 +352,8 @@ describe("prompts", () => {
 
       expect(content).toContain("my-bootstrap-app");
       expect(content).toContain("My Bootstrap App");
-      expect(content).toContain("bootstrap_app");
+      expect(content).toContain("terreno_bootstrap_app");
+      expect(content).toContain("terreno_bootstrap_ai_rules");
     });
   });
 });

--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -5,11 +5,14 @@ describe("tools", () => {
   test("should export all required tools", () => {
     const toolNames = tools.map((t) => t.name);
 
-    expect(toolNames).toContain("generate_model");
-    expect(toolNames).toContain("generate_route");
-    expect(toolNames).toContain("generate_screen");
-    expect(toolNames).toContain("generate_form_fields");
-    expect(toolNames).toContain("validate_model_schema");
+    expect(toolNames).toContain("terreno_generate_model");
+    expect(toolNames).toContain("terreno_generate_route");
+    expect(toolNames).toContain("terreno_generate_screen");
+    expect(toolNames).toContain("terreno_generate_form_fields");
+    expect(toolNames).toContain("terreno_validate_model_schema");
+    expect(toolNames).toContain("terreno_install_admin");
+    expect(toolNames).toContain("terreno_bootstrap_app");
+    expect(toolNames).toContain("terreno_bootstrap_ai_rules");
   });
 
   test("should have valid tool structure", () => {
@@ -22,9 +25,9 @@ describe("tools", () => {
     }
   });
 
-  describe("generate_model", () => {
+  describe("terreno_generate_model", () => {
     test("should generate basic model", () => {
-      const result = handleToolCall("generate_model", {
+      const result = handleToolCall("terreno_generate_model", {
         fields: [
           {name: "title", required: true, type: "String"},
           {name: "price", required: true, type: "Number"},
@@ -44,7 +47,7 @@ describe("tools", () => {
     });
 
     test("should generate model with owner", () => {
-      const result = handleToolCall("generate_model", {
+      const result = handleToolCall("terreno_generate_model", {
         fields: [{name: "title", required: true, type: "String"}],
         hasOwner: true,
         name: "Todo",
@@ -58,7 +61,7 @@ describe("tools", () => {
     });
 
     test("should generate model with soft delete", () => {
-      const result = handleToolCall("generate_model", {
+      const result = handleToolCall("terreno_generate_model", {
         fields: [{name: "name", type: "String"}],
         name: "Item",
         softDelete: true,
@@ -70,7 +73,7 @@ describe("tools", () => {
     });
 
     test("should handle field with reference", () => {
-      const result = handleToolCall("generate_model", {
+      const result = handleToolCall("terreno_generate_model", {
         fields: [{name: "userId", ref: "User", required: true, type: "ObjectId"}],
         name: "Order",
       });
@@ -82,7 +85,7 @@ describe("tools", () => {
     });
 
     test("should handle field with default value", () => {
-      const result = handleToolCall("generate_model", {
+      const result = handleToolCall("terreno_generate_model", {
         fields: [{default: "true", name: "active", type: "Boolean"}],
         name: "Setting",
       });
@@ -93,9 +96,9 @@ describe("tools", () => {
     });
   });
 
-  describe("generate_route", () => {
+  describe("terreno_generate_route", () => {
     test("should generate basic route", () => {
-      const result = handleToolCall("generate_route", {
+      const result = handleToolCall("terreno_generate_route", {
         modelName: "Product",
         routePath: "/products",
       });
@@ -109,7 +112,7 @@ describe("tools", () => {
     });
 
     test("should generate route with custom permissions", () => {
-      const result = handleToolCall("generate_route", {
+      const result = handleToolCall("terreno_generate_route", {
         modelName: "Post",
         permissions: {
           create: "authenticated",
@@ -129,7 +132,7 @@ describe("tools", () => {
     });
 
     test("should generate route with owner filter", () => {
-      const result = handleToolCall("generate_route", {
+      const result = handleToolCall("terreno_generate_route", {
         modelName: "Task",
         ownerFiltered: true,
         routePath: "/tasks",
@@ -144,7 +147,7 @@ describe("tools", () => {
     });
 
     test("should generate route with query fields", () => {
-      const result = handleToolCall("generate_route", {
+      const result = handleToolCall("terreno_generate_route", {
         modelName: "Item",
         queryFields: ["status", "category"],
         routePath: "/items",
@@ -156,7 +159,7 @@ describe("tools", () => {
     });
 
     test("should generate route with sort", () => {
-      const result = handleToolCall("generate_route", {
+      const result = handleToolCall("terreno_generate_route", {
         modelName: "Event",
         routePath: "/events",
         sort: "-startDate",
@@ -168,9 +171,9 @@ describe("tools", () => {
     });
   });
 
-  describe("generate_screen", () => {
+  describe("terreno_generate_screen", () => {
     test("should generate empty screen", () => {
-      const result = handleToolCall("generate_screen", {
+      const result = handleToolCall("terreno_generate_screen", {
         name: "Dashboard",
         type: "empty",
       });
@@ -184,7 +187,7 @@ describe("tools", () => {
     });
 
     test("should generate list screen", () => {
-      const result = handleToolCall("generate_screen", {
+      const result = handleToolCall("terreno_generate_screen", {
         fields: ["title", "price"],
         modelName: "Product",
         name: "ProductList",
@@ -202,7 +205,7 @@ describe("tools", () => {
     });
 
     test("should generate form screen", () => {
-      const result = handleToolCall("generate_screen", {
+      const result = handleToolCall("terreno_generate_screen", {
         fields: ["title", "description"],
         modelName: "Product",
         name: "CreateProduct",
@@ -220,7 +223,7 @@ describe("tools", () => {
     });
 
     test("should generate detail screen", () => {
-      const result = handleToolCall("generate_screen", {
+      const result = handleToolCall("terreno_generate_screen", {
         fields: ["title", "price", "description"],
         modelName: "Product",
         name: "ProductDetail",
@@ -237,9 +240,9 @@ describe("tools", () => {
     });
   });
 
-  describe("generate_form_fields", () => {
+  describe("terreno_generate_form_fields", () => {
     test("should generate text field", () => {
-      const result = handleToolCall("generate_form_fields", {
+      const result = handleToolCall("terreno_generate_form_fields", {
         fields: [{label: "Full Name", name: "name", type: "text"}],
       });
 
@@ -252,7 +255,7 @@ describe("tools", () => {
     });
 
     test("should generate email field", () => {
-      const result = handleToolCall("generate_form_fields", {
+      const result = handleToolCall("terreno_generate_form_fields", {
         fields: [{name: "email", required: true, type: "email"}],
       });
 
@@ -263,7 +266,7 @@ describe("tools", () => {
     });
 
     test("should generate select field with options", () => {
-      const result = handleToolCall("generate_form_fields", {
+      const result = handleToolCall("terreno_generate_form_fields", {
         fields: [
           {
             name: "country",
@@ -285,7 +288,7 @@ describe("tools", () => {
     });
 
     test("should generate boolean field", () => {
-      const result = handleToolCall("generate_form_fields", {
+      const result = handleToolCall("terreno_generate_form_fields", {
         fields: [{name: "active", type: "boolean"}],
       });
 
@@ -296,7 +299,7 @@ describe("tools", () => {
     });
 
     test("should generate date field", () => {
-      const result = handleToolCall("generate_form_fields", {
+      const result = handleToolCall("terreno_generate_form_fields", {
         fields: [{name: "birthDate", type: "date"}],
       });
 
@@ -307,7 +310,7 @@ describe("tools", () => {
     });
 
     test("should generate multiple fields", () => {
-      const result = handleToolCall("generate_form_fields", {
+      const result = handleToolCall("terreno_generate_form_fields", {
         fields: [
           {name: "name", type: "text"},
           {name: "email", type: "email"},
@@ -323,7 +326,7 @@ describe("tools", () => {
     });
   });
 
-  describe("validate_model_schema", () => {
+  describe("terreno_validate_model_schema", () => {
     test("should pass valid schema", () => {
       const validSchema = `
         const schema = new mongoose.Schema({
@@ -337,7 +340,7 @@ describe("tools", () => {
         interface MyDocument extends mongoose.Document {}
       `;
 
-      const result = handleToolCall("validate_model_schema", {
+      const result = handleToolCall("terreno_validate_model_schema", {
         schema: validSchema,
       });
 
@@ -351,7 +354,7 @@ describe("tools", () => {
         });
       `;
 
-      const result = handleToolCall("validate_model_schema", {schema});
+      const result = handleToolCall("terreno_validate_model_schema", {schema});
 
       expect(result.content[0].text).toContain("strict");
     });
@@ -363,7 +366,7 @@ describe("tools", () => {
         });
       `;
 
-      const result = handleToolCall("validate_model_schema", {schema});
+      const result = handleToolCall("terreno_validate_model_schema", {schema});
 
       expect(result.content[0].text).toContain("virtuals");
     });
@@ -376,7 +379,7 @@ describe("tools", () => {
         });
       `;
 
-      const result = handleToolCall("validate_model_schema", {schema});
+      const result = handleToolCall("terreno_validate_model_schema", {schema});
 
       expect(result.content[0].text).toContain("plugins");
     });
@@ -388,7 +391,7 @@ describe("tools", () => {
         };
       `;
 
-      const result = handleToolCall("validate_model_schema", {schema});
+      const result = handleToolCall("terreno_validate_model_schema", {schema});
 
       expect(result.content[0].text).toContain("findOne");
       expect(result.content[0].text).toContain("findOneOrThrow");
@@ -399,7 +402,7 @@ describe("tools", () => {
         const timestamp = new Date();
       `;
 
-      const result = handleToolCall("validate_model_schema", {schema});
+      const result = handleToolCall("terreno_validate_model_schema", {schema});
 
       expect(result.content[0].text).toContain("Luxon");
     });
@@ -413,9 +416,9 @@ describe("tools", () => {
     });
   });
 
-  describe("generate_model edge cases", () => {
+  describe("terreno_generate_model edge cases", () => {
     test("should generate interface types for non-string fields", () => {
-      const result = handleToolCall("generate_model", {
+      const result = handleToolCall("terreno_generate_model", {
         fields: [
           {name: "count", required: true, type: "Number"},
           {name: "isActive", required: true, type: "Boolean"},
@@ -436,7 +439,7 @@ describe("tools", () => {
     });
 
     test("should support hasOwner and softDelete options", () => {
-      const result = handleToolCall("generate_model", {
+      const result = handleToolCall("terreno_generate_model", {
         fields: [{name: "title", required: true, type: "String"}],
         hasOwner: true,
         name: "Article",
@@ -451,7 +454,7 @@ describe("tools", () => {
     });
 
     test("should support unique and default field props", () => {
-      const result = handleToolCall("generate_model", {
+      const result = handleToolCall("terreno_generate_model", {
         fields: [
           {name: "email", required: true, type: "String", unique: true},
           {default: "0", name: "count", required: false, type: "Number"},
@@ -465,9 +468,9 @@ describe("tools", () => {
     });
   });
 
-  describe("generate_route edge cases", () => {
+  describe("terreno_generate_route edge cases", () => {
     test("should generate route with ownerFiltered", () => {
-      const result = handleToolCall("generate_route", {
+      const result = handleToolCall("terreno_generate_route", {
         modelName: "Task",
         ownerFiltered: true,
         permissions: {
@@ -493,9 +496,9 @@ describe("tools", () => {
     });
   });
 
-  describe("generate_screen edge cases", () => {
+  describe("terreno_generate_screen edge cases", () => {
     test("should fall back to empty template when type needs modelName but none given", () => {
-      const result = handleToolCall("generate_screen", {
+      const result = handleToolCall("terreno_generate_screen", {
         name: "Orphan",
         type: "list",
       });
@@ -506,9 +509,9 @@ describe("tools", () => {
     });
   });
 
-  describe("generate_form_fields edge cases", () => {
+  describe("terreno_generate_form_fields edge cases", () => {
     test("should generate password field", () => {
-      const result = handleToolCall("generate_form_fields", {
+      const result = handleToolCall("terreno_generate_form_fields", {
         fields: [{label: "Password", name: "password", required: true, type: "password"}],
       });
       const content = result.content[0].text;
@@ -519,7 +522,7 @@ describe("tools", () => {
     });
 
     test("should generate textarea field", () => {
-      const result = handleToolCall("generate_form_fields", {
+      const result = handleToolCall("terreno_generate_form_fields", {
         fields: [{name: "bio", type: "textarea"}],
       });
       const content = result.content[0].text;
@@ -528,7 +531,7 @@ describe("tools", () => {
     });
 
     test("should generate datetime field", () => {
-      const result = handleToolCall("generate_form_fields", {
+      const result = handleToolCall("terreno_generate_form_fields", {
         fields: [{name: "scheduledAt", type: "datetime"}],
       });
       const content = result.content[0].text;
@@ -538,7 +541,7 @@ describe("tools", () => {
     });
 
     test("should generate select field with empty options", () => {
-      const result = handleToolCall("generate_form_fields", {
+      const result = handleToolCall("terreno_generate_form_fields", {
         fields: [{name: "category", type: "select"}],
       });
       const content = result.content[0].text;
@@ -548,9 +551,9 @@ describe("tools", () => {
     });
   });
 
-  describe("install_admin", () => {
+  describe("terreno_install_admin", () => {
     test("should generate admin panel files and instructions", () => {
-      const result = handleToolCall("install_admin", {
+      const result = handleToolCall("terreno_install_admin", {
         models: [
           {
             displayName: "Todos",
@@ -586,16 +589,16 @@ describe("tools", () => {
   });
 
   describe("handleToolCall - bootstrap dispatch", () => {
-    test("should delegate bootstrap_app to bootstrap handler", () => {
-      const result = handleToolCall("bootstrap_app", {
+    test("should delegate terreno_bootstrap_app to bootstrap handler", () => {
+      const result = handleToolCall("terreno_bootstrap_app", {
         appDisplayName: "Dispatch App",
         appName: "dispatch-app",
       });
       expect(result.content[0].text).toContain("# Bootstrap Dispatch App");
     });
 
-    test("should delegate bootstrap_ai_rules to bootstrap handler", () => {
-      const result = handleToolCall("bootstrap_ai_rules", {
+    test("should delegate terreno_bootstrap_ai_rules to bootstrap handler", () => {
+      const result = handleToolCall("terreno_bootstrap_ai_rules", {
         appDisplayName: "Rules App",
         appName: "rules-app",
       });

--- a/mcp-server/src/bootstrap.ts
+++ b/mcp-server/src/bootstrap.ts
@@ -28,7 +28,7 @@ export const bootstrapTools: Tool[] = [
       required: ["appName", "appDisplayName"],
       type: "object",
     },
-    name: "bootstrap_app",
+    name: "terreno_bootstrap_app",
   },
   {
     description:
@@ -52,7 +52,7 @@ export const bootstrapTools: Tool[] = [
       required: ["appName", "appDisplayName"],
       type: "object",
     },
-    name: "bootstrap_ai_rules",
+    name: "terreno_bootstrap_ai_rules",
   },
 ];
 
@@ -2660,11 +2660,11 @@ export const handleBootstrapToolCall = (
   name: string,
   args: Record<string, unknown>
 ): {content: Array<{type: "text"; text: string}>} => {
-  if (name === "bootstrap_ai_rules") {
+  if (name === "terreno_bootstrap_ai_rules") {
     return handleBootstrapAiRulesToolCall(args);
   }
 
-  if (name !== "bootstrap_app") {
+  if (name !== "terreno_bootstrap_app") {
     return {
       content: [{text: `Unknown bootstrap tool: ${name}`, type: "text"}],
     };
@@ -2813,7 +2813,7 @@ export const bootstrapPrompts: BootstrapPrompt[] = [
     ],
     description:
       "Bootstrap a new Terreno full-stack application with frontend, backend, Cursor rules, and MCP integration",
-    name: "bootstrap_terreno_app",
+    name: "terreno_bootstrap",
   },
 ];
 
@@ -2821,7 +2821,7 @@ export const handleBootstrapPromptRequest = (
   name: string,
   args: Record<string, string>
 ): {messages: Array<{role: "user"; content: {type: "text"; text: string}}>} => {
-  if (name !== "bootstrap_terreno_app") {
+  if (name !== "terreno_bootstrap") {
     return {
       messages: [
         {
@@ -2842,7 +2842,7 @@ export const handleBootstrapPromptRequest = (
 - **App Name** (kebab-case): ${appName}
 - **Display Name**: ${appDisplayName}
 
-Use the \`bootstrap_app\` tool to generate all the necessary files for the application.
+Use the \`terreno_bootstrap_app\` tool to generate all the necessary files for the application.
 
 After generating the files:
 1. Create all directories and files as specified
@@ -2861,7 +2861,7 @@ The application should include:
 - Cursor rules for AI assistance
 - MCP integration for development assistance
 
-**IMPORTANT: After completing the bootstrap_app steps, also run the \`bootstrap_ai_rules\` tool** with the same appName and appDisplayName to set up AI coding assistant rules for Cursor, Windsurf, Claude Code, and GitHub Copilot. This will create:
+**IMPORTANT: After completing the terreno_bootstrap_app steps, also run the \`terreno_bootstrap_ai_rules\` tool** with the same appName and appDisplayName to set up AI coding assistant rules for Cursor, Windsurf, Claude Code, and GitHub Copilot. This will create:
 - AGENTS.md files for each directory
 - .cursorrules and .windsurfrules files
 - GitHub Copilot instructions

--- a/mcp-server/src/prompts.ts
+++ b/mcp-server/src/prompts.ts
@@ -64,7 +64,7 @@ export const prompts: Prompt[] = [
     ],
     description:
       "Generate a complete CRUD feature including model, routes, and frontend screens for Terreno",
-    name: "create_crud_feature",
+    name: "terreno_create_crud_feature",
   },
   {
     arguments: [
@@ -85,7 +85,7 @@ export const prompts: Prompt[] = [
       },
     ],
     description: "Generate a custom API endpoint with OpenAPI documentation for @terreno/api",
-    name: "create_api_endpoint",
+    name: "terreno_create_api_endpoint",
   },
   {
     arguments: [
@@ -101,7 +101,7 @@ export const prompts: Prompt[] = [
       },
     ],
     description: "Generate a reusable UI component using @terreno/ui patterns",
-    name: "create_ui_component",
+    name: "terreno_create_ui_component",
   },
   {
     arguments: [
@@ -123,7 +123,7 @@ export const prompts: Prompt[] = [
       },
     ],
     description: "Generate a form screen with validation using @terreno/ui and RTK Query",
-    name: "create_form_screen",
+    name: "terreno_create_form_screen",
   },
   {
     arguments: [
@@ -135,7 +135,7 @@ export const prompts: Prompt[] = [
     ],
     description:
       "Generate authentication setup including login/signup screens and auth state management",
-    name: "add_authentication",
+    name: "terreno_add_authentication",
   },
   {
     arguments: [],
@@ -153,7 +153,7 @@ export const prompts: Prompt[] = [
     ],
     description:
       "Guide migration from the legacy setupServer function to the new TerrenoApp builder API with plugin support",
-    name: "migrate_to_terreno_app",
+    name: "terreno_migrate_to_terreno_app",
   },
 ];
 
@@ -616,32 +616,32 @@ export const handlePromptRequest = (
   args: Record<string, string>
 ): {messages: Array<{role: "user"; content: {type: "text"; text: string}}>} => {
   // Handle bootstrap prompts
-  if (name === "bootstrap_terreno_app") {
+  if (name === "terreno_bootstrap") {
     return handleBootstrapPromptRequest(name, args);
   }
 
   let content: string;
 
   switch (name) {
-    case "create_crud_feature":
+    case "terreno_create_crud_feature":
       content = createCrudFeaturePrompt(args as Parameters<typeof createCrudFeaturePrompt>[0]);
       break;
-    case "create_api_endpoint":
+    case "terreno_create_api_endpoint":
       content = createApiEndpointPrompt(args as Parameters<typeof createApiEndpointPrompt>[0]);
       break;
-    case "create_ui_component":
+    case "terreno_create_ui_component":
       content = createUiComponentPrompt(args as Parameters<typeof createUiComponentPrompt>[0]);
       break;
-    case "create_form_screen":
+    case "terreno_create_form_screen":
       content = createFormScreenPrompt(args as Parameters<typeof createFormScreenPrompt>[0]);
       break;
-    case "add_authentication":
+    case "terreno_add_authentication":
       content = addAuthenticationPrompt(args as Parameters<typeof addAuthenticationPrompt>[0]);
       break;
     case "terreno_style_guide":
       content = styleGuidePrompt();
       break;
-    case "migrate_to_terreno_app":
+    case "terreno_migrate_to_terreno_app":
       content = migrateToTerrenoAppPrompt(args as Parameters<typeof migrateToTerrenoAppPrompt>[0]);
       break;
     default:

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -49,7 +49,7 @@ export const tools: Tool[] = [
       required: ["name", "fields"],
       type: "object",
     },
-    name: "generate_model",
+    name: "terreno_generate_model",
   },
   {
     description: "Generate a modelRouter route configuration for a Mongoose model",
@@ -91,7 +91,7 @@ export const tools: Tool[] = [
       required: ["modelName", "routePath"],
       type: "object",
     },
-    name: "generate_route",
+    name: "terreno_generate_route",
   },
   {
     description: "Generate a React Native screen component using @terreno/ui components",
@@ -119,7 +119,7 @@ export const tools: Tool[] = [
       required: ["name", "type"],
       type: "object",
     },
-    name: "generate_screen",
+    name: "terreno_generate_screen",
   },
   {
     description: "Generate form field components for a data model",
@@ -168,7 +168,7 @@ export const tools: Tool[] = [
       required: ["fields"],
       type: "object",
     },
-    name: "generate_form_fields",
+    name: "terreno_generate_form_fields",
   },
   {
     description: "Validate a Mongoose schema follows Terreno conventions",
@@ -182,7 +182,7 @@ export const tools: Tool[] = [
       required: ["schema"],
       type: "object",
     },
-    name: "validate_model_schema",
+    name: "terreno_validate_model_schema",
   },
   {
     description:
@@ -221,7 +221,7 @@ export const tools: Tool[] = [
       required: ["models"],
       type: "object",
     },
-    name: "install_admin",
+    name: "terreno_install_admin",
   },
 ];
 
@@ -1014,14 +1014,14 @@ export const handleToolCall = (
   args: Record<string, unknown>
 ): {content: Array<{type: "text"; text: string}>} => {
   // Handle bootstrap tools
-  if (name === "bootstrap_app" || name === "bootstrap_ai_rules") {
+  if (name === "terreno_bootstrap_app" || name === "terreno_bootstrap_ai_rules") {
     return handleBootstrapToolCall(name, args);
   }
 
   let result: string;
 
   switch (name) {
-    case "generate_model": {
+    case "terreno_generate_model": {
       const modelArgs = args as Parameters<typeof generateModel>[0];
       const code = generateModel(modelArgs);
       const modelName = modelArgs.name.toLowerCase();
@@ -1030,7 +1030,7 @@ export const handleToolCall = (
       ]);
       break;
     }
-    case "generate_route": {
+    case "terreno_generate_route": {
       const routeArgs = args as Parameters<typeof generateRoute>[0];
       const code = generateRoute(routeArgs);
       const modelName = routeArgs.modelName.toLowerCase();
@@ -1041,7 +1041,7 @@ export const handleToolCall = (
       ]);
       break;
     }
-    case "generate_screen": {
+    case "terreno_generate_screen": {
       const screenArgs = args as Parameters<typeof generateScreen>[0];
       const code = generateScreen(screenArgs);
       result = wrapWithFileInstructions(code, `frontend/src/screens/${screenArgs.name}Screen.tsx`, [
@@ -1049,17 +1049,17 @@ export const handleToolCall = (
       ]);
       break;
     }
-    case "generate_form_fields": {
+    case "terreno_generate_form_fields": {
       const code = generateFormFields(args as Parameters<typeof generateFormFields>[0]);
       result = wrapWithFileInstructions(code, "your form component file", [
         "Integrate this code into your form screen component",
       ]);
       break;
     }
-    case "validate_model_schema":
+    case "terreno_validate_model_schema":
       result = validateModelSchema(args as Parameters<typeof validateModelSchema>[0]);
       break;
-    case "install_admin":
+    case "terreno_install_admin":
       result = generateInstallAdmin(args as Parameters<typeof generateInstallAdmin>[0]);
       break;
     default:


### PR DESCRIPTION
## Summary

MCP server rules, README, and reference docs were out of date with the `terreno_*` tool and prompt identifiers already used in the implementation. This aligns documentation and tests so assistants and contributors see the correct names.

## Human Testing Steps
- [ ] Connect to the Terreno MCP server and verify tools appear with `terreno_*` names (e.g. `terreno_generate_model`, `terreno_bootstrap_app`)
- [ ] Verify prompts include `terreno_create_crud_feature`, `terreno_bootstrap`, and `terreno_migrate_to_terreno_app`

## Changes
- Sync MCP rules (Cursor, Claude, Windsurf, rulesync, GitHub instructions) with current tool/prompt inventory
- Update `mcp-server/README.md`, `docs/reference/mcp-server.md`, and root README
- Align `tools.ts`, `prompts.ts`, and `bootstrap.ts` handler dispatch with `terreno_*` names
- Update MCP server tests to match

## Automated Tests
- `bun run lint` — passed
- `cd mcp-server && bun test` — 266 tests passed

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renames MCP tool/prompt identifiers and updates dispatch logic, which can break any clients or docs still calling the legacy names. Changes are mostly mechanical but touch the MCP server’s external interface and test coverage.
> 
> **Overview**
> Aligns the MCP server’s **public tool and prompt identifiers** to the `terreno_*` namespace across the server implementation, bootstrap dispatch, and all Bun tests.
> 
> Updates all assistant-facing documentation/rules (`README.md`, `docs/reference/mcp-server.md`, `mcp-server/README.md`, and generated rules for Cursor/Claude/Windsurf/Copilot/rulesync) to list and demonstrate the new `terreno_*` tool/prompt names (including bootstrap and admin install).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 263f22895569e3b94fc71da66bdceeee3d78f9e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->