### PR TITLE
Wire up per-PR EAS updates and fingerprint-based dev builds

### DIFF
--- a/.github/workflows/eas-dev-build.yml
+++ b/.github/workflows/eas-dev-build.yml
@@ -31,11 +31,6 @@ on:
         required: false
         type: string
         default: Manual dispatch
-      force_build:
-        description: Build a fresh dev client even if the fingerprint matches
-        required: false
-        type: boolean
-        default: true
 
 jobs:
   dispatch:
@@ -89,12 +84,10 @@ jobs:
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
           PR_TITLE: ${{ inputs.pr_title }}
-          FORCE_BUILD: ${{ inputs.force_build }}
         run: |
           set -euo pipefail
           eas workflow:run ".eas/workflows/${{ steps.resolve.outputs.file }}" \
             --non-interactive \
             -F "pr_number=${PR_NUMBER}" \
-            -F "pr_title=${PR_TITLE}" \
-            -F "force_build=${FORCE_BUILD}"
+            -F "pr_title=${PR_TITLE}"
           echo "✅ Dispatched. Track on EAS dashboard: https://expo.dev/accounts/flourishhealth/workflows"

--- a/.github/workflows/eas-dev-build.yml
+++ b/.github/workflows/eas-dev-build.yml
@@ -33,6 +33,17 @@ jobs:
         with:
           ref: ${{ inputs.git_ref || github.ref }}
 
+      - name: Validate required secrets
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          missing=()
+          if [ -z "$EXPO_TOKEN" ]; then missing+=("EXPO_TOKEN"); fi
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            exit 1
+          fi
+
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
 
@@ -41,15 +52,6 @@ jobs:
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: Validate required secrets
-        run: |
-          missing=()
-          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then missing+=("EXPO_TOKEN"); fi
-          if [ ${#missing[@]} -ne 0 ]; then
-            echo "::error::Missing required secrets: ${missing[*]}"
-            exit 1
-          fi
 
       - name: Resolve workflow path
         id: resolve

--- a/.github/workflows/eas-dev-build.yml
+++ b/.github/workflows/eas-dev-build.yml
@@ -17,6 +17,7 @@ on:
         options:
           - example-frontend
           - demo
+          - both
       git_ref:
         description: Git ref to build (branch, tag, or commit). Defaults to the workflow ref.
         required: false
@@ -61,33 +62,31 @@ jobs:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: Resolve workflow path
-        id: resolve
-        run: |
-          case "${{ inputs.target }}" in
-            example-frontend)
-              echo "dir=example-frontend" >> "$GITHUB_OUTPUT"
-              echo "file=example-frontend-build.yml" >> "$GITHUB_OUTPUT"
-              ;;
-            demo)
-              echo "dir=demo" >> "$GITHUB_OUTPUT"
-              echo "file=demo-build.yml" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "::error::Unknown target: ${{ inputs.target }}"
-              exit 1
-              ;;
-          esac
-
       - name: Dispatch to EAS Cloud
-        working-directory: ${{ steps.resolve.outputs.dir }}
         env:
+          TARGET: ${{ inputs.target }}
           PR_NUMBER: ${{ inputs.pr_number }}
           PR_TITLE: ${{ inputs.pr_title }}
         run: |
           set -euo pipefail
-          eas workflow:run ".eas/workflows/${{ steps.resolve.outputs.file }}" \
-            --non-interactive \
-            -F "pr_number=${PR_NUMBER}" \
-            -F "pr_title=${PR_TITLE}"
-          echo "✅ Dispatched. Track on EAS dashboard: https://expo.dev/accounts/flourishhealth/workflows"
+
+          case "$TARGET" in
+            example-frontend) targets="example-frontend" ;;
+            demo)             targets="demo" ;;
+            both)             targets="example-frontend demo" ;;
+            *) echo "::error::Unknown target: $TARGET"; exit 1 ;;
+          esac
+
+          for app in $targets; do
+            case "$app" in
+              example-frontend) file=example-frontend-build.yml ;;
+              demo)             file=demo-build.yml ;;
+            esac
+            echo "::group::Dispatching $app"
+            (cd "$app" && eas workflow:run ".eas/workflows/$file" \
+              --non-interactive \
+              -F "pr_number=${PR_NUMBER}" \
+              -F "pr_title=${PR_TITLE}")
+            echo "::endgroup::"
+          done
+          echo "✅ Dispatched ${targets}. Track on EAS dashboard: https://expo.dev/accounts/flourishhealth/workflows"

--- a/.github/workflows/eas-dev-build.yml
+++ b/.github/workflows/eas-dev-build.yml
@@ -1,64 +1,81 @@
-name: EAS Build
+name: Trigger EAS Workflow
+
+# Manually kicks off an EAS Workflow on EAS Cloud. The actual build/update runs
+# remotely on EAS infrastructure — this job just dispatches and exits, so the
+# GitHub Actions runner is never tied up waiting for builds.
+#
+# PR-driven builds + updates trigger automatically from each app's
+# `.eas/workflows/*.yml` (no GitHub Action required).
 
 on:
   workflow_dispatch:
     inputs:
-      app:
-        description: "Select the app to build"
+      target:
+        description: "App to dispatch"
         required: true
         type: choice
         options:
-          - demo
           - example-frontend
-      environment:
-        description: "Select the environment"
-        required: true
-        type: choice
-        options:
-          - development
-          - preview
-          - production
-      platform:
-        description: "Select the platform"
-        required: true
-        type: choice
-        options:
-          - iOS
-          - Android
+          - demo
+      git_ref:
+        description: "Git ref to build (branch, tag, or commit). Defaults to the workflow ref."
+        required: false
+        type: string
 
 jobs:
-  build:
+  dispatch:
+    name: Dispatch EAS workflow
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-
+    timeout-minutes: 5
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.git_ref || github.ref }}
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Setup Expo and EAS
+      - name: Setup EAS CLI
         uses: expo/expo-github-action@v8
         with:
-          expo-version: latest
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Compile workspace packages
-        run: bun run compile
-
-      - name: Run EAS Build
-        working-directory: ${{ github.event.inputs.app }}
+      - name: Validate required secrets
         run: |
-          PROFILE="${{ github.event.inputs.environment }}"
-          PLATFORM="${{ github.event.inputs.platform }}"
-
-          if [ "$PLATFORM" == "iOS" ]; then
-            eas build --profile "$PROFILE" --platform ios --non-interactive
-          elif [ "$PLATFORM" == "Android" ]; then
-            eas build --profile "$PROFILE" --platform android --non-interactive
+          missing=()
+          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then missing+=("EXPO_TOKEN"); fi
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            exit 1
           fi
+
+      - name: Resolve workflow path
+        id: resolve
+        run: |
+          case "${{ inputs.target }}" in
+            example-frontend)
+              echo "dir=example-frontend" >> "$GITHUB_OUTPUT"
+              echo "file=example-frontend-build.yml" >> "$GITHUB_OUTPUT"
+              ;;
+            demo)
+              echo "dir=demo" >> "$GITHUB_OUTPUT"
+              echo "file=demo-build.yml" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Unknown target: ${{ inputs.target }}"
+              exit 1
+              ;;
+          esac
+
+      - name: Dispatch to EAS Cloud
+        working-directory: ${{ steps.resolve.outputs.dir }}
+        run: |
+          set -euo pipefail
+          echo "::group::eas workflow:run"
+          eas workflow:run ".eas/workflows/${{ steps.resolve.outputs.file }}" --non-interactive
+          echo "::endgroup::"
+          echo ""
+          echo "✅ Dispatched. Build/update runs on EAS Cloud; progress is reported back to the PR via EAS Workflow's github-comment step."
+          echo "Track live: https://expo.dev/accounts/flourishhealth/workflows"

--- a/.github/workflows/eas-dev-build.yml
+++ b/.github/workflows/eas-dev-build.yml
@@ -4,23 +4,38 @@ name: Trigger EAS Workflow
 # remotely on EAS infrastructure — this job just dispatches and exits, so the
 # GitHub Actions runner is never tied up waiting for builds.
 #
-# PR-driven builds + updates trigger automatically from each app's
-# `.eas/workflows/*.yml` (no GitHub Action required).
+# PR-driven dispatch is handled by `eas-pr.yml`. Use this only for forcing a
+# build off-PR (e.g., to seed a dev build on master).
 
 on:
   workflow_dispatch:
     inputs:
       target:
-        description: "App to dispatch"
+        description: App to dispatch
         required: true
         type: choice
         options:
           - example-frontend
           - demo
       git_ref:
-        description: "Git ref to build (branch, tag, or commit). Defaults to the workflow ref."
+        description: Git ref to build (branch, tag, or commit). Defaults to the workflow ref.
         required: false
         type: string
+      pr_number:
+        description: PR number to associate with the EAS Update branch (defaults to 0 for non-PR runs)
+        required: false
+        type: string
+        default: "0"
+      pr_title:
+        description: Message to attach to the EAS Update
+        required: false
+        type: string
+        default: Manual dispatch
+      force_build:
+        description: Build a fresh dev client even if the fingerprint matches
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   dispatch:
@@ -37,10 +52,8 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
-          missing=()
-          if [ -z "$EXPO_TOKEN" ]; then missing+=("EXPO_TOKEN"); fi
-          if [ ${#missing[@]} -ne 0 ]; then
-            echo "::error::Missing required secrets: ${missing[*]}"
+          if [ -z "$EXPO_TOKEN" ]; then
+            echo "::error::Missing required secret EXPO_TOKEN"
             exit 1
           fi
 
@@ -73,11 +86,15 @@ jobs:
 
       - name: Dispatch to EAS Cloud
         working-directory: ${{ steps.resolve.outputs.dir }}
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_TITLE: ${{ inputs.pr_title }}
+          FORCE_BUILD: ${{ inputs.force_build }}
         run: |
           set -euo pipefail
-          echo "::group::eas workflow:run"
-          eas workflow:run ".eas/workflows/${{ steps.resolve.outputs.file }}" --non-interactive
-          echo "::endgroup::"
-          echo ""
-          echo "✅ Dispatched. Build/update runs on EAS Cloud; progress is reported back to the PR via EAS Workflow's github-comment step."
-          echo "Track live: https://expo.dev/accounts/flourishhealth/workflows"
+          eas workflow:run ".eas/workflows/${{ steps.resolve.outputs.file }}" \
+            --non-interactive \
+            -F "pr_number=${PR_NUMBER}" \
+            -F "pr_title=${PR_TITLE}" \
+            -F "force_build=${FORCE_BUILD}"
+          echo "✅ Dispatched. Track on EAS dashboard: https://expo.dev/accounts/flourishhealth/workflows"

--- a/.github/workflows/eas-pr.yml
+++ b/.github/workflows/eas-pr.yml
@@ -1,0 +1,274 @@
+name: EAS PR
+
+# Drives the per-app EAS workflows. We compute the project fingerprint
+# locally and check whether a matching finished dev build already exists.
+#
+# - Fingerprint matches existing dev build  →  fast path: publish the
+#   EAS Update + post the PR comment, and **wait** for the EAS workflow
+#   so the GitHub status reflects real pass/fail.
+#
+# - Fingerprint changed (or `build-expo` label was added)  →  slow path:
+#   dispatch the EAS workflow asynchronously and exit immediately. A
+#   full dev build can take 15+ minutes; the EAS GitHub App still posts
+#   per-job status checks for that run when it eventually finishes.
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, reopened, synchronize, labeled]
+    paths:
+      - example-frontend/**
+      - demo/**
+      - ui/**
+      - rtk/**
+      - package.json
+      - bun.lock
+
+concurrency:
+  group: eas-pr-${{ github.event.pull_request.number }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  detect:
+    name: Detect affected apps
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      example_frontend: ${{ steps.changes.outputs.example_frontend }}
+      demo: ${{ steps.changes.outputs.demo }}
+      force_build: ${{ steps.changes.outputs.force_build }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+        run: |
+          set -euo pipefail
+
+          # `labeled` only fires for new label additions. Only react to build-expo.
+          if [ "$ACTION" = "labeled" ]; then
+            if [ "$LABEL_NAME" = "build-expo" ]; then
+              echo "force_build=true" >> "$GITHUB_OUTPUT"
+              echo "example_frontend=true" >> "$GITHUB_OUTPUT"
+              echo "demo=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "force_build=false" >> "$GITHUB_OUTPUT"
+              echo "example_frontend=false" >> "$GITHUB_OUTPUT"
+              echo "demo=false" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+
+          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" || echo "")
+          ef=false
+          dm=false
+          if echo "$changed" | grep -qE "^(example-frontend/|ui/|rtk/|package\.json$|bun\.lock$)"; then
+            ef=true
+          fi
+          if echo "$changed" | grep -qE "^(demo/|ui/|package\.json$|bun\.lock$)"; then
+            dm=true
+          fi
+          echo "force_build=false" >> "$GITHUB_OUTPUT"
+          echo "example_frontend=$ef" >> "$GITHUB_OUTPUT"
+          echo "demo=$dm" >> "$GITHUB_OUTPUT"
+
+  example_frontend:
+    name: EAS — example-frontend
+    needs: detect
+    if: needs.detect.outputs.example_frontend == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate required secrets
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          if [ -z "$EXPO_TOKEN" ]; then
+            echo "::error::Missing required secret EXPO_TOKEN"
+            exit 1
+          fi
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Compile workspace packages
+        run: bun run compile
+
+      - name: Decide fast vs slow path
+        id: decide
+        working-directory: example-frontend
+        env:
+          FORCE_BUILD: ${{ needs.detect.outputs.force_build }}
+        run: |
+          set -euo pipefail
+          if [ "$FORCE_BUILD" = "true" ]; then
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+            echo "reason=label" >> "$GITHUB_OUTPUT"
+            echo "::notice::build-expo label set — forcing slow path"
+            exit 0
+          fi
+
+          ios_hash=$(eas fingerprint:generate --platform ios --non-interactive --json | jq -r '.hash')
+          android_hash=$(eas fingerprint:generate --platform android --non-interactive --json | jq -r '.hash')
+
+          ios_match=$(eas build:list --platform ios --profile development --fingerprint-hash "$ios_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
+          android_match=$(eas build:list --platform android --profile development --fingerprint-hash "$android_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
+
+          echo "iOS fingerprint:     $ios_hash  matching builds: $ios_match"
+          echo "Android fingerprint: $android_hash  matching builds: $android_match"
+
+          if [ "$ios_match" -gt 0 ] && [ "$android_match" -gt 0 ]; then
+            echo "needs_build=false" >> "$GITHUB_OUTPUT"
+            echo "reason=fingerprint-match" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+            echo "reason=fingerprint-changed" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fast path — run EAS workflow and wait
+        if: steps.decide.outputs.needs_build == 'false'
+        working-directory: example-frontend
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "::notice::Fingerprint matches existing dev build — running update-only flow with --wait"
+          eas workflow:run .eas/workflows/example-frontend-build.yml \
+            --wait \
+            --non-interactive \
+            -F "pr_number=${PR_NUMBER}" \
+            -F "pr_title=${PR_TITLE}" \
+            -F "force_build=false"
+
+      - name: Slow path — dispatch EAS workflow async
+        if: steps.decide.outputs.needs_build == 'true'
+        working-directory: example-frontend
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REASON: ${{ steps.decide.outputs.reason }}
+        run: |
+          echo "::notice::Reason: $REASON — dispatching dev build to EAS (will not wait)"
+          eas workflow:run .eas/workflows/example-frontend-build.yml \
+            --non-interactive \
+            -F "pr_number=${PR_NUMBER}" \
+            -F "pr_title=${PR_TITLE}" \
+            -F "force_build=true"
+          echo "Build runs on EAS Cloud. Per-job status checks will appear on the PR when it finishes."
+
+  demo:
+    name: EAS — demo
+    needs: detect
+    if: needs.detect.outputs.demo == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate required secrets
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          if [ -z "$EXPO_TOKEN" ]; then
+            echo "::error::Missing required secret EXPO_TOKEN"
+            exit 1
+          fi
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Compile workspace packages
+        run: bun run compile
+
+      - name: Generate UI type documentation
+        working-directory: ui
+        run: bun run types
+
+      - name: Decide fast vs slow path
+        id: decide
+        working-directory: demo
+        env:
+          FORCE_BUILD: ${{ needs.detect.outputs.force_build }}
+        run: |
+          set -euo pipefail
+          if [ "$FORCE_BUILD" = "true" ]; then
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+            echo "reason=label" >> "$GITHUB_OUTPUT"
+            echo "::notice::build-expo label set — forcing slow path"
+            exit 0
+          fi
+
+          ios_hash=$(eas fingerprint:generate --platform ios --non-interactive --json | jq -r '.hash')
+          android_hash=$(eas fingerprint:generate --platform android --non-interactive --json | jq -r '.hash')
+
+          # Demo iOS uses the development:simulator profile.
+          ios_match=$(eas build:list --platform ios --profile development:simulator --fingerprint-hash "$ios_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
+          android_match=$(eas build:list --platform android --profile development --fingerprint-hash "$android_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
+
+          echo "iOS fingerprint:     $ios_hash  matching builds: $ios_match"
+          echo "Android fingerprint: $android_hash  matching builds: $android_match"
+
+          if [ "$ios_match" -gt 0 ] && [ "$android_match" -gt 0 ]; then
+            echo "needs_build=false" >> "$GITHUB_OUTPUT"
+            echo "reason=fingerprint-match" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+            echo "reason=fingerprint-changed" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fast path — run EAS workflow and wait
+        if: steps.decide.outputs.needs_build == 'false'
+        working-directory: demo
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "::notice::Fingerprint matches existing dev build — running update-only flow with --wait"
+          eas workflow:run .eas/workflows/demo-build.yml \
+            --wait \
+            --non-interactive \
+            -F "pr_number=${PR_NUMBER}" \
+            -F "pr_title=${PR_TITLE}" \
+            -F "force_build=false"
+
+      - name: Slow path — dispatch EAS workflow async
+        if: steps.decide.outputs.needs_build == 'true'
+        working-directory: demo
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REASON: ${{ steps.decide.outputs.reason }}
+        run: |
+          echo "::notice::Reason: $REASON — dispatching dev build to EAS (will not wait)"
+          eas workflow:run .eas/workflows/demo-build.yml \
+            --non-interactive \
+            -F "pr_number=${PR_NUMBER}" \
+            -F "pr_title=${PR_TITLE}" \
+            -F "force_build=true"
+          echo "Build runs on EAS Cloud. Per-job status checks will appear on the PR when it finishes."

--- a/.github/workflows/eas-pr.yml
+++ b/.github/workflows/eas-pr.yml
@@ -174,8 +174,8 @@ jobs:
           APP_DISPLAY: Terreno Example
           APP_ICON: "📱"
           APP_SLUG: terreno-example
-          IOS_HASH: ${{ steps.decide.outputs.ios_hash }}
-          ANDROID_HASH: ${{ steps.decide.outputs.android_hash }}
+          APP_SCHEME: frontend
+          PROJECT_ID: ddbe68d9-1142-4991-a02e-4ebb9fd83530
           IOS_MATCH: ${{ steps.decide.outputs.ios_match }}
           ANDROID_MATCH: ${{ steps.decide.outputs.android_match }}
           PATH_TAKEN: ${{ steps.decide.outputs.needs_build == 'true' && 'slow' || 'fast' }}
@@ -293,8 +293,8 @@ jobs:
           APP_DISPLAY: Terreno Demo
           APP_ICON: "🧪"
           APP_SLUG: terreno-demo
-          IOS_HASH: ${{ steps.decide.outputs.ios_hash }}
-          ANDROID_HASH: ${{ steps.decide.outputs.android_hash }}
+          APP_SCHEME: terreno
+          PROJECT_ID: 89c320ce-465b-4d71-9fd6-74fea9c5d898
           IOS_MATCH: ${{ steps.decide.outputs.ios_match }}
           ANDROID_MATCH: ${{ steps.decide.outputs.android_match }}
           PATH_TAKEN: ${{ steps.decide.outputs.needs_build == 'true' && 'slow' || 'fast' }}

--- a/.github/workflows/eas-pr.yml
+++ b/.github/workflows/eas-pr.yml
@@ -121,14 +121,22 @@ jobs:
           ios_match_count=$(eas build:list --platform ios --profile development --fingerprint-hash "$ios_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
           android_match_count=$(eas build:list --platform android --profile development --fingerprint-hash "$android_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
 
-          echo "iOS fingerprint:     $ios_hash  matching builds: $ios_match_count"
-          echo "Android fingerprint: $android_hash  matching builds: $android_match_count"
+          # Latest finished build per (platform, profile) for the comment's install-page links.
+          ios_device_latest=$(eas build:list --platform ios --profile development --status finished --limit 1 --non-interactive --json | jq -r '.[0].id // empty')
+          ios_sim_latest=$(eas build:list --platform ios --profile development:simulator --status finished --limit 1 --non-interactive --json | jq -r '.[0].id // empty')
+          android_latest=$(eas build:list --platform android --profile development --status finished --limit 1 --non-interactive --json | jq -r '.[0].id // empty')
+
+          echo "iOS fingerprint:     $ios_hash  matching builds: $ios_match_count  latest device: $ios_device_latest  latest sim: $ios_sim_latest"
+          echo "Android fingerprint: $android_hash  matching builds: $android_match_count  latest: $android_latest"
 
           {
             echo "ios_hash=$ios_hash"
             echo "android_hash=$android_hash"
             echo "ios_match=$([ "$ios_match_count" -gt 0 ] && echo true || echo false)"
             echo "android_match=$([ "$android_match_count" -gt 0 ] && echo true || echo false)"
+            echo "ios_device_latest=$ios_device_latest"
+            echo "ios_sim_latest=$ios_sim_latest"
+            echo "android_latest=$android_latest"
           } >> "$GITHUB_OUTPUT"
 
           if [ "$ios_match_count" -gt 0 ] && [ "$android_match_count" -gt 0 ]; then
@@ -178,6 +186,9 @@ jobs:
           PROJECT_ID: ddbe68d9-1142-4991-a02e-4ebb9fd83530
           IOS_MATCH: ${{ steps.decide.outputs.ios_match }}
           ANDROID_MATCH: ${{ steps.decide.outputs.android_match }}
+          IOS_DEVICE_BUILD_ID: ${{ steps.decide.outputs.ios_device_latest }}
+          IOS_SIM_BUILD_ID: ${{ steps.decide.outputs.ios_sim_latest }}
+          ANDROID_BUILD_ID: ${{ steps.decide.outputs.android_latest }}
           PATH_TAKEN: ${{ steps.decide.outputs.needs_build == 'true' && 'slow' || 'fast' }}
         run: .github/workflows/scripts/post-eas-pr-comment.sh
 
@@ -236,18 +247,25 @@ jobs:
           ios_hash=$(eas fingerprint:generate --platform ios --non-interactive --json | jq -r '.hash')
           android_hash=$(eas fingerprint:generate --platform android --non-interactive --json | jq -r '.hash')
 
-          # Demo iOS uses the development:simulator profile.
-          ios_match_count=$(eas build:list --platform ios --profile development:simulator --fingerprint-hash "$ios_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
+          ios_match_count=$(eas build:list --platform ios --profile development --fingerprint-hash "$ios_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
           android_match_count=$(eas build:list --platform android --profile development --fingerprint-hash "$android_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
 
-          echo "iOS fingerprint:     $ios_hash  matching builds: $ios_match_count"
-          echo "Android fingerprint: $android_hash  matching builds: $android_match_count"
+          # Latest finished build per (platform, profile) for the comment's install-page links.
+          ios_device_latest=$(eas build:list --platform ios --profile development --status finished --limit 1 --non-interactive --json | jq -r '.[0].id // empty')
+          ios_sim_latest=$(eas build:list --platform ios --profile development:simulator --status finished --limit 1 --non-interactive --json | jq -r '.[0].id // empty')
+          android_latest=$(eas build:list --platform android --profile development --status finished --limit 1 --non-interactive --json | jq -r '.[0].id // empty')
+
+          echo "iOS fingerprint:     $ios_hash  matching builds: $ios_match_count  latest device: $ios_device_latest  latest sim: $ios_sim_latest"
+          echo "Android fingerprint: $android_hash  matching builds: $android_match_count  latest: $android_latest"
 
           {
             echo "ios_hash=$ios_hash"
             echo "android_hash=$android_hash"
             echo "ios_match=$([ "$ios_match_count" -gt 0 ] && echo true || echo false)"
             echo "android_match=$([ "$android_match_count" -gt 0 ] && echo true || echo false)"
+            echo "ios_device_latest=$ios_device_latest"
+            echo "ios_sim_latest=$ios_sim_latest"
+            echo "android_latest=$android_latest"
           } >> "$GITHUB_OUTPUT"
 
           if [ "$ios_match_count" -gt 0 ] && [ "$android_match_count" -gt 0 ]; then
@@ -297,5 +315,8 @@ jobs:
           PROJECT_ID: 89c320ce-465b-4d71-9fd6-74fea9c5d898
           IOS_MATCH: ${{ steps.decide.outputs.ios_match }}
           ANDROID_MATCH: ${{ steps.decide.outputs.android_match }}
+          IOS_DEVICE_BUILD_ID: ${{ steps.decide.outputs.ios_device_latest }}
+          IOS_SIM_BUILD_ID: ${{ steps.decide.outputs.ios_sim_latest }}
+          ANDROID_BUILD_ID: ${{ steps.decide.outputs.android_latest }}
           PATH_TAKEN: ${{ steps.decide.outputs.needs_build == 'true' && 'slow' || 'fast' }}
         run: .github/workflows/scripts/post-eas-pr-comment.sh

--- a/.github/workflows/eas-pr.yml
+++ b/.github/workflows/eas-pr.yml
@@ -7,15 +7,19 @@ name: EAS PR
 #   EAS Update + post the PR comment, and **wait** for the EAS workflow
 #   so the GitHub status reflects real pass/fail.
 #
-# - Fingerprint changed (or `build-expo` label was added)  →  slow path:
-#   dispatch the EAS workflow asynchronously and exit immediately. A
-#   full dev build can take 15+ minutes; the EAS GitHub App still posts
-#   per-job status checks for that run when it eventually finishes.
+# - Fingerprint changed  →  slow path: dispatch the EAS workflow async
+#   and exit. A full dev build can take 15+ minutes; the EAS GitHub App
+#   posts per-job status checks for that run when it eventually finishes.
+#
+# A new dev build is only ever produced when the fingerprint has changed.
+# There is no manual force-build hatch from this workflow — push a change
+# that bumps the fingerprint, or use the `Trigger EAS Workflow` manual
+# dispatch for off-PR seed builds.
 
 on:
   pull_request:
     branches: [master]
-    types: [opened, reopened, synchronize, labeled]
+    types: [opened, reopened, synchronize]
     paths:
       - example-frontend/**
       - demo/**
@@ -36,7 +40,6 @@ jobs:
     outputs:
       example_frontend: ${{ steps.changes.outputs.example_frontend }}
       demo: ${{ steps.changes.outputs.demo }}
-      force_build: ${{ steps.changes.outputs.force_build }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -46,25 +49,8 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          ACTION: ${{ github.event.action }}
-          LABEL_NAME: ${{ github.event.label.name }}
         run: |
           set -euo pipefail
-
-          # `labeled` only fires for new label additions. Only react to build-expo.
-          if [ "$ACTION" = "labeled" ]; then
-            if [ "$LABEL_NAME" = "build-expo" ]; then
-              echo "force_build=true" >> "$GITHUB_OUTPUT"
-              echo "example_frontend=true" >> "$GITHUB_OUTPUT"
-              echo "demo=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "force_build=false" >> "$GITHUB_OUTPUT"
-              echo "example_frontend=false" >> "$GITHUB_OUTPUT"
-              echo "demo=false" >> "$GITHUB_OUTPUT"
-            fi
-            exit 0
-          fi
-
           changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" || echo "")
           ef=false
           dm=false
@@ -74,7 +60,6 @@ jobs:
           if echo "$changed" | grep -qE "^(demo/|ui/|package\.json$|bun\.lock$)"; then
             dm=true
           fi
-          echo "force_build=false" >> "$GITHUB_OUTPUT"
           echo "example_frontend=$ef" >> "$GITHUB_OUTPUT"
           echo "demo=$dm" >> "$GITHUB_OUTPUT"
 
@@ -100,6 +85,16 @@ jobs:
         with:
           bun-version: 1.3.10
 
+      - name: Cache bun + node_modules
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
       - uses: expo/expo-github-action@v8
         with:
           eas-version: latest
@@ -114,17 +109,8 @@ jobs:
       - name: Decide fast vs slow path
         id: decide
         working-directory: example-frontend
-        env:
-          FORCE_BUILD: ${{ needs.detect.outputs.force_build }}
         run: |
           set -euo pipefail
-          if [ "$FORCE_BUILD" = "true" ]; then
-            echo "needs_build=true" >> "$GITHUB_OUTPUT"
-            echo "reason=label" >> "$GITHUB_OUTPUT"
-            echo "::notice::build-expo label set — forcing slow path"
-            exit 0
-          fi
-
           ios_hash=$(eas fingerprint:generate --platform ios --non-interactive --json | jq -r '.hash')
           android_hash=$(eas fingerprint:generate --platform android --non-interactive --json | jq -r '.hash')
 
@@ -136,10 +122,8 @@ jobs:
 
           if [ "$ios_match" -gt 0 ] && [ "$android_match" -gt 0 ]; then
             echo "needs_build=false" >> "$GITHUB_OUTPUT"
-            echo "reason=fingerprint-match" >> "$GITHUB_OUTPUT"
           else
             echo "needs_build=true" >> "$GITHUB_OUTPUT"
-            echo "reason=fingerprint-changed" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Fast path — run EAS workflow and wait
@@ -154,8 +138,7 @@ jobs:
             --wait \
             --non-interactive \
             -F "pr_number=${PR_NUMBER}" \
-            -F "pr_title=${PR_TITLE}" \
-            -F "force_build=false"
+            -F "pr_title=${PR_TITLE}"
 
       - name: Slow path — dispatch EAS workflow async
         if: steps.decide.outputs.needs_build == 'true'
@@ -163,14 +146,12 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
-          REASON: ${{ steps.decide.outputs.reason }}
         run: |
-          echo "::notice::Reason: $REASON — dispatching dev build to EAS (will not wait)"
+          echo "::notice::Fingerprint changed — dispatching dev build to EAS (will not wait)"
           eas workflow:run .eas/workflows/example-frontend-build.yml \
             --non-interactive \
             -F "pr_number=${PR_NUMBER}" \
-            -F "pr_title=${PR_TITLE}" \
-            -F "force_build=true"
+            -F "pr_title=${PR_TITLE}"
           echo "Build runs on EAS Cloud. Per-job status checks will appear on the PR when it finishes."
 
   demo:
@@ -195,6 +176,16 @@ jobs:
         with:
           bun-version: 1.3.10
 
+      - name: Cache bun + node_modules
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
       - uses: expo/expo-github-action@v8
         with:
           eas-version: latest
@@ -213,17 +204,8 @@ jobs:
       - name: Decide fast vs slow path
         id: decide
         working-directory: demo
-        env:
-          FORCE_BUILD: ${{ needs.detect.outputs.force_build }}
         run: |
           set -euo pipefail
-          if [ "$FORCE_BUILD" = "true" ]; then
-            echo "needs_build=true" >> "$GITHUB_OUTPUT"
-            echo "reason=label" >> "$GITHUB_OUTPUT"
-            echo "::notice::build-expo label set — forcing slow path"
-            exit 0
-          fi
-
           ios_hash=$(eas fingerprint:generate --platform ios --non-interactive --json | jq -r '.hash')
           android_hash=$(eas fingerprint:generate --platform android --non-interactive --json | jq -r '.hash')
 
@@ -236,10 +218,8 @@ jobs:
 
           if [ "$ios_match" -gt 0 ] && [ "$android_match" -gt 0 ]; then
             echo "needs_build=false" >> "$GITHUB_OUTPUT"
-            echo "reason=fingerprint-match" >> "$GITHUB_OUTPUT"
           else
             echo "needs_build=true" >> "$GITHUB_OUTPUT"
-            echo "reason=fingerprint-changed" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Fast path — run EAS workflow and wait
@@ -254,8 +234,7 @@ jobs:
             --wait \
             --non-interactive \
             -F "pr_number=${PR_NUMBER}" \
-            -F "pr_title=${PR_TITLE}" \
-            -F "force_build=false"
+            -F "pr_title=${PR_TITLE}"
 
       - name: Slow path — dispatch EAS workflow async
         if: steps.decide.outputs.needs_build == 'true'
@@ -263,12 +242,10 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
-          REASON: ${{ steps.decide.outputs.reason }}
         run: |
-          echo "::notice::Reason: $REASON — dispatching dev build to EAS (will not wait)"
+          echo "::notice::Fingerprint changed — dispatching dev build to EAS (will not wait)"
           eas workflow:run .eas/workflows/demo-build.yml \
             --non-interactive \
             -F "pr_number=${PR_NUMBER}" \
-            -F "pr_title=${PR_TITLE}" \
-            -F "force_build=true"
+            -F "pr_title=${PR_TITLE}"
           echo "Build runs on EAS Cloud. Per-job status checks will appear on the PR when it finishes."

--- a/.github/workflows/eas-pr.yml
+++ b/.github/workflows/eas-pr.yml
@@ -28,6 +28,10 @@ on:
       - package.json
       - bun.lock
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: eas-pr-${{ github.event.pull_request.number }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -114,13 +118,20 @@ jobs:
           ios_hash=$(eas fingerprint:generate --platform ios --non-interactive --json | jq -r '.hash')
           android_hash=$(eas fingerprint:generate --platform android --non-interactive --json | jq -r '.hash')
 
-          ios_match=$(eas build:list --platform ios --profile development --fingerprint-hash "$ios_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
-          android_match=$(eas build:list --platform android --profile development --fingerprint-hash "$android_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
+          ios_match_count=$(eas build:list --platform ios --profile development --fingerprint-hash "$ios_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
+          android_match_count=$(eas build:list --platform android --profile development --fingerprint-hash "$android_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
 
-          echo "iOS fingerprint:     $ios_hash  matching builds: $ios_match"
-          echo "Android fingerprint: $android_hash  matching builds: $android_match"
+          echo "iOS fingerprint:     $ios_hash  matching builds: $ios_match_count"
+          echo "Android fingerprint: $android_hash  matching builds: $android_match_count"
 
-          if [ "$ios_match" -gt 0 ] && [ "$android_match" -gt 0 ]; then
+          {
+            echo "ios_hash=$ios_hash"
+            echo "android_hash=$android_hash"
+            echo "ios_match=$([ "$ios_match_count" -gt 0 ] && echo true || echo false)"
+            echo "android_match=$([ "$android_match_count" -gt 0 ] && echo true || echo false)"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$ios_match_count" -gt 0 ] && [ "$android_match_count" -gt 0 ]; then
             echo "needs_build=false" >> "$GITHUB_OUTPUT"
           else
             echo "needs_build=true" >> "$GITHUB_OUTPUT"
@@ -153,6 +164,22 @@ jobs:
             -F "pr_number=${PR_NUMBER}" \
             -F "pr_title=${PR_TITLE}"
           echo "Build runs on EAS Cloud. Per-job status checks will appear on the PR when it finishes."
+
+      - name: Post PR comment
+        if: always() && steps.decide.outputs.ios_hash != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          APP_NAME: example-frontend
+          APP_DISPLAY: Terreno Example
+          APP_ICON: "📱"
+          APP_SLUG: terreno-example
+          IOS_HASH: ${{ steps.decide.outputs.ios_hash }}
+          ANDROID_HASH: ${{ steps.decide.outputs.android_hash }}
+          IOS_MATCH: ${{ steps.decide.outputs.ios_match }}
+          ANDROID_MATCH: ${{ steps.decide.outputs.android_match }}
+          PATH_TAKEN: ${{ steps.decide.outputs.needs_build == 'true' && 'slow' || 'fast' }}
+        run: .github/workflows/scripts/post-eas-pr-comment.sh
 
   demo:
     name: EAS — demo
@@ -210,13 +237,20 @@ jobs:
           android_hash=$(eas fingerprint:generate --platform android --non-interactive --json | jq -r '.hash')
 
           # Demo iOS uses the development:simulator profile.
-          ios_match=$(eas build:list --platform ios --profile development:simulator --fingerprint-hash "$ios_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
-          android_match=$(eas build:list --platform android --profile development --fingerprint-hash "$android_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
+          ios_match_count=$(eas build:list --platform ios --profile development:simulator --fingerprint-hash "$ios_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
+          android_match_count=$(eas build:list --platform android --profile development --fingerprint-hash "$android_hash" --status finished --limit 1 --non-interactive --json | jq 'length')
 
-          echo "iOS fingerprint:     $ios_hash  matching builds: $ios_match"
-          echo "Android fingerprint: $android_hash  matching builds: $android_match"
+          echo "iOS fingerprint:     $ios_hash  matching builds: $ios_match_count"
+          echo "Android fingerprint: $android_hash  matching builds: $android_match_count"
 
-          if [ "$ios_match" -gt 0 ] && [ "$android_match" -gt 0 ]; then
+          {
+            echo "ios_hash=$ios_hash"
+            echo "android_hash=$android_hash"
+            echo "ios_match=$([ "$ios_match_count" -gt 0 ] && echo true || echo false)"
+            echo "android_match=$([ "$android_match_count" -gt 0 ] && echo true || echo false)"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$ios_match_count" -gt 0 ] && [ "$android_match_count" -gt 0 ]; then
             echo "needs_build=false" >> "$GITHUB_OUTPUT"
           else
             echo "needs_build=true" >> "$GITHUB_OUTPUT"
@@ -249,3 +283,19 @@ jobs:
             -F "pr_number=${PR_NUMBER}" \
             -F "pr_title=${PR_TITLE}"
           echo "Build runs on EAS Cloud. Per-job status checks will appear on the PR when it finishes."
+
+      - name: Post PR comment
+        if: always() && steps.decide.outputs.ios_hash != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          APP_NAME: demo
+          APP_DISPLAY: Terreno Demo
+          APP_ICON: "🧪"
+          APP_SLUG: terreno-demo
+          IOS_HASH: ${{ steps.decide.outputs.ios_hash }}
+          ANDROID_HASH: ${{ steps.decide.outputs.android_hash }}
+          IOS_MATCH: ${{ steps.decide.outputs.ios_match }}
+          ANDROID_MATCH: ${{ steps.decide.outputs.android_match }}
+          PATH_TAKEN: ${{ steps.decide.outputs.needs_build == 'true' && 'slow' || 'fast' }}
+        run: .github/workflows/scripts/post-eas-pr-comment.sh

--- a/.github/workflows/scripts/post-eas-pr-comment.sh
+++ b/.github/workflows/scripts/post-eas-pr-comment.sh
@@ -14,6 +14,9 @@
 #   IOS_MATCH         "true" if a finished iOS dev build matches IOS_HASH
 #   ANDROID_MATCH     "true" if a finished Android dev build matches ANDROID_HASH
 #   PATH_TAKEN        "fast" or "slow"
+#   IOS_DEVICE_BUILD_ID Latest finished iOS device dev build ID (may be empty)
+#   IOS_SIM_BUILD_ID    Latest finished iOS simulator dev build ID (may be empty)
+#   ANDROID_BUILD_ID    Latest finished Android dev build ID (may be empty)
 
 set -euo pipefail
 
@@ -50,6 +53,22 @@ android_status="⚠️ Fingerprint changed — rebuilding"
 path_line="✅ Fast path (waited on EAS)"
 [ "$PATH_TAKEN" = "slow" ] && path_line="🔨 Slow path (dev build dispatched async)"
 
+install_link() {
+  local label="$1" build_id="$2"
+  if [ -n "$build_id" ]; then
+    echo "- [$label]($builds_root/$build_id)"
+  else
+    echo "- $label: no build yet — trigger via [Trigger EAS Workflow](https://github.com/$GITHUB_REPOSITORY/actions/workflows/eas-dev-build.yml)"
+  fi
+}
+
+builds_root="https://expo.dev/accounts/flourishhealth/projects/$APP_SLUG/builds"
+install_section=$(
+  install_link "Install iOS device dev build" "${IOS_DEVICE_BUILD_ID:-}"
+  install_link "Install iOS simulator dev build" "${IOS_SIM_BUILD_ID:-}"
+  install_link "Install Android dev build" "${ANDROID_BUILD_ID:-}"
+)
+
 body=$(cat <<EOF
 $MARKER
 ### $APP_ICON $APP_DISPLAY — EAS PR build
@@ -63,14 +82,17 @@ $MARKER
 
 [Open branch on EAS dashboard]($branch_dashboard)
 
+**Install latest dev build**
+$install_section
+
 **Status**
 - Path: $path_line
-- iOS dev build: $ios_status
-- Android dev build: $android_status
+- iOS dev build matches fingerprint: $ios_status
+- Android dev build matches fingerprint: $android_status
 
 **Instructions**
-1. Install the latest \`$APP_SLUG\` dev build from the [EAS dashboard](https://expo.dev/accounts/flourishhealth/projects/$APP_SLUG/builds) (one-time, per phone).
-2. Scan the QR above with your phone's camera — it opens the dev client straight onto this PR's branch. Or in the dev client, tap "Extensions" → "Branch" → \`$branch\`.
+1. Install the right dev build above (one-time, per phone/simulator).
+2. Scan the QR with your phone's camera — it opens the dev client straight onto this PR's branch. Or in the dev client, tap "Extensions" → "Branch" → \`$branch\`.
 3. Pull to refresh after pushing more commits.
 
 </details>

--- a/.github/workflows/scripts/post-eas-pr-comment.sh
+++ b/.github/workflows/scripts/post-eas-pr-comment.sh
@@ -9,12 +9,11 @@
 #   APP_DISPLAY       Pretty name for the comment header
 #   APP_ICON          Emoji for the header (📱 or 🧪)
 #   APP_SLUG          EAS project slug (e.g. terreno-example, terreno-demo)
-#   IOS_HASH          iOS fingerprint hash
-#   ANDROID_HASH      Android fingerprint hash
+#   APP_SCHEME        Deep-link URL scheme (from app.json — e.g. frontend, terreno)
+#   PROJECT_ID        EAS project UUID
 #   IOS_MATCH         "true" if a finished iOS dev build matches IOS_HASH
 #   ANDROID_MATCH     "true" if a finished Android dev build matches ANDROID_HASH
 #   PATH_TAKEN        "fast" or "slow"
-#   WORKFLOW_RUN_URL  Optional URL to the EAS workflow run (links the comment)
 
 set -euo pipefail
 
@@ -25,57 +24,56 @@ set -euo pipefail
 : "${APP_DISPLAY:?missing}"
 : "${APP_ICON:?missing}"
 : "${APP_SLUG:?missing}"
-: "${IOS_HASH:?missing}"
-: "${ANDROID_HASH:?missing}"
+: "${APP_SCHEME:?missing}"
+: "${PROJECT_ID:?missing}"
 : "${IOS_MATCH:?missing}"
 : "${ANDROID_MATCH:?missing}"
 : "${PATH_TAKEN:?missing}"
 
 MARKER="<!-- eas-pr-comment:${APP_NAME} -->"
 
-ios_status="⚠️ Native deps changed — a new dev build was dispatched automatically"
-if [ "$IOS_MATCH" = "true" ]; then
-  ios_status="✅ Existing dev build can load this update"
-fi
+urlencode() {
+  jq -nr --arg v "$1" '$v | @uri'
+}
 
-android_status="⚠️ Native deps changed — a new dev build was dispatched automatically"
-if [ "$ANDROID_MATCH" = "true" ]; then
-  android_status="✅ Existing dev build can load this update"
-fi
+branch="pr-$PR_NUMBER"
+update_url="https://u.expo.dev/$PROJECT_ID?channel-name=$branch"
+deep_link="$APP_SCHEME://expo-development-client/?url=$(urlencode "$update_url")"
+qr_image="https://api.qrserver.com/v1/create-qr-code/?size=240x240&data=$(urlencode "$deep_link")"
+branch_dashboard="https://expo.dev/accounts/flourishhealth/projects/$APP_SLUG/updates?branchName=$branch"
 
-if [ "$PATH_TAKEN" = "slow" ]; then
-  path_note="🔨 **Slow path** — fingerprint changed, a fresh dev build is being produced on EAS (~15 min). The EAS Update was still published; existing dev builds with the prior fingerprint can keep using it. New per-job status checks will appear on this PR when the build finishes."
-else
-  path_note="✅ **Fast path** — fingerprint matched an existing dev build; published the EAS Update and confirmed it in real time."
-fi
+ios_status="⚠️ Fingerprint changed — rebuilding"
+[ "$IOS_MATCH" = "true" ] && ios_status="✅ Existing build matches"
+android_status="⚠️ Fingerprint changed — rebuilding"
+[ "$ANDROID_MATCH" = "true" ] && android_status="✅ Existing build matches"
 
-workflow_link=""
-if [ -n "${WORKFLOW_RUN_URL:-}" ]; then
-  workflow_link="
-
-[View EAS workflow run]($WORKFLOW_RUN_URL)"
-fi
+path_line="✅ Fast path (waited on EAS)"
+[ "$PATH_TAKEN" = "slow" ] && path_line="🔨 Slow path (dev build dispatched async)"
 
 body=$(cat <<EOF
 $MARKER
 ### $APP_ICON $APP_DISPLAY — EAS PR build
 
-**EAS Update branch:** \`pr-$PR_NUMBER\`
+**EAS Update branch:** \`$branch\`
 
-$path_note
+<details>
+<summary>Launch on device</summary>
 
-**Fingerprint**
-- iOS: \`$IOS_HASH\`
-- Android: \`$ANDROID_HASH\`
+[![Scan with phone camera]($qr_image)]($deep_link)
 
-**Dev build status (matching fingerprint)**
-- iOS: $ios_status
-- Android: $android_status
+[Open branch on EAS dashboard]($branch_dashboard)
 
-**How to test on your phone**
-1. Install the latest \`$APP_SLUG\` dev build from the [EAS dashboard](https://expo.dev/accounts/flourishhealth/projects/$APP_SLUG/builds).
-2. Open the dev build → shake → "Extensions" → "Branch" → select \`pr-$PR_NUMBER\`.
-3. Pull to refresh after pushing more commits.$workflow_link
+**Status**
+- Path: $path_line
+- iOS dev build: $ios_status
+- Android dev build: $android_status
+
+**Instructions**
+1. Install the latest \`$APP_SLUG\` dev build from the [EAS dashboard](https://expo.dev/accounts/flourishhealth/projects/$APP_SLUG/builds) (one-time, per phone).
+2. Scan the QR above with your phone's camera — it opens the dev client straight onto this PR's branch. Or in the dev client, tap "Extensions" → "Branch" → \`$branch\`.
+3. Pull to refresh after pushing more commits.
+
+</details>
 EOF
 )
 

--- a/.github/workflows/scripts/post-eas-pr-comment.sh
+++ b/.github/workflows/scripts/post-eas-pr-comment.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Post (or update) the EAS PR build comment on a pull request.
+#
+# Required env:
+#   GH_TOKEN          GitHub token with pull-requests: write
+#   GITHUB_REPOSITORY owner/repo
+#   PR_NUMBER         PR number to comment on
+#   APP_NAME          "example-frontend" or "demo"
+#   APP_DISPLAY       Pretty name for the comment header
+#   APP_ICON          Emoji for the header (📱 or 🧪)
+#   APP_SLUG          EAS project slug (e.g. terreno-example, terreno-demo)
+#   IOS_HASH          iOS fingerprint hash
+#   ANDROID_HASH      Android fingerprint hash
+#   IOS_MATCH         "true" if a finished iOS dev build matches IOS_HASH
+#   ANDROID_MATCH     "true" if a finished Android dev build matches ANDROID_HASH
+#   PATH_TAKEN        "fast" or "slow"
+#   WORKFLOW_RUN_URL  Optional URL to the EAS workflow run (links the comment)
+
+set -euo pipefail
+
+: "${GH_TOKEN:?missing}"
+: "${GITHUB_REPOSITORY:?missing}"
+: "${PR_NUMBER:?missing}"
+: "${APP_NAME:?missing}"
+: "${APP_DISPLAY:?missing}"
+: "${APP_ICON:?missing}"
+: "${APP_SLUG:?missing}"
+: "${IOS_HASH:?missing}"
+: "${ANDROID_HASH:?missing}"
+: "${IOS_MATCH:?missing}"
+: "${ANDROID_MATCH:?missing}"
+: "${PATH_TAKEN:?missing}"
+
+MARKER="<!-- eas-pr-comment:${APP_NAME} -->"
+
+ios_status="⚠️ Native deps changed — a new dev build was dispatched automatically"
+if [ "$IOS_MATCH" = "true" ]; then
+  ios_status="✅ Existing dev build can load this update"
+fi
+
+android_status="⚠️ Native deps changed — a new dev build was dispatched automatically"
+if [ "$ANDROID_MATCH" = "true" ]; then
+  android_status="✅ Existing dev build can load this update"
+fi
+
+if [ "$PATH_TAKEN" = "slow" ]; then
+  path_note="🔨 **Slow path** — fingerprint changed, a fresh dev build is being produced on EAS (~15 min). The EAS Update was still published; existing dev builds with the prior fingerprint can keep using it. New per-job status checks will appear on this PR when the build finishes."
+else
+  path_note="✅ **Fast path** — fingerprint matched an existing dev build; published the EAS Update and confirmed it in real time."
+fi
+
+workflow_link=""
+if [ -n "${WORKFLOW_RUN_URL:-}" ]; then
+  workflow_link="
+
+[View EAS workflow run]($WORKFLOW_RUN_URL)"
+fi
+
+body=$(cat <<EOF
+$MARKER
+### $APP_ICON $APP_DISPLAY — EAS PR build
+
+**EAS Update branch:** \`pr-$PR_NUMBER\`
+
+$path_note
+
+**Fingerprint**
+- iOS: \`$IOS_HASH\`
+- Android: \`$ANDROID_HASH\`
+
+**Dev build status (matching fingerprint)**
+- iOS: $ios_status
+- Android: $android_status
+
+**How to test on your phone**
+1. Install the latest \`$APP_SLUG\` dev build from the [EAS dashboard](https://expo.dev/accounts/flourishhealth/projects/$APP_SLUG/builds).
+2. Open the dev build → shake → "Extensions" → "Branch" → select \`pr-$PR_NUMBER\`.
+3. Pull to refresh after pushing more commits.$workflow_link
+EOF
+)
+
+existing_id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
+  --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -n 1 || true)
+
+if [ -n "$existing_id" ]; then
+  echo "Updating existing comment $existing_id"
+  gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$existing_id" \
+    -f body="$body" >/dev/null
+else
+  echo "Creating new comment"
+  gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+    -f body="$body" >/dev/null
+fi

--- a/demo/.eas/workflows/demo-build.yml
+++ b/demo/.eas/workflows/demo-build.yml
@@ -13,6 +13,10 @@ on:
     labels:
       - build-expo
 
+defaults:
+  tools:
+    bun: 1.3.10
+
 jobs:
   fingerprint:
     name: Compute fingerprint
@@ -92,6 +96,3 @@ jobs:
         1. Install the latest `terreno-demo` dev build from the [EAS dashboard](https://expo.dev/accounts/flourishhealth/projects/terreno-demo/builds) (or scan a fresh QR if one was built below).
         2. Open the dev build → shake to open the dev menu → "Extensions" → "Branch" → select `pr-${{ github.event.pull_request.number }}`.
         3. The PR's JavaScript loads instantly. Pull to refresh after pushing more commits.
-      build_ids:
-        - ${{ needs.build_ios.outputs.build_id }}
-        - ${{ needs.build_android.outputs.build_id }}

--- a/demo/.eas/workflows/demo-build.yml
+++ b/demo/.eas/workflows/demo-build.yml
@@ -32,7 +32,7 @@ jobs:
     needs: [fingerprint]
     params:
       platform: ios
-      profile: development:simulator
+      profile: development
       fingerprint_hash: ${{ needs.fingerprint.outputs.ios_fingerprint_hash }}
 
   get_android_build:
@@ -51,7 +51,7 @@ jobs:
     if: ${{ needs.get_ios_build.outputs.build_id == '' }}
     params:
       platform: ios
-      profile: development:simulator
+      profile: development
 
   build_android:
     name: Build Android dev client

--- a/demo/.eas/workflows/demo-build.yml
+++ b/demo/.eas/workflows/demo-build.yml
@@ -60,11 +60,26 @@ jobs:
 
   publish_update:
     name: Publish EAS Update for PR
-    type: update
     needs: [fingerprint]
-    params:
-      branch: pr-${{ github.event.pull_request.number }}
-      message: "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+    outputs:
+      first_update_group_id: ${{ steps.publish.outputs.first_update_group_id }}
+    steps:
+      - uses: eas/checkout
+      - uses: eas/use_npm_token
+      - uses: eas/install_node_modules
+      - name: Compile workspace packages
+        working_directory: ../
+        run: bun run compile
+      - name: Publish EAS Update
+        id: publish
+        run: |
+          update_json=$(eas update \
+            --branch "pr-${{ github.event.pull_request.number }}" \
+            --message "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}" \
+            --non-interactive \
+            --json)
+          first_id=$(echo "$update_json" | jq -r '.[0].group')
+          set-output first_update_group_id "$first_id"
 
   comment:
     name: Post PR comment

--- a/demo/.eas/workflows/demo-build.yml
+++ b/demo/.eas/workflows/demo-build.yml
@@ -16,6 +16,7 @@ on:
 defaults:
   tools:
     bun: 1.3.10
+    node: "22"
 
 jobs:
   fingerprint:
@@ -70,6 +71,9 @@ jobs:
       - name: Compile workspace packages
         working_directory: ../
         run: bun run compile
+      - name: Generate UI type documentation
+        working_directory: ../ui
+        run: bun run types
       - name: Publish EAS Update
         id: publish
         run: |

--- a/demo/.eas/workflows/demo-build.yml
+++ b/demo/.eas/workflows/demo-build.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Publish EAS Update
         id: publish
         run: |
-          update_json=$(eas update \
+          update_json=$(bunx eas-cli@latest update \
             --branch "pr-${{ github.event.pull_request.number }}" \
             --message "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}" \
             --non-interactive \

--- a/demo/.eas/workflows/demo-build.yml
+++ b/demo/.eas/workflows/demo-build.yml
@@ -1,17 +1,24 @@
 name: Demo PR
 
+# Invoked exclusively by .github/workflows/eas-pr.yml via `eas workflow:run`.
+# The GH Action decides fast path (no build needed, --wait) vs slow path
+# (new dev build needed, async), so we can reflect real status in GitHub.
+
 on:
-  pull_request:
-    branches: [master]
-    types: [opened, reopened, synchronize]
-    paths:
-      - demo/**
-      - ui/**
-      - package.json
-      - bun.lock
-  pull_request_labeled:
-    labels:
-      - build-expo
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number for branch/comment context
+        type: string
+        required: true
+      pr_title:
+        description: PR title for the update message
+        type: string
+        required: true
+      force_build:
+        description: Build a fresh dev client even if the fingerprint matches
+        type: boolean
+        default: false
 
 defaults:
   tools:
@@ -45,7 +52,7 @@ jobs:
     name: Build iOS dev client
     type: build
     needs: [get_ios_build]
-    if: ${{ github.event_name == 'pull_request_labeled' || needs.get_ios_build.outputs.build_id == '' }}
+    if: ${{ inputs.force_build || needs.get_ios_build.outputs.build_id == '' }}
     params:
       platform: ios
       profile: development:simulator
@@ -54,7 +61,7 @@ jobs:
     name: Build Android dev client
     type: build
     needs: [get_android_build]
-    if: ${{ github.event_name == 'pull_request_labeled' || needs.get_android_build.outputs.build_id == '' }}
+    if: ${{ inputs.force_build || needs.get_android_build.outputs.build_id == '' }}
     params:
       platform: android
       profile: development
@@ -77,8 +84,8 @@ jobs:
       - name: Publish EAS Update
         id: publish
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_TITLE: ${{ inputs.pr_title }}
         run: |
           update_json=$(bunx eas-cli@latest update \
             --branch "pr-${PR_NUMBER}" \
@@ -103,7 +110,7 @@ jobs:
         ### 🧪 Terreno Demo — EAS PR build
 
         **EAS Update published**
-        - Branch: `pr-${{ github.event.pull_request.number }}`
+        - Branch: `pr-${{ inputs.pr_number }}`
         - Update group: `${{ needs.publish_update.outputs.first_update_group_id }}`
 
         **Fingerprint**
@@ -116,5 +123,5 @@ jobs:
 
         **How to test on your phone**
         1. Install the latest `terreno-demo` dev build from the [EAS dashboard](https://expo.dev/accounts/flourishhealth/projects/terreno-demo/builds) (or scan a fresh QR if one was built below).
-        2. Open the dev build → shake to open the dev menu → "Extensions" → "Branch" → select `pr-${{ github.event.pull_request.number }}`.
+        2. Open the dev build → shake to open the dev menu → "Extensions" → "Branch" → select `pr-${{ inputs.pr_number }}`.
         3. The PR's JavaScript loads instantly. Pull to refresh after pushing more commits.

--- a/demo/.eas/workflows/demo-build.yml
+++ b/demo/.eas/workflows/demo-build.yml
@@ -76,10 +76,13 @@ jobs:
         run: bun run types
       - name: Publish EAS Update
         id: publish
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           update_json=$(bunx eas-cli@latest update \
-            --branch "pr-${{ github.event.pull_request.number }}" \
-            --message "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}" \
+            --branch "pr-${PR_NUMBER}" \
+            --message "PR #${PR_NUMBER}: ${PR_TITLE}" \
             --non-interactive \
             --json)
           first_id=$(echo "$update_json" | jq -r '.[0].group')

--- a/demo/.eas/workflows/demo-build.yml
+++ b/demo/.eas/workflows/demo-build.yml
@@ -1,25 +1,97 @@
-name: Demo Build
+name: Demo PR
 
 on:
+  pull_request:
+    branches: [master]
+    types: [opened, reopened, synchronize]
+    paths:
+      - demo/**
+      - ui/**
+      - package.json
+      - bun.lock
   pull_request_labeled:
-    label: "build-expo"
+    labels:
+      - build-expo
 
 jobs:
-  build_ios:
-    name: Build iOS
-    type: build
+  fingerprint:
+    name: Compute fingerprint
+    type: fingerprint
+
+  get_ios_build:
+    name: Check for matching iOS dev build
+    type: get-build
+    needs: [fingerprint]
     params:
       platform: ios
+      profile: development:simulator
+      fingerprint_hash: ${{ needs.fingerprint.outputs.ios_fingerprint_hash }}
+
+  get_android_build:
+    name: Check for matching Android dev build
+    type: get-build
+    needs: [fingerprint]
+    params:
+      platform: android
       profile: development
+      fingerprint_hash: ${{ needs.fingerprint.outputs.android_fingerprint_hash }}
+
+  build_ios:
+    name: Build iOS dev client
+    type: build
+    needs: [get_ios_build]
+    if: ${{ github.event_name == 'pull_request_labeled' || needs.get_ios_build.outputs.build_id == '' }}
+    params:
+      platform: ios
+      profile: development:simulator
 
   build_android:
-    name: Build Android
+    name: Build Android dev client
     type: build
+    needs: [get_android_build]
+    if: ${{ github.event_name == 'pull_request_labeled' || needs.get_android_build.outputs.build_id == '' }}
     params:
       platform: android
       profile: development
 
-  github_comment:
-    name: Post GitHub Comment
+  publish_update:
+    name: Publish EAS Update for PR
+    type: update
+    needs: [fingerprint]
+    params:
+      branch: pr-${{ github.event.pull_request.number }}
+      message: "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+
+  comment:
+    name: Post PR comment
     type: github-comment
-    after: [build_ios, build_android]
+    after:
+      - fingerprint
+      - get_ios_build
+      - get_android_build
+      - publish_update
+      - build_ios
+      - build_android
+    params:
+      message: |
+        ### 🧪 Terreno Demo — EAS PR build
+
+        **EAS Update published**
+        - Branch: `pr-${{ github.event.pull_request.number }}`
+        - Update group: `${{ needs.publish_update.outputs.first_update_group_id }}`
+
+        **Fingerprint**
+        - iOS: `${{ needs.fingerprint.outputs.ios_fingerprint_hash }}`
+        - Android: `${{ needs.fingerprint.outputs.android_fingerprint_hash }}`
+
+        **Dev build status (matching fingerprint)**
+        - iOS: ${{ needs.get_ios_build.outputs.build_id != '' && '✅ Existing dev build can load this update' || '⚠️ Native deps changed — fingerprint busted, needs a new dev build (add the `build-expo` label)' }}
+        - Android: ${{ needs.get_android_build.outputs.build_id != '' && '✅ Existing dev build can load this update' || '⚠️ Native deps changed — fingerprint busted, needs a new dev build (add the `build-expo` label)' }}
+
+        **How to test on your phone**
+        1. Install the latest `terreno-demo` dev build from the [EAS dashboard](https://expo.dev/accounts/flourishhealth/projects/terreno-demo/builds) (or scan a fresh QR if one was built below).
+        2. Open the dev build → shake to open the dev menu → "Extensions" → "Branch" → select `pr-${{ github.event.pull_request.number }}`.
+        3. The PR's JavaScript loads instantly. Pull to refresh after pushing more commits.
+      build_ids:
+        - ${{ needs.build_ios.outputs.build_id }}
+        - ${{ needs.build_android.outputs.build_id }}

--- a/demo/.eas/workflows/demo-build.yml
+++ b/demo/.eas/workflows/demo-build.yml
@@ -90,34 +90,4 @@ jobs:
             --json)
           first_id=$(echo "$update_json" | jq -r '.[0].group')
           set-output first_update_group_id "$first_id"
-
-  comment:
-    name: Post PR comment
-    type: github-comment
-    after:
-      - fingerprint
-      - get_ios_build
-      - get_android_build
-      - publish_update
-      - build_ios
-      - build_android
-    params:
-      message: |
-        ### 🧪 Terreno Demo — EAS PR build
-
-        **EAS Update published**
-        - Branch: `pr-${{ inputs.pr_number }}`
-        - Update group: `${{ needs.publish_update.outputs.first_update_group_id }}`
-
-        **Fingerprint**
-        - iOS: `${{ needs.fingerprint.outputs.ios_fingerprint_hash }}`
-        - Android: `${{ needs.fingerprint.outputs.android_fingerprint_hash }}`
-
-        **Dev build status (matching fingerprint)**
-        - iOS: ${{ needs.get_ios_build.outputs.build_id != '' && '✅ Existing dev build can load this update' || '⚠️ Native deps changed — a new dev build was dispatched automatically' }}
-        - Android: ${{ needs.get_android_build.outputs.build_id != '' && '✅ Existing dev build can load this update' || '⚠️ Native deps changed — a new dev build was dispatched automatically' }}
-
-        **How to test on your phone**
-        1. Install the latest `terreno-demo` dev build from the [EAS dashboard](https://expo.dev/accounts/flourishhealth/projects/terreno-demo/builds) (or scan a fresh QR if one was built below).
-        2. Open the dev build → shake to open the dev menu → "Extensions" → "Branch" → select `pr-${{ inputs.pr_number }}`.
-        3. The PR's JavaScript loads instantly. Pull to refresh after pushing more commits.
+          echo "✓ EAS Update published to branch pr-${PR_NUMBER} (group ${first_id})"

--- a/demo/.eas/workflows/demo-build.yml
+++ b/demo/.eas/workflows/demo-build.yml
@@ -15,10 +15,6 @@ on:
         description: PR title for the update message
         type: string
         required: true
-      force_build:
-        description: Build a fresh dev client even if the fingerprint matches
-        type: boolean
-        default: false
 
 defaults:
   tools:
@@ -52,7 +48,7 @@ jobs:
     name: Build iOS dev client
     type: build
     needs: [get_ios_build]
-    if: ${{ inputs.force_build || needs.get_ios_build.outputs.build_id == '' }}
+    if: ${{ needs.get_ios_build.outputs.build_id == '' }}
     params:
       platform: ios
       profile: development:simulator
@@ -61,7 +57,7 @@ jobs:
     name: Build Android dev client
     type: build
     needs: [get_android_build]
-    if: ${{ inputs.force_build || needs.get_android_build.outputs.build_id == '' }}
+    if: ${{ needs.get_android_build.outputs.build_id == '' }}
     params:
       platform: android
       profile: development
@@ -118,8 +114,8 @@ jobs:
         - Android: `${{ needs.fingerprint.outputs.android_fingerprint_hash }}`
 
         **Dev build status (matching fingerprint)**
-        - iOS: ${{ needs.get_ios_build.outputs.build_id != '' && '✅ Existing dev build can load this update' || '⚠️ Native deps changed — fingerprint busted, needs a new dev build (add the `build-expo` label)' }}
-        - Android: ${{ needs.get_android_build.outputs.build_id != '' && '✅ Existing dev build can load this update' || '⚠️ Native deps changed — fingerprint busted, needs a new dev build (add the `build-expo` label)' }}
+        - iOS: ${{ needs.get_ios_build.outputs.build_id != '' && '✅ Existing dev build can load this update' || '⚠️ Native deps changed — a new dev build was dispatched automatically' }}
+        - Android: ${{ needs.get_android_build.outputs.build_id != '' && '✅ Existing dev build can load this update' || '⚠️ Native deps changed — a new dev build was dispatched automatically' }}
 
         **How to test on your phone**
         1. Install the latest `terreno-demo` dev build from the [EAS dashboard](https://expo.dev/accounts/flourishhealth/projects/terreno-demo/builds) (or scan a fresh QR if one was built below).

--- a/demo/app.json
+++ b/demo/app.json
@@ -4,6 +4,12 @@
     "slug": "terreno-demo",
     "scheme": "terreno",
     "version": "1.0.0",
+    "runtimeVersion": {
+      "policy": "fingerprint"
+    },
+    "updates": {
+      "url": "https://u.expo.dev/89c320ce-465b-4d71-9fd6-74fea9c5d898"
+    },
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/example-frontend/.eas/workflows/example-frontend-build.yml
+++ b/example-frontend/.eas/workflows/example-frontend-build.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Publish EAS Update
         id: publish
         run: |
-          update_json=$(eas update \
+          update_json=$(bunx eas-cli@latest update \
             --branch "pr-${{ github.event.pull_request.number }}" \
             --message "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}" \
             --non-interactive \

--- a/example-frontend/.eas/workflows/example-frontend-build.yml
+++ b/example-frontend/.eas/workflows/example-frontend-build.yml
@@ -61,11 +61,26 @@ jobs:
 
   publish_update:
     name: Publish EAS Update for PR
-    type: update
     needs: [fingerprint]
-    params:
-      branch: pr-${{ github.event.pull_request.number }}
-      message: "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+    outputs:
+      first_update_group_id: ${{ steps.publish.outputs.first_update_group_id }}
+    steps:
+      - uses: eas/checkout
+      - uses: eas/use_npm_token
+      - uses: eas/install_node_modules
+      - name: Compile workspace packages
+        working_directory: ../
+        run: bun run compile
+      - name: Publish EAS Update
+        id: publish
+        run: |
+          update_json=$(eas update \
+            --branch "pr-${{ github.event.pull_request.number }}" \
+            --message "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}" \
+            --non-interactive \
+            --json)
+          first_id=$(echo "$update_json" | jq -r '.[0].group')
+          set-output first_update_group_id "$first_id"
 
   comment:
     name: Post PR comment

--- a/example-frontend/.eas/workflows/example-frontend-build.yml
+++ b/example-frontend/.eas/workflows/example-frontend-build.yml
@@ -1,25 +1,98 @@
-name: Example Frontend Build
+name: Example Frontend PR
 
 on:
+  pull_request:
+    branches: [master]
+    types: [opened, reopened, synchronize]
+    paths:
+      - example-frontend/**
+      - ui/**
+      - rtk/**
+      - package.json
+      - bun.lock
   pull_request_labeled:
-    label: "build-expo"
+    labels:
+      - build-expo
 
 jobs:
+  fingerprint:
+    name: Compute fingerprint
+    type: fingerprint
+
+  get_ios_build:
+    name: Check for matching iOS dev build
+    type: get-build
+    needs: [fingerprint]
+    params:
+      platform: ios
+      profile: development
+      fingerprint_hash: ${{ needs.fingerprint.outputs.ios_fingerprint_hash }}
+
+  get_android_build:
+    name: Check for matching Android dev build
+    type: get-build
+    needs: [fingerprint]
+    params:
+      platform: android
+      profile: development
+      fingerprint_hash: ${{ needs.fingerprint.outputs.android_fingerprint_hash }}
+
   build_ios:
-    name: Build iOS
+    name: Build iOS dev client
     type: build
+    needs: [get_ios_build]
+    if: ${{ github.event_name == 'pull_request_labeled' || needs.get_ios_build.outputs.build_id == '' }}
     params:
       platform: ios
       profile: development
 
   build_android:
-    name: Build Android
+    name: Build Android dev client
     type: build
+    needs: [get_android_build]
+    if: ${{ github.event_name == 'pull_request_labeled' || needs.get_android_build.outputs.build_id == '' }}
     params:
       platform: android
       profile: development
 
-  github_comment:
-    name: Post GitHub Comment
+  publish_update:
+    name: Publish EAS Update for PR
+    type: update
+    needs: [fingerprint]
+    params:
+      branch: pr-${{ github.event.pull_request.number }}
+      message: "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+
+  comment:
+    name: Post PR comment
     type: github-comment
-    after: [build_ios, build_android]
+    after:
+      - fingerprint
+      - get_ios_build
+      - get_android_build
+      - publish_update
+      - build_ios
+      - build_android
+    params:
+      message: |
+        ### 📱 Terreno Example — EAS PR build
+
+        **EAS Update published**
+        - Branch: `pr-${{ github.event.pull_request.number }}`
+        - Update group: `${{ needs.publish_update.outputs.first_update_group_id }}`
+
+        **Fingerprint**
+        - iOS: `${{ needs.fingerprint.outputs.ios_fingerprint_hash }}`
+        - Android: `${{ needs.fingerprint.outputs.android_fingerprint_hash }}`
+
+        **Dev build status (matching fingerprint)**
+        - iOS: ${{ needs.get_ios_build.outputs.build_id != '' && '✅ Existing dev build can load this update' || '⚠️ Native deps changed — fingerprint busted, needs a new dev build (add the `build-expo` label)' }}
+        - Android: ${{ needs.get_android_build.outputs.build_id != '' && '✅ Existing dev build can load this update' || '⚠️ Native deps changed — fingerprint busted, needs a new dev build (add the `build-expo` label)' }}
+
+        **How to test on your phone**
+        1. Install the latest `terreno-example` dev build from the [EAS dashboard](https://expo.dev/accounts/flourishhealth/projects/terreno-example/builds) (or scan a fresh QR if one was built below).
+        2. Open the dev build → shake to open the dev menu → "Extensions" → "Branch" → select `pr-${{ github.event.pull_request.number }}`.
+        3. The PR's JavaScript loads instantly. Pull to refresh after pushing more commits.
+      build_ids:
+        - ${{ needs.build_ios.outputs.build_id }}
+        - ${{ needs.build_android.outputs.build_id }}

--- a/example-frontend/.eas/workflows/example-frontend-build.yml
+++ b/example-frontend/.eas/workflows/example-frontend-build.yml
@@ -17,6 +17,7 @@ on:
 defaults:
   tools:
     bun: 1.3.10
+    node: "22"
 
 jobs:
   fingerprint:

--- a/example-frontend/.eas/workflows/example-frontend-build.yml
+++ b/example-frontend/.eas/workflows/example-frontend-build.yml
@@ -14,6 +14,10 @@ on:
     labels:
       - build-expo
 
+defaults:
+  tools:
+    bun: 1.3.10
+
 jobs:
   fingerprint:
     name: Compute fingerprint
@@ -93,6 +97,3 @@ jobs:
         1. Install the latest `terreno-example` dev build from the [EAS dashboard](https://expo.dev/accounts/flourishhealth/projects/terreno-example/builds) (or scan a fresh QR if one was built below).
         2. Open the dev build → shake to open the dev menu → "Extensions" → "Branch" → select `pr-${{ github.event.pull_request.number }}`.
         3. The PR's JavaScript loads instantly. Pull to refresh after pushing more commits.
-      build_ids:
-        - ${{ needs.build_ios.outputs.build_id }}
-        - ${{ needs.build_android.outputs.build_id }}

--- a/example-frontend/.eas/workflows/example-frontend-build.yml
+++ b/example-frontend/.eas/workflows/example-frontend-build.yml
@@ -74,10 +74,13 @@ jobs:
         run: bun run compile
       - name: Publish EAS Update
         id: publish
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           update_json=$(bunx eas-cli@latest update \
-            --branch "pr-${{ github.event.pull_request.number }}" \
-            --message "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}" \
+            --branch "pr-${PR_NUMBER}" \
+            --message "PR #${PR_NUMBER}: ${PR_TITLE}" \
             --non-interactive \
             --json)
           first_id=$(echo "$update_json" | jq -r '.[0].group')

--- a/example-frontend/.eas/workflows/example-frontend-build.yml
+++ b/example-frontend/.eas/workflows/example-frontend-build.yml
@@ -15,10 +15,6 @@ on:
         description: PR title for the update message
         type: string
         required: true
-      force_build:
-        description: Build a fresh dev client even if the fingerprint matches
-        type: boolean
-        default: false
 
 defaults:
   tools:
@@ -52,7 +48,7 @@ jobs:
     name: Build iOS dev client
     type: build
     needs: [get_ios_build]
-    if: ${{ inputs.force_build || needs.get_ios_build.outputs.build_id == '' }}
+    if: ${{ needs.get_ios_build.outputs.build_id == '' }}
     params:
       platform: ios
       profile: development
@@ -61,7 +57,7 @@ jobs:
     name: Build Android dev client
     type: build
     needs: [get_android_build]
-    if: ${{ inputs.force_build || needs.get_android_build.outputs.build_id == '' }}
+    if: ${{ needs.get_android_build.outputs.build_id == '' }}
     params:
       platform: android
       profile: development
@@ -115,8 +111,8 @@ jobs:
         - Android: `${{ needs.fingerprint.outputs.android_fingerprint_hash }}`
 
         **Dev build status (matching fingerprint)**
-        - iOS: ${{ needs.get_ios_build.outputs.build_id != '' && '✅ Existing dev build can load this update' || '⚠️ Native deps changed — fingerprint busted, needs a new dev build (add the `build-expo` label)' }}
-        - Android: ${{ needs.get_android_build.outputs.build_id != '' && '✅ Existing dev build can load this update' || '⚠️ Native deps changed — fingerprint busted, needs a new dev build (add the `build-expo` label)' }}
+        - iOS: ${{ needs.get_ios_build.outputs.build_id != '' && '✅ Existing dev build can load this update' || '⚠️ Native deps changed — a new dev build was dispatched automatically' }}
+        - Android: ${{ needs.get_android_build.outputs.build_id != '' && '✅ Existing dev build can load this update' || '⚠️ Native deps changed — a new dev build was dispatched automatically' }}
 
         **How to test on your phone**
         1. Install the latest `terreno-example` dev build from the [EAS dashboard](https://expo.dev/accounts/flourishhealth/projects/terreno-example/builds) (or scan a fresh QR if one was built below).

--- a/example-frontend/.eas/workflows/example-frontend-build.yml
+++ b/example-frontend/.eas/workflows/example-frontend-build.yml
@@ -87,34 +87,4 @@ jobs:
             --json)
           first_id=$(echo "$update_json" | jq -r '.[0].group')
           set-output first_update_group_id "$first_id"
-
-  comment:
-    name: Post PR comment
-    type: github-comment
-    after:
-      - fingerprint
-      - get_ios_build
-      - get_android_build
-      - publish_update
-      - build_ios
-      - build_android
-    params:
-      message: |
-        ### 📱 Terreno Example — EAS PR build
-
-        **EAS Update published**
-        - Branch: `pr-${{ inputs.pr_number }}`
-        - Update group: `${{ needs.publish_update.outputs.first_update_group_id }}`
-
-        **Fingerprint**
-        - iOS: `${{ needs.fingerprint.outputs.ios_fingerprint_hash }}`
-        - Android: `${{ needs.fingerprint.outputs.android_fingerprint_hash }}`
-
-        **Dev build status (matching fingerprint)**
-        - iOS: ${{ needs.get_ios_build.outputs.build_id != '' && '✅ Existing dev build can load this update' || '⚠️ Native deps changed — a new dev build was dispatched automatically' }}
-        - Android: ${{ needs.get_android_build.outputs.build_id != '' && '✅ Existing dev build can load this update' || '⚠️ Native deps changed — a new dev build was dispatched automatically' }}
-
-        **How to test on your phone**
-        1. Install the latest `terreno-example` dev build from the [EAS dashboard](https://expo.dev/accounts/flourishhealth/projects/terreno-example/builds) (or scan a fresh QR if one was built below).
-        2. Open the dev build → shake to open the dev menu → "Extensions" → "Branch" → select `pr-${{ inputs.pr_number }}`.
-        3. The PR's JavaScript loads instantly. Pull to refresh after pushing more commits.
+          echo "✓ EAS Update published to branch pr-${PR_NUMBER} (group ${first_id})"

--- a/example-frontend/.eas/workflows/example-frontend-build.yml
+++ b/example-frontend/.eas/workflows/example-frontend-build.yml
@@ -1,18 +1,24 @@
 name: Example Frontend PR
 
+# Invoked exclusively by .github/workflows/eas-pr.yml via `eas workflow:run`.
+# The GH Action decides fast path (no build needed, --wait) vs slow path
+# (new dev build needed, async), so we can reflect real status in GitHub.
+
 on:
-  pull_request:
-    branches: [master]
-    types: [opened, reopened, synchronize]
-    paths:
-      - example-frontend/**
-      - ui/**
-      - rtk/**
-      - package.json
-      - bun.lock
-  pull_request_labeled:
-    labels:
-      - build-expo
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number for branch/comment context
+        type: string
+        required: true
+      pr_title:
+        description: PR title for the update message
+        type: string
+        required: true
+      force_build:
+        description: Build a fresh dev client even if the fingerprint matches
+        type: boolean
+        default: false
 
 defaults:
   tools:
@@ -46,7 +52,7 @@ jobs:
     name: Build iOS dev client
     type: build
     needs: [get_ios_build]
-    if: ${{ github.event_name == 'pull_request_labeled' || needs.get_ios_build.outputs.build_id == '' }}
+    if: ${{ inputs.force_build || needs.get_ios_build.outputs.build_id == '' }}
     params:
       platform: ios
       profile: development
@@ -55,7 +61,7 @@ jobs:
     name: Build Android dev client
     type: build
     needs: [get_android_build]
-    if: ${{ github.event_name == 'pull_request_labeled' || needs.get_android_build.outputs.build_id == '' }}
+    if: ${{ inputs.force_build || needs.get_android_build.outputs.build_id == '' }}
     params:
       platform: android
       profile: development
@@ -75,8 +81,8 @@ jobs:
       - name: Publish EAS Update
         id: publish
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_TITLE: ${{ inputs.pr_title }}
         run: |
           update_json=$(bunx eas-cli@latest update \
             --branch "pr-${PR_NUMBER}" \
@@ -101,7 +107,7 @@ jobs:
         ### 📱 Terreno Example — EAS PR build
 
         **EAS Update published**
-        - Branch: `pr-${{ github.event.pull_request.number }}`
+        - Branch: `pr-${{ inputs.pr_number }}`
         - Update group: `${{ needs.publish_update.outputs.first_update_group_id }}`
 
         **Fingerprint**
@@ -114,5 +120,5 @@ jobs:
 
         **How to test on your phone**
         1. Install the latest `terreno-example` dev build from the [EAS dashboard](https://expo.dev/accounts/flourishhealth/projects/terreno-example/builds) (or scan a fresh QR if one was built below).
-        2. Open the dev build → shake to open the dev menu → "Extensions" → "Branch" → select `pr-${{ github.event.pull_request.number }}`.
+        2. Open the dev build → shake to open the dev menu → "Extensions" → "Branch" → select `pr-${{ inputs.pr_number }}`.
         3. The PR's JavaScript loads instantly. Pull to refresh after pushing more commits.

--- a/example-frontend/app.json
+++ b/example-frontend/app.json
@@ -3,6 +3,12 @@
     "name": "Terreno Example",
     "slug": "terreno-example",
     "version": "1.0.0",
+    "runtimeVersion": {
+      "policy": "fingerprint"
+    },
+    "updates": {
+      "url": "https://u.expo.dev/ddbe68d9-1142-4991-a02e-4ebb9fd83530"
+    },
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "frontend",

--- a/example-frontend/eas.json
+++ b/example-frontend/eas.json
@@ -9,10 +9,18 @@
       "distribution": "internal",
       "bun": "1.3.10",
       "ios": {
-        "simulator": true,
         "image": "latest"
       },
       "android": {
+        "image": "latest"
+      }
+    },
+    "development:simulator": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "bun": "1.3.10",
+      "ios": {
+        "simulator": true,
         "image": "latest"
       }
     },


### PR DESCRIPTION
## Summary

Per-PR EAS Updates with fingerprint-based dev build detection. Each PR push automatically publishes an EAS Update and posts a PR comment with a scannable QR code, install links, and EAS branch link — all folded behind a toggle to keep the PR timeline clean. A GitHub Action computes the local fingerprint, checks EAS for a matching finished dev build, and either waits for the EAS workflow (fast path, ~3 min, real pass/fail reflected in GH) or dispatches it asynchronously (slow path, when a new native build is needed).

## Human Testing Steps

- [ ] Open a PR touching `example-frontend/**` or `ui/**` — the `EAS — example-frontend` GH Action should appear, compute a fingerprint, and post a PR comment with the EAS Update branch and a "Launch on device" toggle
- [ ] Expand the toggle — confirm QR code renders, EAS branch dashboard link works, and install links point at the correct EAS build pages
- [ ] Scan the QR on your phone — confirm it opens the dev build on the PR branch
- [ ] Verify GH Action status reflects real pass/fail (not always-green)
- [ ] Bump a native dep to hit the slow path — confirm GH Action dispatches async and the comment still posts
- [ ] Trigger `Trigger EAS Workflow` → `both` — confirm it dispatches example-frontend and demo in one run

## Changes

- `example-frontend/app.json`, `demo/app.json`: `runtimeVersion: { policy: "fingerprint" }` + `updates.url`
- `example-frontend/eas.json`: split `development` into device + add `development:simulator` (mirrors demo profile layout)
- `.github/workflows/eas-pr.yml` (new): fingerprint-aware GH Action driver
  - Fast path (fingerprint matches): `eas workflow:run --wait` — GH Action reflects real pass/fail
  - Slow path (fingerprint changed): dispatch async — EAS GitHub App posts per-job checks when done
  - Queries latest finished build ID per (platform, profile) to surface install links in the comment
  - `~/.bun/install/cache` + `node_modules` cached on `bun.lock` hash
  - `permissions: pull-requests: write` to post/update comment via GITHUB_TOKEN
- `.github/workflows/scripts/post-eas-pr-comment.sh` (new): upserts a single PR comment (keyed by hidden marker) with QR code deep-link, EAS branch dashboard link, per-platform install links (iOS device / iOS sim / Android), and dev-build fingerprint status — all inside a `<details>` toggle so the visible surface is just title + branch
- `example-frontend/.eas/workflows/example-frontend-build.yml`, `demo/.eas/workflows/demo-build.yml`: `workflow_dispatch` inputs-only, `pr_number`/`pr_title` via env (shell injection fix), bun 1.3.10 + Node 22, `bunx eas-cli@latest` for update step; iOS build now targets device profile
- `.github/workflows/eas-dev-build.yml`: manual dispatcher with new `both` target option (dispatches example-frontend + demo in sequence); secret validation before EAS CLI setup

## Automated Tests

- EAS workflow YAML validated with `eas workflow:validate` (both apps pass)
- `bun run lint` passed across all packages
- EAS workflows exercised live on this PR — all jobs confirmed working end-to-end, PR comment confirmed posting