### PR TITLE
Add Pressto button press animations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -468,6 +468,7 @@
         "linkify-it": "catalog:",
         "lodash": "catalog:",
         "luxon": "catalog:",
+        "pressto": "catalog:",
         "react-app-polyfill": "^3.0.0",
         "react-date-picker": "^12.0.1",
         "react-datetime-picker": "^7.0.1",
@@ -571,6 +572,7 @@
     "lodash": "^4.17.23",
     "luxon": "^3.7.2",
     "mongoose": "8.23.0",
+    "pressto": "^0.6.1",
     "prettier": "^3.3.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
@@ -3378,6 +3380,8 @@
     "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
+
+    "pressto": ["pressto@0.6.1", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-gesture-handler": "*", "react-native-reanimated": "*", "react-native-worklets": "*" } }, "sha512-tLYEzQTupHYTh556NSDbFc5FPF03g4AR98bYj1yEljKxBtZeMYw095zOUUAsFIuySBT6z7NKCjix6kMcCBxduw=="],
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 

--- a/demo/stories/Button.stories.tsx
+++ b/demo/stories/Button.stories.tsx
@@ -1,49 +1,77 @@
-import {Box, Button, type ButtonProps, Heading} from "@terreno/ui";
+import {Box, Button, type ButtonPressAnimation, type ButtonProps, Heading, Text} from "@terreno/ui";
+import type React from "react";
 
-export const ButtonDemo = (props: Partial<ButtonProps>) => {
+interface ButtonAnimationExample {
+  description: string;
+  label: string;
+  value: ButtonPressAnimation;
+}
+
+interface ButtonVariantExample {
+  iconName?: ButtonProps["iconName"];
+  text: string;
+  variant?: ButtonProps["variant"];
+}
+
+const BUTTON_PRESS_ANIMATIONS: ButtonAnimationExample[] = [
+  {
+    description: "Pressto PressableScale compresses the button while pressed.",
+    label: "Scale",
+    value: "scale",
+  },
+  {
+    description: "Pressto PressableOpacity fades the button while pressed.",
+    label: "Opacity",
+    value: "opacity",
+  },
+  {
+    description: "Pressto PressableWithoutFeedback keeps behavior without visual motion.",
+    label: "None",
+    value: "none",
+  },
+];
+
+const BUTTON_VARIANT_EXAMPLES: ButtonVariantExample[] = [
+  {iconName: "bolt", text: "Primary", variant: "primary"},
+  {iconName: "star", text: "Secondary", variant: "secondary"},
+  {iconName: "border-all", text: "Outline", variant: "outline"},
+  {iconName: "leaf", text: "Muted", variant: "muted"},
+  {iconName: "trash", text: "Destructive", variant: "destructive"},
+];
+
+const handleDemoClick = (): void => {
+  console.info("clicked");
+};
+
+export const ButtonDemo: React.FC<Partial<ButtonProps>> = (props) => {
   return (
     <Box alignItems="center" justifyContent="center">
-      <Button iconName="plus" onClick={() => console.info("clicked")} text="Button" {...props} />
+      <Button iconName="plus" onClick={handleDemoClick} text="Button" {...props} />
     </Box>
   );
 };
 
-export const ButtonVariants = (props: Partial<ButtonProps> = {}) => {
+export const ButtonVariants: React.FC<Partial<ButtonProps>> = (props = {}) => {
   return (
     <>
       <Box direction="row" wrap>
         <Box padding={1}>
-          <Button onClick={() => console.info("clicked")} text="Default/Primary" {...props} />
+          <Button onClick={handleDemoClick} text="Default/Primary" {...props} />
         </Box>
         <Box padding={1}>
-          <Button
-            onClick={() => console.info("clicked")}
-            text="Secondary"
-            variant="secondary"
-            {...props}
-          />
+          <Button onClick={handleDemoClick} text="Secondary" variant="secondary" {...props} />
         </Box>
         <Box padding={1}>
-          <Button
-            onClick={() => console.info("clicked")}
-            text="Outline"
-            variant="outline"
-            {...props}
-          />
+          <Button onClick={handleDemoClick} text="Outline" variant="outline" {...props} />
         </Box>
         <Box padding={1}>
-          <Button
-            onClick={() => console.info("clicked")}
-            text="Destructive"
-            variant="destructive"
-            {...props}
-          />
+          <Button onClick={handleDemoClick} text="Destructive" variant="destructive" {...props} />
         </Box>
         <Box padding={1}>
-          <Button onClick={() => console.info("clicked")} text="Muted" variant="muted" {...props} />
+          <Button onClick={handleDemoClick} text="Muted" variant="muted" {...props} />
         </Box>
         <Box padding={1}>
-          <Button disabled onClick={() => console.info("clicked")} text="Disabled" {...props} />
+          <Button disabled onClick={handleDemoClick} text="Disabled" {...props} />
         </Box>
       </Box>
       <Box direction="column" paddingX={1} paddingY={4}>
@@ -51,78 +79,56 @@ export const ButtonVariants = (props: Partial<ButtonProps> = {}) => {
       </Box>
       <Box direction="row" wrap>
         <Box padding={1}>
-          <Button
-            disabled
-            onClick={() => console.info("clicked")}
-            text="Default/Primary"
-            {...props}
-          />
+          <Button disabled onClick={handleDemoClick} text="Default/Primary" {...props} />
         </Box>
         <Box padding={1}>
           <Button
             disabled
-            onClick={() => console.info("clicked")}
+            onClick={handleDemoClick}
             text="Secondary"
             variant="secondary"
             {...props}
           />
         </Box>
         <Box padding={1}>
-          <Button
-            disabled
-            onClick={() => console.info("clicked")}
-            text="Outline"
-            variant="outline"
-            {...props}
-          />
+          <Button disabled onClick={handleDemoClick} text="Outline" variant="outline" {...props} />
         </Box>
         <Box padding={1}>
           <Button
             disabled
-            onClick={() => console.info("clicked")}
+            onClick={handleDemoClick}
             text="Destructive"
             variant="destructive"
             {...props}
           />
         </Box>
         <Box padding={1}>
-          <Button
-            disabled
-            onClick={() => console.info("clicked")}
-            text="Muted"
-            variant="muted"
-            {...props}
-          />
+          <Button disabled onClick={handleDemoClick} text="Muted" variant="muted" {...props} />
         </Box>
       </Box>
     </>
   );
 };
 
-export const ButtonIconPosition = () => {
+export const ButtonIconPosition: React.FC = () => {
   return (
     <Box direction="row" wrap>
       <Box padding={1}>
-        <Button iconName="check" onClick={() => console.info("clicked")} text="Icon default" />
+        <Button iconName="check" onClick={handleDemoClick} text="Icon default" />
       </Box>
       <Box padding={1}>
-        <Button
-          iconName="check"
-          iconPosition="right"
-          onClick={() => console.info("clicked")}
-          text="Icon Right"
-        />
+        <Button iconName="check" iconPosition="right" onClick={handleDemoClick} text="Icon Right" />
       </Box>
     </Box>
   );
 };
 
-export const ButtonLoading = () => {
+export const ButtonLoading: React.FC = () => {
   return (
     <Box direction="row" wrap>
       <Box padding={1}>
         <Button
-          onClick={async () => {
+          onClick={async (): Promise<void> => {
             return new Promise((resolve) => {
               setTimeout(resolve, 2 * 1000);
             });
@@ -131,27 +137,23 @@ export const ButtonLoading = () => {
         />
       </Box>
       <Box padding={1}>
-        <Button loading onClick={() => console.info("clicked")} text="Is Loading" />
+        <Button loading onClick={handleDemoClick} text="Is Loading" />
       </Box>
     </Box>
   );
 };
 
-export const ConfirmationButton = () => {
+export const ConfirmationButton: React.FC = () => {
   return (
     <Box>
       <Box paddingX={3} paddingY={3}>
-        <Button
-          onClick={() => console.info("clicked")}
-          text="Default Confirmation Modal"
-          withConfirmation
-        />
+        <Button onClick={handleDemoClick} text="Default Confirmation Modal" withConfirmation />
       </Box>
       <Box paddingX={3} paddingY={1}>
         <Button
           confirmationText="And some custom text body!"
           modalTitle="A Custom Title"
-          onClick={() => console.info("clicked")}
+          onClick={handleDemoClick}
           text="With Custom Modal Props"
           withConfirmation
         />
@@ -160,55 +162,99 @@ export const ConfirmationButton = () => {
   );
 };
 
-export const FullWidthButtons = (props: Partial<ButtonProps> = {}) => {
+export const FullWidthButtons: React.FC<Partial<ButtonProps>> = (props = {}) => {
   return (
     <Box gap={4}>
       <Box gap={2}>
         <Heading>Column Layout - default width</Heading>
         <Box color="secondaryLight" direction="column" gap={2} padding={2}>
-          <Button onClick={() => {}} text="Button 1" {...props} />
-          <Button onClick={() => {}} text="Longer Button 2" {...props} />
-          <Button onClick={() => {}} text="Button 3" variant="secondary" {...props} />
+          <Button onClick={handleDemoClick} text="Button 1" {...props} />
+          <Button onClick={handleDemoClick} text="Longer Button 2" {...props} />
+          <Button onClick={handleDemoClick} text="Button 3" variant="secondary" {...props} />
         </Box>
       </Box>
 
       <Box gap={2}>
         <Heading>Column Layout - fullWidth</Heading>
         <Box color="secondaryLight" direction="column" gap={2} padding={2}>
-          <Button fullWidth onClick={() => {}} text="Button 1" {...props} />
-          <Button fullWidth onClick={() => {}} text="Longer Button 2" {...props} />
-          <Button fullWidth onClick={() => {}} text="Button 3" variant="secondary" {...props} />
+          <Button fullWidth onClick={handleDemoClick} text="Button 1" {...props} />
+          <Button fullWidth onClick={handleDemoClick} text="Longer Button 2" {...props} />
+          <Button
+            fullWidth
+            onClick={handleDemoClick}
+            text="Button 3"
+            variant="secondary"
+            {...props}
+          />
         </Box>
       </Box>
 
       <Box gap={2}>
         <Heading>Row Layout - default width</Heading>
         <Box color="secondaryLight" direction="row" gap={2} padding={2}>
-          <Button onClick={() => {}} text="Button 1" {...props} />
-          <Button onClick={() => {}} text="Longer Button 2" {...props} />
-          <Button onClick={() => {}} text="Button 3" variant="secondary" {...props} />
+          <Button onClick={handleDemoClick} text="Button 1" {...props} />
+          <Button onClick={handleDemoClick} text="Longer Button 2" {...props} />
+          <Button onClick={handleDemoClick} text="Button 3" variant="secondary" {...props} />
         </Box>
       </Box>
 
       <Box gap={2}>
         <Heading>Row Layout - fullWidth</Heading>
         <Box color="secondaryLight" direction="row" gap={2} padding={2}>
-          <Button fullWidth onClick={() => {}} text="Button 1" {...props} />
+          <Button fullWidth onClick={handleDemoClick} text="Button 1" {...props} />
         </Box>
       </Box>
     </Box>
   );
 };
 
-export const MultilineButtons = () => (
+export const ButtonPressAnimations: React.FC = () => (
+  <Box gap={4}>
+    <Box gap={1}>
+      <Heading>Pressto press animations</Heading>
+      <Text>Press each row to compare Pressto animations across every button variant.</Text>
+    </Box>
+    {BUTTON_PRESS_ANIMATIONS.map((animation) => (
+      <Box border="default" gap={2} key={animation.value} padding={3} rounding="md">
+        <Box gap={1}>
+          <Heading>{animation.label}</Heading>
+          <Text>{animation.description}</Text>
+        </Box>
+        <Box direction="row" wrap>
+          {BUTTON_VARIANT_EXAMPLES.map((button) => (
+            <Box key={`${animation.value}-${button.text}`} padding={1}>
+              <Button
+                iconName={button.iconName}
+                onClick={handleDemoClick}
+                pressAnimation={animation.value}
+                text={`${button.text} ${animation.label}`}
+                variant={button.variant}
+              />
+            </Box>
+          ))}
+          <Box padding={1}>
+            <Button
+              disabled
+              onClick={handleDemoClick}
+              pressAnimation={animation.value}
+              text={`Disabled ${animation.label}`}
+            />
+          </Box>
+        </Box>
+      </Box>
+    ))}
+  </Box>
+);
+
+export const MultilineButtons: React.FC = () => (
   <Box direction="row" wrap>
     <Box maxWidth={400} padding={1}>
-      <Button onClick={() => {}} text={"Here is some text\nAnd a second line"} />
+      <Button onClick={handleDemoClick} text={"Here is some text\nAnd a second line"} />
     </Box>
     <Box maxWidth={400} padding={1}>
       <Button
         iconName="plus"
-        onClick={() => {}}
+        onClick={handleDemoClick}
         text={"Here is some text and \nA second line with an icon"}
       />
     </Box>

--- a/demo/story-config/Button.config.tsx
+++ b/demo/story-config/Button.config.tsx
@@ -3,6 +3,7 @@ import {
   ButtonDemo,
   ButtonIconPosition,
   ButtonLoading,
+  ButtonPressAnimations,
   ButtonVariants,
   ConfirmationButton,
   FullWidthButtons,
@@ -48,7 +49,7 @@ export const ButtonConfiguration: DemoConfiguration = {
     ],
   },
   props: {},
-  demo: ButtonDemo,
+  demo: (props) => <ButtonDemo {...props} />,
   demoOptions: {
     controls: {
       variant: {
@@ -84,6 +85,15 @@ export const ButtonConfiguration: DemoConfiguration = {
         type: "boolean",
         defaultValue: false,
       },
+      pressAnimation: {
+        type: "select",
+        defaultValue: "scale",
+        options: [
+          {label: "Scale", value: "scale"},
+          {label: "Opacity", value: "opacity"},
+          {label: "None", value: "none"},
+        ],
+      },
       withConfirmation: {
         type: "boolean",
         defaultValue: false,
@@ -91,11 +101,12 @@ export const ButtonConfiguration: DemoConfiguration = {
     },
   },
   stories: {
-    Variants: {render: ButtonVariants},
-    IconPosition: {render: ButtonIconPosition},
-    Loading: {render: ButtonLoading},
-    Confirmation: {render: ConfirmationButton},
-    FullWidth: {render: FullWidthButtons},
-    Multiline: {render: MultilineButtons},
+    Variants: {render: () => <ButtonVariants />},
+    IconPosition: {render: () => <ButtonIconPosition />},
+    Loading: {render: () => <ButtonLoading />},
+    Confirmation: {render: () => <ConfirmationButton />},
+    FullWidth: {render: () => <FullWidthButtons />},
+    PressAnimations: {render: () => <ButtonPressAnimations />},
+    Multiline: {render: () => <MultilineButtons />},
   },
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "luxon": "^3.7.2",
     "mongoose": "8.23.0",
     "prettier": "^3.3.3",
+    "pressto": "^0.6.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",

--- a/ui/package.json
+++ b/ui/package.json
@@ -46,6 +46,7 @@
     "linkify-it": "catalog:",
     "lodash": "catalog:",
     "luxon": "catalog:",
+    "pressto": "catalog:",
     "react-app-polyfill": "^3.0.0",
     "react-date-picker": "^12.0.1",
     "react-datetime-picker": "^7.0.1",

--- a/ui/src/Button.test.tsx
+++ b/ui/src/Button.test.tsx
@@ -56,6 +56,12 @@ describe("Button", () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
+  it("defaults to scale press animation", () => {
+    const tree = renderWithTheme(<Button onClick={() => {}} text="Default animation" />).toJSON();
+    expect(Array.isArray(tree)).toBe(false);
+    expect(tree?.type).toBe("PressableScale");
+  });
+
   it("renders opacity press animation", () => {
     const tree = renderWithTheme(
       <Button onClick={() => {}} pressAnimation="opacity" text="Opacity" />

--- a/ui/src/Button.test.tsx
+++ b/ui/src/Button.test.tsx
@@ -56,6 +56,22 @@ describe("Button", () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
+  it("renders opacity press animation", () => {
+    const tree = renderWithTheme(
+      <Button onClick={() => {}} pressAnimation="opacity" text="Opacity" />
+    ).toJSON();
+    expect(Array.isArray(tree)).toBe(false);
+    expect(tree?.type).toBe("PressableOpacity");
+  });
+
+  it("renders no press animation", () => {
+    const tree = renderWithTheme(
+      <Button onClick={() => {}} pressAnimation="none" text="No animation" />
+    ).toJSON();
+    expect(Array.isArray(tree)).toBe(false);
+    expect(tree?.type).toBe("PressableWithoutFeedback");
+  });
+
   // Disabled state
   it("renders disabled state", () => {
     const {toJSON} = renderWithTheme(<Button disabled onClick={() => {}} text="Disabled" />);

--- a/ui/src/Button.test.tsx
+++ b/ui/src/Button.test.tsx
@@ -133,6 +133,19 @@ describe("Button", () => {
     });
   });
 
+  it("does not call onClick again on the trailing debounce edge after rapid presses", async () => {
+    const handleClick = mock(() => Promise.resolve());
+    const {getByText} = renderWithTheme(<Button onClick={handleClick} text="Click" />);
+
+    await act(async () => {
+      fireEvent.press(getByText("Click"));
+      fireEvent.press(getByText("Click"));
+      await new Promise((resolve) => setTimeout(resolve, 700));
+    });
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
   // Confirmation modal tests
   it("renders with confirmation modal props", () => {
     const {toJSON} = renderWithTheme(

--- a/ui/src/Button.tsx
+++ b/ui/src/Button.tsx
@@ -108,7 +108,7 @@ const ButtonComponent: React.FC<ButtonProps> = ({
   }, [onClick, showConfirmation, withConfirmation]);
 
   const debouncedHandlePress = useMemo(
-    () => debounce(handlePress, 500, {leading: true}),
+    () => debounce(handlePress, 500, {leading: true, trailing: false}),
     [handlePress]
   );
 

--- a/ui/src/Button.tsx
+++ b/ui/src/Button.tsx
@@ -8,7 +8,7 @@ import {
 } from "pressto";
 import type React from "react";
 import {lazy, Suspense, useCallback, useMemo, useState} from "react";
-import {ActivityIndicator, Text, View} from "react-native";
+import {ActivityIndicator, Pressable, type PressableProps, Text, View} from "react-native";
 
 import {Box} from "./Box";
 import type {ButtonPressAnimation, ButtonProps} from "./Common";
@@ -23,12 +23,14 @@ const LazyModal = lazy(() => import("./Modal").then((module) => ({default: modul
 
 const PRESSABLE_BY_ANIMATION: Record<
   ButtonPressAnimation,
-  React.ComponentType<CustomPressableProps & {"aria-disabled"?: "true"}>
+  React.ComponentType<CustomPressableProps>
 > = {
   none: PressableWithoutFeedback,
   opacity: PressableOpacity,
   scale: PressableScale,
 };
+
+type ButtonPressableProps = CustomPressableProps & PressableProps;
 
 const ButtonComponent: React.FC<ButtonProps> = ({
   confirmationText = "Are you sure you want to continue?",
@@ -112,7 +114,11 @@ const ButtonComponent: React.FC<ButtonProps> = ({
     return null;
   }
 
-  const PressableComponent = PRESSABLE_BY_ANIMATION[pressAnimation];
+  const isPressDisabled = disabled || Boolean(loading);
+  const PressableComponent = (
+    isPressDisabled ? Pressable : PRESSABLE_BY_ANIMATION[pressAnimation]
+  ) as React.ComponentType<ButtonPressableProps>;
+  const pressableInteractionProps = isPressDisabled ? {disabled: true} : {enabled: true};
 
   return (
     <PressableComponent
@@ -121,9 +127,8 @@ const ButtonComponent: React.FC<ButtonProps> = ({
       }
       accessibilityLabel={text}
       accessibilityRole="button"
-      accessibilityState={{disabled: disabled || loading}}
-      aria-disabled={disabled || loading ? "true" : undefined}
-      enabled={!disabled && !loading}
+      accessibilityState={{disabled: isPressDisabled}}
+      {...pressableInteractionProps}
       onPress={debouncedHandlePress}
       style={{
         alignItems: "center",

--- a/ui/src/Button.tsx
+++ b/ui/src/Button.tsx
@@ -21,6 +21,8 @@ import {isNative} from "./Utilities";
 // Lazy load Modal to break the circular dependency: Modal -> Button -> Modal
 const LazyModal = lazy(() => import("./Modal").then((module) => ({default: module.Modal})));
 
+const DEFAULT_BUTTON_PRESS_ANIMATION: ButtonPressAnimation = "scale";
+
 const PRESSABLE_BY_ANIMATION: Record<
   ButtonPressAnimation,
   React.ComponentType<CustomPressableProps>
@@ -41,7 +43,7 @@ const ButtonComponent: React.FC<ButtonProps> = ({
   loading: propsLoading,
   modalTitle = "Confirm",
   modalSubTitle,
-  pressAnimation = "scale",
+  pressAnimation = DEFAULT_BUTTON_PRESS_ANIMATION,
   testID,
   text,
   variant = "primary",

--- a/ui/src/Button.tsx
+++ b/ui/src/Button.tsx
@@ -1,10 +1,17 @@
 import FontAwesome6 from "@expo/vector-icons/FontAwesome6";
 import debounce from "lodash/debounce";
-import {type FC, lazy, Suspense, useMemo, useState} from "react";
-import {ActivityIndicator, Pressable, Text, View} from "react-native";
+import {
+  type CustomPressableProps,
+  PressableOpacity,
+  PressableScale,
+  PressableWithoutFeedback,
+} from "pressto";
+import type React from "react";
+import {lazy, Suspense, useCallback, useMemo, useState} from "react";
+import {ActivityIndicator, Text, View} from "react-native";
 
 import {Box} from "./Box";
-import type {ButtonProps} from "./Common";
+import type {ButtonPressAnimation, ButtonProps} from "./Common";
 import {isMobileDevice} from "./MediaQuery";
 import {useTheme} from "./Theme";
 import {Tooltip} from "./Tooltip";
@@ -14,7 +21,16 @@ import {isNative} from "./Utilities";
 // Lazy load Modal to break the circular dependency: Modal -> Button -> Modal
 const LazyModal = lazy(() => import("./Modal").then((module) => ({default: module.Modal})));
 
-const ButtonComponent: FC<ButtonProps> = ({
+const PRESSABLE_BY_ANIMATION: Record<
+  ButtonPressAnimation,
+  React.ComponentType<CustomPressableProps>
+> = {
+  none: PressableWithoutFeedback,
+  opacity: PressableOpacity,
+  scale: PressableScale,
+};
+
+const ButtonComponent: React.FC<ButtonProps> = ({
   confirmationText = "Are you sure you want to continue?",
   disabled = false,
   fullWidth = false,
@@ -23,6 +39,7 @@ const ButtonComponent: FC<ButtonProps> = ({
   loading: propsLoading,
   modalTitle = "Confirm",
   modalSubTitle,
+  pressAnimation = "scale",
   testID,
   text,
   variant = "primary",
@@ -66,41 +83,46 @@ const ButtonComponent: FC<ButtonProps> = ({
     };
   }, [disabled, variant, theme]);
 
+  const handlePress = useCallback(async (): Promise<void> => {
+    await Unifier.utils.haptic();
+    setLoading(true);
+
+    try {
+      // If a confirmation is required, and the confirmation modal is not currently open,
+      // open it.
+      if (withConfirmation && !showConfirmation) {
+        setShowConfirmation(true);
+      } else if (!withConfirmation && onClick) {
+        // If a confirmation is not required, perform the action.
+        await onClick();
+      }
+    } catch (error) {
+      setLoading(false);
+      throw error;
+    }
+    setLoading(false);
+  }, [onClick, showConfirmation, withConfirmation]);
+
+  const debouncedHandlePress = useMemo(
+    () => debounce(handlePress, 500, {leading: true}),
+    [handlePress]
+  );
+
   if (!theme) {
     return null;
   }
 
+  const PressableComponent = PRESSABLE_BY_ANIMATION[pressAnimation];
+
   return (
-    <Pressable
+    <PressableComponent
       accessibilityHint={
         withConfirmation ? "Opens a confirmation dialog" : "Press to perform action"
       }
-      aria-label={text}
-      aria-role="button"
-      disabled={disabled || loading}
-      onPress={debounce(
-        async () => {
-          await Unifier.utils.haptic();
-          setLoading(true);
-
-          try {
-            // If a confirmation is required, and the confirmation modal is not currently open,
-            // open it
-            if (withConfirmation && !showConfirmation) {
-              setShowConfirmation(true);
-            } else if (!withConfirmation && onClick) {
-              // If a confirmation is not required, perform the action.
-              await onClick();
-            }
-          } catch (error) {
-            setLoading(false);
-            throw error;
-          }
-          setLoading(false);
-        },
-        500,
-        {leading: true}
-      )}
+      accessibilityLabel={text}
+      accessibilityRole="button"
+      enabled={!disabled && !loading}
+      onPress={debouncedHandlePress}
       style={{
         alignItems: "center",
         alignSelf: fullWidth ? "stretch" : "flex-start",
@@ -141,7 +163,7 @@ const ButtonComponent: FC<ButtonProps> = ({
         <Suspense fallback={null}>
           <LazyModal
             onDismiss={() => setShowConfirmation(false)}
-            primaryButtonOnClick={async () => {
+            primaryButtonOnClick={async (): Promise<void> => {
               await onClick();
               setShowConfirmation(false);
             }}
@@ -155,11 +177,11 @@ const ButtonComponent: FC<ButtonProps> = ({
           />
         </Suspense>
       )}
-    </Pressable>
+    </PressableComponent>
   );
 };
 
-export const Button: FC<ButtonProps> = (props) => {
+export const Button: React.FC<ButtonProps> = (props) => {
   const {tooltipText, tooltipIdealPosition, tooltipIncludeArrow = false} = props;
   const isMobileOrNative = isMobileDevice() || isNative();
 

--- a/ui/src/Button.tsx
+++ b/ui/src/Button.tsx
@@ -23,7 +23,7 @@ const LazyModal = lazy(() => import("./Modal").then((module) => ({default: modul
 
 const PRESSABLE_BY_ANIMATION: Record<
   ButtonPressAnimation,
-  React.ComponentType<CustomPressableProps>
+  React.ComponentType<CustomPressableProps & {"aria-disabled"?: "true"}>
 > = {
   none: PressableWithoutFeedback,
   opacity: PressableOpacity,
@@ -122,6 +122,7 @@ const ButtonComponent: React.FC<ButtonProps> = ({
       accessibilityLabel={text}
       accessibilityRole="button"
       accessibilityState={{disabled: disabled || loading}}
+      aria-disabled={disabled || loading ? "true" : undefined}
       enabled={!disabled && !loading}
       onPress={debouncedHandlePress}
       style={{

--- a/ui/src/Button.tsx
+++ b/ui/src/Button.tsx
@@ -121,6 +121,7 @@ const ButtonComponent: React.FC<ButtonProps> = ({
       }
       accessibilityLabel={text}
       accessibilityRole="button"
+      accessibilityState={{disabled: disabled || loading}}
       enabled={!disabled && !loading}
       onPress={debouncedHandlePress}
       style={{

--- a/ui/src/Common.ts
+++ b/ui/src/Common.ts
@@ -1501,6 +1501,8 @@ export interface BodyProps {
   children?: ReactNode;
 }
 
+export type ButtonPressAnimation = "scale" | "opacity" | "none";
+
 export interface ButtonProps {
   /**
    * The text content of the confirmation modal.
@@ -1539,6 +1541,11 @@ export interface ButtonProps {
    * The subtitle of the confirmation modal.
    */
   modalSubTitle?: string;
+  /**
+   * The press animation to use when the button is touched.
+   * @default "scale"
+   */
+  pressAnimation?: ButtonPressAnimation;
   /**
    * The test ID for the button, used for testing purposes.
    */

--- a/ui/src/__snapshots__/Button.test.tsx.snap
+++ b/ui/src/__snapshots__/Button.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`Button renders correctly with default props 1`] = `
     "accessibilityState": {
       "disabled": undefined,
     },
+    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -121,6 +122,7 @@ exports[`Button renders primary variant 1`] = `
     "accessibilityState": {
       "disabled": undefined,
     },
+    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -192,6 +194,7 @@ exports[`Button renders secondary variant 1`] = `
     "accessibilityState": {
       "disabled": undefined,
     },
+    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -263,6 +266,7 @@ exports[`Button renders muted variant 1`] = `
     "accessibilityState": {
       "disabled": undefined,
     },
+    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -334,6 +338,7 @@ exports[`Button renders outline variant 1`] = `
     "accessibilityState": {
       "disabled": undefined,
     },
+    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -405,6 +410,7 @@ exports[`Button renders destructive variant 1`] = `
     "accessibilityState": {
       "disabled": undefined,
     },
+    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -476,6 +482,7 @@ exports[`Button renders disabled state 1`] = `
     "accessibilityState": {
       "disabled": true,
     },
+    "aria-disabled": "true",
     "disabled": true,
     "onPress": undefined,
     "style": {
@@ -547,6 +554,7 @@ exports[`Button applies disabled styles when disabled 1`] = `
     "accessibilityState": {
       "disabled": true,
     },
+    "aria-disabled": "true",
     "disabled": true,
     "onPress": undefined,
     "style": {
@@ -641,6 +649,7 @@ exports[`Button renders loading state 1`] = `
     "accessibilityState": {
       "disabled": true,
     },
+    "aria-disabled": "true",
     "disabled": true,
     "onPress": undefined,
     "style": {
@@ -712,6 +721,7 @@ exports[`Button renders fullWidth button 1`] = `
     "accessibilityState": {
       "disabled": undefined,
     },
+    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -796,6 +806,7 @@ exports[`Button renders with icon on left 1`] = `
     "accessibilityState": {
       "disabled": undefined,
     },
+    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -880,6 +891,7 @@ exports[`Button renders with icon on right 1`] = `
     "accessibilityState": {
       "disabled": undefined,
     },
+    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -951,6 +963,7 @@ exports[`Button renders with confirmation modal props 1`] = `
     "accessibilityState": {
       "disabled": undefined,
     },
+    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -1022,6 +1035,7 @@ exports[`Button renders with tooltip on desktop (wrapped in Tooltip) 1`] = `
     "accessibilityState": {
       "disabled": undefined,
     },
+    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {

--- a/ui/src/__snapshots__/Button.test.tsx.snap
+++ b/ui/src/__snapshots__/Button.test.tsx.snap
@@ -47,6 +47,9 @@ exports[`Button renders correctly with default props 1`] = `
     "accessibilityHint": "Press to perform action",
     "accessibilityLabel": "Click me",
     "accessibilityRole": "button",
+    "accessibilityState": {
+      "disabled": undefined,
+    },
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -115,6 +118,9 @@ exports[`Button renders primary variant 1`] = `
     "accessibilityHint": "Press to perform action",
     "accessibilityLabel": "Primary",
     "accessibilityRole": "button",
+    "accessibilityState": {
+      "disabled": undefined,
+    },
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -183,6 +189,9 @@ exports[`Button renders secondary variant 1`] = `
     "accessibilityHint": "Press to perform action",
     "accessibilityLabel": "Secondary",
     "accessibilityRole": "button",
+    "accessibilityState": {
+      "disabled": undefined,
+    },
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -251,6 +260,9 @@ exports[`Button renders muted variant 1`] = `
     "accessibilityHint": "Press to perform action",
     "accessibilityLabel": "Muted",
     "accessibilityRole": "button",
+    "accessibilityState": {
+      "disabled": undefined,
+    },
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -319,6 +331,9 @@ exports[`Button renders outline variant 1`] = `
     "accessibilityHint": "Press to perform action",
     "accessibilityLabel": "Outline",
     "accessibilityRole": "button",
+    "accessibilityState": {
+      "disabled": undefined,
+    },
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -387,6 +402,9 @@ exports[`Button renders destructive variant 1`] = `
     "accessibilityHint": "Press to perform action",
     "accessibilityLabel": "Delete",
     "accessibilityRole": "button",
+    "accessibilityState": {
+      "disabled": undefined,
+    },
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -455,6 +473,9 @@ exports[`Button renders disabled state 1`] = `
     "accessibilityHint": "Press to perform action",
     "accessibilityLabel": "Disabled",
     "accessibilityRole": "button",
+    "accessibilityState": {
+      "disabled": true,
+    },
     "disabled": true,
     "onPress": undefined,
     "style": {
@@ -523,6 +544,9 @@ exports[`Button applies disabled styles when disabled 1`] = `
     "accessibilityHint": "Press to perform action",
     "accessibilityLabel": "Disabled",
     "accessibilityRole": "button",
+    "accessibilityState": {
+      "disabled": true,
+    },
     "disabled": true,
     "onPress": undefined,
     "style": {
@@ -614,6 +638,9 @@ exports[`Button renders loading state 1`] = `
     "accessibilityHint": "Press to perform action",
     "accessibilityLabel": "Loading",
     "accessibilityRole": "button",
+    "accessibilityState": {
+      "disabled": true,
+    },
     "disabled": true,
     "onPress": undefined,
     "style": {
@@ -682,6 +709,9 @@ exports[`Button renders fullWidth button 1`] = `
     "accessibilityHint": "Press to perform action",
     "accessibilityLabel": "Full Width",
     "accessibilityRole": "button",
+    "accessibilityState": {
+      "disabled": undefined,
+    },
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -763,6 +793,9 @@ exports[`Button renders with icon on left 1`] = `
     "accessibilityHint": "Press to perform action",
     "accessibilityLabel": "With Icon",
     "accessibilityRole": "button",
+    "accessibilityState": {
+      "disabled": undefined,
+    },
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -844,6 +877,9 @@ exports[`Button renders with icon on right 1`] = `
     "accessibilityHint": "Press to perform action",
     "accessibilityLabel": "Next",
     "accessibilityRole": "button",
+    "accessibilityState": {
+      "disabled": undefined,
+    },
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -912,6 +948,9 @@ exports[`Button renders with confirmation modal props 1`] = `
     "accessibilityHint": "Opens a confirmation dialog",
     "accessibilityLabel": "Delete",
     "accessibilityRole": "button",
+    "accessibilityState": {
+      "disabled": undefined,
+    },
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -980,6 +1019,9 @@ exports[`Button renders with tooltip on desktop (wrapped in Tooltip) 1`] = `
     "accessibilityHint": "Press to perform action",
     "accessibilityLabel": "Hover me",
     "accessibilityRole": "button",
+    "accessibilityState": {
+      "disabled": undefined,
+    },
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {

--- a/ui/src/__snapshots__/Button.test.tsx.snap
+++ b/ui/src/__snapshots__/Button.test.tsx.snap
@@ -48,9 +48,8 @@ exports[`Button renders correctly with default props 1`] = `
     "accessibilityLabel": "Click me",
     "accessibilityRole": "button",
     "accessibilityState": {
-      "disabled": undefined,
+      "disabled": false,
     },
-    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -120,9 +119,8 @@ exports[`Button renders primary variant 1`] = `
     "accessibilityLabel": "Primary",
     "accessibilityRole": "button",
     "accessibilityState": {
-      "disabled": undefined,
+      "disabled": false,
     },
-    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -192,9 +190,8 @@ exports[`Button renders secondary variant 1`] = `
     "accessibilityLabel": "Secondary",
     "accessibilityRole": "button",
     "accessibilityState": {
-      "disabled": undefined,
+      "disabled": false,
     },
-    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -264,9 +261,8 @@ exports[`Button renders muted variant 1`] = `
     "accessibilityLabel": "Muted",
     "accessibilityRole": "button",
     "accessibilityState": {
-      "disabled": undefined,
+      "disabled": false,
     },
-    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -336,9 +332,8 @@ exports[`Button renders outline variant 1`] = `
     "accessibilityLabel": "Outline",
     "accessibilityRole": "button",
     "accessibilityState": {
-      "disabled": undefined,
+      "disabled": false,
     },
-    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -408,9 +403,8 @@ exports[`Button renders destructive variant 1`] = `
     "accessibilityLabel": "Delete",
     "accessibilityRole": "button",
     "accessibilityState": {
-      "disabled": undefined,
+      "disabled": false,
     },
-    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -482,9 +476,8 @@ exports[`Button renders disabled state 1`] = `
     "accessibilityState": {
       "disabled": true,
     },
-    "aria-disabled": "true",
     "disabled": true,
-    "onPress": undefined,
+    "onPress": [Function: debounced],
     "style": {
       "alignItems": "center",
       "alignSelf": "flex-start",
@@ -500,7 +493,7 @@ exports[`Button renders disabled state 1`] = `
     },
     "testID": undefined,
   },
-  "type": "PressableScale",
+  "type": "Pressable",
 }
 `;
 
@@ -554,9 +547,8 @@ exports[`Button applies disabled styles when disabled 1`] = `
     "accessibilityState": {
       "disabled": true,
     },
-    "aria-disabled": "true",
     "disabled": true,
-    "onPress": undefined,
+    "onPress": [Function: debounced],
     "style": {
       "alignItems": "center",
       "alignSelf": "flex-start",
@@ -572,7 +564,7 @@ exports[`Button applies disabled styles when disabled 1`] = `
     },
     "testID": undefined,
   },
-  "type": "PressableScale",
+  "type": "Pressable",
 }
 `;
 
@@ -649,9 +641,8 @@ exports[`Button renders loading state 1`] = `
     "accessibilityState": {
       "disabled": true,
     },
-    "aria-disabled": "true",
     "disabled": true,
-    "onPress": undefined,
+    "onPress": [Function: debounced],
     "style": {
       "alignItems": "center",
       "alignSelf": "flex-start",
@@ -667,7 +658,7 @@ exports[`Button renders loading state 1`] = `
     },
     "testID": undefined,
   },
-  "type": "PressableScale",
+  "type": "Pressable",
 }
 `;
 
@@ -719,9 +710,8 @@ exports[`Button renders fullWidth button 1`] = `
     "accessibilityLabel": "Full Width",
     "accessibilityRole": "button",
     "accessibilityState": {
-      "disabled": undefined,
+      "disabled": false,
     },
-    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -804,9 +794,8 @@ exports[`Button renders with icon on left 1`] = `
     "accessibilityLabel": "With Icon",
     "accessibilityRole": "button",
     "accessibilityState": {
-      "disabled": undefined,
+      "disabled": false,
     },
-    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -889,9 +878,8 @@ exports[`Button renders with icon on right 1`] = `
     "accessibilityLabel": "Next",
     "accessibilityRole": "button",
     "accessibilityState": {
-      "disabled": undefined,
+      "disabled": false,
     },
-    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -961,9 +949,8 @@ exports[`Button renders with confirmation modal props 1`] = `
     "accessibilityLabel": "Delete",
     "accessibilityRole": "button",
     "accessibilityState": {
-      "disabled": undefined,
+      "disabled": false,
     },
-    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {
@@ -1033,9 +1020,8 @@ exports[`Button renders with tooltip on desktop (wrapped in Tooltip) 1`] = `
     "accessibilityLabel": "Hover me",
     "accessibilityRole": "button",
     "accessibilityState": {
-      "disabled": undefined,
+      "disabled": false,
     },
-    "aria-disabled": undefined,
     "disabled": false,
     "onPress": [Function: debounced],
     "style": {

--- a/ui/src/__snapshots__/Button.test.tsx.snap
+++ b/ui/src/__snapshots__/Button.test.tsx.snap
@@ -45,9 +45,9 @@ exports[`Button renders correctly with default props 1`] = `
   ],
   "props": {
     "accessibilityHint": "Press to perform action",
-    "aria-label": "Click me",
-    "aria-role": "button",
-    "disabled": undefined,
+    "accessibilityLabel": "Click me",
+    "accessibilityRole": "button",
+    "disabled": false,
     "onPress": [Function: debounced],
     "style": {
       "alignItems": "center",
@@ -64,7 +64,7 @@ exports[`Button renders correctly with default props 1`] = `
     },
     "testID": undefined,
   },
-  "type": "Pressable",
+  "type": "PressableScale",
 }
 `;
 
@@ -113,9 +113,9 @@ exports[`Button renders primary variant 1`] = `
   ],
   "props": {
     "accessibilityHint": "Press to perform action",
-    "aria-label": "Primary",
-    "aria-role": "button",
-    "disabled": undefined,
+    "accessibilityLabel": "Primary",
+    "accessibilityRole": "button",
+    "disabled": false,
     "onPress": [Function: debounced],
     "style": {
       "alignItems": "center",
@@ -132,7 +132,7 @@ exports[`Button renders primary variant 1`] = `
     },
     "testID": undefined,
   },
-  "type": "Pressable",
+  "type": "PressableScale",
 }
 `;
 
@@ -181,9 +181,9 @@ exports[`Button renders secondary variant 1`] = `
   ],
   "props": {
     "accessibilityHint": "Press to perform action",
-    "aria-label": "Secondary",
-    "aria-role": "button",
-    "disabled": undefined,
+    "accessibilityLabel": "Secondary",
+    "accessibilityRole": "button",
+    "disabled": false,
     "onPress": [Function: debounced],
     "style": {
       "alignItems": "center",
@@ -200,7 +200,7 @@ exports[`Button renders secondary variant 1`] = `
     },
     "testID": undefined,
   },
-  "type": "Pressable",
+  "type": "PressableScale",
 }
 `;
 
@@ -249,9 +249,9 @@ exports[`Button renders muted variant 1`] = `
   ],
   "props": {
     "accessibilityHint": "Press to perform action",
-    "aria-label": "Muted",
-    "aria-role": "button",
-    "disabled": undefined,
+    "accessibilityLabel": "Muted",
+    "accessibilityRole": "button",
+    "disabled": false,
     "onPress": [Function: debounced],
     "style": {
       "alignItems": "center",
@@ -268,7 +268,7 @@ exports[`Button renders muted variant 1`] = `
     },
     "testID": undefined,
   },
-  "type": "Pressable",
+  "type": "PressableScale",
 }
 `;
 
@@ -317,9 +317,9 @@ exports[`Button renders outline variant 1`] = `
   ],
   "props": {
     "accessibilityHint": "Press to perform action",
-    "aria-label": "Outline",
-    "aria-role": "button",
-    "disabled": undefined,
+    "accessibilityLabel": "Outline",
+    "accessibilityRole": "button",
+    "disabled": false,
     "onPress": [Function: debounced],
     "style": {
       "alignItems": "center",
@@ -336,7 +336,7 @@ exports[`Button renders outline variant 1`] = `
     },
     "testID": undefined,
   },
-  "type": "Pressable",
+  "type": "PressableScale",
 }
 `;
 
@@ -385,9 +385,9 @@ exports[`Button renders destructive variant 1`] = `
   ],
   "props": {
     "accessibilityHint": "Press to perform action",
-    "aria-label": "Delete",
-    "aria-role": "button",
-    "disabled": undefined,
+    "accessibilityLabel": "Delete",
+    "accessibilityRole": "button",
+    "disabled": false,
     "onPress": [Function: debounced],
     "style": {
       "alignItems": "center",
@@ -404,7 +404,7 @@ exports[`Button renders destructive variant 1`] = `
     },
     "testID": undefined,
   },
-  "type": "Pressable",
+  "type": "PressableScale",
 }
 `;
 
@@ -453,10 +453,10 @@ exports[`Button renders disabled state 1`] = `
   ],
   "props": {
     "accessibilityHint": "Press to perform action",
-    "aria-label": "Disabled",
-    "aria-role": "button",
+    "accessibilityLabel": "Disabled",
+    "accessibilityRole": "button",
     "disabled": true,
-    "onPress": [Function: debounced],
+    "onPress": undefined,
     "style": {
       "alignItems": "center",
       "alignSelf": "flex-start",
@@ -472,7 +472,7 @@ exports[`Button renders disabled state 1`] = `
     },
     "testID": undefined,
   },
-  "type": "Pressable",
+  "type": "PressableScale",
 }
 `;
 
@@ -521,10 +521,10 @@ exports[`Button applies disabled styles when disabled 1`] = `
   ],
   "props": {
     "accessibilityHint": "Press to perform action",
-    "aria-label": "Disabled",
-    "aria-role": "button",
+    "accessibilityLabel": "Disabled",
+    "accessibilityRole": "button",
     "disabled": true,
-    "onPress": [Function: debounced],
+    "onPress": undefined,
     "style": {
       "alignItems": "center",
       "alignSelf": "flex-start",
@@ -540,7 +540,7 @@ exports[`Button applies disabled styles when disabled 1`] = `
     },
     "testID": undefined,
   },
-  "type": "Pressable",
+  "type": "PressableScale",
 }
 `;
 
@@ -612,10 +612,10 @@ exports[`Button renders loading state 1`] = `
   ],
   "props": {
     "accessibilityHint": "Press to perform action",
-    "aria-label": "Loading",
-    "aria-role": "button",
+    "accessibilityLabel": "Loading",
+    "accessibilityRole": "button",
     "disabled": true,
-    "onPress": [Function: debounced],
+    "onPress": undefined,
     "style": {
       "alignItems": "center",
       "alignSelf": "flex-start",
@@ -631,7 +631,7 @@ exports[`Button renders loading state 1`] = `
     },
     "testID": undefined,
   },
-  "type": "Pressable",
+  "type": "PressableScale",
 }
 `;
 
@@ -680,9 +680,9 @@ exports[`Button renders fullWidth button 1`] = `
   ],
   "props": {
     "accessibilityHint": "Press to perform action",
-    "aria-label": "Full Width",
-    "aria-role": "button",
-    "disabled": undefined,
+    "accessibilityLabel": "Full Width",
+    "accessibilityRole": "button",
+    "disabled": false,
     "onPress": [Function: debounced],
     "style": {
       "alignItems": "center",
@@ -699,7 +699,7 @@ exports[`Button renders fullWidth button 1`] = `
     },
     "testID": undefined,
   },
-  "type": "Pressable",
+  "type": "PressableScale",
 }
 `;
 
@@ -761,9 +761,9 @@ exports[`Button renders with icon on left 1`] = `
   ],
   "props": {
     "accessibilityHint": "Press to perform action",
-    "aria-label": "With Icon",
-    "aria-role": "button",
-    "disabled": undefined,
+    "accessibilityLabel": "With Icon",
+    "accessibilityRole": "button",
+    "disabled": false,
     "onPress": [Function: debounced],
     "style": {
       "alignItems": "center",
@@ -780,7 +780,7 @@ exports[`Button renders with icon on left 1`] = `
     },
     "testID": undefined,
   },
-  "type": "Pressable",
+  "type": "PressableScale",
 }
 `;
 
@@ -842,9 +842,9 @@ exports[`Button renders with icon on right 1`] = `
   ],
   "props": {
     "accessibilityHint": "Press to perform action",
-    "aria-label": "Next",
-    "aria-role": "button",
-    "disabled": undefined,
+    "accessibilityLabel": "Next",
+    "accessibilityRole": "button",
+    "disabled": false,
     "onPress": [Function: debounced],
     "style": {
       "alignItems": "center",
@@ -861,7 +861,7 @@ exports[`Button renders with icon on right 1`] = `
     },
     "testID": undefined,
   },
-  "type": "Pressable",
+  "type": "PressableScale",
 }
 `;
 
@@ -910,9 +910,9 @@ exports[`Button renders with confirmation modal props 1`] = `
   ],
   "props": {
     "accessibilityHint": "Opens a confirmation dialog",
-    "aria-label": "Delete",
-    "aria-role": "button",
-    "disabled": undefined,
+    "accessibilityLabel": "Delete",
+    "accessibilityRole": "button",
+    "disabled": false,
     "onPress": [Function: debounced],
     "style": {
       "alignItems": "center",
@@ -929,7 +929,7 @@ exports[`Button renders with confirmation modal props 1`] = `
     },
     "testID": undefined,
   },
-  "type": "Pressable",
+  "type": "PressableScale",
 }
 `;
 
@@ -978,9 +978,9 @@ exports[`Button renders with tooltip on desktop (wrapped in Tooltip) 1`] = `
   ],
   "props": {
     "accessibilityHint": "Press to perform action",
-    "aria-label": "Hover me",
-    "aria-role": "button",
-    "disabled": undefined,
+    "accessibilityLabel": "Hover me",
+    "accessibilityRole": "button",
+    "disabled": false,
     "onPress": [Function: debounced],
     "style": {
       "alignItems": "center",
@@ -997,6 +997,6 @@ exports[`Button renders with tooltip on desktop (wrapped in Tooltip) 1`] = `
     },
     "testID": undefined,
   },
-  "type": "Pressable",
+  "type": "PressableScale",
 }
 `;

--- a/ui/src/__snapshots__/DecimalRangeActionSheet.test.tsx.snap
+++ b/ui/src/__snapshots__/DecimalRangeActionSheet.test.tsx.snap
@@ -168,9 +168,9 @@ exports[`DecimalRangeActionSheet renders correctly 1`] = `
                                       ],
                                       "props": {
                                         "accessibilityHint": "Press to perform action",
-                                        "aria-label": "Close",
-                                        "aria-role": "button",
-                                        "disabled": undefined,
+                                        "accessibilityLabel": "Close",
+                                        "accessibilityRole": "button",
+                                        "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {
                                           "alignItems": "center",
@@ -187,7 +187,7 @@ exports[`DecimalRangeActionSheet renders correctly 1`] = `
                                         },
                                         "testID": undefined,
                                       },
-                                      "type": "Pressable",
+                                      "type": "PressableScale",
                                     },
                                   ],
                                   "props": {
@@ -847,9 +847,9 @@ exports[`DecimalRangeActionSheet renders with different min/max range 1`] = `
                                       ],
                                       "props": {
                                         "accessibilityHint": "Press to perform action",
-                                        "aria-label": "Close",
-                                        "aria-role": "button",
-                                        "disabled": undefined,
+                                        "accessibilityLabel": "Close",
+                                        "accessibilityRole": "button",
+                                        "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {
                                           "alignItems": "center",
@@ -866,7 +866,7 @@ exports[`DecimalRangeActionSheet renders with different min/max range 1`] = `
                                         },
                                         "testID": undefined,
                                       },
-                                      "type": "Pressable",
+                                      "type": "PressableScale",
                                     },
                                   ],
                                   "props": {

--- a/ui/src/__snapshots__/DecimalRangeActionSheet.test.tsx.snap
+++ b/ui/src/__snapshots__/DecimalRangeActionSheet.test.tsx.snap
@@ -170,6 +170,9 @@ exports[`DecimalRangeActionSheet renders correctly 1`] = `
                                         "accessibilityHint": "Press to perform action",
                                         "accessibilityLabel": "Close",
                                         "accessibilityRole": "button",
+                                        "accessibilityState": {
+                                          "disabled": undefined,
+                                        },
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {
@@ -849,6 +852,9 @@ exports[`DecimalRangeActionSheet renders with different min/max range 1`] = `
                                         "accessibilityHint": "Press to perform action",
                                         "accessibilityLabel": "Close",
                                         "accessibilityRole": "button",
+                                        "accessibilityState": {
+                                          "disabled": undefined,
+                                        },
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {

--- a/ui/src/__snapshots__/DecimalRangeActionSheet.test.tsx.snap
+++ b/ui/src/__snapshots__/DecimalRangeActionSheet.test.tsx.snap
@@ -171,9 +171,8 @@ exports[`DecimalRangeActionSheet renders correctly 1`] = `
                                         "accessibilityLabel": "Close",
                                         "accessibilityRole": "button",
                                         "accessibilityState": {
-                                          "disabled": undefined,
+                                          "disabled": false,
                                         },
-                                        "aria-disabled": undefined,
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {
@@ -854,9 +853,8 @@ exports[`DecimalRangeActionSheet renders with different min/max range 1`] = `
                                         "accessibilityLabel": "Close",
                                         "accessibilityRole": "button",
                                         "accessibilityState": {
-                                          "disabled": undefined,
+                                          "disabled": false,
                                         },
-                                        "aria-disabled": undefined,
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {

--- a/ui/src/__snapshots__/DecimalRangeActionSheet.test.tsx.snap
+++ b/ui/src/__snapshots__/DecimalRangeActionSheet.test.tsx.snap
@@ -173,6 +173,7 @@ exports[`DecimalRangeActionSheet renders correctly 1`] = `
                                         "accessibilityState": {
                                           "disabled": undefined,
                                         },
+                                        "aria-disabled": undefined,
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {
@@ -855,6 +856,7 @@ exports[`DecimalRangeActionSheet renders with different min/max range 1`] = `
                                         "accessibilityState": {
                                           "disabled": undefined,
                                         },
+                                        "aria-disabled": undefined,
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {

--- a/ui/src/__snapshots__/ErrorPage.test.tsx.snap
+++ b/ui/src/__snapshots__/ErrorPage.test.tsx.snap
@@ -153,9 +153,9 @@ exports[`ErrorPage renders correctly 1`] = `
       ],
       "props": {
         "accessibilityHint": "Press to perform action",
-        "aria-label": "Try again",
-        "aria-role": "button",
-        "disabled": undefined,
+        "accessibilityLabel": "Try again",
+        "accessibilityRole": "button",
+        "disabled": false,
         "onPress": [Function: debounced],
         "style": {
           "alignItems": "center",
@@ -172,7 +172,7 @@ exports[`ErrorPage renders correctly 1`] = `
         },
         "testID": undefined,
       },
-      "type": "Pressable",
+      "type": "PressableScale",
     },
   ],
   "props": {

--- a/ui/src/__snapshots__/ErrorPage.test.tsx.snap
+++ b/ui/src/__snapshots__/ErrorPage.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`ErrorPage renders correctly 1`] = `
         "accessibilityState": {
           "disabled": undefined,
         },
+        "aria-disabled": undefined,
         "disabled": false,
         "onPress": [Function: debounced],
         "style": {

--- a/ui/src/__snapshots__/ErrorPage.test.tsx.snap
+++ b/ui/src/__snapshots__/ErrorPage.test.tsx.snap
@@ -155,6 +155,9 @@ exports[`ErrorPage renders correctly 1`] = `
         "accessibilityHint": "Press to perform action",
         "accessibilityLabel": "Try again",
         "accessibilityRole": "button",
+        "accessibilityState": {
+          "disabled": undefined,
+        },
         "disabled": false,
         "onPress": [Function: debounced],
         "style": {

--- a/ui/src/__snapshots__/ErrorPage.test.tsx.snap
+++ b/ui/src/__snapshots__/ErrorPage.test.tsx.snap
@@ -156,9 +156,8 @@ exports[`ErrorPage renders correctly 1`] = `
         "accessibilityLabel": "Try again",
         "accessibilityRole": "button",
         "accessibilityState": {
-          "disabled": undefined,
+          "disabled": false,
         },
-        "aria-disabled": undefined,
         "disabled": false,
         "onPress": [Function: debounced],
         "style": {

--- a/ui/src/__snapshots__/HeightActionSheet.test.tsx.snap
+++ b/ui/src/__snapshots__/HeightActionSheet.test.tsx.snap
@@ -183,9 +183,9 @@ exports[`HeightActionSheet renders correctly 1`] = `
                                       ],
                                       "props": {
                                         "accessibilityHint": "Press to perform action",
-                                        "aria-label": "Done",
-                                        "aria-role": "button",
-                                        "disabled": undefined,
+                                        "accessibilityLabel": "Done",
+                                        "accessibilityRole": "button",
+                                        "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {
                                           "alignItems": "center",
@@ -202,7 +202,7 @@ exports[`HeightActionSheet renders correctly 1`] = `
                                         },
                                         "testID": undefined,
                                       },
-                                      "type": "Pressable",
+                                      "type": "PressableScale",
                                     },
                                   ],
                                   "props": {
@@ -874,9 +874,9 @@ exports[`HeightActionSheet renders with different height value 1`] = `
                                       ],
                                       "props": {
                                         "accessibilityHint": "Press to perform action",
-                                        "aria-label": "Done",
-                                        "aria-role": "button",
-                                        "disabled": undefined,
+                                        "accessibilityLabel": "Done",
+                                        "accessibilityRole": "button",
+                                        "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {
                                           "alignItems": "center",
@@ -893,7 +893,7 @@ exports[`HeightActionSheet renders with different height value 1`] = `
                                         },
                                         "testID": undefined,
                                       },
-                                      "type": "Pressable",
+                                      "type": "PressableScale",
                                     },
                                   ],
                                   "props": {

--- a/ui/src/__snapshots__/HeightActionSheet.test.tsx.snap
+++ b/ui/src/__snapshots__/HeightActionSheet.test.tsx.snap
@@ -185,6 +185,9 @@ exports[`HeightActionSheet renders correctly 1`] = `
                                         "accessibilityHint": "Press to perform action",
                                         "accessibilityLabel": "Done",
                                         "accessibilityRole": "button",
+                                        "accessibilityState": {
+                                          "disabled": undefined,
+                                        },
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {
@@ -876,6 +879,9 @@ exports[`HeightActionSheet renders with different height value 1`] = `
                                         "accessibilityHint": "Press to perform action",
                                         "accessibilityLabel": "Done",
                                         "accessibilityRole": "button",
+                                        "accessibilityState": {
+                                          "disabled": undefined,
+                                        },
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {

--- a/ui/src/__snapshots__/HeightActionSheet.test.tsx.snap
+++ b/ui/src/__snapshots__/HeightActionSheet.test.tsx.snap
@@ -186,9 +186,8 @@ exports[`HeightActionSheet renders correctly 1`] = `
                                         "accessibilityLabel": "Done",
                                         "accessibilityRole": "button",
                                         "accessibilityState": {
-                                          "disabled": undefined,
+                                          "disabled": false,
                                         },
-                                        "aria-disabled": undefined,
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {
@@ -881,9 +880,8 @@ exports[`HeightActionSheet renders with different height value 1`] = `
                                         "accessibilityLabel": "Done",
                                         "accessibilityRole": "button",
                                         "accessibilityState": {
-                                          "disabled": undefined,
+                                          "disabled": false,
                                         },
-                                        "aria-disabled": undefined,
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {

--- a/ui/src/__snapshots__/HeightActionSheet.test.tsx.snap
+++ b/ui/src/__snapshots__/HeightActionSheet.test.tsx.snap
@@ -188,6 +188,7 @@ exports[`HeightActionSheet renders correctly 1`] = `
                                         "accessibilityState": {
                                           "disabled": undefined,
                                         },
+                                        "aria-disabled": undefined,
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {
@@ -882,6 +883,7 @@ exports[`HeightActionSheet renders with different height value 1`] = `
                                         "accessibilityState": {
                                           "disabled": undefined,
                                         },
+                                        "aria-disabled": undefined,
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {

--- a/ui/src/__snapshots__/HeightField.test.tsx.snap
+++ b/ui/src/__snapshots__/HeightField.test.tsx.snap
@@ -244,9 +244,9 @@ exports[`HeightField snapshots should match snapshot with default props 1`] = `
                                           ],
                                           "props": {
                                             "accessibilityHint": "Press to perform action",
-                                            "aria-label": "Done",
-                                            "aria-role": "button",
-                                            "disabled": undefined,
+                                            "accessibilityLabel": "Done",
+                                            "accessibilityRole": "button",
+                                            "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
                                               "alignItems": "center",
@@ -263,7 +263,7 @@ exports[`HeightField snapshots should match snapshot with default props 1`] = `
                                             },
                                             "testID": undefined,
                                           },
-                                          "type": "Pressable",
+                                          "type": "PressableScale",
                                         },
                                       ],
                                       "props": {
@@ -1006,9 +1006,9 @@ exports[`HeightField snapshots should match snapshot with value 1`] = `
                                           ],
                                           "props": {
                                             "accessibilityHint": "Press to perform action",
-                                            "aria-label": "Done",
-                                            "aria-role": "button",
-                                            "disabled": undefined,
+                                            "accessibilityLabel": "Done",
+                                            "accessibilityRole": "button",
+                                            "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
                                               "alignItems": "center",
@@ -1025,7 +1025,7 @@ exports[`HeightField snapshots should match snapshot with value 1`] = `
                                             },
                                             "testID": undefined,
                                           },
-                                          "type": "Pressable",
+                                          "type": "PressableScale",
                                         },
                                       ],
                                       "props": {
@@ -1865,9 +1865,9 @@ exports[`HeightField snapshots should match snapshot with all props 1`] = `
                                           ],
                                           "props": {
                                             "accessibilityHint": "Press to perform action",
-                                            "aria-label": "Done",
-                                            "aria-role": "button",
-                                            "disabled": undefined,
+                                            "accessibilityLabel": "Done",
+                                            "accessibilityRole": "button",
+                                            "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
                                               "alignItems": "center",
@@ -1884,7 +1884,7 @@ exports[`HeightField snapshots should match snapshot with all props 1`] = `
                                             },
                                             "testID": undefined,
                                           },
-                                          "type": "Pressable",
+                                          "type": "PressableScale",
                                         },
                                       ],
                                       "props": {
@@ -2659,9 +2659,9 @@ exports[`HeightField snapshots should match snapshot when disabled 1`] = `
                                           ],
                                           "props": {
                                             "accessibilityHint": "Press to perform action",
-                                            "aria-label": "Done",
-                                            "aria-role": "button",
-                                            "disabled": undefined,
+                                            "accessibilityLabel": "Done",
+                                            "accessibilityRole": "button",
+                                            "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
                                               "alignItems": "center",
@@ -2678,7 +2678,7 @@ exports[`HeightField snapshots should match snapshot when disabled 1`] = `
                                             },
                                             "testID": undefined,
                                           },
-                                          "type": "Pressable",
+                                          "type": "PressableScale",
                                         },
                                       ],
                                       "props": {
@@ -3492,9 +3492,9 @@ exports[`HeightField snapshots should match snapshot with error state 1`] = `
                                           ],
                                           "props": {
                                             "accessibilityHint": "Press to perform action",
-                                            "aria-label": "Done",
-                                            "aria-role": "button",
-                                            "disabled": undefined,
+                                            "accessibilityLabel": "Done",
+                                            "accessibilityRole": "button",
+                                            "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
                                               "alignItems": "center",
@@ -3511,7 +3511,7 @@ exports[`HeightField snapshots should match snapshot with error state 1`] = `
                                             },
                                             "testID": undefined,
                                           },
-                                          "type": "Pressable",
+                                          "type": "PressableScale",
                                         },
                                       ],
                                       "props": {

--- a/ui/src/__snapshots__/HeightField.test.tsx.snap
+++ b/ui/src/__snapshots__/HeightField.test.tsx.snap
@@ -246,6 +246,9 @@ exports[`HeightField snapshots should match snapshot with default props 1`] = `
                                             "accessibilityHint": "Press to perform action",
                                             "accessibilityLabel": "Done",
                                             "accessibilityRole": "button",
+                                            "accessibilityState": {
+                                              "disabled": undefined,
+                                            },
                                             "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
@@ -1008,6 +1011,9 @@ exports[`HeightField snapshots should match snapshot with value 1`] = `
                                             "accessibilityHint": "Press to perform action",
                                             "accessibilityLabel": "Done",
                                             "accessibilityRole": "button",
+                                            "accessibilityState": {
+                                              "disabled": undefined,
+                                            },
                                             "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
@@ -1867,6 +1873,9 @@ exports[`HeightField snapshots should match snapshot with all props 1`] = `
                                             "accessibilityHint": "Press to perform action",
                                             "accessibilityLabel": "Done",
                                             "accessibilityRole": "button",
+                                            "accessibilityState": {
+                                              "disabled": undefined,
+                                            },
                                             "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
@@ -2661,6 +2670,9 @@ exports[`HeightField snapshots should match snapshot when disabled 1`] = `
                                             "accessibilityHint": "Press to perform action",
                                             "accessibilityLabel": "Done",
                                             "accessibilityRole": "button",
+                                            "accessibilityState": {
+                                              "disabled": undefined,
+                                            },
                                             "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
@@ -3494,6 +3506,9 @@ exports[`HeightField snapshots should match snapshot with error state 1`] = `
                                             "accessibilityHint": "Press to perform action",
                                             "accessibilityLabel": "Done",
                                             "accessibilityRole": "button",
+                                            "accessibilityState": {
+                                              "disabled": undefined,
+                                            },
                                             "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {

--- a/ui/src/__snapshots__/HeightField.test.tsx.snap
+++ b/ui/src/__snapshots__/HeightField.test.tsx.snap
@@ -247,9 +247,8 @@ exports[`HeightField snapshots should match snapshot with default props 1`] = `
                                             "accessibilityLabel": "Done",
                                             "accessibilityRole": "button",
                                             "accessibilityState": {
-                                              "disabled": undefined,
+                                              "disabled": false,
                                             },
-                                            "aria-disabled": undefined,
                                             "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
@@ -1013,9 +1012,8 @@ exports[`HeightField snapshots should match snapshot with value 1`] = `
                                             "accessibilityLabel": "Done",
                                             "accessibilityRole": "button",
                                             "accessibilityState": {
-                                              "disabled": undefined,
+                                              "disabled": false,
                                             },
-                                            "aria-disabled": undefined,
                                             "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
@@ -1876,9 +1874,8 @@ exports[`HeightField snapshots should match snapshot with all props 1`] = `
                                             "accessibilityLabel": "Done",
                                             "accessibilityRole": "button",
                                             "accessibilityState": {
-                                              "disabled": undefined,
+                                              "disabled": false,
                                             },
-                                            "aria-disabled": undefined,
                                             "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
@@ -2674,9 +2671,8 @@ exports[`HeightField snapshots should match snapshot when disabled 1`] = `
                                             "accessibilityLabel": "Done",
                                             "accessibilityRole": "button",
                                             "accessibilityState": {
-                                              "disabled": undefined,
+                                              "disabled": false,
                                             },
-                                            "aria-disabled": undefined,
                                             "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
@@ -3511,9 +3507,8 @@ exports[`HeightField snapshots should match snapshot with error state 1`] = `
                                             "accessibilityLabel": "Done",
                                             "accessibilityRole": "button",
                                             "accessibilityState": {
-                                              "disabled": undefined,
+                                              "disabled": false,
                                             },
-                                            "aria-disabled": undefined,
                                             "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {

--- a/ui/src/__snapshots__/HeightField.test.tsx.snap
+++ b/ui/src/__snapshots__/HeightField.test.tsx.snap
@@ -249,6 +249,7 @@ exports[`HeightField snapshots should match snapshot with default props 1`] = `
                                             "accessibilityState": {
                                               "disabled": undefined,
                                             },
+                                            "aria-disabled": undefined,
                                             "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
@@ -1014,6 +1015,7 @@ exports[`HeightField snapshots should match snapshot with value 1`] = `
                                             "accessibilityState": {
                                               "disabled": undefined,
                                             },
+                                            "aria-disabled": undefined,
                                             "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
@@ -1876,6 +1878,7 @@ exports[`HeightField snapshots should match snapshot with all props 1`] = `
                                             "accessibilityState": {
                                               "disabled": undefined,
                                             },
+                                            "aria-disabled": undefined,
                                             "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
@@ -2673,6 +2676,7 @@ exports[`HeightField snapshots should match snapshot when disabled 1`] = `
                                             "accessibilityState": {
                                               "disabled": undefined,
                                             },
+                                            "aria-disabled": undefined,
                                             "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {
@@ -3509,6 +3513,7 @@ exports[`HeightField snapshots should match snapshot with error state 1`] = `
                                             "accessibilityState": {
                                               "disabled": undefined,
                                             },
+                                            "aria-disabled": undefined,
                                             "disabled": false,
                                             "onPress": [Function: debounced],
                                             "style": {

--- a/ui/src/__snapshots__/InfoModalIcon.test.tsx.snap
+++ b/ui/src/__snapshots__/InfoModalIcon.test.tsx.snap
@@ -172,6 +172,7 @@ exports[`InfoModalIcon renders correctly with required props 1`] = `
                           "accessibilityState": {
                             "disabled": undefined,
                           },
+                          "aria-disabled": undefined,
                           "disabled": false,
                           "onPress": [Function: debounced],
                           "style": {
@@ -503,6 +504,7 @@ exports[`InfoModalIcon renders with subtitle 1`] = `
                           "accessibilityState": {
                             "disabled": undefined,
                           },
+                          "aria-disabled": undefined,
                           "disabled": false,
                           "onPress": [Function: debounced],
                           "style": {
@@ -832,6 +834,7 @@ exports[`InfoModalIcon renders with children content 1`] = `
                           "accessibilityState": {
                             "disabled": undefined,
                           },
+                          "aria-disabled": undefined,
                           "disabled": false,
                           "onPress": [Function: debounced],
                           "style": {
@@ -1122,6 +1125,7 @@ exports[`InfoModalIcon opens modal when pressed 1`] = `
                           "accessibilityState": {
                             "disabled": undefined,
                           },
+                          "aria-disabled": undefined,
                           "disabled": false,
                           "onPress": [Function: debounced],
                           "style": {

--- a/ui/src/__snapshots__/InfoModalIcon.test.tsx.snap
+++ b/ui/src/__snapshots__/InfoModalIcon.test.tsx.snap
@@ -167,9 +167,9 @@ exports[`InfoModalIcon renders correctly with required props 1`] = `
                         ],
                         "props": {
                           "accessibilityHint": "Press to perform action",
-                          "aria-label": "Close",
-                          "aria-role": "button",
-                          "disabled": undefined,
+                          "accessibilityLabel": "Close",
+                          "accessibilityRole": "button",
+                          "disabled": false,
                           "onPress": [Function: debounced],
                           "style": {
                             "alignItems": "center",
@@ -186,7 +186,7 @@ exports[`InfoModalIcon renders correctly with required props 1`] = `
                           },
                           "testID": undefined,
                         },
-                        "type": "Pressable",
+                        "type": "PressableScale",
                       },
                     ],
                     "props": {
@@ -495,9 +495,9 @@ exports[`InfoModalIcon renders with subtitle 1`] = `
                         ],
                         "props": {
                           "accessibilityHint": "Press to perform action",
-                          "aria-label": "Close",
-                          "aria-role": "button",
-                          "disabled": undefined,
+                          "accessibilityLabel": "Close",
+                          "accessibilityRole": "button",
+                          "disabled": false,
                           "onPress": [Function: debounced],
                           "style": {
                             "alignItems": "center",
@@ -514,7 +514,7 @@ exports[`InfoModalIcon renders with subtitle 1`] = `
                           },
                           "testID": undefined,
                         },
-                        "type": "Pressable",
+                        "type": "PressableScale",
                       },
                     ],
                     "props": {
@@ -821,9 +821,9 @@ exports[`InfoModalIcon renders with children content 1`] = `
                         ],
                         "props": {
                           "accessibilityHint": "Press to perform action",
-                          "aria-label": "Close",
-                          "aria-role": "button",
-                          "disabled": undefined,
+                          "accessibilityLabel": "Close",
+                          "accessibilityRole": "button",
+                          "disabled": false,
                           "onPress": [Function: debounced],
                           "style": {
                             "alignItems": "center",
@@ -840,7 +840,7 @@ exports[`InfoModalIcon renders with children content 1`] = `
                           },
                           "testID": undefined,
                         },
-                        "type": "Pressable",
+                        "type": "PressableScale",
                       },
                     ],
                     "props": {
@@ -1108,9 +1108,9 @@ exports[`InfoModalIcon opens modal when pressed 1`] = `
                         ],
                         "props": {
                           "accessibilityHint": "Press to perform action",
-                          "aria-label": "Close",
-                          "aria-role": "button",
-                          "disabled": undefined,
+                          "accessibilityLabel": "Close",
+                          "accessibilityRole": "button",
+                          "disabled": false,
                           "onPress": [Function: debounced],
                           "style": {
                             "alignItems": "center",
@@ -1127,7 +1127,7 @@ exports[`InfoModalIcon opens modal when pressed 1`] = `
                           },
                           "testID": undefined,
                         },
-                        "type": "Pressable",
+                        "type": "PressableScale",
                       },
                     ],
                     "props": {

--- a/ui/src/__snapshots__/InfoModalIcon.test.tsx.snap
+++ b/ui/src/__snapshots__/InfoModalIcon.test.tsx.snap
@@ -169,6 +169,9 @@ exports[`InfoModalIcon renders correctly with required props 1`] = `
                           "accessibilityHint": "Press to perform action",
                           "accessibilityLabel": "Close",
                           "accessibilityRole": "button",
+                          "accessibilityState": {
+                            "disabled": undefined,
+                          },
                           "disabled": false,
                           "onPress": [Function: debounced],
                           "style": {
@@ -497,6 +500,9 @@ exports[`InfoModalIcon renders with subtitle 1`] = `
                           "accessibilityHint": "Press to perform action",
                           "accessibilityLabel": "Close",
                           "accessibilityRole": "button",
+                          "accessibilityState": {
+                            "disabled": undefined,
+                          },
                           "disabled": false,
                           "onPress": [Function: debounced],
                           "style": {
@@ -823,6 +829,9 @@ exports[`InfoModalIcon renders with children content 1`] = `
                           "accessibilityHint": "Press to perform action",
                           "accessibilityLabel": "Close",
                           "accessibilityRole": "button",
+                          "accessibilityState": {
+                            "disabled": undefined,
+                          },
                           "disabled": false,
                           "onPress": [Function: debounced],
                           "style": {
@@ -1110,6 +1119,9 @@ exports[`InfoModalIcon opens modal when pressed 1`] = `
                           "accessibilityHint": "Press to perform action",
                           "accessibilityLabel": "Close",
                           "accessibilityRole": "button",
+                          "accessibilityState": {
+                            "disabled": undefined,
+                          },
                           "disabled": false,
                           "onPress": [Function: debounced],
                           "style": {

--- a/ui/src/__snapshots__/InfoModalIcon.test.tsx.snap
+++ b/ui/src/__snapshots__/InfoModalIcon.test.tsx.snap
@@ -170,9 +170,8 @@ exports[`InfoModalIcon renders correctly with required props 1`] = `
                           "accessibilityLabel": "Close",
                           "accessibilityRole": "button",
                           "accessibilityState": {
-                            "disabled": undefined,
+                            "disabled": false,
                           },
-                          "aria-disabled": undefined,
                           "disabled": false,
                           "onPress": [Function: debounced],
                           "style": {
@@ -502,9 +501,8 @@ exports[`InfoModalIcon renders with subtitle 1`] = `
                           "accessibilityLabel": "Close",
                           "accessibilityRole": "button",
                           "accessibilityState": {
-                            "disabled": undefined,
+                            "disabled": false,
                           },
-                          "aria-disabled": undefined,
                           "disabled": false,
                           "onPress": [Function: debounced],
                           "style": {
@@ -832,9 +830,8 @@ exports[`InfoModalIcon renders with children content 1`] = `
                           "accessibilityLabel": "Close",
                           "accessibilityRole": "button",
                           "accessibilityState": {
-                            "disabled": undefined,
+                            "disabled": false,
                           },
-                          "aria-disabled": undefined,
                           "disabled": false,
                           "onPress": [Function: debounced],
                           "style": {
@@ -1123,9 +1120,8 @@ exports[`InfoModalIcon opens modal when pressed 1`] = `
                           "accessibilityLabel": "Close",
                           "accessibilityRole": "button",
                           "accessibilityState": {
-                            "disabled": undefined,
+                            "disabled": false,
                           },
-                          "aria-disabled": undefined,
                           "disabled": false,
                           "onPress": [Function: debounced],
                           "style": {

--- a/ui/src/__snapshots__/Modal.test.tsx.snap
+++ b/ui/src/__snapshots__/Modal.test.tsx.snap
@@ -534,6 +534,7 @@ exports[`Modal renders with both buttons 1`] = `
                             "accessibilityState": {
                               "disabled": undefined,
                             },
+                            "aria-disabled": undefined,
                             "disabled": false,
                             "onPress": [Function: debounced],
                             "style": {
@@ -611,6 +612,7 @@ exports[`Modal renders with both buttons 1`] = `
                         "accessibilityState": {
                           "disabled": undefined,
                         },
+                        "aria-disabled": undefined,
                         "disabled": false,
                         "onPress": [Function: debounced],
                         "style": {
@@ -861,6 +863,7 @@ exports[`Modal renders with disabled primary button 1`] = `
                         "accessibilityState": {
                           "disabled": true,
                         },
+                        "aria-disabled": "true",
                         "disabled": true,
                         "onPress": undefined,
                         "style": {

--- a/ui/src/__snapshots__/Modal.test.tsx.snap
+++ b/ui/src/__snapshots__/Modal.test.tsx.snap
@@ -532,9 +532,8 @@ exports[`Modal renders with both buttons 1`] = `
                             "accessibilityLabel": "Cancel",
                             "accessibilityRole": "button",
                             "accessibilityState": {
-                              "disabled": undefined,
+                              "disabled": false,
                             },
-                            "aria-disabled": undefined,
                             "disabled": false,
                             "onPress": [Function: debounced],
                             "style": {
@@ -610,9 +609,8 @@ exports[`Modal renders with both buttons 1`] = `
                         "accessibilityLabel": "Save",
                         "accessibilityRole": "button",
                         "accessibilityState": {
-                          "disabled": undefined,
+                          "disabled": false,
                         },
-                        "aria-disabled": undefined,
                         "disabled": false,
                         "onPress": [Function: debounced],
                         "style": {
@@ -863,9 +861,8 @@ exports[`Modal renders with disabled primary button 1`] = `
                         "accessibilityState": {
                           "disabled": true,
                         },
-                        "aria-disabled": "true",
                         "disabled": true,
-                        "onPress": undefined,
+                        "onPress": [Function: debounced],
                         "style": {
                           "alignItems": "center",
                           "alignSelf": "flex-start",
@@ -881,7 +878,7 @@ exports[`Modal renders with disabled primary button 1`] = `
                         },
                         "testID": undefined,
                       },
-                      "type": "PressableScale",
+                      "type": "Pressable",
                     },
                   ],
                   "props": {

--- a/ui/src/__snapshots__/Modal.test.tsx.snap
+++ b/ui/src/__snapshots__/Modal.test.tsx.snap
@@ -529,9 +529,9 @@ exports[`Modal renders with both buttons 1`] = `
                           ],
                           "props": {
                             "accessibilityHint": "Press to perform action",
-                            "aria-label": "Cancel",
-                            "aria-role": "button",
-                            "disabled": undefined,
+                            "accessibilityLabel": "Cancel",
+                            "accessibilityRole": "button",
+                            "disabled": false,
                             "onPress": [Function: debounced],
                             "style": {
                               "alignItems": "center",
@@ -548,7 +548,7 @@ exports[`Modal renders with both buttons 1`] = `
                             },
                             "testID": undefined,
                           },
-                          "type": "Pressable",
+                          "type": "PressableScale",
                         },
                       ],
                       "props": {
@@ -603,9 +603,9 @@ exports[`Modal renders with both buttons 1`] = `
                       ],
                       "props": {
                         "accessibilityHint": "Press to perform action",
-                        "aria-label": "Save",
-                        "aria-role": "button",
-                        "disabled": undefined,
+                        "accessibilityLabel": "Save",
+                        "accessibilityRole": "button",
+                        "disabled": false,
                         "onPress": [Function: debounced],
                         "style": {
                           "alignItems": "center",
@@ -622,7 +622,7 @@ exports[`Modal renders with both buttons 1`] = `
                         },
                         "testID": undefined,
                       },
-                      "type": "Pressable",
+                      "type": "PressableScale",
                     },
                   ],
                   "props": {
@@ -850,10 +850,10 @@ exports[`Modal renders with disabled primary button 1`] = `
                       ],
                       "props": {
                         "accessibilityHint": "Press to perform action",
-                        "aria-label": "Save",
-                        "aria-role": "button",
+                        "accessibilityLabel": "Save",
+                        "accessibilityRole": "button",
                         "disabled": true,
-                        "onPress": [Function: debounced],
+                        "onPress": undefined,
                         "style": {
                           "alignItems": "center",
                           "alignSelf": "flex-start",
@@ -869,7 +869,7 @@ exports[`Modal renders with disabled primary button 1`] = `
                         },
                         "testID": undefined,
                       },
-                      "type": "Pressable",
+                      "type": "PressableScale",
                     },
                   ],
                   "props": {

--- a/ui/src/__snapshots__/Modal.test.tsx.snap
+++ b/ui/src/__snapshots__/Modal.test.tsx.snap
@@ -531,6 +531,9 @@ exports[`Modal renders with both buttons 1`] = `
                             "accessibilityHint": "Press to perform action",
                             "accessibilityLabel": "Cancel",
                             "accessibilityRole": "button",
+                            "accessibilityState": {
+                              "disabled": undefined,
+                            },
                             "disabled": false,
                             "onPress": [Function: debounced],
                             "style": {
@@ -605,6 +608,9 @@ exports[`Modal renders with both buttons 1`] = `
                         "accessibilityHint": "Press to perform action",
                         "accessibilityLabel": "Save",
                         "accessibilityRole": "button",
+                        "accessibilityState": {
+                          "disabled": undefined,
+                        },
                         "disabled": false,
                         "onPress": [Function: debounced],
                         "style": {
@@ -852,6 +858,9 @@ exports[`Modal renders with disabled primary button 1`] = `
                         "accessibilityHint": "Press to perform action",
                         "accessibilityLabel": "Save",
                         "accessibilityRole": "button",
+                        "accessibilityState": {
+                          "disabled": true,
+                        },
                         "disabled": true,
                         "onPress": undefined,
                         "style": {

--- a/ui/src/__snapshots__/NumberPickerActionSheet.test.tsx.snap
+++ b/ui/src/__snapshots__/NumberPickerActionSheet.test.tsx.snap
@@ -168,9 +168,9 @@ exports[`NumberPickerActionSheet renders correctly 1`] = `
                                       ],
                                       "props": {
                                         "accessibilityHint": "Press to perform action",
-                                        "aria-label": "Close",
-                                        "aria-role": "button",
-                                        "disabled": undefined,
+                                        "accessibilityLabel": "Close",
+                                        "accessibilityRole": "button",
+                                        "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {
                                           "alignItems": "center",
@@ -187,7 +187,7 @@ exports[`NumberPickerActionSheet renders correctly 1`] = `
                                         },
                                         "testID": undefined,
                                       },
-                                      "type": "Pressable",
+                                      "type": "PressableScale",
                                     },
                                   ],
                                   "props": {
@@ -1497,9 +1497,9 @@ exports[`NumberPickerActionSheet renders with different range 1`] = `
                                       ],
                                       "props": {
                                         "accessibilityHint": "Press to perform action",
-                                        "aria-label": "Close",
-                                        "aria-role": "button",
-                                        "disabled": undefined,
+                                        "accessibilityLabel": "Close",
+                                        "accessibilityRole": "button",
+                                        "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {
                                           "alignItems": "center",
@@ -1516,7 +1516,7 @@ exports[`NumberPickerActionSheet renders with different range 1`] = `
                                         },
                                         "testID": undefined,
                                       },
-                                      "type": "Pressable",
+                                      "type": "PressableScale",
                                     },
                                   ],
                                   "props": {

--- a/ui/src/__snapshots__/NumberPickerActionSheet.test.tsx.snap
+++ b/ui/src/__snapshots__/NumberPickerActionSheet.test.tsx.snap
@@ -173,6 +173,7 @@ exports[`NumberPickerActionSheet renders correctly 1`] = `
                                         "accessibilityState": {
                                           "disabled": undefined,
                                         },
+                                        "aria-disabled": undefined,
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {
@@ -1505,6 +1506,7 @@ exports[`NumberPickerActionSheet renders with different range 1`] = `
                                         "accessibilityState": {
                                           "disabled": undefined,
                                         },
+                                        "aria-disabled": undefined,
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {

--- a/ui/src/__snapshots__/NumberPickerActionSheet.test.tsx.snap
+++ b/ui/src/__snapshots__/NumberPickerActionSheet.test.tsx.snap
@@ -171,9 +171,8 @@ exports[`NumberPickerActionSheet renders correctly 1`] = `
                                         "accessibilityLabel": "Close",
                                         "accessibilityRole": "button",
                                         "accessibilityState": {
-                                          "disabled": undefined,
+                                          "disabled": false,
                                         },
-                                        "aria-disabled": undefined,
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {
@@ -1504,9 +1503,8 @@ exports[`NumberPickerActionSheet renders with different range 1`] = `
                                         "accessibilityLabel": "Close",
                                         "accessibilityRole": "button",
                                         "accessibilityState": {
-                                          "disabled": undefined,
+                                          "disabled": false,
                                         },
-                                        "aria-disabled": undefined,
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {

--- a/ui/src/__snapshots__/NumberPickerActionSheet.test.tsx.snap
+++ b/ui/src/__snapshots__/NumberPickerActionSheet.test.tsx.snap
@@ -170,6 +170,9 @@ exports[`NumberPickerActionSheet renders correctly 1`] = `
                                         "accessibilityHint": "Press to perform action",
                                         "accessibilityLabel": "Close",
                                         "accessibilityRole": "button",
+                                        "accessibilityState": {
+                                          "disabled": undefined,
+                                        },
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {
@@ -1499,6 +1502,9 @@ exports[`NumberPickerActionSheet renders with different range 1`] = `
                                         "accessibilityHint": "Press to perform action",
                                         "accessibilityLabel": "Close",
                                         "accessibilityRole": "button",
+                                        "accessibilityState": {
+                                          "disabled": undefined,
+                                        },
                                         "disabled": false,
                                         "onPress": [Function: debounced],
                                         "style": {

--- a/ui/src/__snapshots__/Page.test.tsx.snap
+++ b/ui/src/__snapshots__/Page.test.tsx.snap
@@ -815,9 +815,8 @@ exports[`Page renders with right button 1`] = `
                             "accessibilityLabel": "Save",
                             "accessibilityRole": "button",
                             "accessibilityState": {
-                              "disabled": undefined,
+                              "disabled": false,
                             },
-                            "aria-disabled": undefined,
                             "disabled": false,
                             "onPress": [Function: debounced],
                             "style": {

--- a/ui/src/__snapshots__/Page.test.tsx.snap
+++ b/ui/src/__snapshots__/Page.test.tsx.snap
@@ -812,9 +812,9 @@ exports[`Page renders with right button 1`] = `
                           ],
                           "props": {
                             "accessibilityHint": "Press to perform action",
-                            "aria-label": "Save",
-                            "aria-role": "button",
-                            "disabled": undefined,
+                            "accessibilityLabel": "Save",
+                            "accessibilityRole": "button",
+                            "disabled": false,
                             "onPress": [Function: debounced],
                             "style": {
                               "alignItems": "center",
@@ -831,7 +831,7 @@ exports[`Page renders with right button 1`] = `
                             },
                             "testID": undefined,
                           },
-                          "type": "Pressable",
+                          "type": "PressableScale",
                         },
                       ],
                       "props": {

--- a/ui/src/__snapshots__/Page.test.tsx.snap
+++ b/ui/src/__snapshots__/Page.test.tsx.snap
@@ -814,6 +814,9 @@ exports[`Page renders with right button 1`] = `
                             "accessibilityHint": "Press to perform action",
                             "accessibilityLabel": "Save",
                             "accessibilityRole": "button",
+                            "accessibilityState": {
+                              "disabled": undefined,
+                            },
                             "disabled": false,
                             "onPress": [Function: debounced],
                             "style": {

--- a/ui/src/__snapshots__/Page.test.tsx.snap
+++ b/ui/src/__snapshots__/Page.test.tsx.snap
@@ -817,6 +817,7 @@ exports[`Page renders with right button 1`] = `
                             "accessibilityState": {
                               "disabled": undefined,
                             },
+                            "aria-disabled": undefined,
                             "disabled": false,
                             "onPress": [Function: debounced],
                             "style": {

--- a/ui/src/__snapshots__/TerrenoProvider.test.tsx.snap
+++ b/ui/src/__snapshots__/TerrenoProvider.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`TerrenoProvider renders correctly with default props 1`] = `
       },
     ],
     "props": {
+      "style": undefined,
       "testID": "portal-host",
     },
     "type": "View",
@@ -115,6 +116,7 @@ exports[`TerrenoProvider renders with openAPISpecUrl 1`] = `
       },
     ],
     "props": {
+      "style": undefined,
       "testID": "portal-host",
     },
     "type": "View",

--- a/ui/src/__snapshots__/TerrenoProvider.test.tsx.snap
+++ b/ui/src/__snapshots__/TerrenoProvider.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`TerrenoProvider renders correctly with default props 1`] = `
       },
     ],
     "props": {
-      "style": undefined,
       "testID": "portal-host",
     },
     "type": "View",
@@ -116,7 +115,6 @@ exports[`TerrenoProvider renders with openAPISpecUrl 1`] = `
       },
     ],
     "props": {
-      "style": undefined,
       "testID": "portal-host",
     },
     "type": "View",

--- a/ui/src/bunSetup.ts
+++ b/ui/src/bunSetup.ts
@@ -6,6 +6,10 @@ type MockComponentProps = Record<string, unknown> & {
   style?: unknown;
   testID?: string;
 };
+type MockPresstoPressableProps = MockComponentProps & {
+  enabled?: boolean;
+  onPress?: (...args: unknown[]) => unknown;
+};
 type MockStyleValue = unknown;
 type MockAnimation = {
   start?: (callback?: (result: {finished: boolean}) => void) => void;
@@ -446,6 +450,25 @@ mock.module("react-native", () => {
     View,
   };
 });
+
+const createMockPresstoPressable = (name: string): React.FC<MockPresstoPressableProps> => {
+  return ({children, enabled = true, onPress, ...props}) =>
+    React.createElement(
+      name,
+      {
+        ...props,
+        disabled: !enabled,
+        onPress: enabled ? onPress : undefined,
+      },
+      children
+    );
+};
+
+mock.module("pressto", () => ({
+  PressableOpacity: createMockPresstoPressable("PressableOpacity"),
+  PressableScale: createMockPresstoPressable("PressableScale"),
+  PressableWithoutFeedback: createMockPresstoPressable("PressableWithoutFeedback"),
+}));
 
 // Initialize globalThis.expo early for expo-modules-core
 if (typeof globalThis.expo === "undefined") {

--- a/ui/src/login/__snapshots__/LoginScreen.test.tsx.snap
+++ b/ui/src/login/__snapshots__/LoginScreen.test.tsx.snap
@@ -359,6 +359,7 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                                 "accessibilityState": {
                                   "disabled": true,
                                 },
+                                "aria-disabled": "true",
                                 "disabled": true,
                                 "onPress": undefined,
                                 "style": {
@@ -441,6 +442,7 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                                 "accessibilityState": {
                                   "disabled": true,
                                 },
+                                "aria-disabled": "true",
                                 "disabled": true,
                                 "onPress": undefined,
                                 "style": {
@@ -524,6 +526,7 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                                 "accessibilityState": {
                                   "disabled": true,
                                 },
+                                "aria-disabled": "true",
                                 "disabled": true,
                                 "onPress": undefined,
                                 "style": {

--- a/ui/src/login/__snapshots__/LoginScreen.test.tsx.snap
+++ b/ui/src/login/__snapshots__/LoginScreen.test.tsx.snap
@@ -356,6 +356,9 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                                 "accessibilityHint": "Press to perform action",
                                 "accessibilityLabel": "Log In",
                                 "accessibilityRole": "button",
+                                "accessibilityState": {
+                                  "disabled": true,
+                                },
                                 "disabled": true,
                                 "onPress": undefined,
                                 "style": {
@@ -435,6 +438,9 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                                 "accessibilityHint": "Press to perform action",
                                 "accessibilityLabel": "Forgot password?",
                                 "accessibilityRole": "button",
+                                "accessibilityState": {
+                                  "disabled": true,
+                                },
                                 "disabled": true,
                                 "onPress": undefined,
                                 "style": {
@@ -515,6 +521,9 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                                 "accessibilityHint": "Press to perform action",
                                 "accessibilityLabel": "Need an account? Sign Up",
                                 "accessibilityRole": "button",
+                                "accessibilityState": {
+                                  "disabled": true,
+                                },
                                 "disabled": true,
                                 "onPress": undefined,
                                 "style": {

--- a/ui/src/login/__snapshots__/LoginScreen.test.tsx.snap
+++ b/ui/src/login/__snapshots__/LoginScreen.test.tsx.snap
@@ -354,10 +354,10 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                               ],
                               "props": {
                                 "accessibilityHint": "Press to perform action",
-                                "aria-label": "Log In",
-                                "aria-role": "button",
+                                "accessibilityLabel": "Log In",
+                                "accessibilityRole": "button",
                                 "disabled": true,
-                                "onPress": [Function: debounced],
+                                "onPress": undefined,
                                 "style": {
                                   "alignItems": "center",
                                   "alignSelf": "stretch",
@@ -373,7 +373,7 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                                 },
                                 "testID": "login-screen-submit-button",
                               },
-                              "type": "Pressable",
+                              "type": "PressableScale",
                             },
                           ],
                           "props": {
@@ -433,10 +433,10 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                               ],
                               "props": {
                                 "accessibilityHint": "Press to perform action",
-                                "aria-label": "Forgot password?",
-                                "aria-role": "button",
+                                "accessibilityLabel": "Forgot password?",
+                                "accessibilityRole": "button",
                                 "disabled": true,
-                                "onPress": [Function: debounced],
+                                "onPress": undefined,
                                 "style": {
                                   "alignItems": "center",
                                   "alignSelf": "flex-start",
@@ -452,7 +452,7 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                                 },
                                 "testID": "login-screen-forgot-password",
                               },
-                              "type": "Pressable",
+                              "type": "PressableScale",
                             },
                           ],
                           "props": {
@@ -513,10 +513,10 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                               ],
                               "props": {
                                 "accessibilityHint": "Press to perform action",
-                                "aria-label": "Need an account? Sign Up",
-                                "aria-role": "button",
+                                "accessibilityLabel": "Need an account? Sign Up",
+                                "accessibilityRole": "button",
                                 "disabled": true,
-                                "onPress": [Function: debounced],
+                                "onPress": undefined,
                                 "style": {
                                   "alignItems": "center",
                                   "alignSelf": "stretch",
@@ -532,7 +532,7 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                                 },
                                 "testID": "login-screen-signup-link",
                               },
-                              "type": "Pressable",
+                              "type": "PressableScale",
                             },
                           ],
                           "props": {

--- a/ui/src/login/__snapshots__/LoginScreen.test.tsx.snap
+++ b/ui/src/login/__snapshots__/LoginScreen.test.tsx.snap
@@ -359,9 +359,8 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                                 "accessibilityState": {
                                   "disabled": true,
                                 },
-                                "aria-disabled": "true",
                                 "disabled": true,
-                                "onPress": undefined,
+                                "onPress": [Function: debounced],
                                 "style": {
                                   "alignItems": "center",
                                   "alignSelf": "stretch",
@@ -377,7 +376,7 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                                 },
                                 "testID": "login-screen-submit-button",
                               },
-                              "type": "PressableScale",
+                              "type": "Pressable",
                             },
                           ],
                           "props": {
@@ -442,9 +441,8 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                                 "accessibilityState": {
                                   "disabled": true,
                                 },
-                                "aria-disabled": "true",
                                 "disabled": true,
-                                "onPress": undefined,
+                                "onPress": [Function: debounced],
                                 "style": {
                                   "alignItems": "center",
                                   "alignSelf": "flex-start",
@@ -460,7 +458,7 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                                 },
                                 "testID": "login-screen-forgot-password",
                               },
-                              "type": "PressableScale",
+                              "type": "Pressable",
                             },
                           ],
                           "props": {
@@ -526,9 +524,8 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                                 "accessibilityState": {
                                   "disabled": true,
                                 },
-                                "aria-disabled": "true",
                                 "disabled": true,
-                                "onPress": undefined,
+                                "onPress": [Function: debounced],
                                 "style": {
                                   "alignItems": "center",
                                   "alignSelf": "stretch",
@@ -544,7 +541,7 @@ exports[`LoginScreen renders correctly with all props 1`] = `
                                 },
                                 "testID": "login-screen-signup-link",
                               },
-                              "type": "PressableScale",
+                              "type": "Pressable",
                             },
                           ],
                           "props": {

--- a/ui/src/signUp/__snapshots__/SignUpScreen.test.tsx.snap
+++ b/ui/src/signUp/__snapshots__/SignUpScreen.test.tsx.snap
@@ -674,6 +674,7 @@ exports[`SignUpScreen renders correctly with all props 1`] = `
                                 "accessibilityState": {
                                   "disabled": true,
                                 },
+                                "aria-disabled": "true",
                                 "disabled": true,
                                 "onPress": undefined,
                                 "style": {
@@ -756,6 +757,7 @@ exports[`SignUpScreen renders correctly with all props 1`] = `
                                 "accessibilityState": {
                                   "disabled": true,
                                 },
+                                "aria-disabled": "true",
                                 "disabled": true,
                                 "onPress": undefined,
                                 "style": {

--- a/ui/src/signUp/__snapshots__/SignUpScreen.test.tsx.snap
+++ b/ui/src/signUp/__snapshots__/SignUpScreen.test.tsx.snap
@@ -671,6 +671,9 @@ exports[`SignUpScreen renders correctly with all props 1`] = `
                                 "accessibilityHint": "Press to perform action",
                                 "accessibilityLabel": "Sign Up",
                                 "accessibilityRole": "button",
+                                "accessibilityState": {
+                                  "disabled": true,
+                                },
                                 "disabled": true,
                                 "onPress": undefined,
                                 "style": {
@@ -750,6 +753,9 @@ exports[`SignUpScreen renders correctly with all props 1`] = `
                                 "accessibilityHint": "Press to perform action",
                                 "accessibilityLabel": "Already have an account? Log in",
                                 "accessibilityRole": "button",
+                                "accessibilityState": {
+                                  "disabled": true,
+                                },
                                 "disabled": true,
                                 "onPress": undefined,
                                 "style": {

--- a/ui/src/signUp/__snapshots__/SignUpScreen.test.tsx.snap
+++ b/ui/src/signUp/__snapshots__/SignUpScreen.test.tsx.snap
@@ -669,10 +669,10 @@ exports[`SignUpScreen renders correctly with all props 1`] = `
                               ],
                               "props": {
                                 "accessibilityHint": "Press to perform action",
-                                "aria-label": "Sign Up",
-                                "aria-role": "button",
+                                "accessibilityLabel": "Sign Up",
+                                "accessibilityRole": "button",
                                 "disabled": true,
-                                "onPress": [Function: debounced],
+                                "onPress": undefined,
                                 "style": {
                                   "alignItems": "center",
                                   "alignSelf": "stretch",
@@ -688,7 +688,7 @@ exports[`SignUpScreen renders correctly with all props 1`] = `
                                 },
                                 "testID": "signup-screen-submit-button",
                               },
-                              "type": "Pressable",
+                              "type": "PressableScale",
                             },
                           ],
                           "props": {
@@ -748,10 +748,10 @@ exports[`SignUpScreen renders correctly with all props 1`] = `
                               ],
                               "props": {
                                 "accessibilityHint": "Press to perform action",
-                                "aria-label": "Already have an account? Log in",
-                                "aria-role": "button",
+                                "accessibilityLabel": "Already have an account? Log in",
+                                "accessibilityRole": "button",
                                 "disabled": true,
-                                "onPress": [Function: debounced],
+                                "onPress": undefined,
                                 "style": {
                                   "alignItems": "center",
                                   "alignSelf": "stretch",
@@ -767,7 +767,7 @@ exports[`SignUpScreen renders correctly with all props 1`] = `
                                 },
                                 "testID": "signup-screen-login-link",
                               },
-                              "type": "Pressable",
+                              "type": "PressableScale",
                             },
                           ],
                           "props": {

--- a/ui/src/signUp/__snapshots__/SignUpScreen.test.tsx.snap
+++ b/ui/src/signUp/__snapshots__/SignUpScreen.test.tsx.snap
@@ -674,9 +674,8 @@ exports[`SignUpScreen renders correctly with all props 1`] = `
                                 "accessibilityState": {
                                   "disabled": true,
                                 },
-                                "aria-disabled": "true",
                                 "disabled": true,
-                                "onPress": undefined,
+                                "onPress": [Function: debounced],
                                 "style": {
                                   "alignItems": "center",
                                   "alignSelf": "stretch",
@@ -692,7 +691,7 @@ exports[`SignUpScreen renders correctly with all props 1`] = `
                                 },
                                 "testID": "signup-screen-submit-button",
                               },
-                              "type": "PressableScale",
+                              "type": "Pressable",
                             },
                           ],
                           "props": {
@@ -757,9 +756,8 @@ exports[`SignUpScreen renders correctly with all props 1`] = `
                                 "accessibilityState": {
                                   "disabled": true,
                                 },
-                                "aria-disabled": "true",
                                 "disabled": true,
-                                "onPress": undefined,
+                                "onPress": [Function: debounced],
                                 "style": {
                                   "alignItems": "center",
                                   "alignSelf": "stretch",
@@ -775,7 +773,7 @@ exports[`SignUpScreen renders correctly with all props 1`] = `
                                 },
                                 "testID": "signup-screen-login-link",
                               },
-                              "type": "PressableScale",
+                              "type": "Pressable",
                             },
                           ],
                           "props": {


### PR DESCRIPTION
Got Jo's sign off to make our buttons a little more lively. 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add Pressto as the animated pressable layer for enabled `Button` instances with `scale`, `opacity`, and `none` press animation options.
- Make `scale` the explicit default button press animation and cover it with a focused test.
- Add Button demo coverage for all press animations across button variants.
- Preserve disabled/loading button web accessibility by keeping the native `Pressable` path for non-interactive buttons, and update UI snapshots for the new render output.

### Testing
- `bun run ui:compile && bun run ui:lint`
- `bun run --filter '@terreno/ui' test:ci src/Button.test.tsx`
- `bun run --filter '@terreno/ui' test:ci src/Button.test.tsx src/InfoModalIcon.test.tsx src/Page.test.tsx src/DecimalRangeActionSheet.test.tsx src/HeightActionSheet.test.tsx src/Modal.test.tsx src/NumberPickerActionSheet.test.tsx src/ErrorPage.test.tsx src/HeightField.test.tsx src/login/LoginScreen.test.tsx src/signUp/SignUpScreen.test.tsx`
- `bun run demo:compile && bun run demo:lint`
- `bunx playwright test profile.spec.ts --project=chromium` (attempted locally; blocked because the local example backend could not resolve workspace package `@terreno/api` in this environment)
- Manual demo verification on `http://localhost:8085/demo/Button`.
- Netlify deploy-preview jobs previously failed with `Service Temporarily Unavailable`; pushed a no-op retry commit to retrigger CI.

### Walkthrough
[pressto_button_animations_demo.mp4](https://cursor.com/agents/bc-1b62368a-a7b5-4a5b-b2c7-3ae84859e9e5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpressto_button_animations_demo.mp4)
[Pressto button animations section](https://cursor.com/agents/bc-1b62368a-a7b5-4a5b-b2c7-3ae84859e9e5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpressto_button_animations_section.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b62368a-a7b5-4a5b-b2c7-3ae84859e9e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b62368a-a7b5-4a5b-b2c7-3ae84859e9e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

