### PR TITLE
Add GPT consent form translation controls

### DIFF
--- a/admin-frontend/src/AdminFieldRenderer.tsx
+++ b/admin-frontend/src/AdminFieldRenderer.tsx
@@ -12,6 +12,7 @@ import {AdminPrimitiveArrayField} from "./AdminPrimitiveArrayField";
 import {AdminRefField} from "./AdminRefField";
 import {CheckboxListEditor} from "./CheckboxListEditor";
 import {LocaleContentEditor} from "./LocaleContentEditor";
+import {getLocaleOptions} from "./localeLabels";
 import type {AdminFieldConfig, AdminFieldValue, AdminScreenProps, RefRendererMap} from "./types";
 
 // Attempts to parse a string as JSON, returning the parsed value or the raw string
@@ -262,7 +263,7 @@ export const AdminFieldRenderer: React.FC<AdminFieldRendererProps> = ({
         ? Object.keys(contentMap)
         : [];
     const hasLocales = localeKeys.length > 0;
-    const options = localeKeys.map((k) => ({label: k.toUpperCase(), value: k}));
+    const options = getLocaleOptions(localeKeys);
     return (
       <SelectField
         disabled={!hasLocales}

--- a/admin-frontend/src/ConsentFormEditor.test.tsx
+++ b/admin-frontend/src/ConsentFormEditor.test.tsx
@@ -333,7 +333,7 @@ describe("ConsentFormEditor", () => {
   });
 
   it("renders and switches segmented control in multi-locale mode", async () => {
-    const {toJSON} = renderWithTheme(
+    const {toJSON, UNSAFE_root} = renderWithTheme(
       <ConsentFormEditor
         api={makeApi() as any}
         baseUrl="/admin"
@@ -341,6 +341,10 @@ describe("ConsentFormEditor", () => {
         supportedLocales={["en", "es"]}
       />
     );
+    const segmented = UNSAFE_root.findAll(
+      (n: any) => typeof n.props?.onChange === "function" && Array.isArray(n.props?.items)
+    );
+    expect(segmented[0].props.items).toEqual(["English", "Spanish"]);
     expect(toJSON()).toBeDefined();
   });
 
@@ -466,6 +470,45 @@ describe("ConsentFormEditor", () => {
     expect(translateCalls.length).toBe(1);
     expect(translateCalls[0].toLocale).toBe("es");
     expect(translateCalls[0].content).toBe("Hello world");
+  });
+
+  it("auto-translates selected target languages before saving", async () => {
+    state.formData = {
+      content: {en: "Hello world"},
+      defaultLocale: "en",
+      slug: "s",
+      title: "T",
+    };
+    const {UNSAFE_root, getByTestId} = renderWithTheme(
+      <ConsentFormEditor
+        api={makeApi() as any}
+        baseUrl="/admin"
+        hasAiSupport
+        id="f1"
+        supportedLocales={["en", "es", "fr"]}
+      />
+    );
+    const autoTranslateField = UNSAFE_root.findAll(
+      (n: any) => n.props?.title === "Auto translate with GPT"
+    );
+    expect(autoTranslateField.length).toBeGreaterThan(0);
+    await act(async () => {
+      autoTranslateField[0].props.onChange(true);
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    const targetField = UNSAFE_root.findAll((n: any) => n.props?.title === "Translate into");
+    expect(targetField.length).toBeGreaterThan(0);
+    await act(async () => {
+      targetField[0].props.onChange(["es", "fr"]);
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    await press(getByTestId("consent-form-save-button"));
+    expect(translateCalls.length).toBe(2);
+    expect(translateCalls.map((call) => call.toLocale)).toEqual(["es", "fr"]);
+    expect(updateCalls[0].body.content.es).toBe("translated");
+    expect(updateCalls[0].body.content.fr).toBe("translated");
   });
 
   it("short-circuits translation when source locale has empty content", async () => {

--- a/admin-frontend/src/ConsentFormEditor.tsx
+++ b/admin-frontend/src/ConsentFormEditor.tsx
@@ -5,6 +5,7 @@ import {
   Heading,
   MarkdownEditor,
   Modal,
+  MultiselectField,
   NumberField,
   Page,
   SegmentedControl,
@@ -15,6 +16,7 @@ import {
   useToast,
 } from "@terreno/ui";
 import React, {useCallback, useEffect, useMemo, useState} from "react";
+import {getLocaleLabel, getLocaleOptions} from "./localeLabels";
 import type {AdminApi, EndpointBuilder} from "./types";
 import {useAdminApi} from "./useAdminApi";
 
@@ -65,6 +67,16 @@ const TYPE_OPTIONS = [
   {label: "Custom", value: "custom"},
 ];
 
+const DEFAULT_SUPPORTED_LOCALES = ["en"];
+
+const areStringArraysEqual = (first: string[], second: string[]): boolean => {
+  if (first.length !== second.length) {
+    return false;
+  }
+
+  return first.every((value, index) => value === second[index]);
+};
+
 const slugify = (text: string): string => {
   return text
     .toLowerCase()
@@ -77,7 +89,7 @@ export const ConsentFormEditor: React.FC<ConsentFormEditorProps> = ({
   baseUrl,
   api,
   id,
-  supportedLocales = ["en"],
+  supportedLocales = DEFAULT_SUPPORTED_LOCALES,
   hasAiSupport = false,
   onSave,
   onCancel,
@@ -123,6 +135,10 @@ export const ConsentFormEditor: React.FC<ConsentFormEditorProps> = ({
   const [isGenerateModalVisible, setIsGenerateModalVisible] = useState(false);
   const [generateDescription, setGenerateDescription] = useState("");
   const [generateType, setGenerateType] = useState(type);
+  const [isAutoTranslateEnabled, setIsAutoTranslateEnabled] = useState(false);
+  const [translationTargetLocales, setTranslationTargetLocales] = useState<string[]>(() =>
+    supportedLocales.filter((locale) => locale !== defaultLocale)
+  );
 
   const routePath = `${baseUrl}${CONSENT_FORM_ROUTE}`;
   // publish/generate/translate are registered directly under /consent-forms, not the admin base path
@@ -211,6 +227,24 @@ export const ConsentFormEditor: React.FC<ConsentFormEditorProps> = ({
     }
   }, [formData, supportedLocales]);
 
+  // Keep the GPT target list valid when the available or default locale changes.
+  useEffect(() => {
+    const availableTargetLocales = supportedLocales.filter((locale) => locale !== defaultLocale);
+    setTranslationTargetLocales((prev) => {
+      const validTargets = prev.filter((locale) => availableTargetLocales.includes(locale));
+      if (validTargets.length > 0) {
+        if (areStringArraysEqual(prev, validTargets)) {
+          return prev;
+        }
+        return validTargets;
+      }
+      if (areStringArraysEqual(prev, availableTargetLocales)) {
+        return prev;
+      }
+      return availableTargetLocales;
+    });
+  }, [defaultLocale, supportedLocales]);
+
   // Auto-generate slug from title unless manually set
   const handleTitleChange = useCallback(
     (newTitle: string) => {
@@ -250,43 +284,112 @@ export const ConsentFormEditor: React.FC<ConsentFormEditorProps> = ({
     []
   );
 
-  const buildPayload = useCallback(() => {
-    return {
+  const buildPayload = useCallback(
+    (contentOverride?: Record<string, string>) => {
+      return {
+        active,
+        agreeButtonText,
+        allowDecline,
+        captureSignature,
+        checkboxes: checkboxes.map((cb) => ({
+          confirmationPrompt: cb.confirmationPrompt || undefined,
+          label: cb.label,
+          required: cb.required,
+        })),
+        content: contentOverride ?? localeContent,
+        declineButtonText: allowDecline ? declineButtonText : undefined,
+        defaultLocale,
+        order: parseInt(order, 10) || 0,
+        required,
+        requireScrollToBottom,
+        slug,
+        title,
+        type,
+      };
+    },
+    [
       active,
       agreeButtonText,
       allowDecline,
       captureSignature,
-      checkboxes: checkboxes.map((cb) => ({
-        confirmationPrompt: cb.confirmationPrompt || undefined,
-        label: cb.label,
-        required: cb.required,
-      })),
-      content: localeContent,
-      declineButtonText: allowDecline ? declineButtonText : undefined,
+      checkboxes,
       defaultLocale,
-      order: parseInt(order, 10) || 0,
+      localeContent,
+      declineButtonText,
+      order,
       required,
       requireScrollToBottom,
       slug,
       title,
       type,
-    };
-  }, [
-    active,
-    agreeButtonText,
-    allowDecline,
-    captureSignature,
-    checkboxes,
-    defaultLocale,
-    localeContent,
-    declineButtonText,
-    order,
-    required,
-    requireScrollToBottom,
-    slug,
-    title,
-    type,
-  ]);
+    ]
+  );
+
+  const translateLocales = useCallback(
+    async ({
+      sourceContent,
+      startingContent,
+      targetLocales,
+    }: {
+      sourceContent: string;
+      startingContent: Record<string, string>;
+      targetLocales: string[];
+    }): Promise<Record<string, string> | undefined> => {
+      if (!sourceContent.trim()) {
+        toast.error(`No content in ${getLocaleLabel(defaultLocale)} to translate from`);
+        return undefined;
+      }
+
+      if (targetLocales.length === 0) {
+        toast.error("Select at least one language to translate into");
+        return undefined;
+      }
+
+      let translatedContent = {...startingContent};
+      for (const targetLocale of targetLocales) {
+        if (targetLocale === defaultLocale) {
+          continue;
+        }
+
+        try {
+          const result = await translateContent({
+            content: sourceContent,
+            fromLocale: defaultLocale,
+            toLocale: targetLocale,
+          }).unwrap();
+          translatedContent = {
+            ...translatedContent,
+            [targetLocale]: result?.data?.content ?? "",
+          };
+        } catch (err) {
+          toast.catch(err, `Failed to translate content to ${getLocaleLabel(targetLocale)}`);
+          return undefined;
+        }
+      }
+
+      setLocaleContent(translatedContent);
+      return translatedContent;
+    },
+    [defaultLocale, toast, translateContent]
+  );
+
+  const handleTranslateSelectedLocales = useCallback(async (): Promise<
+    Record<string, string> | undefined
+  > => {
+    const sourceContent = localeContent[defaultLocale] ?? "";
+    const translatedContent = await translateLocales({
+      sourceContent,
+      startingContent: localeContent,
+      targetLocales: translationTargetLocales,
+    });
+
+    if (!translatedContent) {
+      return undefined;
+    }
+
+    toast.success(`Translated into ${translationTargetLocales.length} language(s)`);
+    return translatedContent;
+  }, [defaultLocale, localeContent, toast, translateLocales, translationTargetLocales]);
 
   const handleSave = useCallback(async () => {
     if (!title.trim()) {
@@ -298,7 +401,16 @@ export const ConsentFormEditor: React.FC<ConsentFormEditorProps> = ({
       return;
     }
 
-    const payload = buildPayload();
+    let nextLocaleContent = localeContent;
+    if (hasAiSupport && isAutoTranslateEnabled) {
+      const translatedContent = await handleTranslateSelectedLocales();
+      if (!translatedContent) {
+        return;
+      }
+      nextLocaleContent = translatedContent;
+    }
+
+    const payload = buildPayload(nextLocaleContent);
 
     try {
       let result: ConsentFormDocument | undefined;
@@ -312,7 +424,21 @@ export const ConsentFormEditor: React.FC<ConsentFormEditorProps> = ({
     } catch (err) {
       toast.catch(err, `Failed to ${isEditMode ? "update" : "create"} consent form`);
     }
-  }, [buildPayload, createForm, id, isEditMode, onSave, slug, title, toast, updateForm]);
+  }, [
+    buildPayload,
+    createForm,
+    handleTranslateSelectedLocales,
+    hasAiSupport,
+    id,
+    isAutoTranslateEnabled,
+    isEditMode,
+    localeContent,
+    onSave,
+    slug,
+    title,
+    toast,
+    updateForm,
+  ]);
 
   const handlePublish = useCallback(async () => {
     if (!id) {
@@ -342,7 +468,15 @@ export const ConsentFormEditor: React.FC<ConsentFormEditorProps> = ({
         type: generateType,
       }).unwrap();
       const generatedText = result?.data?.content ?? "";
-      handleLocaleContentChange(activeLocale, generatedText);
+      const nextLocaleContent = {...localeContent, [activeLocale]: generatedText};
+      setLocaleContent(nextLocaleContent);
+      if (isAutoTranslateEnabled && activeLocale === defaultLocale) {
+        await translateLocales({
+          sourceContent: generatedText,
+          startingContent: nextLocaleContent,
+          targetLocales: translationTargetLocales,
+        });
+      }
       setIsGenerateModalVisible(false);
       toast.success("Content generated successfully");
     } catch (err) {
@@ -350,37 +484,32 @@ export const ConsentFormEditor: React.FC<ConsentFormEditorProps> = ({
     }
   }, [
     activeLocaleIndex,
+    defaultLocale,
     generateContent,
     generateDescription,
     generateType,
-    handleLocaleContentChange,
+    isAutoTranslateEnabled,
+    localeContent,
     supportedLocales,
     toast,
+    translateLocales,
+    translationTargetLocales,
   ]);
 
   const handleTranslate = useCallback(
     async (targetLocale: string) => {
       const sourceContent = localeContent[defaultLocale] ?? "";
+      const translatedContent = await translateLocales({
+        sourceContent,
+        startingContent: localeContent,
+        targetLocales: [targetLocale],
+      });
 
-      if (!sourceContent.trim()) {
-        toast.error(`No content in ${defaultLocale} to translate from`);
-        return;
-      }
-
-      try {
-        const result = await translateContent({
-          content: sourceContent,
-          fromLocale: defaultLocale,
-          toLocale: targetLocale,
-        }).unwrap();
-        const translatedText = result?.data?.content ?? "";
-        handleLocaleContentChange(targetLocale, translatedText);
-        toast.success(`Content translated to ${targetLocale}`);
-      } catch (err) {
-        toast.catch(err, `Failed to translate content to ${targetLocale}`);
+      if (translatedContent) {
+        toast.success(`Content translated to ${getLocaleLabel(targetLocale)}`);
       }
     },
-    [defaultLocale, handleLocaleContentChange, localeContent, toast, translateContent]
+    [defaultLocale, localeContent, toast, translateLocales]
   );
 
   // Hooks must run before any early returns to keep React's hook order stable across
@@ -390,13 +519,14 @@ export const ConsentFormEditor: React.FC<ConsentFormEditorProps> = ({
     () => Object.keys(localeContent).filter((k) => localeContent[k] !== undefined),
     [localeContent]
   );
-  const defaultLocaleOptions = useMemo(
-    () =>
-      contentLocales.map((locale) => ({
-        label: locale.toUpperCase(),
-        value: locale,
-      })),
-    [contentLocales]
+  const defaultLocaleOptions = useMemo(() => getLocaleOptions(contentLocales), [contentLocales]);
+  const localeSegmentItems = useMemo(
+    () => supportedLocales.map((locale) => getLocaleLabel(locale)),
+    [supportedLocales]
+  );
+  const translationTargetOptions = useMemo(
+    () => getLocaleOptions(supportedLocales.filter((locale) => locale !== defaultLocale)),
+    [defaultLocale, supportedLocales]
   );
 
   if (isEditMode && isFormLoading) {
@@ -574,10 +704,42 @@ export const ConsentFormEditor: React.FC<ConsentFormEditorProps> = ({
           </Box>
           {supportedLocales.length > 1 && (
             <SegmentedControl
-              items={supportedLocales}
+              items={localeSegmentItems}
               onChange={setActiveLocaleIndex}
               selectedIndex={activeLocaleIndex}
             />
+          )}
+          {hasAiSupport && supportedLocales.length > 1 && (
+            <Box border="default" gap={3} padding={3} rounding="md">
+              <BooleanField
+                helperText={`Use GPT to translate from ${getLocaleLabel(defaultLocale)} into selected languages before saving.`}
+                onChange={setIsAutoTranslateEnabled}
+                title="Auto translate with GPT"
+                value={isAutoTranslateEnabled}
+                variant="title"
+              />
+              {isAutoTranslateEnabled && (
+                <Box gap={3}>
+                  <MultiselectField
+                    helperText="Choose every language this consent form should include."
+                    onChange={setTranslationTargetLocales}
+                    options={translationTargetOptions}
+                    title="Translate into"
+                    value={translationTargetLocales}
+                  />
+                  <Button
+                    disabled={translationTargetLocales.length === 0}
+                    loading={isTranslating}
+                    onClick={async () => {
+                      await handleTranslateSelectedLocales();
+                    }}
+                    testID="consent-form-translate-selected-button"
+                    text="Translate Selected Languages"
+                    variant="secondary"
+                  />
+                </Box>
+              )}
+            </Box>
           )}
           {hasAiSupport && isNonDefaultLocale && (
             <Box>
@@ -585,16 +747,18 @@ export const ConsentFormEditor: React.FC<ConsentFormEditorProps> = ({
                 loading={isTranslating}
                 onClick={() => handleTranslate(activeLocale)}
                 testID={`consent-form-translate-${activeLocale}-button`}
-                text={`Translate from ${defaultLocale}`}
+                text={`Translate from ${getLocaleLabel(defaultLocale)}`}
                 variant="secondary"
               />
             </Box>
           )}
           <MarkdownEditor
-            onChange={(content) => handleLocaleContentChange(activeLocale, content)}
-            placeholder={`Enter content for locale: ${activeLocale}`}
+            onChange={(content: string) => handleLocaleContentChange(activeLocale, content)}
+            placeholder={`Enter content for ${getLocaleLabel(activeLocale)}`}
             testID={`consent-form-content-${activeLocale}`}
-            title={supportedLocales.length > 1 ? `Content (${activeLocale})` : "Content"}
+            title={
+              supportedLocales.length > 1 ? `Content (${getLocaleLabel(activeLocale)})` : "Content"
+            }
             value={localeContent[activeLocale] ?? ""}
           />
         </Box>
@@ -632,20 +796,22 @@ export const ConsentFormEditor: React.FC<ConsentFormEditorProps> = ({
                 />
               </Box>
               <TextField
-                onChange={(value) => handleCheckboxChange(index, "label", value)}
+                onChange={(value: string) => handleCheckboxChange(index, "label", value)}
                 placeholder="Checkbox label"
                 testID={`consent-form-checkbox-${index}-label-input`}
                 title="Label"
                 value={checkbox.label}
               />
               <BooleanField
-                onChange={(value) => handleCheckboxChange(index, "required", value)}
+                onChange={(value: boolean) => handleCheckboxChange(index, "required", value)}
                 title="Required"
                 value={checkbox.required}
                 variant="title"
               />
               <TextField
-                onChange={(value) => handleCheckboxChange(index, "confirmationPrompt", value)}
+                onChange={(value: string) =>
+                  handleCheckboxChange(index, "confirmationPrompt", value)
+                }
                 placeholder="Optional confirmation prompt"
                 testID={`consent-form-checkbox-${index}-prompt-input`}
                 title="Confirmation Prompt (optional)"
@@ -677,7 +843,7 @@ export const ConsentFormEditor: React.FC<ConsentFormEditorProps> = ({
               value={generateType}
             />
             <Text color="secondaryDark" size="sm">
-              Locale: {activeLocale}
+              Locale: {getLocaleLabel(activeLocale)}
             </Text>
             <TextField
               multiline

--- a/admin-frontend/src/LocaleContentEditor.test.tsx
+++ b/admin-frontend/src/LocaleContentEditor.test.tsx
@@ -40,7 +40,7 @@ describe("LocaleContentEditor", () => {
     );
 
     await press(getByText("French"));
-    expect(getByText("Editing: fr")).toBeDefined();
+    expect(getByText("Editing: French")).toBeDefined();
   });
 
   it("removes the active locale when remove is pressed", async () => {
@@ -138,7 +138,7 @@ describe("LocaleContentEditor", () => {
     const {getByText} = renderWithTheme(
       <LocaleContentEditor onChange={onChange} value={{en: "Hi", es: "Hola"}} />
     );
-    await press(getByText("Remove en"));
+    await press(getByText("Remove English"));
     expect(onChange).toHaveBeenCalled();
   });
 });

--- a/admin-frontend/src/LocaleContentEditor.tsx
+++ b/admin-frontend/src/LocaleContentEditor.tsx
@@ -1,5 +1,6 @@
 import {Box, Button, MarkdownEditorField, SelectField, Text} from "@terreno/ui";
 import React, {useCallback, useMemo, useState} from "react";
+import {COMMON_LOCALES, getLocaleLabel} from "./localeLabels";
 
 interface LocaleContentEditorProps {
   value: Record<string, string>;
@@ -8,19 +9,6 @@ interface LocaleContentEditorProps {
   helperText?: string;
   errorText?: string;
 }
-
-const COMMON_LOCALES = [
-  {label: "English", value: "en"},
-  {label: "Spanish", value: "es"},
-  {label: "French", value: "fr"},
-  {label: "German", value: "de"},
-  {label: "Portuguese", value: "pt"},
-  {label: "Chinese", value: "zh"},
-  {label: "Japanese", value: "ja"},
-  {label: "Korean", value: "ko"},
-  {label: "Arabic", value: "ar"},
-  {label: "Hindi", value: "hi"},
-];
 
 export const LocaleContentEditor: React.FC<LocaleContentEditorProps> = ({
   value = {},
@@ -89,7 +77,7 @@ export const LocaleContentEditor: React.FC<LocaleContentEditorProps> = ({
             <Button
               key={locale}
               onClick={() => setActiveLocale(locale)}
-              text={COMMON_LOCALES.find((l) => l.value === locale)?.label ?? locale.toUpperCase()}
+              text={getLocaleLabel(locale)}
               variant={locale === activeLocale ? "primary" : "outline"}
             />
           ))}
@@ -100,12 +88,12 @@ export const LocaleContentEditor: React.FC<LocaleContentEditorProps> = ({
         <Box gap={1}>
           <Box alignItems="center" direction="row" justifyContent="between">
             <Text color="secondaryDark" size="sm">
-              Editing: {activeLocale}
+              Editing: {getLocaleLabel(activeLocale)}
             </Text>
             {locales.length > 1 && (
               <Button
                 onClick={() => handleRemoveLocale(activeLocale)}
-                text={`Remove ${activeLocale}`}
+                text={`Remove ${getLocaleLabel(activeLocale)}`}
                 variant="destructive"
               />
             )}

--- a/admin-frontend/src/localeLabels.ts
+++ b/admin-frontend/src/localeLabels.ts
@@ -1,0 +1,33 @@
+export interface LocaleOption {
+  label: string;
+  value: string;
+}
+
+export const COMMON_LOCALES: LocaleOption[] = [
+  {label: "English", value: "en"},
+  {label: "Spanish", value: "es"},
+  {label: "French", value: "fr"},
+  {label: "German", value: "de"},
+  {label: "Portuguese", value: "pt"},
+  {label: "Chinese", value: "zh"},
+  {label: "Japanese", value: "ja"},
+  {label: "Korean", value: "ko"},
+  {label: "Arabic", value: "ar"},
+  {label: "Hindi", value: "hi"},
+];
+
+const COMMON_LOCALE_LABELS = COMMON_LOCALES.reduce<Record<string, string>>((labels, locale) => {
+  labels[locale.value] = locale.label;
+  return labels;
+}, {});
+
+export const getLocaleLabel = (locale: string): string => {
+  return COMMON_LOCALE_LABELS[locale] ?? locale.toUpperCase();
+};
+
+export const getLocaleOptions = (locales: string[]): LocaleOption[] => {
+  return locales.map((locale) => ({
+    label: getLocaleLabel(locale),
+    value: locale,
+  }));
+};

--- a/example-backend/src/api/ai.ts
+++ b/example-backend/src/api/ai.ts
@@ -9,13 +9,18 @@ import {
   MCPService,
   preparePromptForAI,
 } from "@terreno/ai";
-import type {ModelRouterOptions} from "@terreno/api";
-import {logger} from "@terreno/api";
+import {APIError, type ConsentAppOptions, logger, type ModelRouterOptions} from "@terreno/api";
 import type {ImageModel, LanguageModel, Tool} from "ai";
 import {generateImage, tool, zodSchema} from "ai";
 import type express from "express";
 import {PDFDocument, rgb, StandardFonts} from "pdf-lib";
 import {z} from "zod";
+
+const CONSENT_CONTENT_SYSTEM_PROMPT =
+  "You draft consent form content for regulated healthcare and research applications. Return clear Markdown only, with legally precise language and no extra commentary.";
+
+const CONSENT_CONTENT_USER_PROMPT =
+  "Create a {type} consent form in {locale}. Requirements and context: {description}";
 
 /** A provider that creates language models and image models from model IDs. */
 interface AIProvider {
@@ -138,6 +143,50 @@ const createModelFromKey = (apiKey: string, modelId?: string) => {
   const provider = google.createGoogleGenerativeAI({apiKey});
   return provider(modelId ?? DEFAULT_MODEL);
 };
+
+const requireAiService = (): AIService => {
+  const aiService = getAiService();
+  if (!aiService) {
+    throw new APIError({
+      status: 503,
+      title: "AI service is not configured",
+    });
+  }
+  return aiService;
+};
+
+const buildConsentContentPrompt = ({
+  description,
+  locale,
+  type,
+}: {
+  description: string;
+  locale: string;
+  type: string;
+}): string => {
+  return CONSENT_CONTENT_USER_PROMPT.replace("{type}", type)
+    .replace("{locale}", locale)
+    .replace("{description}", description);
+};
+
+export const getConsentAiConfig = (): NonNullable<ConsentAppOptions["aiConfig"]> => ({
+  generateContent: async ({description, locale, type}) => {
+    const aiService = requireAiService();
+    return aiService.generateText({
+      prompt: buildConsentContentPrompt({description, locale, type}),
+      systemPrompt: CONSENT_CONTENT_SYSTEM_PROMPT,
+      temperature: 0.3,
+    });
+  },
+  translateContent: async ({content, fromLocale, toLocale}) => {
+    const aiService = requireAiService();
+    return aiService.translateText({
+      sourceLanguage: fromLocale,
+      targetLanguage: toLocale,
+      text: content,
+    });
+  },
+});
 
 const getMcpService = (): MCPService | undefined => {
   if (mcpServiceInstance) {

--- a/example-backend/src/server.ts
+++ b/example-backend/src/server.ts
@@ -23,7 +23,7 @@ import {FeatureFlagsApp, featureFlagAdminConfig} from "@terreno/feature-flags";
 import express from "express";
 import mongoose from "mongoose";
 import {addAdminUserRoutes} from "./api/adminUsers";
-import {addAiRoutes} from "./api/ai";
+import {addAiRoutes, getConsentAiConfig} from "./api/ai";
 import {addSettingsRoutes} from "./api/settings";
 import {addTodoRoutes} from "./api/todos";
 import {addUserRoutes} from "./api/users";
@@ -324,6 +324,7 @@ export async function start(skipListen = false): Promise<express.Application> {
       )
       .register(
         new ConsentApp({
+          aiConfig: getConsentAiConfig(),
           auditTrail: true,
           resolveConsentForms: (user, forms) => (user.admin ? [] : forms),
           supportedLocales: ["en", "es"],

--- a/example-frontend/app/admin/consent-forms/[id].tsx
+++ b/example-frontend/app/admin/consent-forms/[id].tsx
@@ -2,6 +2,7 @@ import {ConsentFormEditor} from "@terreno/admin-frontend";
 import {useLocalSearchParams, useRouter} from "expo-router";
 import React from "react";
 import {terrenoApi} from "@/store/sdk";
+import {CONSENT_SUPPORTED_LOCALES} from "./constants";
 
 const ADMIN_BASE_URL = "/admin";
 
@@ -12,9 +13,11 @@ const EditConsentFormScreen: React.FC = () => {
     <ConsentFormEditor
       api={terrenoApi}
       baseUrl={ADMIN_BASE_URL}
+      hasAiSupport
       id={id}
       onCancel={() => router.back()}
       onSave={() => router.back()}
+      supportedLocales={CONSENT_SUPPORTED_LOCALES}
     />
   );
 };

--- a/example-frontend/app/admin/consent-forms/constants.ts
+++ b/example-frontend/app/admin/consent-forms/constants.ts
@@ -1,0 +1,1 @@
+export const CONSENT_SUPPORTED_LOCALES = ["en", "es"];

--- a/example-frontend/app/admin/consent-forms/create.tsx
+++ b/example-frontend/app/admin/consent-forms/create.tsx
@@ -2,6 +2,7 @@ import {ConsentFormEditor} from "@terreno/admin-frontend";
 import {useRouter} from "expo-router";
 import React from "react";
 import {terrenoApi} from "@/store/sdk";
+import {CONSENT_SUPPORTED_LOCALES} from "./constants";
 
 const ADMIN_BASE_URL = "/admin";
 
@@ -11,8 +12,10 @@ const CreateConsentFormScreen: React.FC = () => {
     <ConsentFormEditor
       api={terrenoApi}
       baseUrl={ADMIN_BASE_URL}
+      hasAiSupport
       onCancel={() => router.back()}
       onSave={() => router.back()}
+      supportedLocales={CONSENT_SUPPORTED_LOCALES}
     />
   );
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add full language labels and shared locale option helpers for consent form locale selectors.
- Add GPT auto-translation controls to the consent form editor, including a toggle, multi-language target selection, selected-language translation, and translate-before-save behavior.
- Wire the example backend consent app to AI generate/translate handlers and pass supported locale/AI props from example admin consent screens.

## Testing
Automated checks:
- [x] `bun run ui:compile`
- [x] `bun run admin-frontend:compile`
- [x] `bun run admin-frontend:lint`
- [x] `bun run api:compile`
- [x] `bun run ai:compile`
- [x] `bun run admin-backend:compile`
- [x] `bun run feature-flags:compile`
- [x] `bun run api-health:compile && bun run --filter '@terreno/example-backend' compile`
- [x] `bun run --filter '@terreno/example-frontend' lint`
- [x] `git diff --check`

Additional validation:
- [x] `bun run --filter '@terreno/admin-frontend' test` ran consent editor tests successfully, including full language labels and auto-translate-before-save coverage.
- [ ] Package test command still has unrelated pre-existing failures in `AdminScriptRunModal.test.tsx` (5 tests cannot find expected confirm-phase buttons).
- [ ] SDK regeneration was attempted but blocked because the local example backend cannot connect to MongoDB at `localhost:27017`.

Manual steps:
- [ ] Open Admin > Consent Forms > Create/Edit, confirm locale tabs show full names like English and Spanish.
- [ ] Enable "Auto translate with GPT", select target languages, save, and confirm selected locale content is translated before the form is saved.
- [ ] On a non-default locale tab, click "Translate from English" and confirm that locale content updates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df26ca86-3981-41e2-bd4f-1a23252e076e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df26ca86-3981-41e2-bd4f-1a23252e076e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

