### PR TITLE
Port flourish workflow skills, move adapted skills to .rulesync

### DIFF
--- a/.agents/skills/ai-prompt-governance/SKILL.md
+++ b/.agents/skills/ai-prompt-governance/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: ai-prompt-governance
+description: >-
+  Invoke when adding, modifying, or reviewing any prompt used by `@terreno/ai`
+  (AIService methods, system prompts, helpers). Provides prompt-as-constant
+  rules, temperature preset guidance, logging requirements, and a testing
+  checklist.
+---
+# AI Prompt Governance — `@terreno/ai`
+
+`@terreno/ai` is a backend-only, provider-agnostic AI layer built on the Vercel AI SDK. Consuming apps inject a `LanguageModel` (Google, Anthropic, OpenAI, etc.) and call `AIService` methods. All requests are logged through the `AIRequest` model.
+
+See `ai/src/service/aiService.ts` and `ai/src/service/prompts.ts` for the canonical implementation.
+
+## Prompt Writing Rules
+
+1. **Always a named constant** — Define prompts in `ai/src/service/prompts.ts` (or the consuming app's equivalent constants file). Never inline prompt strings in route handlers, services, or `AIService` method bodies.
+2. **Self-contained** — A prompt should read coherently on its own. If you must inject runtime context, document why in a comment above the constant.
+3. **Typed return** — If the prompt asks for structured JSON, define a matching TypeScript interface in `ai/src/types/index.ts` and parse against it on every response.
+4. **Don't bake user-identifiable data into the prompt template itself** — inject it at call time as runtime parameters, never as defaults in the constant.
+
+## Temperature Preset Guidance
+
+Use the presets exported from `@terreno/ai`:
+
+| Preset | Value | When to use |
+|--------|-------|-------------|
+| `DETERMINISTIC` | 0 | Structured extraction, classification, deterministic transforms |
+| `LOW` | 0.3 | Summarization, translation, faithful rewording |
+| `BALANCED` | 0.7 | General Q&A, balanced creativity |
+| `DEFAULT` | 1.0 | Chat, open-ended responses |
+| `HIGH` | 1.5 | Brainstorming, creative variation |
+| `MAXIMUM` | 2.0 | Maximum variability — rarely the right choice |
+
+Pick the lowest temperature that still produces good results. Don't override the default unless you can name a reason in the call site.
+
+## Logging
+
+Every `AIService` method already logs to the `AIRequest` model via the internal `logRequest()` call. Do not bypass `AIService` and call the Vercel SDK directly from routes — you lose request logging, error capture, and the `requestType` taxonomy.
+
+Current `AIRequest.requestType` values: `"general" | "remix" | "summarization" | "translation"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
+
+Logging failures must never break the main flow — the existing pattern catches and logs internally. Preserve that behavior.
+
+## Testing a Prompt Change
+
+`@terreno/ai` tests inject a mock `LanguageModel` with `doGenerate` / `doStream` methods. See the mock pattern in `ai/src/aiApp.test.ts`. Never hit a live provider in unit tests.
+
+1. Add or update a unit test that mocks `doGenerate` / `doStream` and asserts the prompt your code sends matches expectations.
+2. Run against at least 3 inputs:
+   - A normal/expected case
+   - An edge case (empty input, very long input, missing optional fields)
+   - An adversarial case that could break structured JSON output
+3. For structured JSON: assert the response parses against the typed return interface.
+4. If the prompt affects streaming behavior, mock `doStream` and assert the emitted chunks.
+
+For a one-off manual smoke against a real provider, temporarily add `logger.debug("prompt test", {prompt, response})` in the `AIService` method, run locally, then remove the log before committing.
+
+## Prompt Change Checklist
+
+- [ ] Prompt is a named constant in `prompts.ts` (or app equivalent) — not inlined
+- [ ] Prompt still produces valid, parseable structured JSON if applicable (tested with 3+ inputs)
+- [ ] Temperature preset is appropriate (lowest viable for the task)
+- [ ] Call goes through `AIService` (so `AIRequest` logging fires) — no direct Vercel SDK calls from routes
+- [ ] If `requestType` taxonomy changed, the type union and admin explorer filters were updated
+- [ ] No user-identifiable data baked into the prompt template (only injected at call time)
+- [ ] Unit test added/updated with a mock model
+- [ ] Commit message explains the behavioral change (the prompt is the behavior)
+
+## Adding a New AI Feature
+
+1. Define prompt(s) as named constants in `ai/src/service/prompts.ts`.
+2. If structured JSON output, define the TypeScript interface for the return shape in `ai/src/types/index.ts`.
+3. Add a method to `AIService` (or a new service class) that calls `generateText` / `generateTextStream` and goes through the existing logging path.
+4. If exposing via HTTP, add a route in `ai/src/routes/` following the patterns in `gpt.ts` / `gptHistories.ts`. Use `createOpenApiBuilder` for OpenAPI docs.
+5. Add an integration test with a mock model that verifies:
+   - The prompt sent to the model matches the constant
+   - The structured JSON return parses against the typed interface
+   - `AIRequest.logRequest` is called with the correct `requestType`
+
+## Common Pitfalls
+
+- Calling the Vercel SDK directly from a route — bypasses logging and request typing
+- Inlining a prompt string in a route handler — makes future changes invisible and untestable
+- Using the wrong `requestType` value (or `"general"` as a catch-all) — degrades the admin explorer
+- Setting `temperature` numerically instead of via a preset — drifts away from the documented presets
+- Forgetting to type the JSON return — runtime parse failures show up later as confusing errors

--- a/.agents/skills/backend-test-env/SKILL.md
+++ b/.agents/skills/backend-test-env/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: backend-test-env
+description: >-
+  Invoke when writing tests that mutate `process.env` in `@terreno/api`,
+  `@terreno/ai`, or `example-backend` — feature flags, auth secrets, integration
+  toggles. Covers the preload contract, `setupEnvironment()`, and safe mutation
+  patterns.
+---
+# Backend Test — `process.env` Contract
+
+Bun's test runner preloads a per-package setup file (configured in each package's `bunfig.toml` under `[test].preload`):
+
+| Package | Preload file |
+|---------|--------------|
+| `@terreno/api` | `api/src/tests/bunSetup.ts` |
+| `@terreno/ai` | `ai/src/tests/bunSetup.ts` |
+| `example-backend` | `example-backend/src/tests/setup.ts` |
+
+The `@terreno/api` preload uses a global `beforeEach` to (1) reset the canonical auth secrets, (2) call `setupEnvironment()` (exported from `expressServer.ts`) for the wider baseline, and (3) re-silence the winston loggers. The next test always starts from the canonical baseline — you normally **do not** need to re-call `setupEnvironment()` in a file-level `beforeEach`.
+
+## Default — Rely on the Preload
+
+- Do not assume a toggle left by another file. Treat the preload's `beforeEach` as the source of truth for the canonical baseline.
+- Set only the keys this test needs in its own `beforeEach` or test body.
+- Don't reach in and call `setupEnvironment()` again unless you're explicitly testing env-driven behavior that the preload didn't cover.
+
+## When a Test Mutates `process.env`
+
+1. **Add the key to the preload's reset list** if it should always start from a fixed test value. Otherwise it leaks into the next test in the same worker.
+2. **Set only what this case needs** in the test body — avoid redundant manual restore if the preload already resets that key in `beforeEach`.
+3. **For keys that should be absent (unset)**, use **`Reflect.deleteProperty(process.env, "KEY")`**. Avoid `process.env.KEY = ""` to mean "unset" — on some platforms empty string and unset behave differently and can make tests flaky.
+4. **Avoid whole-env snapshots** (`const OLD_ENV = process.env; ...; process.env = OLD_ENV;`). This pattern exists in some older test files (`auth.test.ts`) — don't propagate it. It captures pre-`beforeEach` state and breaks ordering guarantees if the preload's `beforeEach` runs in between. Use targeted mutations + the preload's reset instead.
+
+## Adding a New Required Env Var
+
+If you introduce a new `process.env.FOO` that backend code reads at startup:
+
+1. Add `FOO` to `setupEnvironment()` in `api/src/expressServer.ts` so every package picks it up via the preload's `setupEnvironment()` call.
+2. If `example-backend` has its own startup needs for it, also add to `example-backend/src/tests/setup.ts`'s `beforeAll`.
+3. If a test needs to mutate it, follow the rules above — don't snapshot the whole env.
+
+## Auth-Related Keys
+
+`api/src/tests/bunSetup.ts` resets four auth keys in `beforeEach`: `TOKEN_SECRET`, `TOKEN_ISSUER`, `SESSION_SECRET`, `REFRESH_TOKEN_SECRET`. If your test changes any of these, you do not need to restore — the next `beforeEach` already does. If your test relies on them being **absent** for a code path, use `Reflect.deleteProperty` within the test, knowing the next `beforeEach` will restore.
+
+`auth.test.ts` is the established home for env-driven auth assertions; mirror its newer patterns (per-test `beforeEach` setting only what changes) rather than its older whole-env-snapshot blocks.
+
+## Log Capture & Sentry
+
+The preload silences winston and `console.*` and captures into an in-memory buffer (cleared in `beforeEach`/`afterEach`). It also mocks `@sentry/bun`. Don't re-mock Sentry inside individual tests — the preload's mock is shared and reset across tests.
+
+## Checklist
+
+- [ ] New env var added to `setupEnvironment()` and (if needed) `example-backend/src/tests/setup.ts`
+- [ ] Test mutations are targeted — no whole-env snapshots
+- [ ] "Unset" expressed as `Reflect.deleteProperty(process.env, "KEY")`, not `= ""`
+- [ ] No manual restore that duplicates the preload's `beforeEach` reset
+- [ ] No re-mock of `@sentry/bun` — the preload's mock is already in place
+- [ ] If you added an env-driven branch in code, a test covers both the set and the unset case

--- a/.agents/skills/check-watcher/SKILL.md
+++ b/.agents/skills/check-watcher/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: check-watcher
+description: Monitor GitHub Actions checks and automatically fix failures
+---
+# Check Watcher
+
+Monitor GitHub Actions checks and auto-fix failures. Designed to be called standalone or from other skills.
+
+## Instructions
+
+1. Get the PR number:
+   ```bash
+   gh pr view --json number -q .number
+   ```
+   If no PR exists, inform the user and exit.
+
+2. Wait for CI to finish using `--watch` (no manual polling):
+   ```bash
+   gh pr checks --watch --fail-fast
+   ```
+   - All passing → go to step 6
+   - Failed → continue to step 3
+
+3. Get failure details:
+   ```bash
+   gh run view <run-id> --log-failed
+   ```
+
+4. Determine if flaky or real:
+   - Compare failed files/tests against `gh pr diff` — is the failure in code you changed?
+   - Check for flaky signals: timeouts, race conditions, ECONNRESET, intermittent assertions
+   - If flaky (not in your code + flaky signals), rerun once: `gh run rerun <run-id> --failed`
+   - Run `gh pr checks --watch --fail-fast` again. If still failing, file an issue and move on:
+     ```bash
+     gh issue create --title "Flaky test: <test name>" --body "<error details and job link>"
+     ```
+
+5. If failure IS related to PR changes:
+   - Fix the code
+   - Run lint and compile locally to validate
+   - Commit and push (no AI attribution, no conventional prefixes)
+   - Return to step 2
+
+6. When all checks pass, check for bot review comments:
+   ```bash
+   gh api repos/:owner/:repo/pulls/<pr_number>/comments --jq '.[] | select(.user.type == "Bot") | "\(.path):\(.line) @\(.user.login): \(.body)"'
+   ```
+   Report any actionable bot comments found. Do NOT auto-fix — just report them.
+
+7. Print the PR link:
+   ```bash
+   gh pr view --json title,url -q '"**\(.title)** — \(.url)"'
+   ```
+
+Cap fix attempts at $MAX_ATTEMPTS (default: 5).
+
+## Arguments
+
+$MAX_ATTEMPTS: Optional max fix attempts before stopping (default: 5)

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: commit
+description: >-
+  Create a commit for the current staged/unstaged changes with a clear, accurate
+  message
+---
+# Commit Changes
+
+Create a commit for the current staged/unstaged changes.
+
+## Instructions
+
+1. Check git status and diff to understand what changed:
+   ```
+   git status
+   git diff
+   git diff --cached
+   ```
+
+
+2. Stage changes appropriately and create a commit:
+   - Review the actual changes to write an accurate commit message
+
+   **Message Format:**
+   - The first line must be under 72 characters
+   - Add a body if more context is needed
+   - Exclude conventional commit prefixes (feat:, fix:, chore:, etc.)
+
+   **Content Restrictions:**
+   - Exclude any mention of AI, Claude, or any AI assistant
+   - Exclude making the commit coauthored by any AI
+   - Exclude adding "Co-Authored-By" trailers
+
+   *If constraints conflict, prioritize Message Format for clarity and readability.*
+
+3. Never push unless explicitly asked.
+
+## Arguments
+
+$DESCRIPTION: Optional description to guide the commit message

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: create-pr
+description: Create a draft pull request for the current branch
+---
+# Create Pull Request
+
+Create a pull request for the current branch.
+
+## Instructions
+
+1. First ensure changes are committed and pushed:
+   ```
+   git status
+   git log origin/master..HEAD --oneline
+   ```
+
+2. If there are uncommitted changes, commit them first (run `/commit` command).
+
+3. Push the branch if not already pushed:
+   ```
+   git push origin HEAD
+   ```
+
+4. Create the pull request:
+   ```
+   gh pr create --title "<title>" --body "<body>" --draft
+   ```
+
+   Guidelines for the PR:
+   - Title: Clear, concise summary of the changes
+   - Do not use prefix commit format (feat:, fix:, chore:, etc.)
+   - Do not mention AI, Claude, or any AI assistant in the title or body
+   - Do not add "Generated with Claude" or similar footers
+   - Always create as draft
+
+   **PR Body Structure:**
+
+   ```markdown
+   ## Summary
+
+   [What changed and why — 2-4 sentences]
+
+   ## Human Testing Steps
+
+   - [ ] [Step-by-step instructions a reviewer can follow to verify the change works]
+   - [ ] [Cover happy path and at least one edge case]
+
+   ## Changes
+
+   - [Bullet list of specific changes]
+
+   ## Automated Tests
+
+   - [Tests that ran and passed, or "No automated tests"]
+   ```
+
+5. Return the PR URL to the user.
+
+## Arguments
+
+$DESCRIPTION: Optional description for the PR title and body

--- a/.agents/skills/fix-conflicts/SKILL.md
+++ b/.agents/skills/fix-conflicts/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: fix-conflicts
+description: >-
+  Pull latest from master, resolve merge conflicts, validate with lint/compile
+  checks, and monitor CI
+---
+# Fix Conflicts
+
+Pull latest from master, resolve merge conflicts, validate with lint/compile checks, and monitor CI.
+
+## Instructions
+
+1. Ensure the working tree is clean before starting:
+   ```
+   git status
+   ```
+   - If there are uncommitted changes, ask the user whether to stash them or abort
+
+2. Fetch and merge the latest master into the current branch:
+   ```
+   git fetch origin master
+   git merge origin/master
+   ```
+   - If the fetch or merge fails, check network connectivity and repository access permissions. Notify the user if the issue persists.
+
+3. Check for merge conflicts:
+   ```
+   git diff --name-only --diff-filter=U
+   ```
+   - If there are no conflicts, skip to step 5
+
+4. For each conflicted file:
+    - Read the file and understand both sides of the conflict
+    - Resolve the conflict by combining changes in a way that retains the functionality and purpose of both sets of changes, ensuring no critical information is lost.
+    - If the conflict cannot be resolved automatically, notify the user and provide a summary of the conflicting changes.
+    - After resolving all conflicts in a file, stage it:
+       ```
+       git add <file>
+       ```
+    - After all conflicts are resolved, complete the merge:
+       ```
+       git commit --no-edit
+       ```
+
+## Running Checks
+
+5. Run lint and compile checks at the project root:
+    ```
+    git rev-parse --show-toplevel
+    ```
+    - Run linting:
+       ```
+       cd <project-root> && bun run lint
+       ```
+       - If linting fails, fix the issues and re-run until passing
+    - Run type compilation/checking:
+       ```
+       cd <project-root> && bun run compile
+       ```
+       - If compilation fails, fix the type errors and re-run until passing
+    - If linting or compilation fails repeatedly and cannot be resolved, notify the user with the error details and suggest seeking assistance.
+
+## Handling Fixes and Commits
+
+6. If any fixes were needed in step 5, stage and commit them:
+   - Review the changes made
+   - Create a commit with a clear message describing what was fixed
+   - In step 6, do not use prefix commit format (feat:, fix:, chore:, etc.) for the commit message.
+   - Do not mention AI, Claude, or any AI assistant
+
+7. Push the changes:
+   ```
+   git push origin HEAD
+   ```
+
+8. Run check-watcher by invoking `/check-watcher`:
+   - This monitors GitHub Actions checks
+   - If checks fail, it will automatically read failures, fix them, and push again
+   - Continue until all checks pass
+
+## Arguments
+
+None

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: implement
+description: >-
+  Test-driven implementation execution skill for applying implementation plans
+  directly in code
+---
+# Implementation Execution Skill
+
+Use this skill when an Implementation Plan (IP) or implementation requirements are provided.
+
+
+The goal of this skill is to execute the implementation directly in code using test-driven development.
+
+If the implementation plan is incomplete or contains contradictions, highlight the conflicts and request clarification before proceeding.
+
+Do not stop after analysis or task generation unless blocked by material ambiguity.
+
+## Primary Behavior
+
+When an IP is provided:
+
+1. Read the full IP carefully.
+2. Determine implementation scope.
+3. Identify the smallest meaningful automated test coverage that should fail for the requested behavior.
+4. Write or update the failing tests before implementation code.
+5. Run the targeted tests and confirm they fail for the expected product reason, not because of syntax, setup, or unrelated failures.
+6. Implement the requested changes directly.
+7. Run the previously failing tests until they pass.
+8. Run relevant validation or broader test commands when available.
+9. Summarize completed work, assumptions, and remaining risks.
+
+Exclude generating a separate implementation plan unless explicitly requested.
+
+## Scope Detection
+
+Determine whether the implementation is:
+
+- backend only
+- frontend only
+- full stack
+- phased implementation
+- rollout-gated
+- migration-dependent
+
+
+// --- Assumption Rules ---
+Use best-effort assumptions when the assumption does not affect compliance, data integrity, or user experience.
+
+If the correct scope is unclear and could materially change implementation, ask concise clarifying questions before coding.
+
+## Clarifying Question Rules
+
+Only ask questions if missing information would materially affect:
+
+- architecture
+- data model behavior
+- API contracts
+- permissions/access control
+- user/admin visibility
+- rollout sequencing
+- migration/backfill behavior
+- destructive operations
+- compliance-sensitive behavior
+- whether implementation should be backend only, frontend only, phased, or full stack
+
+// --- Clarifying Question Exclusions ---
+Exclude asking questions for implementation details that do not affect functionality, performance, or compliance, and can reasonably be inferred.
+
+
+## Execution Expectations
+
+Implement the requested behavior directly in the codebase.
+
+### Test-Driven Development Flow
+
+Default to red/green/refactor:
+
+- red: write the focused failing test or regression test first
+- green: implement only enough production code to satisfy the requested behavior
+- refactor: clean up the implementation while preserving passing tests
+
+If no meaningful automated test can be written for the change, document why before implementation and use the strongest available manual or static validation instead.
+
+### Implementation Steps
+- update or add focused failing tests
+- update schemas/models
+- update services/controllers/routes
+- update validation
+- update frontend UI
+- update state management/API hooks
+- update OpenAPI/types
+- update permissions/visibility logic
+- update feature flags
+- update fixtures/mocks
+- rerun the focused tests that failed first
+- run broader validation when appropriate
+- preserve existing behavior unless the IP explicitly changes it
+
+## Phased Implementations
+
+If the IP implies phased implementation:
+
+- determine whether backend and frontend should be separated
+- determine whether rollout gating is required
+- determine whether app-version compatibility matters
+
+If phase requirements are unclear and could affect implementation safety, ask before coding.
+
+Otherwise proceed with best-effort assumptions.
+
+## Testing Requirements
+
+Add or update relevant tests before production implementation whenever applicable.
+
+Possible test types include:
+
+- backend unit tests
+- backend integration tests
+- API tests
+- frontend component tests
+- frontend flow tests
+- regression tests
+
+Run the most targeted available tests first and capture the initial failure before writing production code. After implementation, rerun the same focused tests to confirm the red-to-green transition.
+
+If full test execution is not practical, run the closest focused validation possible and document what was not run.
+
+## File Modification Rules
+
+Prefer modifying existing patterns consistently with the codebase.
+
+Avoid introducing new architectural patterns unless required.
+
+Do not invent exact file paths unless strongly implied by the repository structure.
+
+Prefer consistency over novelty.
+
+## Safety Rules
+
+Do not make destructive or irreversible changes without clear instruction.
+
+Do not silently change existing product behavior outside the requested scope.
+
+If implementation could create compliance, privacy, permission, or rollout risk, explicitly call it out in the final response.
+
+## Final Response Requirements
+
+At completion, summarize:
+
+- implementation scope
+- major code changes
+- assumptions made
+- tests updated/run
+- remaining risks or follow-up work
+
+Keep the summary concise and implementation-focused.

--- a/.agents/skills/improve-rulesync/SKILL.md
+++ b/.agents/skills/improve-rulesync/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: improve-rulesync
+description: >-
+  Invoke at the end of a session to evaluate whether any skills or rules were
+  misleading, incorrect, or missing — and fix or create them. Trigger with
+  /improve-rulesync.
+---
+# Improve Rulesync
+
+### Trigger
+Invoke explicitly at the end of a session with `/improve-rulesync`.
+
+### Behavior
+Review the current conversation session and evaluate the skills and rules in `.rulesync/`. Identify any that:
+- Gave misleading or incorrect guidance that caused errors or rework
+- Were missing and would have prevented incorrect behavior
+- Need to be updated to reflect decisions or patterns established in this session
+
+Then make the changes directly.
+
+### Step 1 — Session Review
+Scan the session for:
+- Moments where a skill or rule was followed but produced a wrong or suboptimal result
+- User corrections or decisions about AI model behavior (these indicate a gap or error in the rules)
+- New patterns, decisions, or constraints established that should be codified
+
+### Step 2 — Rules Audit
+Check `.rulesync/` for relevant existing rules and skills. Evaluate:
+- Are trigger conditions accurate?
+- Is the guidance still correct given what happened this session?
+- Are there gaps that caused confusion?
+
+### Step 3 — Make Changes
+For each issue found:
+- **Incorrect/misleading**: Edit the existing file to fix it
+- **Missing**: Create a new skill or rule file in `.rulesync/skills/` or `.rulesync/rules/`
+- **Outdated**: Update or remove the stale content
+
+Always edit `.rulesync/` as the source of truth.
+
+### Step 4 — Sync
+After all changes, run `bun run rules` to sync to all AI tool directories.
+
+### Step 5 — Summary
+Output a brief summary of what was changed and why. Format:
+- **Fixed**: [file] — [what was wrong and what was corrected]
+- **Created**: [file] — [what gap it fills]
+- **No changes needed**: [reason]

--- a/.agents/skills/ip/SKILL.md
+++ b/.agents/skills/ip/SKILL.md
@@ -1,0 +1,1559 @@
+---
+name: ip
+description: >-
+  Implementation Plan (/ip) — build an implementation plan from a PRD through an
+  interactive, multi-step process
+---
+# Implementation Plan (/ip)
+
+Build an implementation plan from a PRD through an interactive, multi-step process. Produces both a human-readable implementation plan and a structured task list for bot consumption.
+
+## Overview
+
+This skill walks through the Shape Up-inspired process of turning a raw PRD into a concrete implementation plan. Each step is a self-contained section in this file — you can re-run individual steps if needed by jumping to the matching section.
+
+**Every IP targets a specific project.** The project must be specified via the `$PROJECT` argument or selected interactively.
+
+## Project Registry
+
+| Alias(es) | GitHub Repo | Local Dir |
+|-----------|-------------|-----------|
+| `ter`, `terreno` | `flourishhealth/terreno` | `~/src/terreno` |
+
+Local Dir is derived from the repo name (the part after `/`). All repos clone into `~/src/`.
+
+If a project isn't in the registry, attempt to resolve it via `gh repo view <input>`. If found, use it. If not, ask the user for the full `owner/repo`.
+
+## Planning Workflow
+
+Run the following steps in order. Each step builds on the previous one.
+
+### Step 0: Project Setup (always runs first)
+
+This step is **mandatory** and runs before everything else, even when `$STEP` is provided.
+
+#### 0a. GitHub Auth Check
+
+```bash
+gh auth status
+```
+
+If not authenticated, tell the user:
+> You need to authenticate with GitHub. Run this in your terminal:
+> `! gh auth login --web`
+> Follow the prompts to open the browser link and enter the code.
+
+Then **stop** — do not proceed until the user confirms auth is complete.
+
+#### 0b. Resolve Project
+
+If `$PROJECT` was provided, match it against the registry aliases (case-insensitive). If no `$PROJECT`, show the registry table and ask the user to pick one.
+
+#### 0c. Clone if Needed
+
+Check if the local directory exists:
+```bash
+ls -d ~/src/{repo-name} 2>/dev/null
+```
+
+If it doesn't exist, clone it:
+```bash
+gh repo clone {owner/repo} ~/src/{repo-name}
+```
+
+#### 0d. Fetch Latest & Enter Worktree
+
+Navigate to the repo and ensure we have the latest code:
+```bash
+cd ~/src/{repo-name} && git fetch origin && git checkout master && git pull origin master
+```
+
+(If the default branch is `main` instead of `master`, detect it with `git remote show origin | grep 'HEAD branch'` and use that.)
+
+Then create a worktree for this IP using the `EnterWorktree` tool:
+- **name**: `ip-{feature-slug}` (derive from the PRD title once known, or use a temporary name like `ip-draft` and note that it can be renamed)
+
+Since the PRD title isn't known yet at this point, use `ip-draft` as the worktree name. After Step 1 (Ingest), if the worktree name doesn't match the feature, note the mismatch but continue — the branch can be renamed later.
+
+#### 0e. Confirm Ready
+
+Print a summary:
+```
+Project: {repo-name} ({owner/repo})
+Branch: {worktree-branch}
+Working dir: {worktree-path}
+Latest master: {short SHA + date of HEAD}
+```
+
+Proceed to Step 1.
+
+### Step 1: Ingest PRD
+
+Collect the PRD (Product Requirements Document) that will drive the implementation plan.
+
+1. `$PRD` is **required**. If it was not provided, stop immediately and tell the user: **"Error: /ip requires a PRD as the first argument (either a file path or the inline PRD text). Please re-run as `/ip <path-or-text>`."** Do not prompt for it interactively.
+
+2. Determine what the user provided:
+   - If it looks like a file path (e.g., ends in `.md`, `.txt`, contains `/` or `\`, or matches an existing file), read that file and use its contents as the PRD.
+   - Otherwise, treat the input as the PRD text itself.
+
+3. The PRD should contain at minimum a **Problem** section and ideally a **Business Case** section. If either is missing, note what's missing but proceed anyway.
+
+4. Display a brief summary of what you understood from the PRD:
+   - The core problem (1-2 sentences)
+   - The business impact (1-2 sentences)
+   - Key stakeholders or affected teams
+   - Any constraints or requirements called out
+
+5. Ask: "Does this summary capture the intent? Anything to add or correct?" and let the user adjust before moving on.
+
+6. Once confirmed, say: **"PRD ingested. Moving to research phase..."** and proceed to Step 2.
+
+### Step 2: Research Context
+
+Investigate the codebase and gather context for the PRD topic. Do this inline — do not invoke `/research` via the Skill tool. Follow this procedure:
+
+1. **Scope** — restate the topic in one sentence and tell the user what you plan to investigate. Ask if they want anything specific covered.
+2. **Codebase deep dive** — read relevant source files in depth (models, routes, screens, components, configs, tests). Search for existing patterns, conventions, and dependencies. Check `docs/`, `README.md`, `CLAUDE.md`, and any feature documentation. Note file paths, function names, and line numbers as you go.
+3. **External research** — search the web for any APIs, libraries, or best practices that aren't already in the codebase.
+4. **Present findings** — output a complete research document in chat with: Summary, Context, Findings (with file paths and snippets), Options Considered (table with pros/cons/effort), Recommendation (be opinionated), Open Questions, References.
+5. **Iterate** — ask "Anything you want me to dig deeper on, adjust, or investigate further?" If the user gives feedback, investigate and re-output the **full** updated document.
+6. **Save** — once the user is satisfied, write the final version to `research.md` in the project root and continue to Step 3.
+
+Be specific (file paths, line numbers, code snippets) and opinionated (recommend an approach, don't just list options).
+
+### Step 3: Shape & Question
+
+This is the core shaping step inspired by the Shape Up methodology. The goal is to narrow the solution from a raw idea to a well-defined approach with clear boundaries.
+
+#### Phase 1: Models & APIs (get alignment first)
+
+This is the most important part. Models and APIs define the shape of the feature — everything else follows from them.
+
+1. **Draft the data model** based on the PRD and research:
+   - Mongoose schemas with types, required fields, enums, defaults
+   - Relationships to existing models (refs)
+   - Indexes if relevant
+   - Plugins (soft delete, timestamps, etc.) based on existing patterns
+
+2. **Draft the API surface**:
+   - List each endpoint (method, path, description)
+   - Note if it's a standard CRUD modelRouter or custom
+   - Specify permissions for each endpoint
+   - Call out any special query parameters, filters, or bulk operations
+
+3. **Present both together** and ask the user: "Are these models and APIs the right approach?" Use AskUserQuestion.
+
+4. **Iterate** until the user confirms the models and APIs are right. This is the foundation — don't move on until it's solid.
+
+#### Phase 2: Everything Else (flows from models/APIs)
+
+Once models and APIs are confirmed, draft the remaining concerns in a single pass. These should follow naturally from the model/API decisions:
+
+- **Notifications**: Push, email, in-app — who gets notified, when, what content. If none needed, say so.
+- **Activity Log**: What actions get logged, which surface as User Updates, which user groups see them. If none, say so.
+- **Permissions & Access**: Role-based differences beyond what's already covered in API permissions.
+- **UI**: New screens/components, navigation flow, key interactions and states, reusable vs new components.
+- **Feature Flags & Migration**: Whether a flag is needed, any data migrations, rollout strategy.
+- **Phases**: How to break the work into PRs (Phase 1: models + APIs, Phase 2: core UI, Phase 3: polish). If small enough, say "single phase."
+- **Not Included / Future Work**: Compile out-of-scope items and deferred ideas.
+
+Present all of this as a single shaped solution summary:
+
+```
+## Shaped Solution
+
+### Core Concept
+[1-2 sentence description of the approach]
+
+### Models
+[schemas from Phase 1]
+
+### APIs
+[endpoints from Phase 1]
+
+### Notifications
+[notification plan or "none needed"]
+
+### Activity Log
+[logging plan or "none needed"]
+
+### UI
+[screens, flows, interactions]
+
+### Phases
+[implementation phases]
+
+### Not Included
+[explicitly excluded items]
+
+### Risks & Mitigations
+- [risk]: [mitigation approach]
+```
+
+Surface any **risks and rabbit holes** inline:
+- Technical risks: things that might be harder than they look
+- Scope risks: features that could balloon if not bounded
+- For each risk, suggest a mitigation or simpler fallback
+
+Ask: "Does this shaped solution look right? Any decisions you want to revisit?"
+
+Once confirmed, say: **"Solution shaped. Moving to plan sections..."** and proceed to Step 4.
+
+### Step 4: Plan Sections (optional deep pass)
+
+Optional interactive walk-through of each plan section, useful when Step 3 left details fuzzy. For each section: present a draft, ask the user if it looks right, let them refine, then move on.
+
+#### Section 1: Models
+
+1. Draft Mongoose schemas based on the shaped solution. Include:
+   - Full schema code blocks with types, required fields, enums, defaults
+   - Relationships to existing models (refs)
+   - Indexes if relevant
+   - Plugins (soft delete, timestamps, etc.) based on existing patterns found in research
+
+2. Present the schemas and ask:
+   - "Do these models look right?"
+   - "Any fields missing or that should be changed?"
+   - "Should any of these fields be optional vs required?"
+
+#### Section 2: APIs
+
+1. Draft the API surface:
+   - List each endpoint (method, path, description)
+   - Note if it's a standard CRUD modelRouter or custom
+   - Specify permissions for each endpoint
+   - Call out any special query parameters, filters, or bulk operations
+   - Note any webhook or external API integrations
+
+2. Present and ask: "Any endpoints missing? Do the permissions look right?"
+
+#### Section 3: Notifications
+
+1. Based on the shaped solution, list:
+   - Push notifications (who, when, what content)
+   - Email/text notifications
+   - In-app notifications or alerts
+   - If none needed, explicitly state "No notifications required for this feature"
+
+2. Present and confirm with user.
+
+#### Section 4: UI
+
+1. Draft the UI plan:
+   - List new screens/components
+   - Describe navigation flow (how users get there)
+   - Describe key interactions and states
+   - Note any reusable components that already exist vs need to be created
+   - Suggest fat-marker sketches if the UI is complex (describe what should be sketched)
+
+2. Present and ask: "Does this UI approach make sense? Any screens or interactions missing?"
+
+#### Section 5: Phases
+
+1. Propose how to break the work into phases/PRs:
+   - Phase 1: Usually models + basic APIs
+   - Phase 2: Core UI and integrations
+   - Phase 3: Polish, notifications, edge cases
+   - If the feature is small enough, note "Single phase - no need to break up"
+
+2. For each phase, list what's included and what the deliverable looks like.
+
+3. Present and ask: "Does this phasing make sense? Want to adjust?"
+
+#### Section 6: Feature Flags & Migrations
+
+1. Based on the shaped solution, recommend:
+   - Whether a feature flag is needed (and what it controls)
+   - Any data migrations required
+   - Rollout strategy
+
+2. Present and confirm.
+
+#### Section 7: Activity Log & User Updates
+
+1. List:
+   - What actions get logged to the activity log
+   - Which of those surface as User Updates
+   - Which user groups see the updates
+
+2. If no activity logging is needed, say so explicitly.
+
+#### Section 8: Not Included / Future Work
+
+1. Compile the "out of scope" items from shaping into this section
+2. Add any ideas that came up during planning but were deferred
+3. Present and confirm.
+
+After all sections are finalized, say: **"All sections planned. Moving to output generation..."** and proceed to Step 5.
+
+### Step 5: Generate Output
+
+Produce the final implementation plan document and a structured task list, then save them.
+
+1. **Generate the Implementation Plan** in the standard format:
+
+   ```markdown
+   # Implementation Plan: [Feature Name]
+
+   *When an engineer is assigned to a project but before you begin coding, you should fill in the implementation plan and get feedback from the engineering team. Once you have finished or you make any changes, tag Josh with the @ symbol so he can review. Also tag anyone else that needs to be notified, has conflicting work, etc.*
+
+   ## **Models**
+   [Content from plan step]
+
+   ## **APIs**
+   [Content from plan step]
+
+   ## **Notifications**
+   [Content from plan step]
+
+   ## **UI**
+   [Content from plan step]
+
+   ## Phases
+   [Content from plan step]
+
+   ## Feature Flags & Migrations
+   [Content from plan step]
+
+   ## Activity Log & User Updates
+   [Content from plan step]
+
+   ## **Not included/Future work**
+   [Content from plan step]
+
+   ## Acceptance Criteria
+   [If criteria exist from the PRD or shaping, include them here. Otherwise, leave a placeholder noting to run Step 6 (Acceptance Criteria) to generate them.]
+   ```
+
+2. **Generate the Task List** as a structured section at the bottom of the document:
+
+   ```markdown
+   ---
+
+   ## Task List (Bot Consumption)
+
+   *Structured task breakdown for automated implementation. Each task should be independently implementable and testable.*
+
+   ### Phase 1: [Phase Name]
+
+   - [ ] **Task 1.1**: [Short title]
+     - Description: [What to implement]
+     - Files: [Expected files to create/modify]
+     - Depends on: [Other task IDs, or "none"]
+     - Acceptance: [How to verify it's done]
+
+   - [ ] **Task 1.2**: [Short title]
+     ...
+
+   ### Phase 2: [Phase Name]
+   ...
+   ```
+
+   Tasks should be:
+   - Small enough to be a single PR or commit
+   - Ordered by dependency (models first, then APIs, then UI)
+   - Specific about which files to create/modify
+   - Clear about acceptance criteria
+
+3. **Ask the user for the feature name** to use in the filename (suggest one based on the PRD). The filename should be kebab-case.
+
+4. **Save the implementation plan:**
+   - Ensure `docs/implementationPlans/` directory exists (create if needed)
+   - Save to `docs/implementationPlans/[feature-name].md`
+   - Confirm the file was saved and show the path
+
+5. **Save the task plan:**
+   - Ensure `docs/tasks/` directory exists (create if needed)
+   - Save to `docs/tasks/[feature-name].md`
+   - Confirm the file was saved and show the path
+
+6. **Final summary:**
+
+   ```
+   ## Implementation Plan Complete
+
+   **Saved to**: docs/implementationPlans/[feature-name].md
+
+   ### Quick Stats
+   - Models: [count] new/modified
+   - API Endpoints: [count]
+   - Screens: [count]
+   - Phases: [count]
+   - Tasks: [count] total
+
+   ### Next Steps
+   1. Share with the engineering team for review
+   2. Tag @Josh and relevant stakeholders
+   3. Once approved, tasks can be loaded for implementation
+   ```
+
+7. Ask: "Want to make any final changes, or is this ready to share?"
+
+### Step 6: Acceptance Criteria
+
+Generate structured acceptance criteria for an implementation plan. The criteria should be specific enough for a human to manually test AND for a bot to translate into Playwright E2E tests.
+
+`$IP` (optional): path to an existing IP file. If not provided, look for the IP in the current conversation context or ask the user which IP to use.
+
+#### 1. Load the IP
+
+- If `$IP` is provided, read the file
+- Otherwise, check if an IP was generated in the current conversation
+- If neither, list available IPs from `docs/implementationPlans/` and ask which one to use
+
+#### 2. Check for existing acceptance criteria
+
+- If the PRD or IP already has an `## Acceptance Criteria` section, read it carefully
+- Also check each task in the Task List for `Acceptance:` lines
+- These are your starting point — you'll expand and formalize them, not replace them
+
+#### 3. Analyze the IP to identify testable behaviors
+
+Walk through each section of the IP and identify user-facing behaviors:
+
+- **Models & APIs**: What responses should the API return? What validation errors should occur?
+- **UI**: What should the user see? What happens when they interact with elements?
+- **Notifications**: What triggers them? What content appears?
+- **Permissions**: What should different roles see/not see?
+- **Error states**: What happens when things fail?
+- **Edge cases**: Empty states, boundary values, concurrent actions
+
+#### 4. Write acceptance criteria
+
+Write criteria in a dual-format that works for both humans and bots:
+
+```markdown
+## Acceptance Criteria
+
+### Feature: [Feature area name]
+
+#### AC-1: [Short descriptive title]
+**Priority:** P0 | P1 | P2
+**Screen:** [screen name, e.g., "Login Screen"]
+**Preconditions:**
+- [Any setup needed before testing, e.g., "User is logged in", "At least 3 items exist"]
+
+**Steps:**
+1. [Navigate to / open / tap specific element]
+2. [Perform action — be specific about what to type, tap, select]
+3. [Observe result]
+
+**Expected results:**
+- [ ] [Specific, observable outcome — what the user sees]
+- [ ] [Another expected outcome]
+
+**testIDs needed:** `screen-element-qualifier`, `screen-another-element`
+
+---
+```
+
+Format rules:
+
+- **Steps must reference specific UI elements** using the `{screen}-{element}-{qualifier}` testID naming convention
+- **Expected results must be visually verifiable** — things a human can see AND a bot can assert (`toBeVisible`, `toHaveText`, `toHaveCount`, etc.)
+- **Include the `testIDs needed` line** listing every testID the test will need. This serves as a checklist for the developer to add testIDs to components before tests can run.
+- **Priority levels:**
+  - **P0**: Core happy path — feature is broken without this
+  - **P1**: Important flows — error handling, validation, key edge cases
+  - **P2**: Nice-to-have — polish, edge cases, minor interactions
+- **Group by feature area** (e.g., "User Authentication", "Item Management", "Notifications")
+
+#### 5. Cover these categories
+
+Ensure you have at least one criterion for each:
+
+- **Happy path**: The main flow works end to end
+- **Validation**: Required fields, format checks, boundary values
+- **Error handling**: Network errors, server errors, invalid states
+- **Empty states**: What shows when there's no data?
+- **Permissions** (if applicable): Different roles see different things
+- **Navigation**: Moving between screens works correctly
+- **Data persistence**: Changes are saved and visible after refresh
+
+#### 6. Add the section to the IP
+
+Insert the `## Acceptance Criteria` section into the IP file, after the main plan sections but before the `## Task List` section.
+
+#### 7. Summary
+
+Present a summary:
+
+```
+## Acceptance Criteria Generated
+
+**Added to**: [IP file path]
+
+### Coverage
+- P0 (critical): [count] criteria
+- P1 (important): [count] criteria
+- P2 (nice-to-have): [count] criteria
+- Total testIDs needed: [count]
+
+### Next Steps
+1. Review criteria with the team
+2. Ensure all listed testIDs are added to components
+3. Run Step 7 (E2E Tests) to generate Playwright tests from these criteria
+```
+
+Ask: "Want to adjust any criteria or add coverage for something I missed?"
+
+### Step 7: E2E Tests (optional)
+
+Generate Playwright end-to-end tests from an IP's acceptance criteria. Uses the project's Playwright skill and testing conventions.
+
+`$IP` (optional): path to an IP file with acceptance criteria. If not provided, look for the IP in the current conversation context or ask the user which IP to use.
+
+#### 1. Load the IP and acceptance criteria
+
+- If `$IP` is provided, read the file
+- Otherwise, check if an IP was loaded in the current conversation
+- If neither, list available IPs from `docs/implementationPlans/` and ask which one to use
+- The IP **must** have an `## Acceptance Criteria` section. If it doesn't, tell the user to run Step 6 (Acceptance Criteria) first.
+
+#### 2. Research the codebase
+
+Before writing tests, understand the existing test setup:
+
+- Check if `playwright.config.ts` exists — if not, note that it needs to be created
+- Check if `e2e/` directory exists and what tests are already there
+- Check for `e2e/helpers/` and `e2e/fixtures/` for reusable utilities
+- Check for `e2e/auth.setup.ts` to understand auth patterns
+- Look at existing test files to match the style and patterns in use
+- Check if the testIDs listed in acceptance criteria already exist in the component code
+
+#### 3. Plan the test files
+
+Map acceptance criteria to test files:
+
+- **One test file per feature area** (matching the `### Feature:` groups in acceptance criteria)
+- File naming: `e2e/{feature-name}.spec.ts` (kebab-case)
+- Group related ACs into `test.describe()` blocks
+
+Present the plan to the user:
+
+```
+## E2E Test Plan
+
+### Files to create:
+- `e2e/feature-name.spec.ts` — [count] tests from [AC numbers]
+- `e2e/another-feature.spec.ts` — [count] tests from [AC numbers]
+
+### Missing testIDs (must be added to components first):
+- `screen-element-name` — [component file if known]
+- ...
+
+### Missing infrastructure:
+- [ ] playwright.config.ts (will create)
+- [ ] e2e/helpers/auth.ts (will create)
+- ...
+```
+
+Ask: "Should I generate these test files? Any changes to the plan?"
+
+#### 4. Generate test files
+
+For each test file, follow these rules strictly:
+
+**Structure:**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Feature: [Feature Name]', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to starting screen
+    // Wait for screen to be visible
+  });
+
+  // One test per acceptance criterion
+  test('[AC title — as user behavior]', async ({ page }) => {
+    // Steps from the AC, translated to Playwright actions
+    // Expected results as assertions
+  });
+});
+```
+
+**Translation rules (AC → Playwright):**
+
+| AC Step | Playwright Code |
+|---------|----------------|
+| Navigate to [screen] | `await page.goto('/path'); await page.getByTestId('screen-name').waitFor({ state: 'visible' });` |
+| Tap / click [element] | `await page.getByTestId('testid').click();` |
+| Type [text] into [field] | `await page.getByTestId('testid').fill('text');` |
+| Toggle [switch] | `await page.getByTestId('testid').click();` |
+| See [text/element] | `await expect(page.getByTestId('testid')).toBeVisible();` |
+| See text [content] | `await expect(page.getByTestId('testid')).toHaveText(/content/i);` |
+| Don't see [element] | `await expect(page.getByTestId('testid')).not.toBeVisible();` |
+| See [N] items in list | `await expect(page.getByTestId('list').getByTestId(/^item-/)).toHaveCount(N);` |
+| Wait for loading | `await page.getByTestId('loading-indicator').waitFor({ state: 'hidden' });` |
+| Page URL contains [path] | `await expect(page).toHaveURL(/path/);` |
+
+**Mandatory rules:**
+- Use `getByTestId()` as primary selector — never class names or deep selectors
+- Never use `waitForTimeout()` — always wait for element state
+- Wait for screen visibility after every navigation
+- Wait for `networkidle` after data-fetching actions when appropriate
+- Add `// AC-N: [title]` comment above each test for traceability
+- Mark tests that need auth setup with the appropriate Playwright project dependency
+- Use `test.skip()` with a reason for any AC that can't be automated yet (e.g., requires native device features)
+
+#### 5. Report missing testIDs
+
+After generating tests, produce a checklist of testIDs that need to be added to components:
+
+```markdown
+## testIDs to Add
+
+These testIDs are referenced in the generated tests but may not exist in the app yet.
+Add them before running the tests.
+
+### [Screen Name]
+- [ ] `screen-element-name` on `<ComponentType>` — [purpose]
+- [ ] `screen-another-element` on `<ComponentType>` — [purpose]
+```
+
+If you can identify the component files where testIDs should be added, include the file paths.
+
+#### 6. E2E Summary
+
+```
+## E2E Tests Generated
+
+### Files created:
+- `e2e/feature-name.spec.ts` — [count] tests
+- ...
+
+### Coverage:
+- P0 criteria covered: [count]/[total]
+- P1 criteria covered: [count]/[total]
+- P2 criteria covered: [count]/[total]
+- Skipped (not automatable): [count] — [reasons]
+
+### Before running tests:
+1. Add missing testIDs to components (see checklist above)
+2. Ensure `playwright.config.ts` is configured
+3. Start the dev server
+4. Run: `bunx playwright test`
+
+### After tests pass:
+Run `/verify` to verify the full implementation
+```
+
+### Step 8: Review (optional, dual-model)
+
+Review an implementation plan using both Claude (sub-agent) and OpenAI Codex in parallel. Each reviewer independently identifies issues, gaps, and questions. Results are combined, deduplicated, and presented as a structured question list for the user. After the user answers, the IP is updated.
+
+Argument: IP number, filename, or path to the plan file. If empty, infer from conversation context. Parse as `$ARGUMENTS`.
+
+#### Phase 1: Locate the Plan
+
+1. If argument provided, find the matching IP file:
+   - Check `docs/implementationPlans/` for matching file (by IP number, slug, or full path)
+   - If a path was given directly, use that
+2. If no argument, infer from conversation context (most recently discussed IP)
+3. If ambiguous, ask the user
+4. Read the full plan file
+5. If a corresponding task file exists in `docs/tasks/`, read that too
+
+#### Phase 2: Gather Codebase Context
+
+Collect context both reviewers will need:
+
+1. **CLAUDE.md** -- project conventions, tech stack, constraints
+2. **Relevant source files** -- scan the plan's "Files to Create/Modify" or "Files:" fields in tasks, read 3-5 of the most critical existing files
+3. **Data models** -- if the plan references models, find and read their current definitions
+4. **Recent changes** -- `git log --oneline -10` for recent momentum
+
+Keep context focused. Prioritize the plan itself and the most relevant code.
+
+#### Phase 3: Run Both Reviews in Parallel
+
+Launch both reviewers at the same time using parallel tool calls. Do NOT wait for one before starting the other.
+
+##### 3a: Claude Sub-Agent
+
+Use the **Agent tool** with `subagent_type: "general-purpose"`:
+
+Prompt the sub-agent with all gathered context and these instructions:
+
+> You are a senior engineer reviewing an implementation plan. Your goal is to surface issues, gaps, risks, and questions that should be answered before implementation begins.
+>
+> ## The Plan
+>
+> {full plan content}
+>
+> ## Task Breakdown
+>
+> {task list content, if available}
+>
+> ## Codebase Context
+>
+> {CLAUDE.md excerpt -- tech stack, conventions}
+>
+> {relevant source file excerpts}
+>
+> ## Your Review
+>
+> Analyze this plan and produce two outputs:
+>
+> ### Issues & Gaps
+>
+> For each issue found, provide:
+> - **Severity**: CRITICAL / HIGH / MEDIUM / LOW
+> - **Category**: one of: Missing Requirements, Unstated Assumptions, Technical Risks, Security & Data Integrity, Task Breakdown Gaps, Architecture Concerns, Scope Concerns
+> - **Description**: What's wrong or missing -- be specific, cite the plan section
+> - **Suggestion**: How to address it
+>
+> ### Questions for the Author
+>
+> Generate questions that, if answered, would materially improve the plan. Focus on:
+> - Ambiguous requirements that could be interpreted multiple ways
+> - Unstated preferences (e.g., "should this be real-time or batch?")
+> - Tradeoffs where the plan picked one side without discussing alternatives
+> - Missing context that would change the approach
+> - Scale/performance expectations that aren't specified
+> - Integration points with unclear contracts
+> - Rollback/migration strategies that aren't defined
+>
+> For each question:
+> - **Question**: The question itself
+> - **Why it matters**: What changes depending on the answer
+> - **Default assumption**: What the plan currently assumes (if anything)
+>
+> Do NOT ask questions that can be answered by reading the codebase -- use Glob, Grep, and Read to verify before asking. Only ask questions that require human judgment or domain knowledge.
+
+##### 3b: Codex CLI
+
+Build a prompt file at `$TMPDIR/ip-review-prompt.md` with the plan, tasks, and codebase context, then run:
+
+```bash
+codex --model o3 --quiet --approval-mode full-auto "$TMPDIR/ip-review-prompt.md"
+```
+
+The prompt file should contain:
+
+```markdown
+# Implementation Plan Review: {plan title}
+
+You are a senior engineer reviewing an implementation plan. Find issues, gaps, and generate questions for the plan author.
+
+## The Plan
+
+{full plan content}
+
+## Task Breakdown
+
+{task list content, if available}
+
+## Codebase Context
+
+{CLAUDE.md excerpt}
+
+{relevant source file excerpts}
+
+## Your Review
+
+### Part 1: Issues & Gaps
+
+For each issue, provide:
+- **Severity**: CRITICAL / HIGH / MEDIUM / LOW
+- **Category**: Missing Requirements, Unstated Assumptions, Technical Risks, Security & Data Integrity, Task Breakdown Gaps, Architecture Concerns, or Scope Concerns
+- **Description**: Be specific -- cite the plan section and explain exactly what's wrong or missing
+- **Suggestion**: How to fix it
+
+### Part 2: Questions for the Author
+
+Generate questions that require human judgment or domain knowledge to answer. For each:
+- **Question**: The question
+- **Why it matters**: What would change depending on the answer
+- **Default assumption**: What the plan currently assumes
+
+Focus on: ambiguous requirements, unstated tradeoffs, missing scale/performance expectations, unclear integration contracts, and migration/rollback gaps.
+
+Do NOT ask questions answerable from the codebase. Focus on decisions that need human input.
+```
+
+**Model selection:** Use `o3` for strong reasoning. If unavailable, fall back to `o4-mini`.
+
+If `codex` is not installed or fails, report the error and continue with Claude-only results.
+
+Capture the full output.
+
+#### Phase 4: Combine & Deduplicate
+
+After both reviews return:
+
+##### Issues
+
+1. Parse all issues from both reviewers
+2. Deduplicate: if both flagged the same issue (same plan section, similar concern), merge and keep the more detailed description
+3. Tag each with its source:
+   - `[Claude]` -- only Claude found it
+   - `[Codex]` -- only Codex found it
+   - `[Both]` -- both flagged it (higher confidence)
+4. Sort by severity: CRITICAL > HIGH > MEDIUM > LOW
+
+##### Questions
+
+1. Parse all questions from both reviewers
+2. Deduplicate: merge questions asking essentially the same thing
+3. Tag with source (`[Claude]`, `[Codex]`, `[Both]`)
+4. Group by theme (e.g., "Scope", "Architecture", "Data", "Performance", "Migration")
+5. Within each group, sort by impact (questions where the answer would most change the plan come first)
+
+##### Verify Critical Claims
+
+For CRITICAL and HIGH issues, do a quick Glob/Grep/Read to confirm the issue is real. Note which are verified vs unverified.
+
+#### Phase 5: Present Results
+
+Present the combined review:
+
+```
+## IP Review: {plan title}
+
+**Reviewers:** Claude (sub-agent) + OpenAI Codex ({model used})
+**Plan:** {IP file path}
+
+---
+
+### Issues Found
+
+#### Critical
+1. [Both] **{category}** -- {description}
+   → {suggestion}
+
+#### High
+2. [Claude] **{category}** -- {description}
+   → {suggestion}
+
+#### Medium / Low
+3. [Codex] **{category}** -- {description}
+   → {suggestion}
+
+---
+
+### Questions for You
+
+**Scope & Requirements**
+1. [Both] {question}
+   _Why it matters:_ {impact}
+   _Current assumption:_ {what plan assumes}
+
+**Architecture & Design**
+2. [Claude] {question}
+   _Why it matters:_ {impact}
+   _Current assumption:_ {what plan assumes}
+
+**Performance & Scale**
+3. [Codex] {question}
+   _Why it matters:_ {impact}
+
+{...more grouped questions...}
+```
+
+#### Phase 6: Collect Answers
+
+Use **AskUserQuestion** to collect the user's answers. Present the questions in a numbered list and ask the user to answer them. Options:
+
+- Answer all at once (numbered responses)
+- Answer one at a time interactively
+- Skip questions they don't want to address yet (mark as "deferred")
+
+For skipped questions, note the current assumption the plan makes and flag it as an unresolved decision.
+
+#### Phase 7: Update the Plan
+
+After collecting answers:
+
+1. **Read the current IP file** fresh (in case it changed)
+2. **For each answered question**, determine what section(s) of the plan need updating
+3. **For each confirmed issue**, draft the fix
+4. **Draft all changes** and present them to the user as a before/after diff for each section
+5. Ask: "Apply these updates to the plan?"
+6. If yes, edit the IP file with all changes
+7. If a task file exists, update it too if any tasks are affected
+8. Add an "## Review Log" entry at the bottom of the IP file:
+
+```markdown
+## Review Log
+
+### {today's date} -- Dual-Model Review
+- **Reviewers:** Claude + Codex ({model})
+- **Issues found:** {N} ({breakdown by severity})
+- **Questions asked:** {N} ({answered}/{deferred})
+- **Plan updated:** Yes/No
+- **Unresolved:** {list any deferred questions or unverified issues}
+```
+
+#### Cleanup
+
+```bash
+rm -f "$TMPDIR/ip-review-prompt.md"
+```
+
+#### Notes on Review
+
+- The value is **dual perspective** -- Claude and Codex have different biases and catch different things
+- Questions tagged `[Both]` deserve the most attention -- two independent models flagged the same gap
+- Don't pre-filter findings. Present honestly even if they contradict earlier Claude work on the plan
+- This step fits between Step 5 (Generate) and implementation -- use it as a quality gate
+- Can also be run mid-implementation to reassess the plan as understanding deepens
+
+### Step 9: Attack & Adjust
+
+Adversarially red-team the plan and then update it inline based on what comes back. This is the last thing `/ip` does before handing off to implementation.
+
+1. **Locate the plan** — use the file just saved in Step 5 (`docs/implementationPlans/[feature-name].md`). Read it, plus the task file in `docs/tasks/` if present.
+
+2. **Gather focused context** — collect what an external reviewer will need:
+   - `CLAUDE.md` (tech stack, conventions, constraints)
+   - 3–5 of the most critical existing files referenced in the plan's "Files to Create/Modify"
+   - Current definitions of any models the plan touches
+   - `git log --oneline -10` for recent momentum
+
+3. **Build the attack prompt** at `$TMPDIR/ip-attack-prompt.md`:
+
+   ```markdown
+   # Adversarial Review: {plan title}
+
+   You are a senior staff engineer conducting a hostile review of this implementation plan. Find every flaw, gap, risk, and unstated assumption. Be uncharitable — assume nothing works until proven otherwise.
+
+   ## The Plan
+   {full plan content}
+
+   ## Task Breakdown
+   {task list content, if available}
+
+   ## Codebase Context
+   {CLAUDE.md excerpt + relevant source file excerpts}
+
+   ## Your Review
+
+   For each finding, cite the section of the plan and explain exactly what's wrong or missing. Cover:
+
+   1. **Missing Requirements** — what the PRD implies but the plan ignores; uncovered user flows and error states.
+   2. **Unstated Assumptions** — what the plan assumes about codebase/infra/data/scale that isn't verified.
+   3. **Technical Risks** — parts harder than the plan suggests; highest rewrite probability.
+   4. **Security & Data Integrity** — injection, auth gaps, input validation, race conditions.
+   5. **Task Breakdown Gaps** — tasks not actually independent/testable; wrong dependencies; missing setup/migration/testing/docs tasks.
+   6. **Architecture Concerns** — fit with existing patterns; tech debt; simpler approaches overlooked.
+   7. **Verdict** — SHIP IT / REVISE / RETHINK.
+
+   Classify each finding: CRITICAL / HIGH / MEDIUM / LOW.
+   ```
+
+4. **Run the attacker — OpenAI first, Opus fallback:**
+
+   Try OpenAI Codex CLI:
+   ```bash
+   codex --model o3-pro --quiet --approval-mode full-auto "$TMPDIR/ip-attack-prompt.md"
+   ```
+   If `o3-pro` is unavailable or rate-limited, try `o3`, then `o4-mini`.
+
+   If the `codex` CLI is missing or every model fails, fall back to an Opus subagent: spawn a `general-purpose` Agent with `model: "opus"` and pass it the same prompt file contents, telling it to act as the hostile reviewer. Report clearly which path was taken.
+
+5. **Process the findings:**
+   - Deduplicate overlapping issues.
+   - For each CRITICAL/HIGH finding, verify with Glob/Grep/Read before treating it as real — reviewers hallucinate.
+   - Drop anything the plan actually already addresses.
+
+6. **Report to the user** in this shape:
+
+   ```
+   ## Adversarial Review: {plan title}
+
+   **Reviewer:** {OpenAI model used, or "Opus fallback"}
+   **Verdict:** {SHIP IT / REVISE / RETHINK}
+
+   ### Critical / High / Medium / Low
+   {findings grouped by severity, each with a one-line plan-section reference}
+
+   ### Verified vs Unverified
+   - Verified: {confirmed against the codebase}
+   - Unverified: {couldn't confirm — may be false positives}
+   ```
+
+7. **Adjust the plan** — don't stop at reporting. For every verified CRITICAL/HIGH finding, edit the IP file in place: tighten assumptions, add missing tasks, patch acceptance criteria, rewrite risky phases. For MEDIUM/LOW, ask the user which to fold in. Show the diff of your plan edits and ask "Anything else to adjust, or is this ready for implementation?"
+
+If the user provides a `$STEP` argument, skip to that step (assumes prior steps have been completed and context is available in conversation).
+
+## Lifecycle Operations
+
+These operations manage IPs through their lifecycle after creation. Each is self-contained and can be invoked directly by name.
+
+### Lifecycle: Init
+
+Set up the directory structure and tracking index for implementation plans in the current project.
+
+Argument: optional project description or notes (`$ARGUMENTS`).
+
+#### Before Starting
+
+1. Identify the **project root** -- this is the current working directory
+2. Check if IP tracking already exists by looking for `docs/implementationPlans/PLAN_INDEX.md`
+   - If it exists, report what's already set up and ask what to regenerate
+   - If it doesn't exist, proceed with full setup
+
+#### Init Step 1: Infer Project Context
+
+1. Read `CLAUDE.md` if it exists -- note the project name, key conventions, commit style
+2. Check `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, or similar for project name
+3. Look at recent git log for commit message style
+4. Note the primary language and any existing docs structure
+5. Check if `docs/implementationPlans/` already exists with plan files -- if so, scan them for the highest IP number to seed the index
+
+#### Init Step 2: Create Directory Structure
+
+```bash
+mkdir -p docs/implementationPlans/archive
+mkdir -p docs/tasks
+```
+
+#### Init Step 3: Create PLAN_INDEX.md
+
+Create `docs/implementationPlans/PLAN_INDEX.md`:
+
+```markdown
+# Implementation Plan Index
+
+Tracked implementation plans for {project_name}.
+
+See `CLAUDE.md` for IP lifecycle stages and management guidelines.
+
+## Active Plans
+
+| IP | Title | Status | Effort | Priority |
+|----|-------|--------|--------|----------|
+| - | - | - | - | No active plans yet |
+
+## Completed
+
+| IP | Title | Completed | Notes |
+|----|-------|-----------|-------|
+| - | - | - | No completed plans yet |
+
+## Deferred / Closed
+
+| IP | Title | Status | Notes |
+|----|-------|--------|-------|
+| - | - | - | No deferred plans yet |
+
+## Backlog
+
+Low-priority or blocked items. Promote to Active when ready to plan.
+
+| IP | Title | Notes |
+|----|-------|-------|
+| - | - | No backlog items yet |
+```
+
+If existing plan files were found in `docs/implementationPlans/`, populate the Active table with entries for each file, inferring IP numbers from filenames or assigning new ones.
+
+#### Init Step 4: Create IP_TEMPLATE.md
+
+Only create if `docs/implementationPlans/IP_TEMPLATE.md` does not already exist. If it exists, skip this step and report it was found.
+
+Create `docs/implementationPlans/IP_TEMPLATE.md`:
+
+```markdown
+# Implementation Plan: Title
+
+**Status:** Open
+**Priority:** Low | Medium | High
+**Effort:** Small batch (1-2 days) | Big batch (1-2 weeks) | Epic (2+ weeks)
+**IP:** IP-XXX
+
+*When an engineer is assigned to a project but before you begin coding, you should fill in the implementation plan and get feedback from the engineering team.*
+
+## Models
+
+New or modified data models, schemas, relationships.
+
+## APIs
+
+Endpoints, permissions, special queries, bulk operations.
+
+## Notifications
+
+Push, email, in-app alerts -- who, when, what.
+
+## UI
+
+New screens/components, navigation flow, key interactions, states.
+
+## Phases
+
+How to break the work into phases/PRs.
+
+## Feature Flags & Migrations
+
+Feature flags, data migrations, rollout strategy.
+
+## Activity Log & User Updates
+
+What actions get logged, what surfaces as user updates.
+
+## Not Included / Future Work
+
+Explicitly out of scope.
+
+---
+
+## Task List
+
+*Structured task breakdown. Each task should be independently implementable and testable.*
+
+### Phase 1: [Phase Name]
+
+- [ ] **Task 1.1**: [Short title]
+  - Description: [What to implement]
+  - Files: [Expected files to create/modify]
+  - Depends on: [Other task IDs, or "none"]
+  - Acceptance: [How to verify it's done]
+```
+
+#### Init Step 5: Update Project CLAUDE.md
+
+Read the project's `CLAUDE.md`. If it doesn't exist, create it with a minimal header.
+
+**Check if an IP section already exists** by searching for `## Implementation Plan` or `## IP Management`. If found, skip and report.
+
+Otherwise, **append** the following section:
+
+```markdown
+
+---
+
+## Implementation Plan (IP) Management
+
+Implementation plans are tracked in `docs/implementationPlans/`. Each IP has a dedicated file and is indexed in `PLAN_INDEX.md`.
+
+### IP Lifecycle
+
+| Stage | Description |
+|-------|-------------|
+| **Planned** | Identified but not yet designed |
+| **Design** | Actively designing (PRD ingested, shaping) |
+| **Open** | Shaped and ready for implementation |
+| **In Progress** | Currently being implemented |
+| **Pending Verification** | Code complete, awaiting verification |
+| **Complete** | Verified working, ready to archive |
+| **Deferred** | Postponed (low priority or blocked) |
+| **Closed** | Won't implement (superseded or not needed) |
+
+### Conventions
+
+- **IP files**: `docs/implementationPlans/{Title-Case-Name}.md` (e.g. `Zoom-Integration-Mvp.md`)
+- **Template**: `docs/implementationPlans/IP_TEMPLATE.md`
+- **Task files**: `docs/tasks/{feature-name}.md` (created by Step 5: Generate)
+- **Commit format**: `IP-XXX: Brief description`
+- **Numbering**: Next number = highest across all index sections + 1
+- **Source of truth**: IP file status > index (if discrepancy, file wins)
+- **Archive**: Completed IPs move to `docs/implementationPlans/archive/`
+
+### Inline Annotations (`%%`)
+
+Lines starting with `%%` in any file are **inline annotations from the user**. When you encounter them:
+- Treat each `%%` annotation as a direct instruction
+- Address **every** `%%` annotation in the file; do not skip any
+- After acting on an annotation, remove the `%%` line from the file
+- If an annotation is ambiguous, ask for clarification before acting
+```
+
+#### Init Step 6: Init Summary
+
+Report what was created:
+
+```
+## IP Tracking Initialized
+
+### Files Created
+- `docs/implementationPlans/PLAN_INDEX.md` -- Plan index
+- `docs/implementationPlans/IP_TEMPLATE.md` -- IP file template (if not already present)
+- `docs/implementationPlans/archive/` -- Archive directory
+- `docs/tasks/` -- Task files directory
+- `CLAUDE.md` -- Updated with IP conventions
+
+### Next Steps
+1. Run /ip to create your first implementation plan from a PRD
+2. Run the Lifecycle: Status operation to check the current state
+```
+
+### Lifecycle: Explore
+
+General-purpose exploration of any project using the IP system. Uses parallel subagents to quickly build context.
+
+#### Step 1: Launch Parallel Subagents
+
+Launch these THREE subagents IN PARALLEL (single message with multiple Task tool calls):
+
+##### Agent 1: Project Overview
+
+Explore the project root to understand what this project is and how it works:
+
+1. **Read key docs** -- `CLAUDE.md`, `README.md`, any top-level docs
+2. **Directory structure** -- Glob for top-level files and key subdirectories
+3. **Tech stack** -- Identify languages, frameworks, build tools from config files (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `Makefile`, etc.)
+4. **Gotchas** -- Note any warnings, constraints, or non-obvious conventions from CLAUDE.md
+
+Return: project name, purpose, tech stack, directory layout, key gotchas.
+
+##### Agent 2: IP History
+
+Explore the implementation plan system to understand what's been built and what's planned:
+
+1. **Read index** -- `docs/implementationPlans/PLAN_INDEX.md`
+2. **Active IPs** -- Read each active IP file (non-Complete status)
+3. **Archived IPs** -- List files in `docs/implementationPlans/archive/` to understand completed work
+4. **Task files** -- List and scan `docs/tasks/` for active task lists
+5. **Recent IP commits** -- Search git log for commits matching `IP-` pattern (last 20)
+
+Return: active IPs table, count of archived IPs, active tasks summary, recent IP commit summary.
+
+##### Agent 3: Recent Activity
+
+Explore recent development activity to understand current momentum:
+
+1. **Recent commits** -- Last 15 commits with messages
+2. **Modified files** -- Files changed in the last 5 commits
+3. **Branch context** -- Current branch name and how far ahead of main
+4. **Uncommitted work** -- Check git status for staged/unstaged changes
+
+Return: recent commit summary, files in flux, branch status, open work.
+
+#### Step 2: Synthesize Results
+
+Combine all agent outputs into a single briefing:
+
+##### Project Overview
+- Name, purpose, tech stack (from Agent 1)
+- Key gotchas or constraints
+
+##### IP Status
+- Active plans table (from Agent 2)
+- Active tasks and progress
+- Archived count and notable completions
+
+##### Recent Activity
+- What's been happening (from Agent 3)
+- Current branch and open work
+
+##### Quick Reference
+
+| Item | Value |
+|------|-------|
+| **Project** | {name} |
+| **Branch** | {current branch} |
+| **Active IPs** | {count} |
+| **Active Tasks** | {count remaining} |
+| **Recent focus** | {summary of last few commits} |
+
+Use the current working directory as the project root.
+
+### Lifecycle: Deep Analysis
+
+Parallel exploration of a hard problem from multiple angles, inspired by test-time compute scaling. Use when stuck, when the problem is complex enough to benefit from diverse perspectives, or when you need "big brains" on something.
+
+Argument: problem description or context (`$ARGUMENTS`).
+
+#### Phase 1: Understand the Problem
+
+1. **Parse the argument** -- what is the user stuck on? What are they trying to achieve?
+2. **Gather context** -- read conversation history for what's already been tried or discussed
+3. **Check for active IP** -- if there's a relevant implementation plan, read it for design context
+4. **Scan the codebase** -- do a quick targeted search to understand the relevant code area (key files, architecture, constraints). Keep this brief -- the agents will do the deep exploration.
+
+#### Phase 2: Design the Exploration
+
+Based on the problem, design **4 exploration angles**. These are NOT redundant -- each agent gets a **distinct lens** on the problem.
+
+**Before launching, check orthogonality:** Would two of these angles likely explore the same code paths and reach similar conclusions? If so, reframe one to ensure genuine diversity.
+
+**How to choose angles -- infer from the problem type:**
+
+For **performance optimization**:
+- Algorithmic: Can the approach itself be fundamentally different?
+- Structural: Can the data layout, schema, or architecture reduce work?
+- Incremental: Can we avoid redoing work (caching, materialization, deltas)?
+- Environmental: Are we fighting the platform? (query patterns, Python GIL, network topology)
+
+For **architecture/design decisions**:
+- Simplicity: What's the minimal viable approach?
+- Scalability: What happens at 10x/100x current load?
+- Precedent: How do similar systems/libraries solve this?
+- Contrarian: What if the obvious approach is wrong? What's the unconventional path?
+
+For **debugging / "why is this broken"**:
+- Symptoms: Trace the failure path precisely -- what's the chain of events?
+- Environment: What changed? Versions, configs, data, dependencies?
+- Assumptions: What are we assuming that might not be true?
+- Similar: Has this pattern of failure been seen elsewhere in the codebase or in public?
+
+For **anything else** -- choose angles that maximize diversity of insight. Ask: "If these 4 experts were in a room, what different specialties would give me the most useful debate?"
+
+**For each angle, decide:**
+- What codebase areas the agent should explore (specific files, directories, patterns)
+- What question the agent should answer
+- How deep vs. broad the agent should go
+- What existing context (if any) to seed the agent with -- only what's necessary, avoid anchoring
+
+#### Phase 3: Launch Parallel Exploration
+
+**Briefly tell the user** what angles you're exploring (2-3 words each) -- then launch immediately. Don't wait for approval. Speed matters when stuck.
+
+Launch **4 Explore agents IN PARALLEL** (single message with 4 Task tool calls). Use `model: "opus"` explicitly on each agent to ensure heavyweight reasoning. Each agent gets:
+
+```
+You are exploring a specific angle of a hard problem. Your analysis is input to a multi-agent synthesis -- be precise, flag uncertainties, and show your evidence.
+
+## Problem
+{problem description}
+
+## Your Angle
+{specific lens -- what you're looking for, what question you're answering}
+
+## Where to Look (Starting Points)
+{specific files, directories, or search patterns to start with}
+
+These are entry points, not the complete scope. Follow evidence wherever it leads -- if the trail points to related code outside this list, explore it.
+
+## Key Constraint
+You have read-only tools (Glob, Grep, Read). Use them liberally. If you can't verify something exists, don't claim it. Better to say "I couldn't locate a config file for X" than to guess at its name or path.
+
+## Instructions
+- Use Glob, Grep, and Read to thoroughly explore the relevant code
+- Think deeply about your specific angle -- don't try to solve the whole problem
+- Look for evidence, patterns, constraints, and opportunities related to your angle
+- Note anything surprising or that contradicts assumptions
+- Be concrete -- reference specific files, functions, line numbers, data flows
+- If you find something important outside your angle, note it briefly but stay focused
+- Before you finalize: is there evidence that contradicts your recommendation? If yes, address it directly rather than ignore it
+
+## Output
+Return a focused analysis (aim for 600-1000 words):
+
+1. **Key findings** -- specific observations with evidence. For each finding, cite the file/line or code pattern that shows it's true. Avoid vague claims like "this is slow" -- show why.
+
+2. **Implications** -- what this means for the problem. For each implication, explain the logical link: if this finding is true, then we should try X because [reason].
+
+3. **Recommendation** -- your angle's proposed direction:
+   - **Proposed approach:** [specific, actionable idea]
+   - **Why this angle suggests it:** [link findings -> recommendation]
+   - **Tradeoffs:** [what you'd give up]
+   - **Key assumptions:** [what has to be true for this to work]
+   - **Biggest uncertainty:** [what would most change your mind]
+```
+
+#### Phase 4: Verify Key Claims
+
+Before synthesizing, two verification passes:
+
+##### Pass 1: Contradiction Detection
+
+Scan all 4 agent reports for **opposing claims**. Examples:
+- Agent A says "this runs synchronously" while Agent B says "this is async"
+- Agent A says "no index on this column" while Agent C assumes an index exists
+- Two agents recommend opposite directions
+
+Flag contradictions prominently. **Prioritize verifying contradicted claims first** -- these are where the highest-value corrections live.
+
+##### Pass 2: Factual Verification
+
+**Cross-check the most important factual claims** from the agents. Agents can hallucinate file paths, function signatures, config options, or behavioral assumptions.
+
+**What to verify:**
+- **File paths and function names** -- do the files/functions agents referenced actually exist? Spot-check with Glob/Grep.
+- **Behavioral claims** -- "this function does X" or "this config controls Y" -- Read the actual code for the 2-3 most critical claims that the recommendation will hinge on.
+- **Performance/complexity claims** -- if an agent says "this is O(n^2)" or "this query scans the full table," verify against the actual code or query plan.
+- **Assumption checks** -- if agents assumed something about the system (e.g., "this runs synchronously," "this table has an index on X"), verify the ones that matter most.
+
+**How to verify:**
+- Focus on the **top 3-5 claims that would change the recommendation if wrong**. Don't verify everything -- verify what matters.
+- Use Glob, Grep, and Read directly (no subagents -- this should be fast).
+- If a claim is wrong, note the correction. If it's right, move on.
+
+**Output:** Note any corrections or confirmations. Flag anything that was wrong -- this changes the synthesis.
+
+#### Phase 5: Synthesize
+
+After verification, synthesize the agents' findings (with corrections applied) into a single analysis. This is the critical step -- don't just concatenate.
+
+**Synthesis structure:**
+
+##### 1. Agreements
+Where do multiple angles converge? High-confidence insights.
+
+##### 2. Tensions
+Where do angles disagree or present tradeoffs? These are the real design decisions.
+
+##### 3. Surprises
+What did agents find that wasn't expected? Novel insights that change the framing.
+
+##### 4. Corrections
+Any agent claims that were wrong or misleading, and what the truth is. Be transparent -- this builds trust in the analysis.
+
+##### 5. Recommendation
+Your synthesized recommendation. Be opinionated -- rank the options, state which direction you'd go and why. Tag each element with confidence (High/Medium/Low) and a one-line justification. Include:
+- **Proposed approach** -- the synthesized best path forward
+- **Key tradeoffs** -- what you're giving up
+- **Risks** -- what could go wrong
+- **Key assumptions** -- what the recommendation depends on being true
+- **First step** -- the concrete next action
+
+##### 6. Assumption Check
+After drafting the recommendation, note what assumptions it hinges on. Verify those specific assumptions with a quick Glob/Grep/Read check. If any fail, flag them and reassess.
+
+##### 7. If applicable: IP Update
+If there's an active IP related to this problem, propose specific updates to the plan's relevant sections based on the analysis. Don't update the file -- present the proposed changes for the user to approve.
+
+#### Notes on Deep Analysis
+
+- **Agent count**: Always 4. Four distinct angles. No exceptions.
+- **Agent type**: Always use `subagent_type: "Explore"` with `model: "opus"` -- read-only research agents on the heaviest model.
+- **Thoroughness**: Tell agents to be "very thorough" in their Task descriptions.
+- **No anchoring**: Don't give agents each other's angles. They should explore independently.
+- **Speed over perfection**: The user is stuck. A good-enough synthesis in 2 minutes beats a perfect one in 10. Don't over-polish the output.
+
+### Lifecycle: Status
+
+Generate an up-to-date summary of active implementation plans.
+
+#### Fast Path vs Full Grooming
+
+**Decide which path to take based on conversation context:**
+
+##### Fast Path (just print the table)
+Use this when you are **confident the index is up to date** -- for example:
+- You've been working on IPs in this session (closing, creating, updating)
+- You just ran a full grooming pass recently
+- The user just asked you to "print the status"
+
+Simply read `docs/implementationPlans/PLAN_INDEX.md` and each active IP file, then output the table.
+
+##### Full Grooming (first invocation or uncertain state)
+Use this when you have **no context about the current state**:
+- Start of a new conversation
+- You haven't touched any IPs yet
+- The user explicitly asks for a grooming check
+
+Perform these housekeeping checks:
+
+###### 1. Status Sync Check
+- Read each active IP file and compare its `**Status:**` line to the index
+- If discrepancy, update the index to match the file (file is source of truth)
+- Report any discrepancies found and fixed
+
+###### 2. Archive Check
+- Look for IP files in `docs/implementationPlans/` (not in `archive/`) with status: Complete, Deferred, or Closed
+- For each such IP not yet archived:
+  - Move to `docs/implementationPlans/archive/`
+  - Ensure it's in the appropriate section of the index
+- Report any files archived
+
+###### 3. Orphan Check
+- Check if any IPs in the index don't have corresponding files
+- Check if any IP files exist that aren't in the index (exclude IP_TEMPLATE.md and PLAN_INDEX.md)
+- Report any orphans found
+
+###### 4. Task Progress Check
+- For each active IP, check if a corresponding task file exists in `docs/tasks/`
+- Count completed vs total tasks (checked vs unchecked checkboxes)
+- Include task progress in the output table
+
+#### Status Output
+
+Format the output as a markdown table:
+
+    ## Active Implementation Plans
+
+    | IP | Title | Status | Effort | Tasks | Description |
+    |----|-------|--------|--------|-------|-------------|
+    | IP-XXX | Title here | Status | Effort | 3/10 | Brief description |
+
+    **Total:** X active plans (Y design, Z open, W in progress)
+
+If full grooming was performed and changes were made, prepend a grooming report.
+
+Notes:
+- Keep descriptions concise (< 60 chars if possible)
+- Include a count summary at the bottom
+- Task column shows completed/total if task file exists, "-" otherwise
+
+### Lifecycle: Close
+
+Close an IP by marking it complete (or closed/deferred), archiving the file, and updating the index.
+
+Argument should contain:
+- **IP number or name** (required-ish): e.g. `1`, `IP-001`, or the plan filename slug
+- **Disposition** (optional): `complete` (default), `closed`, or `deferred`
+- **Notes** (optional): any additional context
+
+Examples:
+- close 1 -- mark IP-001 as Complete
+- close user-permissions deferred blocked on auth refactor -- mark by name, Deferred
+- close 3 closed superseded by IP-005 -- mark IP-003 as Closed
+- close (no args) -- infer from conversation context
+
+Parse the argument: `$ARGUMENTS`
+
+#### Inferring the IP
+
+If no IP number/name provided, infer from conversation context:
+- Look at which IP was most recently discussed or worked on
+- If exactly one IP is obvious, use it and state which one
+- If ambiguous, ask the user
+
+#### Close Steps
+
+##### 1. Find and read the IP file
+
+- Search `docs/implementationPlans/` for matching file (by IP number, Title-Case filename, or slug)
+- Read to get title, current status
+- If already archived or not found, report and stop
+
+##### 2. Update the IP file
+
+- Set `**Status:**` to `Complete`, `Closed`, or `Deferred`
+- For Complete: add `**Completed:** {today YYYY-MM-DD}` after Status
+- For Closed/Deferred: add `**Closed:** {today}` if not present
+
+##### 3. Update PLAN_INDEX.md
+
+- Read `docs/implementationPlans/PLAN_INDEX.md`
+- Remove IP's row from **Active Plans** table
+- Add to appropriate section:
+  - **Complete** -> add to top of `## Completed` table with date and notes
+  - **Closed/Deferred** -> add to top of `## Deferred / Closed` table with status and notes
+
+##### 4. Archive the files
+
+- Move IP file to `docs/implementationPlans/archive/`
+- If a corresponding task file exists in `docs/tasks/`, move it to `docs/implementationPlans/archive/` as well (or leave in place if tasks are still referenced)
+
+##### 5. Commit
+
+Commit all changes in a single atomic commit:
+- Check `git status` for uncommitted changes related to the IP implementation
+- Stage implementation files, archived IP, deleted original path, `PLAN_INDEX.md`
+- Commit with message: `IP-{number}: {title}`
+
+##### 6. Close Summary
+
+Report:
+- IP number and title
+- Disposition (Complete / Closed / Deferred)
+- Status updated in IP file
+- Moved from Active to the appropriate section in index
+- Archived to `docs/implementationPlans/archive/`
+- Committed: {short hash}
+
+## Submitting the IP
+
+Once the plan is finalized, use `/submit` to commit the IP files, push the branch, and create a PR on the target project's GitHub repo. The worktree is already on a dedicated branch, so `/submit` works directly.
+
+## Arguments
+
+$PROJECT: Project alias or `owner/repo` (required — if omitted, user is prompted to select from the registry)
+$STEP: Optional step to skip to (ingest, research, shape, plan, generate, acceptance, e2e, review, attack). Note: Step 0 (project setup) always runs regardless of $STEP.
+$PRD: Optional path to a PRD markdown file (skips the paste prompt in ingest step)

--- a/.agents/skills/mongoose-schema-safety/SKILL.md
+++ b/.agents/skills/mongoose-schema-safety/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: mongoose-schema-safety
+description: >-
+  Invoke when making any Mongoose schema change: adding/removing/renaming
+  fields, creating a new model, adding indexes, or writing a backfill migration.
+  Provides the five-type pattern, risk matrix, type file checklist, and rollout
+  safety steps for terreno backends.
+---
+# Mongoose Schema Safety — Terreno
+
+## Where Schemas and Types Live
+
+| Package | Schemas | Types |
+|---------|---------|-------|
+| `@terreno/api` (built-in models like `User`, `ConsentForm`) | `api/src/models/*.ts` | `api/src/types/*.ts` (or co-located in the model file via `mongoose.Schema<Doc, Model, Methods>` generics) |
+| `example-backend` (`User`, `Todo`, `Configuration`) | `example-backend/src/models/*.ts` | `example-backend/src/types/models/*.ts` (`userTypes.ts`, `todoTypes.ts`, …) |
+| `@terreno/ai` (`AIRequest`, `GptHistory`) | `ai/src/models/*.ts` | `ai/src/types/index.ts` |
+
+Every field in every schema **must** have a `description` (see the API rule `01-model-field-descriptions.md`). Descriptions flow through to the OpenAPI spec via `mongoose-to-swagger`.
+
+## The Five-Type Pattern
+
+Every model has manually-maintained TypeScript types. **Types are NOT auto-generated** — every schema change must include a matching type update in the same commit/PR.
+
+```typescript
+import type {DefaultDoc, DefaultModel, DefaultStatics} from "@terreno/api";
+
+// 1. Instance methods (on the document)
+export type YourModelMethods = {
+  customMethod: (this: YourModelDocument, param: string) => Promise<void>;
+};
+
+// 2. Static methods (on the model class) — extend DefaultStatics for findExactlyOne / findOneOrNone
+export type YourModelStatics = DefaultStatics<YourModelDocument> & {
+  customStatic: (this: YourModelModel, param: string) => Promise<YourModelDocument>;
+};
+
+// 3. Model type combining document + statics
+export type YourModelModel = DefaultModel<YourModelDocument> & YourModelStatics;
+
+// 4. Schema type
+export type YourModelSchema = mongoose.Schema<YourModelDocument, YourModelModel, YourModelMethods>;
+
+// 5. Document type (the shape of a single record)
+export type YourModelDocument = DefaultDoc & YourModelMethods & {
+  fieldName: string;
+  optionalField?: number;
+  enumField: "value1" | "value2";
+};
+```
+
+Follow existing type files in `example-backend/src/types/models/` and `ai/src/types/index.ts` for naming and structure.
+
+## Statics & Methods — Direct Assignment
+
+Define statics and methods by direct assignment on the schema — not via `.method()` / `.static()` / `.add()`:
+
+```typescript
+schema.methods = {
+  getDisplayName(this: YourModelDocument): string { return this.name; },
+};
+schema.statics = {
+  async findByEmail(this: YourModelModel, email: string) { return this.findOne({email}); },
+};
+```
+
+## Critical Mongoose Rules
+
+- **Never use `Model.findOne`** — use `Model.findExactlyOne` (throws on 0 or many) or `Model.findOneOrNone` (throws on many). These come from the `findExactlyOne` / `findOneOrNone` plugins in `@terreno/api`.
+- Apply the standard plugins (`createdUpdatedPlugin`, `isDeletedPlugin`, `findOneOrNone`, `findExactlyOne`) on every new model. Most existing models go through `addDefaultPlugins`.
+- `checkModelsStrict()` runs at non-prod startup (`server.ts`) and validates schema consistency — keep it passing.
+
+## Schema Change Risk Matrix
+
+| Change Type | Risk Level | Required Mitigation |
+|-------------|-----------|---------------------|
+| Add optional field | Low | Safe to ship directly (still requires `description`) |
+| Add required field | High | Must provide a default value, OR write a backfill migration script first |
+| Remove field | Medium | Soft-remove first (mark optional, stop writing); hard-remove in next PR after deploys settle |
+| Rename field | High | Three-step: add new → backfill → remove old (separate PRs) |
+| Change field type | Critical | Treat as rename: new field + migration + remove old |
+| Add index | Medium | Safe in code, but build can slow writes on large collections — coordinate with ops |
+| Remove index | Low | Safe to ship directly |
+| Add unique index | High | Dedup migration must run first; otherwise the index build fails on existing duplicates |
+
+## Migration Scripts
+
+Migration / backfill scripts live in `example-backend/src/scripts/` (e.g. `syncConsents.ts`, `seedConsents.ts`). They use the `ScriptRunner` type and `BackgroundTask` model from `@terreno/api` (`api/src/scriptRunner.ts`):
+
+```typescript
+import type {ScriptContext, ScriptResult, ScriptRunner} from "@terreno/api";
+
+export const run: ScriptRunner = async (wetRun, ctx) => {
+  const results: string[] = [];
+  // ... do work ...
+  if (wetRun) {
+    // commit changes
+  }
+  return {success: true, results};
+};
+```
+
+Always run with `wetRun = false` first to verify the dry-run output. Use `ctx.checkCancellation()`, `ctx.addLog()`, and `ctx.updateProgress()` for long-running tasks.
+
+## Cross-Package Ripple
+
+A schema change in one place often ripples:
+
+- **API surface affected?** Regenerate the SDK with `cd example-frontend && bun run sdk` (or invoke the `generate-sdk` skill). The OpenAPI spec is derived from the schema, so the frontend hooks will go stale otherwise.
+- **`modelRouter` config?** If you added/removed a field, update `queryFields`, `populatePaths`, and `responseHandler` for any router that touches the model.
+- **Admin panel?** If the model is registered in `AdminApp`, update `listFields` so the table reflects the new shape.
+- **Populated refs?** If another model references this one via `ObjectId` + `ref`, and the referenced document shape changed, the consumer's populated type may need updating.
+
+## Post-Change Checklist
+
+- [ ] All new fields have a `description` (flows to OpenAPI)
+- [ ] Type file updated in the same commit/PR — field names, optionality, enum values, array types, refs, statics/methods all match the schema
+- [ ] For a new model: all five types (`Document`, `Methods`, `Statics`, `Model`, `Schema`) created
+- [ ] Statics/methods assigned directly on schema (`schema.statics = {...}`, `schema.methods = {...}`) — not `.static()` / `.method()`
+- [ ] Other model type files checked — any model that populates this one updated if its shape changed
+- [ ] Migration script written (and dry-run verified with `wetRun = false`) for any backfill
+- [ ] `modelRouter` config updated (`queryFields`, `populatePaths`, `responseHandler`) if needed
+- [ ] `AdminApp` `listFields` updated if the model is in the admin panel
+- [ ] `bun run sdk` run from `example-frontend/` if the API response shape changed
+- [ ] Test covers old-format document behavior (missing new field) if the change rolls out before a backfill
+- [ ] Unique index: dedup migration written and run before the index is added
+- [ ] `checkModelsStrict()` still passes (it runs on non-prod startup)
+- [ ] No `Model.findOne` introduced — use `findExactlyOne` / `findOneOrNone`
+
+## Common Pitfalls
+
+- Adding a required field without a default — first deploy fails for documents that pre-date the field
+- Skipping the type file update — TS happily compiles older callers but new ones break at runtime
+- Adding a `unique` index without dedup — index build fails on collections with existing duplicates
+- Renaming a field in one PR — frontend gets old field, backend writes new field, neither side is happy
+- Forgetting to regenerate the SDK after a shape change — frontend types drift from reality
+- Using `.method()` / `.static()` API — terreno's convention is direct assignment, and mixing styles makes types hard to maintain

--- a/.agents/skills/respond-to-review/SKILL.md
+++ b/.agents/skills/respond-to-review/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: respond-to-review
+description: >-
+  Review PR comments, plan fixes, and implement — auto-submitting when no
+  clarifications are needed
+---
+# PR Review Response Workflow
+
+Review comments on PR #$ARGUMENTS and plan fixes. If the plan has open questions for the user, pause for confirmation; otherwise implement, commit, and run `/submit` automatically without prompting.
+
+## Step 1: Setup Working Directory
+
+1. Check if we're already in a git worktree:
+   ```bash
+   git rev-parse --show-toplevel
+   git worktree list
+   ```
+
+2. **If already in a worktree**, use the current directory — skip to Step 2.
+
+3. **If NOT in a worktree**, set one up:
+
+   a. Get the repo name:
+      ```bash
+      basename $(git rev-parse --show-toplevel)
+      ```
+
+   b. Fetch PR details and branch name:
+      ```bash
+      gh pr view $ARGUMENTS --json headRefName,number,title,url,author
+      ```
+
+   c. Fetch the PR branch:
+      ```bash
+      git fetch origin pull/$ARGUMENTS/head
+      ```
+
+   d. Create worktree at `~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS`:
+      ```bash
+      git worktree add ~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS FETCH_HEAD
+      ```
+
+   e. Change to the worktree directory:
+      ```bash
+      cd ~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS
+      ```
+
+   f. Set up tracking for the PR branch:
+      ```bash
+      git checkout -B <branch-name> FETCH_HEAD
+      git branch --set-upstream-to=origin/<branch-name>
+      ```
+
+**Important**: All subsequent work happens in the working directory (worktree or current).
+
+## Step 2: Find the Reviews
+
+1. Get review threads with resolution status using GraphQL. **Important**: capture the thread `id` for each unresolved thread so you can resolve them later.
+   ```bash
+   gh api graphql -f query='
+     query($owner: String!, $repo: String!, $pr: Int!) {
+       repository(owner: $owner, name: $repo) {
+         pullRequest(number: $pr) {
+           reviewThreads(first: 100) {
+             nodes {
+               id
+               isResolved
+               comments(first: 50) {
+                 nodes {
+                   author { login }
+                   body
+                   path
+                   line
+                   createdAt
+                 }
+               }
+             }
+           }
+           reviews(first: 50) {
+             nodes {
+               author { login }
+               state
+               body
+             }
+           }
+         }
+       }
+     }' -F owner=':owner' -F repo=':repo' -F pr=$ARGUMENTS
+   ```
+
+2. **Ignore resolved threads entirely** — only process threads where `isResolved` is `false`
+
+3. Filter to comments from other users (not the PR author)
+
+4. Identify which remaining comments are:
+   - Blocking (CHANGES_REQUESTED) vs suggestions
+   - Inline code comments vs general comments
+
+## Step 3: Decide What To Do & Propose a Plan
+
+Decide the right action for each unresolved comment (fix, skip, ask), then present a structured plan organized by priority:
+
+```
+## PR #$ARGUMENTS Review Comments Plan
+
+### 🔴 Must Fix (Blocking)
+1. [file:line] @reviewer: "comment text"
+   → Proposed fix: <description>
+
+### ⚠️ Should Address (Suggestions)
+2. [file:line] @reviewer: "comment text"
+   → Proposed fix: <description>
+
+### 💬 Questions/Clarifications Needed
+- Comment X: Need your input on approach
+- Comment Y: Conflicts with existing pattern, which to use?
+
+### 📝 Will Skip (N/A or out of scope)
+- Comment Z: Not applicable or out of scope
+
+### 💬 Suggested Replies to Human Commenters
+For any comments that warrant a reply (e.g., to clarify a decision or thank a reviewer):
+- **Print the suggested reply text** so the user can see it
+- **Never post replies** via `gh pr comment`, `gh api`, or any other method — leave posting to the user
+```
+
+## Step 4: Confirmation (only if there are open questions)
+
+**If the plan has any items under 💬 Questions/Clarifications Needed:**
+Ask: **"Need your input on the questions above. Anything else to change before I implement?"**
+- Wait for explicit approval before making any changes
+- Incorporate any feedback
+- Re-present plan if significant changes requested
+
+**If there are no open questions:** skip confirmation entirely. Proceed directly to Step 5 — implement, commit, run `/submit`, and resolve threads without further prompts. Do not ask the user for plan approval in this case.
+
+## Step 5: Make the Fix
+
+After approval:
+
+1. Implement fixes one at a time, in priority order
+2. After each fix, briefly confirm what was changed
+
+## Step 6: Show the diff
+
+Show the complete diff so the user can scan what was implemented:
+```bash
+git diff
+git diff --stat
+```
+
+Do **not** commit here. `/submit` (next step) handles pre-commit checks, staging, commit, push, and PR updates — running pre-commit *before* the commit, which is the correct order. Committing here would invert that order and leave broken code committed locally if pre-commit fails.
+
+## Step 7: Run /submit
+
+Invoke the `/submit` skill to handle pre-commit checks, commit, push, and PR updates. This will also launch the CI check-watcher in the background. Pass a `$DESCRIPTION` summarizing what review comments were addressed so the commit message reflects the work.
+
+## Step 8: Resolve Addressed Threads
+
+After `/submit` completes, resolve each review thread that was addressed in the implementation. Use the thread `id` captured in Step 2.
+
+For each thread that was fixed or addressed (from the "Must Fix" and "Should Address" categories in the plan):
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }' -f threadId="<thread_id>"
+```
+
+Do NOT resolve threads that were:
+- Skipped (marked as N/A or out of scope)
+- Questions/clarifications that were not answered by code changes
+- Threads where the user decided not to take action
+
+Report which threads were resolved and which were left open.
+
+---
+
+## Error Handling
+
+- If worktree already exists, ask if user wants to reset it or use existing
+- If PR not found, show error and available PRs: `gh pr list`
+- If no comments found, inform user and ask if they want to proceed anyway
+- If merge conflicts occur during implementation, pause and ask for guidance
+
+## Cleanup Reminder
+
+If a new worktree was created, remind user:
+```
+To remove this worktree later:
+  git worktree remove ~/.claude-worktrees/<repo>/pr-$ARGUMENTS
+
+Or to keep working on it, you can open a new Claude session in:
+  cd ~/.claude-worktrees/<repo>/pr-$ARGUMENTS
+```

--- a/.agents/skills/submit/SKILL.md
+++ b/.agents/skills/submit/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: submit
+description: >-
+  Lightweight pre-commit + commit + push + create/update PR, then spawn
+  check-watcher in the background. Use /fullsend for the full pipeline with code
+  review.
+---
+# Submit: Quick Commit & PR
+
+Lightweight path to run pre-commit checks, commit, push, and monitor CI. After pushing, this skill launches `/check-watcher` as a background sub-agent so CI is watched without blocking. Use `/fullsend` for the full pipeline that also includes code review.
+
+## Step 1: Assess Changes
+
+```bash
+git status && git diff --stat
+```
+
+```bash
+gh pr view --json number -q .number 2>/dev/null || echo "no-pr"
+```
+
+## Step 1.5: Pre-Commit Checks
+
+Delegate lint, type check, and related tests to the `pre-commit` subagent before committing.
+
+Use the `Agent` tool:
+- `subagent_type`: `pre-commit`
+- `description`: `Run pre-commit checks`
+- `prompt`: instruct it to run lint, compile, and related tests for the current project, fix any issues, and report back. Mention this is being run as part of `/submit` for an upcoming commit.
+
+Wait for the subagent to return its Pre-Commit Report. If it surfaces unfixable failures, STOP and report them — do not commit or push.
+
+If invoked from `/fullsend` (which already ran pre-commit), skip this step.
+
+## Step 2: Commit
+
+Stage and commit:
+- Review the diff to write an accurate message
+- Keep first line under 72 characters
+- No conventional commit prefixes
+- No AI attribution
+
+## Step 3: Push
+
+```bash
+git push origin HEAD
+```
+
+## Step 4: Create or Update PR
+
+### If no PR exists
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+[What changed and why — 2-4 sentences]
+
+## Human Testing Steps
+- [ ] [Step-by-step verification instructions]
+
+## Changes
+- [Bullet list of specific changes]
+
+## Automated Tests
+- [Tests that ran and passed, or "None"]
+EOF
+)" --draft
+```
+
+### If a PR already exists
+
+Read the current title and body, then compare against the full set of commits on the branch:
+
+```bash
+gh pr view --json title,body,baseRefName
+git log $(gh pr view --json baseRefName -q .baseRefName)..HEAD --oneline
+git diff $(gh pr view --json baseRefName -q .baseRefName)...HEAD --stat
+```
+
+Decide whether the description still reflects what's on the branch — pay attention to commits added since the PR was opened:
+- **Summary** still matches the actual goal of the changes
+- **Changes** list covers the new commits, not just the original ones
+- **Human Testing Steps** still cover what reviewers need to verify
+- **Automated Tests** section reflects current test state
+
+If the description is stale or incomplete, update it. Preserve sections the user has clearly edited by hand — only rewrite what's actually out of date, and merge new bullets into existing lists rather than replacing them wholesale:
+
+```bash
+gh pr edit --title "<title>" --body "$(cat <<'EOF'
+<updated body>
+EOF
+)"
+```
+
+If the description is already accurate, skip the edit and note that it's up to date.
+
+## Step 5: Print PR Link
+
+```bash
+gh pr view --json title,url -q '"**\(.title)** — \(.url)"'
+```
+
+## Step 6: Launch Check Watcher Sub-Agent
+
+Spawn `/check-watcher` as a **background sub-agent** so CI monitoring runs autonomously without blocking the parent conversation. Use the `Agent` tool with `run_in_background: true`.
+
+- `subagent_type`: `general-purpose`
+- `description`: `Watch CI for current PR`
+- `run_in_background`: `true`
+- `prompt`: instruct the sub-agent to invoke the `/check-watcher` skill for the current PR, fix any failures, and report back when checks are green or max attempts are hit. Include the PR number/URL from Step 5 so the sub-agent has context.
+
+Do **not** wait on the sub-agent — return control immediately after spawning. The user will be notified when it completes.
+
+By the time you reach this step, a PR is guaranteed to exist — either it pre-existed (from Step 1) or Step 4 just created it. Always spawn check-watcher.
+
+## Arguments
+
+$DESCRIPTION: Optional description to guide the commit message and PR

--- a/.claude/skills/check-watcher/SKILL.md
+++ b/.claude/skills/check-watcher/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: check-watcher
+description: Monitor GitHub Actions checks and automatically fix failures
+---
+# Check Watcher
+
+Monitor GitHub Actions checks and auto-fix failures. Designed to be called standalone or from other skills.
+
+## Instructions
+
+1. Get the PR number:
+   ```bash
+   gh pr view --json number -q .number
+   ```
+   If no PR exists, inform the user and exit.
+
+2. Wait for CI to finish using `--watch` (no manual polling):
+   ```bash
+   gh pr checks --watch --fail-fast
+   ```
+   - All passing → go to step 6
+   - Failed → continue to step 3
+
+3. Get failure details:
+   ```bash
+   gh run view <run-id> --log-failed
+   ```
+
+4. Determine if flaky or real:
+   - Compare failed files/tests against `gh pr diff` — is the failure in code you changed?
+   - Check for flaky signals: timeouts, race conditions, ECONNRESET, intermittent assertions
+   - If flaky (not in your code + flaky signals), rerun once: `gh run rerun <run-id> --failed`
+   - Run `gh pr checks --watch --fail-fast` again. If still failing, file an issue and move on:
+     ```bash
+     gh issue create --title "Flaky test: <test name>" --body "<error details and job link>"
+     ```
+
+5. If failure IS related to PR changes:
+   - Fix the code
+   - Run lint and compile locally to validate
+   - Commit and push (no AI attribution, no conventional prefixes)
+   - Return to step 2
+
+6. When all checks pass, check for bot review comments:
+   ```bash
+   gh api repos/:owner/:repo/pulls/<pr_number>/comments --jq '.[] | select(.user.type == "Bot") | "\(.path):\(.line) @\(.user.login): \(.body)"'
+   ```
+   Report any actionable bot comments found. Do NOT auto-fix — just report them.
+
+7. Print the PR link:
+   ```bash
+   gh pr view --json title,url -q '"**\(.title)** — \(.url)"'
+   ```
+
+Cap fix attempts at $MAX_ATTEMPTS (default: 5).
+
+## Arguments
+
+$MAX_ATTEMPTS: Optional max fix attempts before stopping (default: 5)

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: commit
+description: >-
+  Create a commit for the current staged/unstaged changes with a clear, accurate
+  message
+---
+# Commit Changes
+
+Create a commit for the current staged/unstaged changes.
+
+## Instructions
+
+1. Check git status and diff to understand what changed:
+   ```
+   git status
+   git diff
+   git diff --cached
+   ```
+
+
+2. Stage changes appropriately and create a commit:
+   - Review the actual changes to write an accurate commit message
+
+   **Message Format:**
+   - The first line must be under 72 characters
+   - Add a body if more context is needed
+   - Exclude conventional commit prefixes (feat:, fix:, chore:, etc.)
+
+   **Content Restrictions:**
+   - Exclude any mention of AI, Claude, or any AI assistant
+   - Exclude making the commit coauthored by any AI
+   - Exclude adding "Co-Authored-By" trailers
+
+   *If constraints conflict, prioritize Message Format for clarity and readability.*
+
+3. Never push unless explicitly asked.
+
+## Arguments
+
+$DESCRIPTION: Optional description to guide the commit message

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: create-pr
+description: Create a draft pull request for the current branch
+---
+# Create Pull Request
+
+Create a pull request for the current branch.
+
+## Instructions
+
+1. First ensure changes are committed and pushed:
+   ```
+   git status
+   git log origin/master..HEAD --oneline
+   ```
+
+2. If there are uncommitted changes, commit them first (run `/commit` command).
+
+3. Push the branch if not already pushed:
+   ```
+   git push origin HEAD
+   ```
+
+4. Create the pull request:
+   ```
+   gh pr create --title "<title>" --body "<body>" --draft
+   ```
+
+   Guidelines for the PR:
+   - Title: Clear, concise summary of the changes
+   - Do not use prefix commit format (feat:, fix:, chore:, etc.)
+   - Do not mention AI, Claude, or any AI assistant in the title or body
+   - Do not add "Generated with Claude" or similar footers
+   - Always create as draft
+
+   **PR Body Structure:**
+
+   ```markdown
+   ## Summary
+
+   [What changed and why — 2-4 sentences]
+
+   ## Human Testing Steps
+
+   - [ ] [Step-by-step instructions a reviewer can follow to verify the change works]
+   - [ ] [Cover happy path and at least one edge case]
+
+   ## Changes
+
+   - [Bullet list of specific changes]
+
+   ## Automated Tests
+
+   - [Tests that ran and passed, or "No automated tests"]
+   ```
+
+5. Return the PR URL to the user.
+
+## Arguments
+
+$DESCRIPTION: Optional description for the PR title and body

--- a/.claude/skills/fix-conflicts/SKILL.md
+++ b/.claude/skills/fix-conflicts/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: fix-conflicts
+description: >-
+  Pull latest from master, resolve merge conflicts, validate with lint/compile
+  checks, and monitor CI
+---
+# Fix Conflicts
+
+Pull latest from master, resolve merge conflicts, validate with lint/compile checks, and monitor CI.
+
+## Instructions
+
+1. Ensure the working tree is clean before starting:
+   ```
+   git status
+   ```
+   - If there are uncommitted changes, ask the user whether to stash them or abort
+
+2. Fetch and merge the latest master into the current branch:
+   ```
+   git fetch origin master
+   git merge origin/master
+   ```
+   - If the fetch or merge fails, check network connectivity and repository access permissions. Notify the user if the issue persists.
+
+3. Check for merge conflicts:
+   ```
+   git diff --name-only --diff-filter=U
+   ```
+   - If there are no conflicts, skip to step 5
+
+4. For each conflicted file:
+    - Read the file and understand both sides of the conflict
+    - Resolve the conflict by combining changes in a way that retains the functionality and purpose of both sets of changes, ensuring no critical information is lost.
+    - If the conflict cannot be resolved automatically, notify the user and provide a summary of the conflicting changes.
+    - After resolving all conflicts in a file, stage it:
+       ```
+       git add <file>
+       ```
+    - After all conflicts are resolved, complete the merge:
+       ```
+       git commit --no-edit
+       ```
+
+## Running Checks
+
+5. Run lint and compile checks at the project root:
+    ```
+    git rev-parse --show-toplevel
+    ```
+    - Run linting:
+       ```
+       cd <project-root> && bun run lint
+       ```
+       - If linting fails, fix the issues and re-run until passing
+    - Run type compilation/checking:
+       ```
+       cd <project-root> && bun run compile
+       ```
+       - If compilation fails, fix the type errors and re-run until passing
+    - If linting or compilation fails repeatedly and cannot be resolved, notify the user with the error details and suggest seeking assistance.
+
+## Handling Fixes and Commits
+
+6. If any fixes were needed in step 5, stage and commit them:
+   - Review the changes made
+   - Create a commit with a clear message describing what was fixed
+   - In step 6, do not use prefix commit format (feat:, fix:, chore:, etc.) for the commit message.
+   - Do not mention AI, Claude, or any AI assistant
+
+7. Push the changes:
+   ```
+   git push origin HEAD
+   ```
+
+8. Run check-watcher by invoking `/check-watcher`:
+   - This monitors GitHub Actions checks
+   - If checks fail, it will automatically read failures, fix them, and push again
+   - Continue until all checks pass
+
+## Arguments
+
+None

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: implement
+description: >-
+  Test-driven implementation execution skill for applying implementation plans
+  directly in code
+---
+# Implementation Execution Skill
+
+Use this skill when an Implementation Plan (IP) or implementation requirements are provided.
+
+
+The goal of this skill is to execute the implementation directly in code using test-driven development.
+
+If the implementation plan is incomplete or contains contradictions, highlight the conflicts and request clarification before proceeding.
+
+Do not stop after analysis or task generation unless blocked by material ambiguity.
+
+## Primary Behavior
+
+When an IP is provided:
+
+1. Read the full IP carefully.
+2. Determine implementation scope.
+3. Identify the smallest meaningful automated test coverage that should fail for the requested behavior.
+4. Write or update the failing tests before implementation code.
+5. Run the targeted tests and confirm they fail for the expected product reason, not because of syntax, setup, or unrelated failures.
+6. Implement the requested changes directly.
+7. Run the previously failing tests until they pass.
+8. Run relevant validation or broader test commands when available.
+9. Summarize completed work, assumptions, and remaining risks.
+
+Exclude generating a separate implementation plan unless explicitly requested.
+
+## Scope Detection
+
+Determine whether the implementation is:
+
+- backend only
+- frontend only
+- full stack
+- phased implementation
+- rollout-gated
+- migration-dependent
+
+
+// --- Assumption Rules ---
+Use best-effort assumptions when the assumption does not affect compliance, data integrity, or user experience.
+
+If the correct scope is unclear and could materially change implementation, ask concise clarifying questions before coding.
+
+## Clarifying Question Rules
+
+Only ask questions if missing information would materially affect:
+
+- architecture
+- data model behavior
+- API contracts
+- permissions/access control
+- user/admin visibility
+- rollout sequencing
+- migration/backfill behavior
+- destructive operations
+- compliance-sensitive behavior
+- whether implementation should be backend only, frontend only, phased, or full stack
+
+// --- Clarifying Question Exclusions ---
+Exclude asking questions for implementation details that do not affect functionality, performance, or compliance, and can reasonably be inferred.
+
+
+## Execution Expectations
+
+Implement the requested behavior directly in the codebase.
+
+### Test-Driven Development Flow
+
+Default to red/green/refactor:
+
+- red: write the focused failing test or regression test first
+- green: implement only enough production code to satisfy the requested behavior
+- refactor: clean up the implementation while preserving passing tests
+
+If no meaningful automated test can be written for the change, document why before implementation and use the strongest available manual or static validation instead.
+
+### Implementation Steps
+- update or add focused failing tests
+- update schemas/models
+- update services/controllers/routes
+- update validation
+- update frontend UI
+- update state management/API hooks
+- update OpenAPI/types
+- update permissions/visibility logic
+- update feature flags
+- update fixtures/mocks
+- rerun the focused tests that failed first
+- run broader validation when appropriate
+- preserve existing behavior unless the IP explicitly changes it
+
+## Phased Implementations
+
+If the IP implies phased implementation:
+
+- determine whether backend and frontend should be separated
+- determine whether rollout gating is required
+- determine whether app-version compatibility matters
+
+If phase requirements are unclear and could affect implementation safety, ask before coding.
+
+Otherwise proceed with best-effort assumptions.
+
+## Testing Requirements
+
+Add or update relevant tests before production implementation whenever applicable.
+
+Possible test types include:
+
+- backend unit tests
+- backend integration tests
+- API tests
+- frontend component tests
+- frontend flow tests
+- regression tests
+
+Run the most targeted available tests first and capture the initial failure before writing production code. After implementation, rerun the same focused tests to confirm the red-to-green transition.
+
+If full test execution is not practical, run the closest focused validation possible and document what was not run.
+
+## File Modification Rules
+
+Prefer modifying existing patterns consistently with the codebase.
+
+Avoid introducing new architectural patterns unless required.
+
+Do not invent exact file paths unless strongly implied by the repository structure.
+
+Prefer consistency over novelty.
+
+## Safety Rules
+
+Do not make destructive or irreversible changes without clear instruction.
+
+Do not silently change existing product behavior outside the requested scope.
+
+If implementation could create compliance, privacy, permission, or rollout risk, explicitly call it out in the final response.
+
+## Final Response Requirements
+
+At completion, summarize:
+
+- implementation scope
+- major code changes
+- assumptions made
+- tests updated/run
+- remaining risks or follow-up work
+
+Keep the summary concise and implementation-focused.

--- a/.claude/skills/ip/SKILL.md
+++ b/.claude/skills/ip/SKILL.md
@@ -1,0 +1,1559 @@
+---
+name: ip
+description: >-
+  Implementation Plan (/ip) — build an implementation plan from a PRD through an
+  interactive, multi-step process
+---
+# Implementation Plan (/ip)
+
+Build an implementation plan from a PRD through an interactive, multi-step process. Produces both a human-readable implementation plan and a structured task list for bot consumption.
+
+## Overview
+
+This skill walks through the Shape Up-inspired process of turning a raw PRD into a concrete implementation plan. Each step is a self-contained section in this file — you can re-run individual steps if needed by jumping to the matching section.
+
+**Every IP targets a specific project.** The project must be specified via the `$PROJECT` argument or selected interactively.
+
+## Project Registry
+
+| Alias(es) | GitHub Repo | Local Dir |
+|-----------|-------------|-----------|
+| `ter`, `terreno` | `flourishhealth/terreno` | `~/src/terreno` |
+
+Local Dir is derived from the repo name (the part after `/`). All repos clone into `~/src/`.
+
+If a project isn't in the registry, attempt to resolve it via `gh repo view <input>`. If found, use it. If not, ask the user for the full `owner/repo`.
+
+## Planning Workflow
+
+Run the following steps in order. Each step builds on the previous one.
+
+### Step 0: Project Setup (always runs first)
+
+This step is **mandatory** and runs before everything else, even when `$STEP` is provided.
+
+#### 0a. GitHub Auth Check
+
+```bash
+gh auth status
+```
+
+If not authenticated, tell the user:
+> You need to authenticate with GitHub. Run this in your terminal:
+> `! gh auth login --web`
+> Follow the prompts to open the browser link and enter the code.
+
+Then **stop** — do not proceed until the user confirms auth is complete.
+
+#### 0b. Resolve Project
+
+If `$PROJECT` was provided, match it against the registry aliases (case-insensitive). If no `$PROJECT`, show the registry table and ask the user to pick one.
+
+#### 0c. Clone if Needed
+
+Check if the local directory exists:
+```bash
+ls -d ~/src/{repo-name} 2>/dev/null
+```
+
+If it doesn't exist, clone it:
+```bash
+gh repo clone {owner/repo} ~/src/{repo-name}
+```
+
+#### 0d. Fetch Latest & Enter Worktree
+
+Navigate to the repo and ensure we have the latest code:
+```bash
+cd ~/src/{repo-name} && git fetch origin && git checkout master && git pull origin master
+```
+
+(If the default branch is `main` instead of `master`, detect it with `git remote show origin | grep 'HEAD branch'` and use that.)
+
+Then create a worktree for this IP using the `EnterWorktree` tool:
+- **name**: `ip-{feature-slug}` (derive from the PRD title once known, or use a temporary name like `ip-draft` and note that it can be renamed)
+
+Since the PRD title isn't known yet at this point, use `ip-draft` as the worktree name. After Step 1 (Ingest), if the worktree name doesn't match the feature, note the mismatch but continue — the branch can be renamed later.
+
+#### 0e. Confirm Ready
+
+Print a summary:
+```
+Project: {repo-name} ({owner/repo})
+Branch: {worktree-branch}
+Working dir: {worktree-path}
+Latest master: {short SHA + date of HEAD}
+```
+
+Proceed to Step 1.
+
+### Step 1: Ingest PRD
+
+Collect the PRD (Product Requirements Document) that will drive the implementation plan.
+
+1. `$PRD` is **required**. If it was not provided, stop immediately and tell the user: **"Error: /ip requires a PRD as the first argument (either a file path or the inline PRD text). Please re-run as `/ip <path-or-text>`."** Do not prompt for it interactively.
+
+2. Determine what the user provided:
+   - If it looks like a file path (e.g., ends in `.md`, `.txt`, contains `/` or `\`, or matches an existing file), read that file and use its contents as the PRD.
+   - Otherwise, treat the input as the PRD text itself.
+
+3. The PRD should contain at minimum a **Problem** section and ideally a **Business Case** section. If either is missing, note what's missing but proceed anyway.
+
+4. Display a brief summary of what you understood from the PRD:
+   - The core problem (1-2 sentences)
+   - The business impact (1-2 sentences)
+   - Key stakeholders or affected teams
+   - Any constraints or requirements called out
+
+5. Ask: "Does this summary capture the intent? Anything to add or correct?" and let the user adjust before moving on.
+
+6. Once confirmed, say: **"PRD ingested. Moving to research phase..."** and proceed to Step 2.
+
+### Step 2: Research Context
+
+Investigate the codebase and gather context for the PRD topic. Do this inline — do not invoke `/research` via the Skill tool. Follow this procedure:
+
+1. **Scope** — restate the topic in one sentence and tell the user what you plan to investigate. Ask if they want anything specific covered.
+2. **Codebase deep dive** — read relevant source files in depth (models, routes, screens, components, configs, tests). Search for existing patterns, conventions, and dependencies. Check `docs/`, `README.md`, `CLAUDE.md`, and any feature documentation. Note file paths, function names, and line numbers as you go.
+3. **External research** — search the web for any APIs, libraries, or best practices that aren't already in the codebase.
+4. **Present findings** — output a complete research document in chat with: Summary, Context, Findings (with file paths and snippets), Options Considered (table with pros/cons/effort), Recommendation (be opinionated), Open Questions, References.
+5. **Iterate** — ask "Anything you want me to dig deeper on, adjust, or investigate further?" If the user gives feedback, investigate and re-output the **full** updated document.
+6. **Save** — once the user is satisfied, write the final version to `research.md` in the project root and continue to Step 3.
+
+Be specific (file paths, line numbers, code snippets) and opinionated (recommend an approach, don't just list options).
+
+### Step 3: Shape & Question
+
+This is the core shaping step inspired by the Shape Up methodology. The goal is to narrow the solution from a raw idea to a well-defined approach with clear boundaries.
+
+#### Phase 1: Models & APIs (get alignment first)
+
+This is the most important part. Models and APIs define the shape of the feature — everything else follows from them.
+
+1. **Draft the data model** based on the PRD and research:
+   - Mongoose schemas with types, required fields, enums, defaults
+   - Relationships to existing models (refs)
+   - Indexes if relevant
+   - Plugins (soft delete, timestamps, etc.) based on existing patterns
+
+2. **Draft the API surface**:
+   - List each endpoint (method, path, description)
+   - Note if it's a standard CRUD modelRouter or custom
+   - Specify permissions for each endpoint
+   - Call out any special query parameters, filters, or bulk operations
+
+3. **Present both together** and ask the user: "Are these models and APIs the right approach?" Use AskUserQuestion.
+
+4. **Iterate** until the user confirms the models and APIs are right. This is the foundation — don't move on until it's solid.
+
+#### Phase 2: Everything Else (flows from models/APIs)
+
+Once models and APIs are confirmed, draft the remaining concerns in a single pass. These should follow naturally from the model/API decisions:
+
+- **Notifications**: Push, email, in-app — who gets notified, when, what content. If none needed, say so.
+- **Activity Log**: What actions get logged, which surface as User Updates, which user groups see them. If none, say so.
+- **Permissions & Access**: Role-based differences beyond what's already covered in API permissions.
+- **UI**: New screens/components, navigation flow, key interactions and states, reusable vs new components.
+- **Feature Flags & Migration**: Whether a flag is needed, any data migrations, rollout strategy.
+- **Phases**: How to break the work into PRs (Phase 1: models + APIs, Phase 2: core UI, Phase 3: polish). If small enough, say "single phase."
+- **Not Included / Future Work**: Compile out-of-scope items and deferred ideas.
+
+Present all of this as a single shaped solution summary:
+
+```
+## Shaped Solution
+
+### Core Concept
+[1-2 sentence description of the approach]
+
+### Models
+[schemas from Phase 1]
+
+### APIs
+[endpoints from Phase 1]
+
+### Notifications
+[notification plan or "none needed"]
+
+### Activity Log
+[logging plan or "none needed"]
+
+### UI
+[screens, flows, interactions]
+
+### Phases
+[implementation phases]
+
+### Not Included
+[explicitly excluded items]
+
+### Risks & Mitigations
+- [risk]: [mitigation approach]
+```
+
+Surface any **risks and rabbit holes** inline:
+- Technical risks: things that might be harder than they look
+- Scope risks: features that could balloon if not bounded
+- For each risk, suggest a mitigation or simpler fallback
+
+Ask: "Does this shaped solution look right? Any decisions you want to revisit?"
+
+Once confirmed, say: **"Solution shaped. Moving to plan sections..."** and proceed to Step 4.
+
+### Step 4: Plan Sections (optional deep pass)
+
+Optional interactive walk-through of each plan section, useful when Step 3 left details fuzzy. For each section: present a draft, ask the user if it looks right, let them refine, then move on.
+
+#### Section 1: Models
+
+1. Draft Mongoose schemas based on the shaped solution. Include:
+   - Full schema code blocks with types, required fields, enums, defaults
+   - Relationships to existing models (refs)
+   - Indexes if relevant
+   - Plugins (soft delete, timestamps, etc.) based on existing patterns found in research
+
+2. Present the schemas and ask:
+   - "Do these models look right?"
+   - "Any fields missing or that should be changed?"
+   - "Should any of these fields be optional vs required?"
+
+#### Section 2: APIs
+
+1. Draft the API surface:
+   - List each endpoint (method, path, description)
+   - Note if it's a standard CRUD modelRouter or custom
+   - Specify permissions for each endpoint
+   - Call out any special query parameters, filters, or bulk operations
+   - Note any webhook or external API integrations
+
+2. Present and ask: "Any endpoints missing? Do the permissions look right?"
+
+#### Section 3: Notifications
+
+1. Based on the shaped solution, list:
+   - Push notifications (who, when, what content)
+   - Email/text notifications
+   - In-app notifications or alerts
+   - If none needed, explicitly state "No notifications required for this feature"
+
+2. Present and confirm with user.
+
+#### Section 4: UI
+
+1. Draft the UI plan:
+   - List new screens/components
+   - Describe navigation flow (how users get there)
+   - Describe key interactions and states
+   - Note any reusable components that already exist vs need to be created
+   - Suggest fat-marker sketches if the UI is complex (describe what should be sketched)
+
+2. Present and ask: "Does this UI approach make sense? Any screens or interactions missing?"
+
+#### Section 5: Phases
+
+1. Propose how to break the work into phases/PRs:
+   - Phase 1: Usually models + basic APIs
+   - Phase 2: Core UI and integrations
+   - Phase 3: Polish, notifications, edge cases
+   - If the feature is small enough, note "Single phase - no need to break up"
+
+2. For each phase, list what's included and what the deliverable looks like.
+
+3. Present and ask: "Does this phasing make sense? Want to adjust?"
+
+#### Section 6: Feature Flags & Migrations
+
+1. Based on the shaped solution, recommend:
+   - Whether a feature flag is needed (and what it controls)
+   - Any data migrations required
+   - Rollout strategy
+
+2. Present and confirm.
+
+#### Section 7: Activity Log & User Updates
+
+1. List:
+   - What actions get logged to the activity log
+   - Which of those surface as User Updates
+   - Which user groups see the updates
+
+2. If no activity logging is needed, say so explicitly.
+
+#### Section 8: Not Included / Future Work
+
+1. Compile the "out of scope" items from shaping into this section
+2. Add any ideas that came up during planning but were deferred
+3. Present and confirm.
+
+After all sections are finalized, say: **"All sections planned. Moving to output generation..."** and proceed to Step 5.
+
+### Step 5: Generate Output
+
+Produce the final implementation plan document and a structured task list, then save them.
+
+1. **Generate the Implementation Plan** in the standard format:
+
+   ```markdown
+   # Implementation Plan: [Feature Name]
+
+   *When an engineer is assigned to a project but before you begin coding, you should fill in the implementation plan and get feedback from the engineering team. Once you have finished or you make any changes, tag Josh with the @ symbol so he can review. Also tag anyone else that needs to be notified, has conflicting work, etc.*
+
+   ## **Models**
+   [Content from plan step]
+
+   ## **APIs**
+   [Content from plan step]
+
+   ## **Notifications**
+   [Content from plan step]
+
+   ## **UI**
+   [Content from plan step]
+
+   ## Phases
+   [Content from plan step]
+
+   ## Feature Flags & Migrations
+   [Content from plan step]
+
+   ## Activity Log & User Updates
+   [Content from plan step]
+
+   ## **Not included/Future work**
+   [Content from plan step]
+
+   ## Acceptance Criteria
+   [If criteria exist from the PRD or shaping, include them here. Otherwise, leave a placeholder noting to run Step 6 (Acceptance Criteria) to generate them.]
+   ```
+
+2. **Generate the Task List** as a structured section at the bottom of the document:
+
+   ```markdown
+   ---
+
+   ## Task List (Bot Consumption)
+
+   *Structured task breakdown for automated implementation. Each task should be independently implementable and testable.*
+
+   ### Phase 1: [Phase Name]
+
+   - [ ] **Task 1.1**: [Short title]
+     - Description: [What to implement]
+     - Files: [Expected files to create/modify]
+     - Depends on: [Other task IDs, or "none"]
+     - Acceptance: [How to verify it's done]
+
+   - [ ] **Task 1.2**: [Short title]
+     ...
+
+   ### Phase 2: [Phase Name]
+   ...
+   ```
+
+   Tasks should be:
+   - Small enough to be a single PR or commit
+   - Ordered by dependency (models first, then APIs, then UI)
+   - Specific about which files to create/modify
+   - Clear about acceptance criteria
+
+3. **Ask the user for the feature name** to use in the filename (suggest one based on the PRD). The filename should be kebab-case.
+
+4. **Save the implementation plan:**
+   - Ensure `docs/implementationPlans/` directory exists (create if needed)
+   - Save to `docs/implementationPlans/[feature-name].md`
+   - Confirm the file was saved and show the path
+
+5. **Save the task plan:**
+   - Ensure `docs/tasks/` directory exists (create if needed)
+   - Save to `docs/tasks/[feature-name].md`
+   - Confirm the file was saved and show the path
+
+6. **Final summary:**
+
+   ```
+   ## Implementation Plan Complete
+
+   **Saved to**: docs/implementationPlans/[feature-name].md
+
+   ### Quick Stats
+   - Models: [count] new/modified
+   - API Endpoints: [count]
+   - Screens: [count]
+   - Phases: [count]
+   - Tasks: [count] total
+
+   ### Next Steps
+   1. Share with the engineering team for review
+   2. Tag @Josh and relevant stakeholders
+   3. Once approved, tasks can be loaded for implementation
+   ```
+
+7. Ask: "Want to make any final changes, or is this ready to share?"
+
+### Step 6: Acceptance Criteria
+
+Generate structured acceptance criteria for an implementation plan. The criteria should be specific enough for a human to manually test AND for a bot to translate into Playwright E2E tests.
+
+`$IP` (optional): path to an existing IP file. If not provided, look for the IP in the current conversation context or ask the user which IP to use.
+
+#### 1. Load the IP
+
+- If `$IP` is provided, read the file
+- Otherwise, check if an IP was generated in the current conversation
+- If neither, list available IPs from `docs/implementationPlans/` and ask which one to use
+
+#### 2. Check for existing acceptance criteria
+
+- If the PRD or IP already has an `## Acceptance Criteria` section, read it carefully
+- Also check each task in the Task List for `Acceptance:` lines
+- These are your starting point — you'll expand and formalize them, not replace them
+
+#### 3. Analyze the IP to identify testable behaviors
+
+Walk through each section of the IP and identify user-facing behaviors:
+
+- **Models & APIs**: What responses should the API return? What validation errors should occur?
+- **UI**: What should the user see? What happens when they interact with elements?
+- **Notifications**: What triggers them? What content appears?
+- **Permissions**: What should different roles see/not see?
+- **Error states**: What happens when things fail?
+- **Edge cases**: Empty states, boundary values, concurrent actions
+
+#### 4. Write acceptance criteria
+
+Write criteria in a dual-format that works for both humans and bots:
+
+```markdown
+## Acceptance Criteria
+
+### Feature: [Feature area name]
+
+#### AC-1: [Short descriptive title]
+**Priority:** P0 | P1 | P2
+**Screen:** [screen name, e.g., "Login Screen"]
+**Preconditions:**
+- [Any setup needed before testing, e.g., "User is logged in", "At least 3 items exist"]
+
+**Steps:**
+1. [Navigate to / open / tap specific element]
+2. [Perform action — be specific about what to type, tap, select]
+3. [Observe result]
+
+**Expected results:**
+- [ ] [Specific, observable outcome — what the user sees]
+- [ ] [Another expected outcome]
+
+**testIDs needed:** `screen-element-qualifier`, `screen-another-element`
+
+---
+```
+
+Format rules:
+
+- **Steps must reference specific UI elements** using the `{screen}-{element}-{qualifier}` testID naming convention
+- **Expected results must be visually verifiable** — things a human can see AND a bot can assert (`toBeVisible`, `toHaveText`, `toHaveCount`, etc.)
+- **Include the `testIDs needed` line** listing every testID the test will need. This serves as a checklist for the developer to add testIDs to components before tests can run.
+- **Priority levels:**
+  - **P0**: Core happy path — feature is broken without this
+  - **P1**: Important flows — error handling, validation, key edge cases
+  - **P2**: Nice-to-have — polish, edge cases, minor interactions
+- **Group by feature area** (e.g., "User Authentication", "Item Management", "Notifications")
+
+#### 5. Cover these categories
+
+Ensure you have at least one criterion for each:
+
+- **Happy path**: The main flow works end to end
+- **Validation**: Required fields, format checks, boundary values
+- **Error handling**: Network errors, server errors, invalid states
+- **Empty states**: What shows when there's no data?
+- **Permissions** (if applicable): Different roles see different things
+- **Navigation**: Moving between screens works correctly
+- **Data persistence**: Changes are saved and visible after refresh
+
+#### 6. Add the section to the IP
+
+Insert the `## Acceptance Criteria` section into the IP file, after the main plan sections but before the `## Task List` section.
+
+#### 7. Summary
+
+Present a summary:
+
+```
+## Acceptance Criteria Generated
+
+**Added to**: [IP file path]
+
+### Coverage
+- P0 (critical): [count] criteria
+- P1 (important): [count] criteria
+- P2 (nice-to-have): [count] criteria
+- Total testIDs needed: [count]
+
+### Next Steps
+1. Review criteria with the team
+2. Ensure all listed testIDs are added to components
+3. Run Step 7 (E2E Tests) to generate Playwright tests from these criteria
+```
+
+Ask: "Want to adjust any criteria or add coverage for something I missed?"
+
+### Step 7: E2E Tests (optional)
+
+Generate Playwright end-to-end tests from an IP's acceptance criteria. Uses the project's Playwright skill and testing conventions.
+
+`$IP` (optional): path to an IP file with acceptance criteria. If not provided, look for the IP in the current conversation context or ask the user which IP to use.
+
+#### 1. Load the IP and acceptance criteria
+
+- If `$IP` is provided, read the file
+- Otherwise, check if an IP was loaded in the current conversation
+- If neither, list available IPs from `docs/implementationPlans/` and ask which one to use
+- The IP **must** have an `## Acceptance Criteria` section. If it doesn't, tell the user to run Step 6 (Acceptance Criteria) first.
+
+#### 2. Research the codebase
+
+Before writing tests, understand the existing test setup:
+
+- Check if `playwright.config.ts` exists — if not, note that it needs to be created
+- Check if `e2e/` directory exists and what tests are already there
+- Check for `e2e/helpers/` and `e2e/fixtures/` for reusable utilities
+- Check for `e2e/auth.setup.ts` to understand auth patterns
+- Look at existing test files to match the style and patterns in use
+- Check if the testIDs listed in acceptance criteria already exist in the component code
+
+#### 3. Plan the test files
+
+Map acceptance criteria to test files:
+
+- **One test file per feature area** (matching the `### Feature:` groups in acceptance criteria)
+- File naming: `e2e/{feature-name}.spec.ts` (kebab-case)
+- Group related ACs into `test.describe()` blocks
+
+Present the plan to the user:
+
+```
+## E2E Test Plan
+
+### Files to create:
+- `e2e/feature-name.spec.ts` — [count] tests from [AC numbers]
+- `e2e/another-feature.spec.ts` — [count] tests from [AC numbers]
+
+### Missing testIDs (must be added to components first):
+- `screen-element-name` — [component file if known]
+- ...
+
+### Missing infrastructure:
+- [ ] playwright.config.ts (will create)
+- [ ] e2e/helpers/auth.ts (will create)
+- ...
+```
+
+Ask: "Should I generate these test files? Any changes to the plan?"
+
+#### 4. Generate test files
+
+For each test file, follow these rules strictly:
+
+**Structure:**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Feature: [Feature Name]', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to starting screen
+    // Wait for screen to be visible
+  });
+
+  // One test per acceptance criterion
+  test('[AC title — as user behavior]', async ({ page }) => {
+    // Steps from the AC, translated to Playwright actions
+    // Expected results as assertions
+  });
+});
+```
+
+**Translation rules (AC → Playwright):**
+
+| AC Step | Playwright Code |
+|---------|----------------|
+| Navigate to [screen] | `await page.goto('/path'); await page.getByTestId('screen-name').waitFor({ state: 'visible' });` |
+| Tap / click [element] | `await page.getByTestId('testid').click();` |
+| Type [text] into [field] | `await page.getByTestId('testid').fill('text');` |
+| Toggle [switch] | `await page.getByTestId('testid').click();` |
+| See [text/element] | `await expect(page.getByTestId('testid')).toBeVisible();` |
+| See text [content] | `await expect(page.getByTestId('testid')).toHaveText(/content/i);` |
+| Don't see [element] | `await expect(page.getByTestId('testid')).not.toBeVisible();` |
+| See [N] items in list | `await expect(page.getByTestId('list').getByTestId(/^item-/)).toHaveCount(N);` |
+| Wait for loading | `await page.getByTestId('loading-indicator').waitFor({ state: 'hidden' });` |
+| Page URL contains [path] | `await expect(page).toHaveURL(/path/);` |
+
+**Mandatory rules:**
+- Use `getByTestId()` as primary selector — never class names or deep selectors
+- Never use `waitForTimeout()` — always wait for element state
+- Wait for screen visibility after every navigation
+- Wait for `networkidle` after data-fetching actions when appropriate
+- Add `// AC-N: [title]` comment above each test for traceability
+- Mark tests that need auth setup with the appropriate Playwright project dependency
+- Use `test.skip()` with a reason for any AC that can't be automated yet (e.g., requires native device features)
+
+#### 5. Report missing testIDs
+
+After generating tests, produce a checklist of testIDs that need to be added to components:
+
+```markdown
+## testIDs to Add
+
+These testIDs are referenced in the generated tests but may not exist in the app yet.
+Add them before running the tests.
+
+### [Screen Name]
+- [ ] `screen-element-name` on `<ComponentType>` — [purpose]
+- [ ] `screen-another-element` on `<ComponentType>` — [purpose]
+```
+
+If you can identify the component files where testIDs should be added, include the file paths.
+
+#### 6. E2E Summary
+
+```
+## E2E Tests Generated
+
+### Files created:
+- `e2e/feature-name.spec.ts` — [count] tests
+- ...
+
+### Coverage:
+- P0 criteria covered: [count]/[total]
+- P1 criteria covered: [count]/[total]
+- P2 criteria covered: [count]/[total]
+- Skipped (not automatable): [count] — [reasons]
+
+### Before running tests:
+1. Add missing testIDs to components (see checklist above)
+2. Ensure `playwright.config.ts` is configured
+3. Start the dev server
+4. Run: `bunx playwright test`
+
+### After tests pass:
+Run `/verify` to verify the full implementation
+```
+
+### Step 8: Review (optional, dual-model)
+
+Review an implementation plan using both Claude (sub-agent) and OpenAI Codex in parallel. Each reviewer independently identifies issues, gaps, and questions. Results are combined, deduplicated, and presented as a structured question list for the user. After the user answers, the IP is updated.
+
+Argument: IP number, filename, or path to the plan file. If empty, infer from conversation context. Parse as `$ARGUMENTS`.
+
+#### Phase 1: Locate the Plan
+
+1. If argument provided, find the matching IP file:
+   - Check `docs/implementationPlans/` for matching file (by IP number, slug, or full path)
+   - If a path was given directly, use that
+2. If no argument, infer from conversation context (most recently discussed IP)
+3. If ambiguous, ask the user
+4. Read the full plan file
+5. If a corresponding task file exists in `docs/tasks/`, read that too
+
+#### Phase 2: Gather Codebase Context
+
+Collect context both reviewers will need:
+
+1. **CLAUDE.md** -- project conventions, tech stack, constraints
+2. **Relevant source files** -- scan the plan's "Files to Create/Modify" or "Files:" fields in tasks, read 3-5 of the most critical existing files
+3. **Data models** -- if the plan references models, find and read their current definitions
+4. **Recent changes** -- `git log --oneline -10` for recent momentum
+
+Keep context focused. Prioritize the plan itself and the most relevant code.
+
+#### Phase 3: Run Both Reviews in Parallel
+
+Launch both reviewers at the same time using parallel tool calls. Do NOT wait for one before starting the other.
+
+##### 3a: Claude Sub-Agent
+
+Use the **Agent tool** with `subagent_type: "general-purpose"`:
+
+Prompt the sub-agent with all gathered context and these instructions:
+
+> You are a senior engineer reviewing an implementation plan. Your goal is to surface issues, gaps, risks, and questions that should be answered before implementation begins.
+>
+> ## The Plan
+>
+> {full plan content}
+>
+> ## Task Breakdown
+>
+> {task list content, if available}
+>
+> ## Codebase Context
+>
+> {CLAUDE.md excerpt -- tech stack, conventions}
+>
+> {relevant source file excerpts}
+>
+> ## Your Review
+>
+> Analyze this plan and produce two outputs:
+>
+> ### Issues & Gaps
+>
+> For each issue found, provide:
+> - **Severity**: CRITICAL / HIGH / MEDIUM / LOW
+> - **Category**: one of: Missing Requirements, Unstated Assumptions, Technical Risks, Security & Data Integrity, Task Breakdown Gaps, Architecture Concerns, Scope Concerns
+> - **Description**: What's wrong or missing -- be specific, cite the plan section
+> - **Suggestion**: How to address it
+>
+> ### Questions for the Author
+>
+> Generate questions that, if answered, would materially improve the plan. Focus on:
+> - Ambiguous requirements that could be interpreted multiple ways
+> - Unstated preferences (e.g., "should this be real-time or batch?")
+> - Tradeoffs where the plan picked one side without discussing alternatives
+> - Missing context that would change the approach
+> - Scale/performance expectations that aren't specified
+> - Integration points with unclear contracts
+> - Rollback/migration strategies that aren't defined
+>
+> For each question:
+> - **Question**: The question itself
+> - **Why it matters**: What changes depending on the answer
+> - **Default assumption**: What the plan currently assumes (if anything)
+>
+> Do NOT ask questions that can be answered by reading the codebase -- use Glob, Grep, and Read to verify before asking. Only ask questions that require human judgment or domain knowledge.
+
+##### 3b: Codex CLI
+
+Build a prompt file at `$TMPDIR/ip-review-prompt.md` with the plan, tasks, and codebase context, then run:
+
+```bash
+codex --model o3 --quiet --approval-mode full-auto "$TMPDIR/ip-review-prompt.md"
+```
+
+The prompt file should contain:
+
+```markdown
+# Implementation Plan Review: {plan title}
+
+You are a senior engineer reviewing an implementation plan. Find issues, gaps, and generate questions for the plan author.
+
+## The Plan
+
+{full plan content}
+
+## Task Breakdown
+
+{task list content, if available}
+
+## Codebase Context
+
+{CLAUDE.md excerpt}
+
+{relevant source file excerpts}
+
+## Your Review
+
+### Part 1: Issues & Gaps
+
+For each issue, provide:
+- **Severity**: CRITICAL / HIGH / MEDIUM / LOW
+- **Category**: Missing Requirements, Unstated Assumptions, Technical Risks, Security & Data Integrity, Task Breakdown Gaps, Architecture Concerns, or Scope Concerns
+- **Description**: Be specific -- cite the plan section and explain exactly what's wrong or missing
+- **Suggestion**: How to fix it
+
+### Part 2: Questions for the Author
+
+Generate questions that require human judgment or domain knowledge to answer. For each:
+- **Question**: The question
+- **Why it matters**: What would change depending on the answer
+- **Default assumption**: What the plan currently assumes
+
+Focus on: ambiguous requirements, unstated tradeoffs, missing scale/performance expectations, unclear integration contracts, and migration/rollback gaps.
+
+Do NOT ask questions answerable from the codebase. Focus on decisions that need human input.
+```
+
+**Model selection:** Use `o3` for strong reasoning. If unavailable, fall back to `o4-mini`.
+
+If `codex` is not installed or fails, report the error and continue with Claude-only results.
+
+Capture the full output.
+
+#### Phase 4: Combine & Deduplicate
+
+After both reviews return:
+
+##### Issues
+
+1. Parse all issues from both reviewers
+2. Deduplicate: if both flagged the same issue (same plan section, similar concern), merge and keep the more detailed description
+3. Tag each with its source:
+   - `[Claude]` -- only Claude found it
+   - `[Codex]` -- only Codex found it
+   - `[Both]` -- both flagged it (higher confidence)
+4. Sort by severity: CRITICAL > HIGH > MEDIUM > LOW
+
+##### Questions
+
+1. Parse all questions from both reviewers
+2. Deduplicate: merge questions asking essentially the same thing
+3. Tag with source (`[Claude]`, `[Codex]`, `[Both]`)
+4. Group by theme (e.g., "Scope", "Architecture", "Data", "Performance", "Migration")
+5. Within each group, sort by impact (questions where the answer would most change the plan come first)
+
+##### Verify Critical Claims
+
+For CRITICAL and HIGH issues, do a quick Glob/Grep/Read to confirm the issue is real. Note which are verified vs unverified.
+
+#### Phase 5: Present Results
+
+Present the combined review:
+
+```
+## IP Review: {plan title}
+
+**Reviewers:** Claude (sub-agent) + OpenAI Codex ({model used})
+**Plan:** {IP file path}
+
+---
+
+### Issues Found
+
+#### Critical
+1. [Both] **{category}** -- {description}
+   → {suggestion}
+
+#### High
+2. [Claude] **{category}** -- {description}
+   → {suggestion}
+
+#### Medium / Low
+3. [Codex] **{category}** -- {description}
+   → {suggestion}
+
+---
+
+### Questions for You
+
+**Scope & Requirements**
+1. [Both] {question}
+   _Why it matters:_ {impact}
+   _Current assumption:_ {what plan assumes}
+
+**Architecture & Design**
+2. [Claude] {question}
+   _Why it matters:_ {impact}
+   _Current assumption:_ {what plan assumes}
+
+**Performance & Scale**
+3. [Codex] {question}
+   _Why it matters:_ {impact}
+
+{...more grouped questions...}
+```
+
+#### Phase 6: Collect Answers
+
+Use **AskUserQuestion** to collect the user's answers. Present the questions in a numbered list and ask the user to answer them. Options:
+
+- Answer all at once (numbered responses)
+- Answer one at a time interactively
+- Skip questions they don't want to address yet (mark as "deferred")
+
+For skipped questions, note the current assumption the plan makes and flag it as an unresolved decision.
+
+#### Phase 7: Update the Plan
+
+After collecting answers:
+
+1. **Read the current IP file** fresh (in case it changed)
+2. **For each answered question**, determine what section(s) of the plan need updating
+3. **For each confirmed issue**, draft the fix
+4. **Draft all changes** and present them to the user as a before/after diff for each section
+5. Ask: "Apply these updates to the plan?"
+6. If yes, edit the IP file with all changes
+7. If a task file exists, update it too if any tasks are affected
+8. Add an "## Review Log" entry at the bottom of the IP file:
+
+```markdown
+## Review Log
+
+### {today's date} -- Dual-Model Review
+- **Reviewers:** Claude + Codex ({model})
+- **Issues found:** {N} ({breakdown by severity})
+- **Questions asked:** {N} ({answered}/{deferred})
+- **Plan updated:** Yes/No
+- **Unresolved:** {list any deferred questions or unverified issues}
+```
+
+#### Cleanup
+
+```bash
+rm -f "$TMPDIR/ip-review-prompt.md"
+```
+
+#### Notes on Review
+
+- The value is **dual perspective** -- Claude and Codex have different biases and catch different things
+- Questions tagged `[Both]` deserve the most attention -- two independent models flagged the same gap
+- Don't pre-filter findings. Present honestly even if they contradict earlier Claude work on the plan
+- This step fits between Step 5 (Generate) and implementation -- use it as a quality gate
+- Can also be run mid-implementation to reassess the plan as understanding deepens
+
+### Step 9: Attack & Adjust
+
+Adversarially red-team the plan and then update it inline based on what comes back. This is the last thing `/ip` does before handing off to implementation.
+
+1. **Locate the plan** — use the file just saved in Step 5 (`docs/implementationPlans/[feature-name].md`). Read it, plus the task file in `docs/tasks/` if present.
+
+2. **Gather focused context** — collect what an external reviewer will need:
+   - `CLAUDE.md` (tech stack, conventions, constraints)
+   - 3–5 of the most critical existing files referenced in the plan's "Files to Create/Modify"
+   - Current definitions of any models the plan touches
+   - `git log --oneline -10` for recent momentum
+
+3. **Build the attack prompt** at `$TMPDIR/ip-attack-prompt.md`:
+
+   ```markdown
+   # Adversarial Review: {plan title}
+
+   You are a senior staff engineer conducting a hostile review of this implementation plan. Find every flaw, gap, risk, and unstated assumption. Be uncharitable — assume nothing works until proven otherwise.
+
+   ## The Plan
+   {full plan content}
+
+   ## Task Breakdown
+   {task list content, if available}
+
+   ## Codebase Context
+   {CLAUDE.md excerpt + relevant source file excerpts}
+
+   ## Your Review
+
+   For each finding, cite the section of the plan and explain exactly what's wrong or missing. Cover:
+
+   1. **Missing Requirements** — what the PRD implies but the plan ignores; uncovered user flows and error states.
+   2. **Unstated Assumptions** — what the plan assumes about codebase/infra/data/scale that isn't verified.
+   3. **Technical Risks** — parts harder than the plan suggests; highest rewrite probability.
+   4. **Security & Data Integrity** — injection, auth gaps, input validation, race conditions.
+   5. **Task Breakdown Gaps** — tasks not actually independent/testable; wrong dependencies; missing setup/migration/testing/docs tasks.
+   6. **Architecture Concerns** — fit with existing patterns; tech debt; simpler approaches overlooked.
+   7. **Verdict** — SHIP IT / REVISE / RETHINK.
+
+   Classify each finding: CRITICAL / HIGH / MEDIUM / LOW.
+   ```
+
+4. **Run the attacker — OpenAI first, Opus fallback:**
+
+   Try OpenAI Codex CLI:
+   ```bash
+   codex --model o3-pro --quiet --approval-mode full-auto "$TMPDIR/ip-attack-prompt.md"
+   ```
+   If `o3-pro` is unavailable or rate-limited, try `o3`, then `o4-mini`.
+
+   If the `codex` CLI is missing or every model fails, fall back to an Opus subagent: spawn a `general-purpose` Agent with `model: "opus"` and pass it the same prompt file contents, telling it to act as the hostile reviewer. Report clearly which path was taken.
+
+5. **Process the findings:**
+   - Deduplicate overlapping issues.
+   - For each CRITICAL/HIGH finding, verify with Glob/Grep/Read before treating it as real — reviewers hallucinate.
+   - Drop anything the plan actually already addresses.
+
+6. **Report to the user** in this shape:
+
+   ```
+   ## Adversarial Review: {plan title}
+
+   **Reviewer:** {OpenAI model used, or "Opus fallback"}
+   **Verdict:** {SHIP IT / REVISE / RETHINK}
+
+   ### Critical / High / Medium / Low
+   {findings grouped by severity, each with a one-line plan-section reference}
+
+   ### Verified vs Unverified
+   - Verified: {confirmed against the codebase}
+   - Unverified: {couldn't confirm — may be false positives}
+   ```
+
+7. **Adjust the plan** — don't stop at reporting. For every verified CRITICAL/HIGH finding, edit the IP file in place: tighten assumptions, add missing tasks, patch acceptance criteria, rewrite risky phases. For MEDIUM/LOW, ask the user which to fold in. Show the diff of your plan edits and ask "Anything else to adjust, or is this ready for implementation?"
+
+If the user provides a `$STEP` argument, skip to that step (assumes prior steps have been completed and context is available in conversation).
+
+## Lifecycle Operations
+
+These operations manage IPs through their lifecycle after creation. Each is self-contained and can be invoked directly by name.
+
+### Lifecycle: Init
+
+Set up the directory structure and tracking index for implementation plans in the current project.
+
+Argument: optional project description or notes (`$ARGUMENTS`).
+
+#### Before Starting
+
+1. Identify the **project root** -- this is the current working directory
+2. Check if IP tracking already exists by looking for `docs/implementationPlans/PLAN_INDEX.md`
+   - If it exists, report what's already set up and ask what to regenerate
+   - If it doesn't exist, proceed with full setup
+
+#### Init Step 1: Infer Project Context
+
+1. Read `CLAUDE.md` if it exists -- note the project name, key conventions, commit style
+2. Check `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, or similar for project name
+3. Look at recent git log for commit message style
+4. Note the primary language and any existing docs structure
+5. Check if `docs/implementationPlans/` already exists with plan files -- if so, scan them for the highest IP number to seed the index
+
+#### Init Step 2: Create Directory Structure
+
+```bash
+mkdir -p docs/implementationPlans/archive
+mkdir -p docs/tasks
+```
+
+#### Init Step 3: Create PLAN_INDEX.md
+
+Create `docs/implementationPlans/PLAN_INDEX.md`:
+
+```markdown
+# Implementation Plan Index
+
+Tracked implementation plans for {project_name}.
+
+See `CLAUDE.md` for IP lifecycle stages and management guidelines.
+
+## Active Plans
+
+| IP | Title | Status | Effort | Priority |
+|----|-------|--------|--------|----------|
+| - | - | - | - | No active plans yet |
+
+## Completed
+
+| IP | Title | Completed | Notes |
+|----|-------|-----------|-------|
+| - | - | - | No completed plans yet |
+
+## Deferred / Closed
+
+| IP | Title | Status | Notes |
+|----|-------|--------|-------|
+| - | - | - | No deferred plans yet |
+
+## Backlog
+
+Low-priority or blocked items. Promote to Active when ready to plan.
+
+| IP | Title | Notes |
+|----|-------|-------|
+| - | - | No backlog items yet |
+```
+
+If existing plan files were found in `docs/implementationPlans/`, populate the Active table with entries for each file, inferring IP numbers from filenames or assigning new ones.
+
+#### Init Step 4: Create IP_TEMPLATE.md
+
+Only create if `docs/implementationPlans/IP_TEMPLATE.md` does not already exist. If it exists, skip this step and report it was found.
+
+Create `docs/implementationPlans/IP_TEMPLATE.md`:
+
+```markdown
+# Implementation Plan: Title
+
+**Status:** Open
+**Priority:** Low | Medium | High
+**Effort:** Small batch (1-2 days) | Big batch (1-2 weeks) | Epic (2+ weeks)
+**IP:** IP-XXX
+
+*When an engineer is assigned to a project but before you begin coding, you should fill in the implementation plan and get feedback from the engineering team.*
+
+## Models
+
+New or modified data models, schemas, relationships.
+
+## APIs
+
+Endpoints, permissions, special queries, bulk operations.
+
+## Notifications
+
+Push, email, in-app alerts -- who, when, what.
+
+## UI
+
+New screens/components, navigation flow, key interactions, states.
+
+## Phases
+
+How to break the work into phases/PRs.
+
+## Feature Flags & Migrations
+
+Feature flags, data migrations, rollout strategy.
+
+## Activity Log & User Updates
+
+What actions get logged, what surfaces as user updates.
+
+## Not Included / Future Work
+
+Explicitly out of scope.
+
+---
+
+## Task List
+
+*Structured task breakdown. Each task should be independently implementable and testable.*
+
+### Phase 1: [Phase Name]
+
+- [ ] **Task 1.1**: [Short title]
+  - Description: [What to implement]
+  - Files: [Expected files to create/modify]
+  - Depends on: [Other task IDs, or "none"]
+  - Acceptance: [How to verify it's done]
+```
+
+#### Init Step 5: Update Project CLAUDE.md
+
+Read the project's `CLAUDE.md`. If it doesn't exist, create it with a minimal header.
+
+**Check if an IP section already exists** by searching for `## Implementation Plan` or `## IP Management`. If found, skip and report.
+
+Otherwise, **append** the following section:
+
+```markdown
+
+---
+
+## Implementation Plan (IP) Management
+
+Implementation plans are tracked in `docs/implementationPlans/`. Each IP has a dedicated file and is indexed in `PLAN_INDEX.md`.
+
+### IP Lifecycle
+
+| Stage | Description |
+|-------|-------------|
+| **Planned** | Identified but not yet designed |
+| **Design** | Actively designing (PRD ingested, shaping) |
+| **Open** | Shaped and ready for implementation |
+| **In Progress** | Currently being implemented |
+| **Pending Verification** | Code complete, awaiting verification |
+| **Complete** | Verified working, ready to archive |
+| **Deferred** | Postponed (low priority or blocked) |
+| **Closed** | Won't implement (superseded or not needed) |
+
+### Conventions
+
+- **IP files**: `docs/implementationPlans/{Title-Case-Name}.md` (e.g. `Zoom-Integration-Mvp.md`)
+- **Template**: `docs/implementationPlans/IP_TEMPLATE.md`
+- **Task files**: `docs/tasks/{feature-name}.md` (created by Step 5: Generate)
+- **Commit format**: `IP-XXX: Brief description`
+- **Numbering**: Next number = highest across all index sections + 1
+- **Source of truth**: IP file status > index (if discrepancy, file wins)
+- **Archive**: Completed IPs move to `docs/implementationPlans/archive/`
+
+### Inline Annotations (`%%`)
+
+Lines starting with `%%` in any file are **inline annotations from the user**. When you encounter them:
+- Treat each `%%` annotation as a direct instruction
+- Address **every** `%%` annotation in the file; do not skip any
+- After acting on an annotation, remove the `%%` line from the file
+- If an annotation is ambiguous, ask for clarification before acting
+```
+
+#### Init Step 6: Init Summary
+
+Report what was created:
+
+```
+## IP Tracking Initialized
+
+### Files Created
+- `docs/implementationPlans/PLAN_INDEX.md` -- Plan index
+- `docs/implementationPlans/IP_TEMPLATE.md` -- IP file template (if not already present)
+- `docs/implementationPlans/archive/` -- Archive directory
+- `docs/tasks/` -- Task files directory
+- `CLAUDE.md` -- Updated with IP conventions
+
+### Next Steps
+1. Run /ip to create your first implementation plan from a PRD
+2. Run the Lifecycle: Status operation to check the current state
+```
+
+### Lifecycle: Explore
+
+General-purpose exploration of any project using the IP system. Uses parallel subagents to quickly build context.
+
+#### Step 1: Launch Parallel Subagents
+
+Launch these THREE subagents IN PARALLEL (single message with multiple Task tool calls):
+
+##### Agent 1: Project Overview
+
+Explore the project root to understand what this project is and how it works:
+
+1. **Read key docs** -- `CLAUDE.md`, `README.md`, any top-level docs
+2. **Directory structure** -- Glob for top-level files and key subdirectories
+3. **Tech stack** -- Identify languages, frameworks, build tools from config files (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `Makefile`, etc.)
+4. **Gotchas** -- Note any warnings, constraints, or non-obvious conventions from CLAUDE.md
+
+Return: project name, purpose, tech stack, directory layout, key gotchas.
+
+##### Agent 2: IP History
+
+Explore the implementation plan system to understand what's been built and what's planned:
+
+1. **Read index** -- `docs/implementationPlans/PLAN_INDEX.md`
+2. **Active IPs** -- Read each active IP file (non-Complete status)
+3. **Archived IPs** -- List files in `docs/implementationPlans/archive/` to understand completed work
+4. **Task files** -- List and scan `docs/tasks/` for active task lists
+5. **Recent IP commits** -- Search git log for commits matching `IP-` pattern (last 20)
+
+Return: active IPs table, count of archived IPs, active tasks summary, recent IP commit summary.
+
+##### Agent 3: Recent Activity
+
+Explore recent development activity to understand current momentum:
+
+1. **Recent commits** -- Last 15 commits with messages
+2. **Modified files** -- Files changed in the last 5 commits
+3. **Branch context** -- Current branch name and how far ahead of main
+4. **Uncommitted work** -- Check git status for staged/unstaged changes
+
+Return: recent commit summary, files in flux, branch status, open work.
+
+#### Step 2: Synthesize Results
+
+Combine all agent outputs into a single briefing:
+
+##### Project Overview
+- Name, purpose, tech stack (from Agent 1)
+- Key gotchas or constraints
+
+##### IP Status
+- Active plans table (from Agent 2)
+- Active tasks and progress
+- Archived count and notable completions
+
+##### Recent Activity
+- What's been happening (from Agent 3)
+- Current branch and open work
+
+##### Quick Reference
+
+| Item | Value |
+|------|-------|
+| **Project** | {name} |
+| **Branch** | {current branch} |
+| **Active IPs** | {count} |
+| **Active Tasks** | {count remaining} |
+| **Recent focus** | {summary of last few commits} |
+
+Use the current working directory as the project root.
+
+### Lifecycle: Deep Analysis
+
+Parallel exploration of a hard problem from multiple angles, inspired by test-time compute scaling. Use when stuck, when the problem is complex enough to benefit from diverse perspectives, or when you need "big brains" on something.
+
+Argument: problem description or context (`$ARGUMENTS`).
+
+#### Phase 1: Understand the Problem
+
+1. **Parse the argument** -- what is the user stuck on? What are they trying to achieve?
+2. **Gather context** -- read conversation history for what's already been tried or discussed
+3. **Check for active IP** -- if there's a relevant implementation plan, read it for design context
+4. **Scan the codebase** -- do a quick targeted search to understand the relevant code area (key files, architecture, constraints). Keep this brief -- the agents will do the deep exploration.
+
+#### Phase 2: Design the Exploration
+
+Based on the problem, design **4 exploration angles**. These are NOT redundant -- each agent gets a **distinct lens** on the problem.
+
+**Before launching, check orthogonality:** Would two of these angles likely explore the same code paths and reach similar conclusions? If so, reframe one to ensure genuine diversity.
+
+**How to choose angles -- infer from the problem type:**
+
+For **performance optimization**:
+- Algorithmic: Can the approach itself be fundamentally different?
+- Structural: Can the data layout, schema, or architecture reduce work?
+- Incremental: Can we avoid redoing work (caching, materialization, deltas)?
+- Environmental: Are we fighting the platform? (query patterns, Python GIL, network topology)
+
+For **architecture/design decisions**:
+- Simplicity: What's the minimal viable approach?
+- Scalability: What happens at 10x/100x current load?
+- Precedent: How do similar systems/libraries solve this?
+- Contrarian: What if the obvious approach is wrong? What's the unconventional path?
+
+For **debugging / "why is this broken"**:
+- Symptoms: Trace the failure path precisely -- what's the chain of events?
+- Environment: What changed? Versions, configs, data, dependencies?
+- Assumptions: What are we assuming that might not be true?
+- Similar: Has this pattern of failure been seen elsewhere in the codebase or in public?
+
+For **anything else** -- choose angles that maximize diversity of insight. Ask: "If these 4 experts were in a room, what different specialties would give me the most useful debate?"
+
+**For each angle, decide:**
+- What codebase areas the agent should explore (specific files, directories, patterns)
+- What question the agent should answer
+- How deep vs. broad the agent should go
+- What existing context (if any) to seed the agent with -- only what's necessary, avoid anchoring
+
+#### Phase 3: Launch Parallel Exploration
+
+**Briefly tell the user** what angles you're exploring (2-3 words each) -- then launch immediately. Don't wait for approval. Speed matters when stuck.
+
+Launch **4 Explore agents IN PARALLEL** (single message with 4 Task tool calls). Use `model: "opus"` explicitly on each agent to ensure heavyweight reasoning. Each agent gets:
+
+```
+You are exploring a specific angle of a hard problem. Your analysis is input to a multi-agent synthesis -- be precise, flag uncertainties, and show your evidence.
+
+## Problem
+{problem description}
+
+## Your Angle
+{specific lens -- what you're looking for, what question you're answering}
+
+## Where to Look (Starting Points)
+{specific files, directories, or search patterns to start with}
+
+These are entry points, not the complete scope. Follow evidence wherever it leads -- if the trail points to related code outside this list, explore it.
+
+## Key Constraint
+You have read-only tools (Glob, Grep, Read). Use them liberally. If you can't verify something exists, don't claim it. Better to say "I couldn't locate a config file for X" than to guess at its name or path.
+
+## Instructions
+- Use Glob, Grep, and Read to thoroughly explore the relevant code
+- Think deeply about your specific angle -- don't try to solve the whole problem
+- Look for evidence, patterns, constraints, and opportunities related to your angle
+- Note anything surprising or that contradicts assumptions
+- Be concrete -- reference specific files, functions, line numbers, data flows
+- If you find something important outside your angle, note it briefly but stay focused
+- Before you finalize: is there evidence that contradicts your recommendation? If yes, address it directly rather than ignore it
+
+## Output
+Return a focused analysis (aim for 600-1000 words):
+
+1. **Key findings** -- specific observations with evidence. For each finding, cite the file/line or code pattern that shows it's true. Avoid vague claims like "this is slow" -- show why.
+
+2. **Implications** -- what this means for the problem. For each implication, explain the logical link: if this finding is true, then we should try X because [reason].
+
+3. **Recommendation** -- your angle's proposed direction:
+   - **Proposed approach:** [specific, actionable idea]
+   - **Why this angle suggests it:** [link findings -> recommendation]
+   - **Tradeoffs:** [what you'd give up]
+   - **Key assumptions:** [what has to be true for this to work]
+   - **Biggest uncertainty:** [what would most change your mind]
+```
+
+#### Phase 4: Verify Key Claims
+
+Before synthesizing, two verification passes:
+
+##### Pass 1: Contradiction Detection
+
+Scan all 4 agent reports for **opposing claims**. Examples:
+- Agent A says "this runs synchronously" while Agent B says "this is async"
+- Agent A says "no index on this column" while Agent C assumes an index exists
+- Two agents recommend opposite directions
+
+Flag contradictions prominently. **Prioritize verifying contradicted claims first** -- these are where the highest-value corrections live.
+
+##### Pass 2: Factual Verification
+
+**Cross-check the most important factual claims** from the agents. Agents can hallucinate file paths, function signatures, config options, or behavioral assumptions.
+
+**What to verify:**
+- **File paths and function names** -- do the files/functions agents referenced actually exist? Spot-check with Glob/Grep.
+- **Behavioral claims** -- "this function does X" or "this config controls Y" -- Read the actual code for the 2-3 most critical claims that the recommendation will hinge on.
+- **Performance/complexity claims** -- if an agent says "this is O(n^2)" or "this query scans the full table," verify against the actual code or query plan.
+- **Assumption checks** -- if agents assumed something about the system (e.g., "this runs synchronously," "this table has an index on X"), verify the ones that matter most.
+
+**How to verify:**
+- Focus on the **top 3-5 claims that would change the recommendation if wrong**. Don't verify everything -- verify what matters.
+- Use Glob, Grep, and Read directly (no subagents -- this should be fast).
+- If a claim is wrong, note the correction. If it's right, move on.
+
+**Output:** Note any corrections or confirmations. Flag anything that was wrong -- this changes the synthesis.
+
+#### Phase 5: Synthesize
+
+After verification, synthesize the agents' findings (with corrections applied) into a single analysis. This is the critical step -- don't just concatenate.
+
+**Synthesis structure:**
+
+##### 1. Agreements
+Where do multiple angles converge? High-confidence insights.
+
+##### 2. Tensions
+Where do angles disagree or present tradeoffs? These are the real design decisions.
+
+##### 3. Surprises
+What did agents find that wasn't expected? Novel insights that change the framing.
+
+##### 4. Corrections
+Any agent claims that were wrong or misleading, and what the truth is. Be transparent -- this builds trust in the analysis.
+
+##### 5. Recommendation
+Your synthesized recommendation. Be opinionated -- rank the options, state which direction you'd go and why. Tag each element with confidence (High/Medium/Low) and a one-line justification. Include:
+- **Proposed approach** -- the synthesized best path forward
+- **Key tradeoffs** -- what you're giving up
+- **Risks** -- what could go wrong
+- **Key assumptions** -- what the recommendation depends on being true
+- **First step** -- the concrete next action
+
+##### 6. Assumption Check
+After drafting the recommendation, note what assumptions it hinges on. Verify those specific assumptions with a quick Glob/Grep/Read check. If any fail, flag them and reassess.
+
+##### 7. If applicable: IP Update
+If there's an active IP related to this problem, propose specific updates to the plan's relevant sections based on the analysis. Don't update the file -- present the proposed changes for the user to approve.
+
+#### Notes on Deep Analysis
+
+- **Agent count**: Always 4. Four distinct angles. No exceptions.
+- **Agent type**: Always use `subagent_type: "Explore"` with `model: "opus"` -- read-only research agents on the heaviest model.
+- **Thoroughness**: Tell agents to be "very thorough" in their Task descriptions.
+- **No anchoring**: Don't give agents each other's angles. They should explore independently.
+- **Speed over perfection**: The user is stuck. A good-enough synthesis in 2 minutes beats a perfect one in 10. Don't over-polish the output.
+
+### Lifecycle: Status
+
+Generate an up-to-date summary of active implementation plans.
+
+#### Fast Path vs Full Grooming
+
+**Decide which path to take based on conversation context:**
+
+##### Fast Path (just print the table)
+Use this when you are **confident the index is up to date** -- for example:
+- You've been working on IPs in this session (closing, creating, updating)
+- You just ran a full grooming pass recently
+- The user just asked you to "print the status"
+
+Simply read `docs/implementationPlans/PLAN_INDEX.md` and each active IP file, then output the table.
+
+##### Full Grooming (first invocation or uncertain state)
+Use this when you have **no context about the current state**:
+- Start of a new conversation
+- You haven't touched any IPs yet
+- The user explicitly asks for a grooming check
+
+Perform these housekeeping checks:
+
+###### 1. Status Sync Check
+- Read each active IP file and compare its `**Status:**` line to the index
+- If discrepancy, update the index to match the file (file is source of truth)
+- Report any discrepancies found and fixed
+
+###### 2. Archive Check
+- Look for IP files in `docs/implementationPlans/` (not in `archive/`) with status: Complete, Deferred, or Closed
+- For each such IP not yet archived:
+  - Move to `docs/implementationPlans/archive/`
+  - Ensure it's in the appropriate section of the index
+- Report any files archived
+
+###### 3. Orphan Check
+- Check if any IPs in the index don't have corresponding files
+- Check if any IP files exist that aren't in the index (exclude IP_TEMPLATE.md and PLAN_INDEX.md)
+- Report any orphans found
+
+###### 4. Task Progress Check
+- For each active IP, check if a corresponding task file exists in `docs/tasks/`
+- Count completed vs total tasks (checked vs unchecked checkboxes)
+- Include task progress in the output table
+
+#### Status Output
+
+Format the output as a markdown table:
+
+    ## Active Implementation Plans
+
+    | IP | Title | Status | Effort | Tasks | Description |
+    |----|-------|--------|--------|-------|-------------|
+    | IP-XXX | Title here | Status | Effort | 3/10 | Brief description |
+
+    **Total:** X active plans (Y design, Z open, W in progress)
+
+If full grooming was performed and changes were made, prepend a grooming report.
+
+Notes:
+- Keep descriptions concise (< 60 chars if possible)
+- Include a count summary at the bottom
+- Task column shows completed/total if task file exists, "-" otherwise
+
+### Lifecycle: Close
+
+Close an IP by marking it complete (or closed/deferred), archiving the file, and updating the index.
+
+Argument should contain:
+- **IP number or name** (required-ish): e.g. `1`, `IP-001`, or the plan filename slug
+- **Disposition** (optional): `complete` (default), `closed`, or `deferred`
+- **Notes** (optional): any additional context
+
+Examples:
+- close 1 -- mark IP-001 as Complete
+- close user-permissions deferred blocked on auth refactor -- mark by name, Deferred
+- close 3 closed superseded by IP-005 -- mark IP-003 as Closed
+- close (no args) -- infer from conversation context
+
+Parse the argument: `$ARGUMENTS`
+
+#### Inferring the IP
+
+If no IP number/name provided, infer from conversation context:
+- Look at which IP was most recently discussed or worked on
+- If exactly one IP is obvious, use it and state which one
+- If ambiguous, ask the user
+
+#### Close Steps
+
+##### 1. Find and read the IP file
+
+- Search `docs/implementationPlans/` for matching file (by IP number, Title-Case filename, or slug)
+- Read to get title, current status
+- If already archived or not found, report and stop
+
+##### 2. Update the IP file
+
+- Set `**Status:**` to `Complete`, `Closed`, or `Deferred`
+- For Complete: add `**Completed:** {today YYYY-MM-DD}` after Status
+- For Closed/Deferred: add `**Closed:** {today}` if not present
+
+##### 3. Update PLAN_INDEX.md
+
+- Read `docs/implementationPlans/PLAN_INDEX.md`
+- Remove IP's row from **Active Plans** table
+- Add to appropriate section:
+  - **Complete** -> add to top of `## Completed` table with date and notes
+  - **Closed/Deferred** -> add to top of `## Deferred / Closed` table with status and notes
+
+##### 4. Archive the files
+
+- Move IP file to `docs/implementationPlans/archive/`
+- If a corresponding task file exists in `docs/tasks/`, move it to `docs/implementationPlans/archive/` as well (or leave in place if tasks are still referenced)
+
+##### 5. Commit
+
+Commit all changes in a single atomic commit:
+- Check `git status` for uncommitted changes related to the IP implementation
+- Stage implementation files, archived IP, deleted original path, `PLAN_INDEX.md`
+- Commit with message: `IP-{number}: {title}`
+
+##### 6. Close Summary
+
+Report:
+- IP number and title
+- Disposition (Complete / Closed / Deferred)
+- Status updated in IP file
+- Moved from Active to the appropriate section in index
+- Archived to `docs/implementationPlans/archive/`
+- Committed: {short hash}
+
+## Submitting the IP
+
+Once the plan is finalized, use `/submit` to commit the IP files, push the branch, and create a PR on the target project's GitHub repo. The worktree is already on a dedicated branch, so `/submit` works directly.
+
+## Arguments
+
+$PROJECT: Project alias or `owner/repo` (required — if omitted, user is prompted to select from the registry)
+$STEP: Optional step to skip to (ingest, research, shape, plan, generate, acceptance, e2e, review, attack). Note: Step 0 (project setup) always runs regardless of $STEP.
+$PRD: Optional path to a PRD markdown file (skips the paste prompt in ingest step)

--- a/.claude/skills/respond-to-review/SKILL.md
+++ b/.claude/skills/respond-to-review/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: respond-to-review
+description: >-
+  Review PR comments, plan fixes, and implement — auto-submitting when no
+  clarifications are needed
+---
+# PR Review Response Workflow
+
+Review comments on PR #$ARGUMENTS and plan fixes. If the plan has open questions for the user, pause for confirmation; otherwise implement, commit, and run `/submit` automatically without prompting.
+
+## Step 1: Setup Working Directory
+
+1. Check if we're already in a git worktree:
+   ```bash
+   git rev-parse --show-toplevel
+   git worktree list
+   ```
+
+2. **If already in a worktree**, use the current directory — skip to Step 2.
+
+3. **If NOT in a worktree**, set one up:
+
+   a. Get the repo name:
+      ```bash
+      basename $(git rev-parse --show-toplevel)
+      ```
+
+   b. Fetch PR details and branch name:
+      ```bash
+      gh pr view $ARGUMENTS --json headRefName,number,title,url,author
+      ```
+
+   c. Fetch the PR branch:
+      ```bash
+      git fetch origin pull/$ARGUMENTS/head
+      ```
+
+   d. Create worktree at `~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS`:
+      ```bash
+      git worktree add ~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS FETCH_HEAD
+      ```
+
+   e. Change to the worktree directory:
+      ```bash
+      cd ~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS
+      ```
+
+   f. Set up tracking for the PR branch:
+      ```bash
+      git checkout -B <branch-name> FETCH_HEAD
+      git branch --set-upstream-to=origin/<branch-name>
+      ```
+
+**Important**: All subsequent work happens in the working directory (worktree or current).
+
+## Step 2: Find the Reviews
+
+1. Get review threads with resolution status using GraphQL. **Important**: capture the thread `id` for each unresolved thread so you can resolve them later.
+   ```bash
+   gh api graphql -f query='
+     query($owner: String!, $repo: String!, $pr: Int!) {
+       repository(owner: $owner, name: $repo) {
+         pullRequest(number: $pr) {
+           reviewThreads(first: 100) {
+             nodes {
+               id
+               isResolved
+               comments(first: 50) {
+                 nodes {
+                   author { login }
+                   body
+                   path
+                   line
+                   createdAt
+                 }
+               }
+             }
+           }
+           reviews(first: 50) {
+             nodes {
+               author { login }
+               state
+               body
+             }
+           }
+         }
+       }
+     }' -F owner=':owner' -F repo=':repo' -F pr=$ARGUMENTS
+   ```
+
+2. **Ignore resolved threads entirely** — only process threads where `isResolved` is `false`
+
+3. Filter to comments from other users (not the PR author)
+
+4. Identify which remaining comments are:
+   - Blocking (CHANGES_REQUESTED) vs suggestions
+   - Inline code comments vs general comments
+
+## Step 3: Decide What To Do & Propose a Plan
+
+Decide the right action for each unresolved comment (fix, skip, ask), then present a structured plan organized by priority:
+
+```
+## PR #$ARGUMENTS Review Comments Plan
+
+### 🔴 Must Fix (Blocking)
+1. [file:line] @reviewer: "comment text"
+   → Proposed fix: <description>
+
+### ⚠️ Should Address (Suggestions)
+2. [file:line] @reviewer: "comment text"
+   → Proposed fix: <description>
+
+### 💬 Questions/Clarifications Needed
+- Comment X: Need your input on approach
+- Comment Y: Conflicts with existing pattern, which to use?
+
+### 📝 Will Skip (N/A or out of scope)
+- Comment Z: Not applicable or out of scope
+
+### 💬 Suggested Replies to Human Commenters
+For any comments that warrant a reply (e.g., to clarify a decision or thank a reviewer):
+- **Print the suggested reply text** so the user can see it
+- **Never post replies** via `gh pr comment`, `gh api`, or any other method — leave posting to the user
+```
+
+## Step 4: Confirmation (only if there are open questions)
+
+**If the plan has any items under 💬 Questions/Clarifications Needed:**
+Ask: **"Need your input on the questions above. Anything else to change before I implement?"**
+- Wait for explicit approval before making any changes
+- Incorporate any feedback
+- Re-present plan if significant changes requested
+
+**If there are no open questions:** skip confirmation entirely. Proceed directly to Step 5 — implement, commit, run `/submit`, and resolve threads without further prompts. Do not ask the user for plan approval in this case.
+
+## Step 5: Make the Fix
+
+After approval:
+
+1. Implement fixes one at a time, in priority order
+2. After each fix, briefly confirm what was changed
+
+## Step 6: Show the diff
+
+Show the complete diff so the user can scan what was implemented:
+```bash
+git diff
+git diff --stat
+```
+
+Do **not** commit here. `/submit` (next step) handles pre-commit checks, staging, commit, push, and PR updates — running pre-commit *before* the commit, which is the correct order. Committing here would invert that order and leave broken code committed locally if pre-commit fails.
+
+## Step 7: Run /submit
+
+Invoke the `/submit` skill to handle pre-commit checks, commit, push, and PR updates. This will also launch the CI check-watcher in the background. Pass a `$DESCRIPTION` summarizing what review comments were addressed so the commit message reflects the work.
+
+## Step 8: Resolve Addressed Threads
+
+After `/submit` completes, resolve each review thread that was addressed in the implementation. Use the thread `id` captured in Step 2.
+
+For each thread that was fixed or addressed (from the "Must Fix" and "Should Address" categories in the plan):
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }' -f threadId="<thread_id>"
+```
+
+Do NOT resolve threads that were:
+- Skipped (marked as N/A or out of scope)
+- Questions/clarifications that were not answered by code changes
+- Threads where the user decided not to take action
+
+Report which threads were resolved and which were left open.
+
+---
+
+## Error Handling
+
+- If worktree already exists, ask if user wants to reset it or use existing
+- If PR not found, show error and available PRs: `gh pr list`
+- If no comments found, inform user and ask if they want to proceed anyway
+- If merge conflicts occur during implementation, pause and ask for guidance
+
+## Cleanup Reminder
+
+If a new worktree was created, remind user:
+```
+To remove this worktree later:
+  git worktree remove ~/.claude-worktrees/<repo>/pr-$ARGUMENTS
+
+Or to keep working on it, you can open a new Claude session in:
+  cd ~/.claude-worktrees/<repo>/pr-$ARGUMENTS
+```

--- a/.claude/skills/submit/SKILL.md
+++ b/.claude/skills/submit/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: submit
+description: >-
+  Lightweight pre-commit + commit + push + create/update PR, then spawn
+  check-watcher in the background. Use /fullsend for the full pipeline with code
+  review.
+---
+# Submit: Quick Commit & PR
+
+Lightweight path to run pre-commit checks, commit, push, and monitor CI. After pushing, this skill launches `/check-watcher` as a background sub-agent so CI is watched without blocking. Use `/fullsend` for the full pipeline that also includes code review.
+
+## Step 1: Assess Changes
+
+```bash
+git status && git diff --stat
+```
+
+```bash
+gh pr view --json number -q .number 2>/dev/null || echo "no-pr"
+```
+
+## Step 1.5: Pre-Commit Checks
+
+Delegate lint, type check, and related tests to the `pre-commit` subagent before committing.
+
+Use the `Agent` tool:
+- `subagent_type`: `pre-commit`
+- `description`: `Run pre-commit checks`
+- `prompt`: instruct it to run lint, compile, and related tests for the current project, fix any issues, and report back. Mention this is being run as part of `/submit` for an upcoming commit.
+
+Wait for the subagent to return its Pre-Commit Report. If it surfaces unfixable failures, STOP and report them — do not commit or push.
+
+If invoked from `/fullsend` (which already ran pre-commit), skip this step.
+
+## Step 2: Commit
+
+Stage and commit:
+- Review the diff to write an accurate message
+- Keep first line under 72 characters
+- No conventional commit prefixes
+- No AI attribution
+
+## Step 3: Push
+
+```bash
+git push origin HEAD
+```
+
+## Step 4: Create or Update PR
+
+### If no PR exists
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+[What changed and why — 2-4 sentences]
+
+## Human Testing Steps
+- [ ] [Step-by-step verification instructions]
+
+## Changes
+- [Bullet list of specific changes]
+
+## Automated Tests
+- [Tests that ran and passed, or "None"]
+EOF
+)" --draft
+```
+
+### If a PR already exists
+
+Read the current title and body, then compare against the full set of commits on the branch:
+
+```bash
+gh pr view --json title,body,baseRefName
+git log $(gh pr view --json baseRefName -q .baseRefName)..HEAD --oneline
+git diff $(gh pr view --json baseRefName -q .baseRefName)...HEAD --stat
+```
+
+Decide whether the description still reflects what's on the branch — pay attention to commits added since the PR was opened:
+- **Summary** still matches the actual goal of the changes
+- **Changes** list covers the new commits, not just the original ones
+- **Human Testing Steps** still cover what reviewers need to verify
+- **Automated Tests** section reflects current test state
+
+If the description is stale or incomplete, update it. Preserve sections the user has clearly edited by hand — only rewrite what's actually out of date, and merge new bullets into existing lists rather than replacing them wholesale:
+
+```bash
+gh pr edit --title "<title>" --body "$(cat <<'EOF'
+<updated body>
+EOF
+)"
+```
+
+If the description is already accurate, skip the edit and note that it's up to date.
+
+## Step 5: Print PR Link
+
+```bash
+gh pr view --json title,url -q '"**\(.title)** — \(.url)"'
+```
+
+## Step 6: Launch Check Watcher Sub-Agent
+
+Spawn `/check-watcher` as a **background sub-agent** so CI monitoring runs autonomously without blocking the parent conversation. Use the `Agent` tool with `run_in_background: true`.
+
+- `subagent_type`: `general-purpose`
+- `description`: `Watch CI for current PR`
+- `run_in_background`: `true`
+- `prompt`: instruct the sub-agent to invoke the `/check-watcher` skill for the current PR, fix any failures, and report back when checks are green or max attempts are hit. Include the PR number/URL from Step 5 so the sub-agent has context.
+
+Do **not** wait on the sub-agent — return control immediately after spawning. The user will be notified when it completes.
+
+By the time you reach this step, a PR is guaranteed to exist — either it pre-existed (from Step 1) or Step 4 just created it. Always spawn check-watcher.
+
+## Arguments
+
+$DESCRIPTION: Optional description to guide the commit message and PR

--- a/.cursor/skills/ai-prompt-governance/SKILL.md
+++ b/.cursor/skills/ai-prompt-governance/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: ai-prompt-governance
+description: Invoke when adding, modifying, or reviewing any prompt used by `@terreno/ai` (AIService methods, system prompts, helpers). Provides prompt-as-constant rules, temperature preset guidance, logging requirements, and a testing checklist.
+---
+# AI Prompt Governance — `@terreno/ai`
+
+`@terreno/ai` is a backend-only, provider-agnostic AI layer built on the Vercel AI SDK. Consuming apps inject a `LanguageModel` (Google, Anthropic, OpenAI, etc.) and call `AIService` methods. All requests are logged through the `AIRequest` model.
+
+See `ai/src/service/aiService.ts` and `ai/src/service/prompts.ts` for the canonical implementation.
+
+## Prompt Writing Rules
+
+1. **Always a named constant** — Define prompts in `ai/src/service/prompts.ts` (or the consuming app's equivalent constants file). Never inline prompt strings in route handlers, services, or `AIService` method bodies.
+2. **Self-contained** — A prompt should read coherently on its own. If you must inject runtime context, document why in a comment above the constant.
+3. **Typed return** — If the prompt asks for structured JSON, define a matching TypeScript interface in `ai/src/types/index.ts` and parse against it on every response.
+4. **Don't bake user-identifiable data into the prompt template itself** — inject it at call time as runtime parameters, never as defaults in the constant.
+
+## Temperature Preset Guidance
+
+Use the presets exported from `@terreno/ai`:
+
+| Preset | Value | When to use |
+|--------|-------|-------------|
+| `DETERMINISTIC` | 0 | Structured extraction, classification, deterministic transforms |
+| `LOW` | 0.3 | Summarization, translation, faithful rewording |
+| `BALANCED` | 0.7 | General Q&A, balanced creativity |
+| `DEFAULT` | 1.0 | Chat, open-ended responses |
+| `HIGH` | 1.5 | Brainstorming, creative variation |
+| `MAXIMUM` | 2.0 | Maximum variability — rarely the right choice |
+
+Pick the lowest temperature that still produces good results. Don't override the default unless you can name a reason in the call site.
+
+## Logging
+
+Every `AIService` method already logs to the `AIRequest` model via the internal `logRequest()` call. Do not bypass `AIService` and call the Vercel SDK directly from routes — you lose request logging, error capture, and the `requestType` taxonomy.
+
+Current `AIRequest.requestType` values: `"general" | "remix" | "summarization" | "translation"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
+
+Logging failures must never break the main flow — the existing pattern catches and logs internally. Preserve that behavior.
+
+## Testing a Prompt Change
+
+`@terreno/ai` tests inject a mock `LanguageModel` with `doGenerate` / `doStream` methods. See the mock pattern in `ai/src/aiApp.test.ts`. Never hit a live provider in unit tests.
+
+1. Add or update a unit test that mocks `doGenerate` / `doStream` and asserts the prompt your code sends matches expectations.
+2. Run against at least 3 inputs:
+   - A normal/expected case
+   - An edge case (empty input, very long input, missing optional fields)
+   - An adversarial case that could break structured JSON output
+3. For structured JSON: assert the response parses against the typed return interface.
+4. If the prompt affects streaming behavior, mock `doStream` and assert the emitted chunks.
+
+For a one-off manual smoke against a real provider, temporarily add `logger.debug("prompt test", {prompt, response})` in the `AIService` method, run locally, then remove the log before committing.
+
+## Prompt Change Checklist
+
+- [ ] Prompt is a named constant in `prompts.ts` (or app equivalent) — not inlined
+- [ ] Prompt still produces valid, parseable structured JSON if applicable (tested with 3+ inputs)
+- [ ] Temperature preset is appropriate (lowest viable for the task)
+- [ ] Call goes through `AIService` (so `AIRequest` logging fires) — no direct Vercel SDK calls from routes
+- [ ] If `requestType` taxonomy changed, the type union and admin explorer filters were updated
+- [ ] No user-identifiable data baked into the prompt template (only injected at call time)
+- [ ] Unit test added/updated with a mock model
+- [ ] Commit message explains the behavioral change (the prompt is the behavior)
+
+## Adding a New AI Feature
+
+1. Define prompt(s) as named constants in `ai/src/service/prompts.ts`.
+2. If structured JSON output, define the TypeScript interface for the return shape in `ai/src/types/index.ts`.
+3. Add a method to `AIService` (or a new service class) that calls `generateText` / `generateTextStream` and goes through the existing logging path.
+4. If exposing via HTTP, add a route in `ai/src/routes/` following the patterns in `gpt.ts` / `gptHistories.ts`. Use `createOpenApiBuilder` for OpenAPI docs.
+5. Add an integration test with a mock model that verifies:
+   - The prompt sent to the model matches the constant
+   - The structured JSON return parses against the typed interface
+   - `AIRequest.logRequest` is called with the correct `requestType`
+
+## Common Pitfalls
+
+- Calling the Vercel SDK directly from a route — bypasses logging and request typing
+- Inlining a prompt string in a route handler — makes future changes invisible and untestable
+- Using the wrong `requestType` value (or `"general"` as a catch-all) — degrades the admin explorer
+- Setting `temperature` numerically instead of via a preset — drifts away from the documented presets
+- Forgetting to type the JSON return — runtime parse failures show up later as confusing errors

--- a/.cursor/skills/backend-test-env/SKILL.md
+++ b/.cursor/skills/backend-test-env/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: backend-test-env
+description: Invoke when writing tests that mutate `process.env` in `@terreno/api`, `@terreno/ai`, or `example-backend` — feature flags, auth secrets, integration toggles. Covers the preload contract, `setupEnvironment()`, and safe mutation patterns.
+---
+# Backend Test — `process.env` Contract
+
+Bun's test runner preloads a per-package setup file (configured in each package's `bunfig.toml` under `[test].preload`):
+
+| Package | Preload file |
+|---------|--------------|
+| `@terreno/api` | `api/src/tests/bunSetup.ts` |
+| `@terreno/ai` | `ai/src/tests/bunSetup.ts` |
+| `example-backend` | `example-backend/src/tests/setup.ts` |
+
+The `@terreno/api` preload uses a global `beforeEach` to (1) reset the canonical auth secrets, (2) call `setupEnvironment()` (exported from `expressServer.ts`) for the wider baseline, and (3) re-silence the winston loggers. The next test always starts from the canonical baseline — you normally **do not** need to re-call `setupEnvironment()` in a file-level `beforeEach`.
+
+## Default — Rely on the Preload
+
+- Do not assume a toggle left by another file. Treat the preload's `beforeEach` as the source of truth for the canonical baseline.
+- Set only the keys this test needs in its own `beforeEach` or test body.
+- Don't reach in and call `setupEnvironment()` again unless you're explicitly testing env-driven behavior that the preload didn't cover.
+
+## When a Test Mutates `process.env`
+
+1. **Add the key to the preload's reset list** if it should always start from a fixed test value. Otherwise it leaks into the next test in the same worker.
+2. **Set only what this case needs** in the test body — avoid redundant manual restore if the preload already resets that key in `beforeEach`.
+3. **For keys that should be absent (unset)**, use **`Reflect.deleteProperty(process.env, "KEY")`**. Avoid `process.env.KEY = ""` to mean "unset" — on some platforms empty string and unset behave differently and can make tests flaky.
+4. **Avoid whole-env snapshots** (`const OLD_ENV = process.env; ...; process.env = OLD_ENV;`). This pattern exists in some older test files (`auth.test.ts`) — don't propagate it. It captures pre-`beforeEach` state and breaks ordering guarantees if the preload's `beforeEach` runs in between. Use targeted mutations + the preload's reset instead.
+
+## Adding a New Required Env Var
+
+If you introduce a new `process.env.FOO` that backend code reads at startup:
+
+1. Add `FOO` to `setupEnvironment()` in `api/src/expressServer.ts` so every package picks it up via the preload's `setupEnvironment()` call.
+2. If `example-backend` has its own startup needs for it, also add to `example-backend/src/tests/setup.ts`'s `beforeAll`.
+3. If a test needs to mutate it, follow the rules above — don't snapshot the whole env.
+
+## Auth-Related Keys
+
+`api/src/tests/bunSetup.ts` resets four auth keys in `beforeEach`: `TOKEN_SECRET`, `TOKEN_ISSUER`, `SESSION_SECRET`, `REFRESH_TOKEN_SECRET`. If your test changes any of these, you do not need to restore — the next `beforeEach` already does. If your test relies on them being **absent** for a code path, use `Reflect.deleteProperty` within the test, knowing the next `beforeEach` will restore.
+
+`auth.test.ts` is the established home for env-driven auth assertions; mirror its newer patterns (per-test `beforeEach` setting only what changes) rather than its older whole-env-snapshot blocks.
+
+## Log Capture & Sentry
+
+The preload silences winston and `console.*` and captures into an in-memory buffer (cleared in `beforeEach`/`afterEach`). It also mocks `@sentry/bun`. Don't re-mock Sentry inside individual tests — the preload's mock is shared and reset across tests.
+
+## Checklist
+
+- [ ] New env var added to `setupEnvironment()` and (if needed) `example-backend/src/tests/setup.ts`
+- [ ] Test mutations are targeted — no whole-env snapshots
+- [ ] "Unset" expressed as `Reflect.deleteProperty(process.env, "KEY")`, not `= ""`
+- [ ] No manual restore that duplicates the preload's `beforeEach` reset
+- [ ] No re-mock of `@sentry/bun` — the preload's mock is already in place
+- [ ] If you added an env-driven branch in code, a test covers both the set and the unset case

--- a/.cursor/skills/check-watcher/SKILL.md
+++ b/.cursor/skills/check-watcher/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: check-watcher
+description: Monitor GitHub Actions checks and automatically fix failures
+---
+# Check Watcher
+
+Monitor GitHub Actions checks and auto-fix failures. Designed to be called standalone or from other skills.
+
+## Instructions
+
+1. Get the PR number:
+   ```bash
+   gh pr view --json number -q .number
+   ```
+   If no PR exists, inform the user and exit.
+
+2. Wait for CI to finish using `--watch` (no manual polling):
+   ```bash
+   gh pr checks --watch --fail-fast
+   ```
+   - All passing → go to step 6
+   - Failed → continue to step 3
+
+3. Get failure details:
+   ```bash
+   gh run view <run-id> --log-failed
+   ```
+
+4. Determine if flaky or real:
+   - Compare failed files/tests against `gh pr diff` — is the failure in code you changed?
+   - Check for flaky signals: timeouts, race conditions, ECONNRESET, intermittent assertions
+   - If flaky (not in your code + flaky signals), rerun once: `gh run rerun <run-id> --failed`
+   - Run `gh pr checks --watch --fail-fast` again. If still failing, file an issue and move on:
+     ```bash
+     gh issue create --title "Flaky test: <test name>" --body "<error details and job link>"
+     ```
+
+5. If failure IS related to PR changes:
+   - Fix the code
+   - Run lint and compile locally to validate
+   - Commit and push (no AI attribution, no conventional prefixes)
+   - Return to step 2
+
+6. When all checks pass, check for bot review comments:
+   ```bash
+   gh api repos/:owner/:repo/pulls/<pr_number>/comments --jq '.[] | select(.user.type == "Bot") | "\(.path):\(.line) @\(.user.login): \(.body)"'
+   ```
+   Report any actionable bot comments found. Do NOT auto-fix — just report them.
+
+7. Print the PR link:
+   ```bash
+   gh pr view --json title,url -q '"**\(.title)** — \(.url)"'
+   ```
+
+Cap fix attempts at $MAX_ATTEMPTS (default: 5).
+
+## Arguments
+
+$MAX_ATTEMPTS: Optional max fix attempts before stopping (default: 5)

--- a/.cursor/skills/commit/SKILL.md
+++ b/.cursor/skills/commit/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: commit
+description: Create a commit for the current staged/unstaged changes with a clear, accurate message
+---
+# Commit Changes
+
+Create a commit for the current staged/unstaged changes.
+
+## Instructions
+
+1. Check git status and diff to understand what changed:
+   ```
+   git status
+   git diff
+   git diff --cached
+   ```
+
+
+2. Stage changes appropriately and create a commit:
+   - Review the actual changes to write an accurate commit message
+
+   **Message Format:**
+   - The first line must be under 72 characters
+   - Add a body if more context is needed
+   - Exclude conventional commit prefixes (feat:, fix:, chore:, etc.)
+
+   **Content Restrictions:**
+   - Exclude any mention of AI, Claude, or any AI assistant
+   - Exclude making the commit coauthored by any AI
+   - Exclude adding "Co-Authored-By" trailers
+
+   *If constraints conflict, prioritize Message Format for clarity and readability.*
+
+3. Never push unless explicitly asked.
+
+## Arguments
+
+$DESCRIPTION: Optional description to guide the commit message

--- a/.cursor/skills/create-pr/SKILL.md
+++ b/.cursor/skills/create-pr/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: create-pr
+description: Create a draft pull request for the current branch
+---
+# Create Pull Request
+
+Create a pull request for the current branch.
+
+## Instructions
+
+1. First ensure changes are committed and pushed:
+   ```
+   git status
+   git log origin/master..HEAD --oneline
+   ```
+
+2. If there are uncommitted changes, commit them first (run `/commit` command).
+
+3. Push the branch if not already pushed:
+   ```
+   git push origin HEAD
+   ```
+
+4. Create the pull request:
+   ```
+   gh pr create --title "<title>" --body "<body>" --draft
+   ```
+
+   Guidelines for the PR:
+   - Title: Clear, concise summary of the changes
+   - Do not use prefix commit format (feat:, fix:, chore:, etc.)
+   - Do not mention AI, Claude, or any AI assistant in the title or body
+   - Do not add "Generated with Claude" or similar footers
+   - Always create as draft
+
+   **PR Body Structure:**
+
+   ```markdown
+   ## Summary
+
+   [What changed and why — 2-4 sentences]
+
+   ## Human Testing Steps
+
+   - [ ] [Step-by-step instructions a reviewer can follow to verify the change works]
+   - [ ] [Cover happy path and at least one edge case]
+
+   ## Changes
+
+   - [Bullet list of specific changes]
+
+   ## Automated Tests
+
+   - [Tests that ran and passed, or "No automated tests"]
+   ```
+
+5. Return the PR URL to the user.
+
+## Arguments
+
+$DESCRIPTION: Optional description for the PR title and body

--- a/.cursor/skills/fix-conflicts/SKILL.md
+++ b/.cursor/skills/fix-conflicts/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: fix-conflicts
+description: Pull latest from master, resolve merge conflicts, validate with lint/compile checks, and monitor CI
+---
+# Fix Conflicts
+
+Pull latest from master, resolve merge conflicts, validate with lint/compile checks, and monitor CI.
+
+## Instructions
+
+1. Ensure the working tree is clean before starting:
+   ```
+   git status
+   ```
+   - If there are uncommitted changes, ask the user whether to stash them or abort
+
+2. Fetch and merge the latest master into the current branch:
+   ```
+   git fetch origin master
+   git merge origin/master
+   ```
+   - If the fetch or merge fails, check network connectivity and repository access permissions. Notify the user if the issue persists.
+
+3. Check for merge conflicts:
+   ```
+   git diff --name-only --diff-filter=U
+   ```
+   - If there are no conflicts, skip to step 5
+
+4. For each conflicted file:
+    - Read the file and understand both sides of the conflict
+    - Resolve the conflict by combining changes in a way that retains the functionality and purpose of both sets of changes, ensuring no critical information is lost.
+    - If the conflict cannot be resolved automatically, notify the user and provide a summary of the conflicting changes.
+    - After resolving all conflicts in a file, stage it:
+       ```
+       git add <file>
+       ```
+    - After all conflicts are resolved, complete the merge:
+       ```
+       git commit --no-edit
+       ```
+
+## Running Checks
+
+5. Run lint and compile checks at the project root:
+    ```
+    git rev-parse --show-toplevel
+    ```
+    - Run linting:
+       ```
+       cd <project-root> && bun run lint
+       ```
+       - If linting fails, fix the issues and re-run until passing
+    - Run type compilation/checking:
+       ```
+       cd <project-root> && bun run compile
+       ```
+       - If compilation fails, fix the type errors and re-run until passing
+    - If linting or compilation fails repeatedly and cannot be resolved, notify the user with the error details and suggest seeking assistance.
+
+## Handling Fixes and Commits
+
+6. If any fixes were needed in step 5, stage and commit them:
+   - Review the changes made
+   - Create a commit with a clear message describing what was fixed
+   - In step 6, do not use prefix commit format (feat:, fix:, chore:, etc.) for the commit message.
+   - Do not mention AI, Claude, or any AI assistant
+
+7. Push the changes:
+   ```
+   git push origin HEAD
+   ```
+
+8. Run check-watcher by invoking `/check-watcher`:
+   - This monitors GitHub Actions checks
+   - If checks fail, it will automatically read failures, fix them, and push again
+   - Continue until all checks pass
+
+## Arguments
+
+None

--- a/.cursor/skills/implement/SKILL.md
+++ b/.cursor/skills/implement/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: implement
+description: Test-driven implementation execution skill for applying implementation plans directly in code
+---
+# Implementation Execution Skill
+
+Use this skill when an Implementation Plan (IP) or implementation requirements are provided.
+
+
+The goal of this skill is to execute the implementation directly in code using test-driven development.
+
+If the implementation plan is incomplete or contains contradictions, highlight the conflicts and request clarification before proceeding.
+
+Do not stop after analysis or task generation unless blocked by material ambiguity.
+
+## Primary Behavior
+
+When an IP is provided:
+
+1. Read the full IP carefully.
+2. Determine implementation scope.
+3. Identify the smallest meaningful automated test coverage that should fail for the requested behavior.
+4. Write or update the failing tests before implementation code.
+5. Run the targeted tests and confirm they fail for the expected product reason, not because of syntax, setup, or unrelated failures.
+6. Implement the requested changes directly.
+7. Run the previously failing tests until they pass.
+8. Run relevant validation or broader test commands when available.
+9. Summarize completed work, assumptions, and remaining risks.
+
+Exclude generating a separate implementation plan unless explicitly requested.
+
+## Scope Detection
+
+Determine whether the implementation is:
+
+- backend only
+- frontend only
+- full stack
+- phased implementation
+- rollout-gated
+- migration-dependent
+
+
+// --- Assumption Rules ---
+Use best-effort assumptions when the assumption does not affect compliance, data integrity, or user experience.
+
+If the correct scope is unclear and could materially change implementation, ask concise clarifying questions before coding.
+
+## Clarifying Question Rules
+
+Only ask questions if missing information would materially affect:
+
+- architecture
+- data model behavior
+- API contracts
+- permissions/access control
+- user/admin visibility
+- rollout sequencing
+- migration/backfill behavior
+- destructive operations
+- compliance-sensitive behavior
+- whether implementation should be backend only, frontend only, phased, or full stack
+
+// --- Clarifying Question Exclusions ---
+Exclude asking questions for implementation details that do not affect functionality, performance, or compliance, and can reasonably be inferred.
+
+
+## Execution Expectations
+
+Implement the requested behavior directly in the codebase.
+
+### Test-Driven Development Flow
+
+Default to red/green/refactor:
+
+- red: write the focused failing test or regression test first
+- green: implement only enough production code to satisfy the requested behavior
+- refactor: clean up the implementation while preserving passing tests
+
+If no meaningful automated test can be written for the change, document why before implementation and use the strongest available manual or static validation instead.
+
+### Implementation Steps
+- update or add focused failing tests
+- update schemas/models
+- update services/controllers/routes
+- update validation
+- update frontend UI
+- update state management/API hooks
+- update OpenAPI/types
+- update permissions/visibility logic
+- update feature flags
+- update fixtures/mocks
+- rerun the focused tests that failed first
+- run broader validation when appropriate
+- preserve existing behavior unless the IP explicitly changes it
+
+## Phased Implementations
+
+If the IP implies phased implementation:
+
+- determine whether backend and frontend should be separated
+- determine whether rollout gating is required
+- determine whether app-version compatibility matters
+
+If phase requirements are unclear and could affect implementation safety, ask before coding.
+
+Otherwise proceed with best-effort assumptions.
+
+## Testing Requirements
+
+Add or update relevant tests before production implementation whenever applicable.
+
+Possible test types include:
+
+- backend unit tests
+- backend integration tests
+- API tests
+- frontend component tests
+- frontend flow tests
+- regression tests
+
+Run the most targeted available tests first and capture the initial failure before writing production code. After implementation, rerun the same focused tests to confirm the red-to-green transition.
+
+If full test execution is not practical, run the closest focused validation possible and document what was not run.
+
+## File Modification Rules
+
+Prefer modifying existing patterns consistently with the codebase.
+
+Avoid introducing new architectural patterns unless required.
+
+Do not invent exact file paths unless strongly implied by the repository structure.
+
+Prefer consistency over novelty.
+
+## Safety Rules
+
+Do not make destructive or irreversible changes without clear instruction.
+
+Do not silently change existing product behavior outside the requested scope.
+
+If implementation could create compliance, privacy, permission, or rollout risk, explicitly call it out in the final response.
+
+## Final Response Requirements
+
+At completion, summarize:
+
+- implementation scope
+- major code changes
+- assumptions made
+- tests updated/run
+- remaining risks or follow-up work
+
+Keep the summary concise and implementation-focused.

--- a/.cursor/skills/improve-rulesync/SKILL.md
+++ b/.cursor/skills/improve-rulesync/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: improve-rulesync
+description: Invoke at the end of a session to evaluate whether any skills or rules were misleading, incorrect, or missing — and fix or create them. Trigger with /improve-rulesync.
+---
+# Improve Rulesync
+
+### Trigger
+Invoke explicitly at the end of a session with `/improve-rulesync`.
+
+### Behavior
+Review the current conversation session and evaluate the skills and rules in `.rulesync/`. Identify any that:
+- Gave misleading or incorrect guidance that caused errors or rework
+- Were missing and would have prevented incorrect behavior
+- Need to be updated to reflect decisions or patterns established in this session
+
+Then make the changes directly.
+
+### Step 1 — Session Review
+Scan the session for:
+- Moments where a skill or rule was followed but produced a wrong or suboptimal result
+- User corrections or decisions about AI model behavior (these indicate a gap or error in the rules)
+- New patterns, decisions, or constraints established that should be codified
+
+### Step 2 — Rules Audit
+Check `.rulesync/` for relevant existing rules and skills. Evaluate:
+- Are trigger conditions accurate?
+- Is the guidance still correct given what happened this session?
+- Are there gaps that caused confusion?
+
+### Step 3 — Make Changes
+For each issue found:
+- **Incorrect/misleading**: Edit the existing file to fix it
+- **Missing**: Create a new skill or rule file in `.rulesync/skills/` or `.rulesync/rules/`
+- **Outdated**: Update or remove the stale content
+
+Always edit `.rulesync/` as the source of truth.
+
+### Step 4 — Sync
+After all changes, run `bun run rules` to sync to all AI tool directories.
+
+### Step 5 — Summary
+Output a brief summary of what was changed and why. Format:
+- **Fixed**: [file] — [what was wrong and what was corrected]
+- **Created**: [file] — [what gap it fills]
+- **No changes needed**: [reason]

--- a/.cursor/skills/ip/SKILL.md
+++ b/.cursor/skills/ip/SKILL.md
@@ -1,0 +1,1557 @@
+---
+name: ip
+description: Implementation Plan (/ip) — build an implementation plan from a PRD through an interactive, multi-step process
+---
+# Implementation Plan (/ip)
+
+Build an implementation plan from a PRD through an interactive, multi-step process. Produces both a human-readable implementation plan and a structured task list for bot consumption.
+
+## Overview
+
+This skill walks through the Shape Up-inspired process of turning a raw PRD into a concrete implementation plan. Each step is a self-contained section in this file — you can re-run individual steps if needed by jumping to the matching section.
+
+**Every IP targets a specific project.** The project must be specified via the `$PROJECT` argument or selected interactively.
+
+## Project Registry
+
+| Alias(es) | GitHub Repo | Local Dir |
+|-----------|-------------|-----------|
+| `ter`, `terreno` | `flourishhealth/terreno` | `~/src/terreno` |
+
+Local Dir is derived from the repo name (the part after `/`). All repos clone into `~/src/`.
+
+If a project isn't in the registry, attempt to resolve it via `gh repo view <input>`. If found, use it. If not, ask the user for the full `owner/repo`.
+
+## Planning Workflow
+
+Run the following steps in order. Each step builds on the previous one.
+
+### Step 0: Project Setup (always runs first)
+
+This step is **mandatory** and runs before everything else, even when `$STEP` is provided.
+
+#### 0a. GitHub Auth Check
+
+```bash
+gh auth status
+```
+
+If not authenticated, tell the user:
+> You need to authenticate with GitHub. Run this in your terminal:
+> `! gh auth login --web`
+> Follow the prompts to open the browser link and enter the code.
+
+Then **stop** — do not proceed until the user confirms auth is complete.
+
+#### 0b. Resolve Project
+
+If `$PROJECT` was provided, match it against the registry aliases (case-insensitive). If no `$PROJECT`, show the registry table and ask the user to pick one.
+
+#### 0c. Clone if Needed
+
+Check if the local directory exists:
+```bash
+ls -d ~/src/{repo-name} 2>/dev/null
+```
+
+If it doesn't exist, clone it:
+```bash
+gh repo clone {owner/repo} ~/src/{repo-name}
+```
+
+#### 0d. Fetch Latest & Enter Worktree
+
+Navigate to the repo and ensure we have the latest code:
+```bash
+cd ~/src/{repo-name} && git fetch origin && git checkout master && git pull origin master
+```
+
+(If the default branch is `main` instead of `master`, detect it with `git remote show origin | grep 'HEAD branch'` and use that.)
+
+Then create a worktree for this IP using the `EnterWorktree` tool:
+- **name**: `ip-{feature-slug}` (derive from the PRD title once known, or use a temporary name like `ip-draft` and note that it can be renamed)
+
+Since the PRD title isn't known yet at this point, use `ip-draft` as the worktree name. After Step 1 (Ingest), if the worktree name doesn't match the feature, note the mismatch but continue — the branch can be renamed later.
+
+#### 0e. Confirm Ready
+
+Print a summary:
+```
+Project: {repo-name} ({owner/repo})
+Branch: {worktree-branch}
+Working dir: {worktree-path}
+Latest master: {short SHA + date of HEAD}
+```
+
+Proceed to Step 1.
+
+### Step 1: Ingest PRD
+
+Collect the PRD (Product Requirements Document) that will drive the implementation plan.
+
+1. `$PRD` is **required**. If it was not provided, stop immediately and tell the user: **"Error: /ip requires a PRD as the first argument (either a file path or the inline PRD text). Please re-run as `/ip <path-or-text>`."** Do not prompt for it interactively.
+
+2. Determine what the user provided:
+   - If it looks like a file path (e.g., ends in `.md`, `.txt`, contains `/` or `\`, or matches an existing file), read that file and use its contents as the PRD.
+   - Otherwise, treat the input as the PRD text itself.
+
+3. The PRD should contain at minimum a **Problem** section and ideally a **Business Case** section. If either is missing, note what's missing but proceed anyway.
+
+4. Display a brief summary of what you understood from the PRD:
+   - The core problem (1-2 sentences)
+   - The business impact (1-2 sentences)
+   - Key stakeholders or affected teams
+   - Any constraints or requirements called out
+
+5. Ask: "Does this summary capture the intent? Anything to add or correct?" and let the user adjust before moving on.
+
+6. Once confirmed, say: **"PRD ingested. Moving to research phase..."** and proceed to Step 2.
+
+### Step 2: Research Context
+
+Investigate the codebase and gather context for the PRD topic. Do this inline — do not invoke `/research` via the Skill tool. Follow this procedure:
+
+1. **Scope** — restate the topic in one sentence and tell the user what you plan to investigate. Ask if they want anything specific covered.
+2. **Codebase deep dive** — read relevant source files in depth (models, routes, screens, components, configs, tests). Search for existing patterns, conventions, and dependencies. Check `docs/`, `README.md`, `CLAUDE.md`, and any feature documentation. Note file paths, function names, and line numbers as you go.
+3. **External research** — search the web for any APIs, libraries, or best practices that aren't already in the codebase.
+4. **Present findings** — output a complete research document in chat with: Summary, Context, Findings (with file paths and snippets), Options Considered (table with pros/cons/effort), Recommendation (be opinionated), Open Questions, References.
+5. **Iterate** — ask "Anything you want me to dig deeper on, adjust, or investigate further?" If the user gives feedback, investigate and re-output the **full** updated document.
+6. **Save** — once the user is satisfied, write the final version to `research.md` in the project root and continue to Step 3.
+
+Be specific (file paths, line numbers, code snippets) and opinionated (recommend an approach, don't just list options).
+
+### Step 3: Shape & Question
+
+This is the core shaping step inspired by the Shape Up methodology. The goal is to narrow the solution from a raw idea to a well-defined approach with clear boundaries.
+
+#### Phase 1: Models & APIs (get alignment first)
+
+This is the most important part. Models and APIs define the shape of the feature — everything else follows from them.
+
+1. **Draft the data model** based on the PRD and research:
+   - Mongoose schemas with types, required fields, enums, defaults
+   - Relationships to existing models (refs)
+   - Indexes if relevant
+   - Plugins (soft delete, timestamps, etc.) based on existing patterns
+
+2. **Draft the API surface**:
+   - List each endpoint (method, path, description)
+   - Note if it's a standard CRUD modelRouter or custom
+   - Specify permissions for each endpoint
+   - Call out any special query parameters, filters, or bulk operations
+
+3. **Present both together** and ask the user: "Are these models and APIs the right approach?" Use AskUserQuestion.
+
+4. **Iterate** until the user confirms the models and APIs are right. This is the foundation — don't move on until it's solid.
+
+#### Phase 2: Everything Else (flows from models/APIs)
+
+Once models and APIs are confirmed, draft the remaining concerns in a single pass. These should follow naturally from the model/API decisions:
+
+- **Notifications**: Push, email, in-app — who gets notified, when, what content. If none needed, say so.
+- **Activity Log**: What actions get logged, which surface as User Updates, which user groups see them. If none, say so.
+- **Permissions & Access**: Role-based differences beyond what's already covered in API permissions.
+- **UI**: New screens/components, navigation flow, key interactions and states, reusable vs new components.
+- **Feature Flags & Migration**: Whether a flag is needed, any data migrations, rollout strategy.
+- **Phases**: How to break the work into PRs (Phase 1: models + APIs, Phase 2: core UI, Phase 3: polish). If small enough, say "single phase."
+- **Not Included / Future Work**: Compile out-of-scope items and deferred ideas.
+
+Present all of this as a single shaped solution summary:
+
+```
+## Shaped Solution
+
+### Core Concept
+[1-2 sentence description of the approach]
+
+### Models
+[schemas from Phase 1]
+
+### APIs
+[endpoints from Phase 1]
+
+### Notifications
+[notification plan or "none needed"]
+
+### Activity Log
+[logging plan or "none needed"]
+
+### UI
+[screens, flows, interactions]
+
+### Phases
+[implementation phases]
+
+### Not Included
+[explicitly excluded items]
+
+### Risks & Mitigations
+- [risk]: [mitigation approach]
+```
+
+Surface any **risks and rabbit holes** inline:
+- Technical risks: things that might be harder than they look
+- Scope risks: features that could balloon if not bounded
+- For each risk, suggest a mitigation or simpler fallback
+
+Ask: "Does this shaped solution look right? Any decisions you want to revisit?"
+
+Once confirmed, say: **"Solution shaped. Moving to plan sections..."** and proceed to Step 4.
+
+### Step 4: Plan Sections (optional deep pass)
+
+Optional interactive walk-through of each plan section, useful when Step 3 left details fuzzy. For each section: present a draft, ask the user if it looks right, let them refine, then move on.
+
+#### Section 1: Models
+
+1. Draft Mongoose schemas based on the shaped solution. Include:
+   - Full schema code blocks with types, required fields, enums, defaults
+   - Relationships to existing models (refs)
+   - Indexes if relevant
+   - Plugins (soft delete, timestamps, etc.) based on existing patterns found in research
+
+2. Present the schemas and ask:
+   - "Do these models look right?"
+   - "Any fields missing or that should be changed?"
+   - "Should any of these fields be optional vs required?"
+
+#### Section 2: APIs
+
+1. Draft the API surface:
+   - List each endpoint (method, path, description)
+   - Note if it's a standard CRUD modelRouter or custom
+   - Specify permissions for each endpoint
+   - Call out any special query parameters, filters, or bulk operations
+   - Note any webhook or external API integrations
+
+2. Present and ask: "Any endpoints missing? Do the permissions look right?"
+
+#### Section 3: Notifications
+
+1. Based on the shaped solution, list:
+   - Push notifications (who, when, what content)
+   - Email/text notifications
+   - In-app notifications or alerts
+   - If none needed, explicitly state "No notifications required for this feature"
+
+2. Present and confirm with user.
+
+#### Section 4: UI
+
+1. Draft the UI plan:
+   - List new screens/components
+   - Describe navigation flow (how users get there)
+   - Describe key interactions and states
+   - Note any reusable components that already exist vs need to be created
+   - Suggest fat-marker sketches if the UI is complex (describe what should be sketched)
+
+2. Present and ask: "Does this UI approach make sense? Any screens or interactions missing?"
+
+#### Section 5: Phases
+
+1. Propose how to break the work into phases/PRs:
+   - Phase 1: Usually models + basic APIs
+   - Phase 2: Core UI and integrations
+   - Phase 3: Polish, notifications, edge cases
+   - If the feature is small enough, note "Single phase - no need to break up"
+
+2. For each phase, list what's included and what the deliverable looks like.
+
+3. Present and ask: "Does this phasing make sense? Want to adjust?"
+
+#### Section 6: Feature Flags & Migrations
+
+1. Based on the shaped solution, recommend:
+   - Whether a feature flag is needed (and what it controls)
+   - Any data migrations required
+   - Rollout strategy
+
+2. Present and confirm.
+
+#### Section 7: Activity Log & User Updates
+
+1. List:
+   - What actions get logged to the activity log
+   - Which of those surface as User Updates
+   - Which user groups see the updates
+
+2. If no activity logging is needed, say so explicitly.
+
+#### Section 8: Not Included / Future Work
+
+1. Compile the "out of scope" items from shaping into this section
+2. Add any ideas that came up during planning but were deferred
+3. Present and confirm.
+
+After all sections are finalized, say: **"All sections planned. Moving to output generation..."** and proceed to Step 5.
+
+### Step 5: Generate Output
+
+Produce the final implementation plan document and a structured task list, then save them.
+
+1. **Generate the Implementation Plan** in the standard format:
+
+   ```markdown
+   # Implementation Plan: [Feature Name]
+
+   *When an engineer is assigned to a project but before you begin coding, you should fill in the implementation plan and get feedback from the engineering team. Once you have finished or you make any changes, tag Josh with the @ symbol so he can review. Also tag anyone else that needs to be notified, has conflicting work, etc.*
+
+   ## **Models**
+   [Content from plan step]
+
+   ## **APIs**
+   [Content from plan step]
+
+   ## **Notifications**
+   [Content from plan step]
+
+   ## **UI**
+   [Content from plan step]
+
+   ## Phases
+   [Content from plan step]
+
+   ## Feature Flags & Migrations
+   [Content from plan step]
+
+   ## Activity Log & User Updates
+   [Content from plan step]
+
+   ## **Not included/Future work**
+   [Content from plan step]
+
+   ## Acceptance Criteria
+   [If criteria exist from the PRD or shaping, include them here. Otherwise, leave a placeholder noting to run Step 6 (Acceptance Criteria) to generate them.]
+   ```
+
+2. **Generate the Task List** as a structured section at the bottom of the document:
+
+   ```markdown
+   ---
+
+   ## Task List (Bot Consumption)
+
+   *Structured task breakdown for automated implementation. Each task should be independently implementable and testable.*
+
+   ### Phase 1: [Phase Name]
+
+   - [ ] **Task 1.1**: [Short title]
+     - Description: [What to implement]
+     - Files: [Expected files to create/modify]
+     - Depends on: [Other task IDs, or "none"]
+     - Acceptance: [How to verify it's done]
+
+   - [ ] **Task 1.2**: [Short title]
+     ...
+
+   ### Phase 2: [Phase Name]
+   ...
+   ```
+
+   Tasks should be:
+   - Small enough to be a single PR or commit
+   - Ordered by dependency (models first, then APIs, then UI)
+   - Specific about which files to create/modify
+   - Clear about acceptance criteria
+
+3. **Ask the user for the feature name** to use in the filename (suggest one based on the PRD). The filename should be kebab-case.
+
+4. **Save the implementation plan:**
+   - Ensure `docs/implementationPlans/` directory exists (create if needed)
+   - Save to `docs/implementationPlans/[feature-name].md`
+   - Confirm the file was saved and show the path
+
+5. **Save the task plan:**
+   - Ensure `docs/tasks/` directory exists (create if needed)
+   - Save to `docs/tasks/[feature-name].md`
+   - Confirm the file was saved and show the path
+
+6. **Final summary:**
+
+   ```
+   ## Implementation Plan Complete
+
+   **Saved to**: docs/implementationPlans/[feature-name].md
+
+   ### Quick Stats
+   - Models: [count] new/modified
+   - API Endpoints: [count]
+   - Screens: [count]
+   - Phases: [count]
+   - Tasks: [count] total
+
+   ### Next Steps
+   1. Share with the engineering team for review
+   2. Tag @Josh and relevant stakeholders
+   3. Once approved, tasks can be loaded for implementation
+   ```
+
+7. Ask: "Want to make any final changes, or is this ready to share?"
+
+### Step 6: Acceptance Criteria
+
+Generate structured acceptance criteria for an implementation plan. The criteria should be specific enough for a human to manually test AND for a bot to translate into Playwright E2E tests.
+
+`$IP` (optional): path to an existing IP file. If not provided, look for the IP in the current conversation context or ask the user which IP to use.
+
+#### 1. Load the IP
+
+- If `$IP` is provided, read the file
+- Otherwise, check if an IP was generated in the current conversation
+- If neither, list available IPs from `docs/implementationPlans/` and ask which one to use
+
+#### 2. Check for existing acceptance criteria
+
+- If the PRD or IP already has an `## Acceptance Criteria` section, read it carefully
+- Also check each task in the Task List for `Acceptance:` lines
+- These are your starting point — you'll expand and formalize them, not replace them
+
+#### 3. Analyze the IP to identify testable behaviors
+
+Walk through each section of the IP and identify user-facing behaviors:
+
+- **Models & APIs**: What responses should the API return? What validation errors should occur?
+- **UI**: What should the user see? What happens when they interact with elements?
+- **Notifications**: What triggers them? What content appears?
+- **Permissions**: What should different roles see/not see?
+- **Error states**: What happens when things fail?
+- **Edge cases**: Empty states, boundary values, concurrent actions
+
+#### 4. Write acceptance criteria
+
+Write criteria in a dual-format that works for both humans and bots:
+
+```markdown
+## Acceptance Criteria
+
+### Feature: [Feature area name]
+
+#### AC-1: [Short descriptive title]
+**Priority:** P0 | P1 | P2
+**Screen:** [screen name, e.g., "Login Screen"]
+**Preconditions:**
+- [Any setup needed before testing, e.g., "User is logged in", "At least 3 items exist"]
+
+**Steps:**
+1. [Navigate to / open / tap specific element]
+2. [Perform action — be specific about what to type, tap, select]
+3. [Observe result]
+
+**Expected results:**
+- [ ] [Specific, observable outcome — what the user sees]
+- [ ] [Another expected outcome]
+
+**testIDs needed:** `screen-element-qualifier`, `screen-another-element`
+
+---
+```
+
+Format rules:
+
+- **Steps must reference specific UI elements** using the `{screen}-{element}-{qualifier}` testID naming convention
+- **Expected results must be visually verifiable** — things a human can see AND a bot can assert (`toBeVisible`, `toHaveText`, `toHaveCount`, etc.)
+- **Include the `testIDs needed` line** listing every testID the test will need. This serves as a checklist for the developer to add testIDs to components before tests can run.
+- **Priority levels:**
+  - **P0**: Core happy path — feature is broken without this
+  - **P1**: Important flows — error handling, validation, key edge cases
+  - **P2**: Nice-to-have — polish, edge cases, minor interactions
+- **Group by feature area** (e.g., "User Authentication", "Item Management", "Notifications")
+
+#### 5. Cover these categories
+
+Ensure you have at least one criterion for each:
+
+- **Happy path**: The main flow works end to end
+- **Validation**: Required fields, format checks, boundary values
+- **Error handling**: Network errors, server errors, invalid states
+- **Empty states**: What shows when there's no data?
+- **Permissions** (if applicable): Different roles see different things
+- **Navigation**: Moving between screens works correctly
+- **Data persistence**: Changes are saved and visible after refresh
+
+#### 6. Add the section to the IP
+
+Insert the `## Acceptance Criteria` section into the IP file, after the main plan sections but before the `## Task List` section.
+
+#### 7. Summary
+
+Present a summary:
+
+```
+## Acceptance Criteria Generated
+
+**Added to**: [IP file path]
+
+### Coverage
+- P0 (critical): [count] criteria
+- P1 (important): [count] criteria
+- P2 (nice-to-have): [count] criteria
+- Total testIDs needed: [count]
+
+### Next Steps
+1. Review criteria with the team
+2. Ensure all listed testIDs are added to components
+3. Run Step 7 (E2E Tests) to generate Playwright tests from these criteria
+```
+
+Ask: "Want to adjust any criteria or add coverage for something I missed?"
+
+### Step 7: E2E Tests (optional)
+
+Generate Playwright end-to-end tests from an IP's acceptance criteria. Uses the project's Playwright skill and testing conventions.
+
+`$IP` (optional): path to an IP file with acceptance criteria. If not provided, look for the IP in the current conversation context or ask the user which IP to use.
+
+#### 1. Load the IP and acceptance criteria
+
+- If `$IP` is provided, read the file
+- Otherwise, check if an IP was loaded in the current conversation
+- If neither, list available IPs from `docs/implementationPlans/` and ask which one to use
+- The IP **must** have an `## Acceptance Criteria` section. If it doesn't, tell the user to run Step 6 (Acceptance Criteria) first.
+
+#### 2. Research the codebase
+
+Before writing tests, understand the existing test setup:
+
+- Check if `playwright.config.ts` exists — if not, note that it needs to be created
+- Check if `e2e/` directory exists and what tests are already there
+- Check for `e2e/helpers/` and `e2e/fixtures/` for reusable utilities
+- Check for `e2e/auth.setup.ts` to understand auth patterns
+- Look at existing test files to match the style and patterns in use
+- Check if the testIDs listed in acceptance criteria already exist in the component code
+
+#### 3. Plan the test files
+
+Map acceptance criteria to test files:
+
+- **One test file per feature area** (matching the `### Feature:` groups in acceptance criteria)
+- File naming: `e2e/{feature-name}.spec.ts` (kebab-case)
+- Group related ACs into `test.describe()` blocks
+
+Present the plan to the user:
+
+```
+## E2E Test Plan
+
+### Files to create:
+- `e2e/feature-name.spec.ts` — [count] tests from [AC numbers]
+- `e2e/another-feature.spec.ts` — [count] tests from [AC numbers]
+
+### Missing testIDs (must be added to components first):
+- `screen-element-name` — [component file if known]
+- ...
+
+### Missing infrastructure:
+- [ ] playwright.config.ts (will create)
+- [ ] e2e/helpers/auth.ts (will create)
+- ...
+```
+
+Ask: "Should I generate these test files? Any changes to the plan?"
+
+#### 4. Generate test files
+
+For each test file, follow these rules strictly:
+
+**Structure:**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Feature: [Feature Name]', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to starting screen
+    // Wait for screen to be visible
+  });
+
+  // One test per acceptance criterion
+  test('[AC title — as user behavior]', async ({ page }) => {
+    // Steps from the AC, translated to Playwright actions
+    // Expected results as assertions
+  });
+});
+```
+
+**Translation rules (AC → Playwright):**
+
+| AC Step | Playwright Code |
+|---------|----------------|
+| Navigate to [screen] | `await page.goto('/path'); await page.getByTestId('screen-name').waitFor({ state: 'visible' });` |
+| Tap / click [element] | `await page.getByTestId('testid').click();` |
+| Type [text] into [field] | `await page.getByTestId('testid').fill('text');` |
+| Toggle [switch] | `await page.getByTestId('testid').click();` |
+| See [text/element] | `await expect(page.getByTestId('testid')).toBeVisible();` |
+| See text [content] | `await expect(page.getByTestId('testid')).toHaveText(/content/i);` |
+| Don't see [element] | `await expect(page.getByTestId('testid')).not.toBeVisible();` |
+| See [N] items in list | `await expect(page.getByTestId('list').getByTestId(/^item-/)).toHaveCount(N);` |
+| Wait for loading | `await page.getByTestId('loading-indicator').waitFor({ state: 'hidden' });` |
+| Page URL contains [path] | `await expect(page).toHaveURL(/path/);` |
+
+**Mandatory rules:**
+- Use `getByTestId()` as primary selector — never class names or deep selectors
+- Never use `waitForTimeout()` — always wait for element state
+- Wait for screen visibility after every navigation
+- Wait for `networkidle` after data-fetching actions when appropriate
+- Add `// AC-N: [title]` comment above each test for traceability
+- Mark tests that need auth setup with the appropriate Playwright project dependency
+- Use `test.skip()` with a reason for any AC that can't be automated yet (e.g., requires native device features)
+
+#### 5. Report missing testIDs
+
+After generating tests, produce a checklist of testIDs that need to be added to components:
+
+```markdown
+## testIDs to Add
+
+These testIDs are referenced in the generated tests but may not exist in the app yet.
+Add them before running the tests.
+
+### [Screen Name]
+- [ ] `screen-element-name` on `<ComponentType>` — [purpose]
+- [ ] `screen-another-element` on `<ComponentType>` — [purpose]
+```
+
+If you can identify the component files where testIDs should be added, include the file paths.
+
+#### 6. E2E Summary
+
+```
+## E2E Tests Generated
+
+### Files created:
+- `e2e/feature-name.spec.ts` — [count] tests
+- ...
+
+### Coverage:
+- P0 criteria covered: [count]/[total]
+- P1 criteria covered: [count]/[total]
+- P2 criteria covered: [count]/[total]
+- Skipped (not automatable): [count] — [reasons]
+
+### Before running tests:
+1. Add missing testIDs to components (see checklist above)
+2. Ensure `playwright.config.ts` is configured
+3. Start the dev server
+4. Run: `bunx playwright test`
+
+### After tests pass:
+Run `/verify` to verify the full implementation
+```
+
+### Step 8: Review (optional, dual-model)
+
+Review an implementation plan using both Claude (sub-agent) and OpenAI Codex in parallel. Each reviewer independently identifies issues, gaps, and questions. Results are combined, deduplicated, and presented as a structured question list for the user. After the user answers, the IP is updated.
+
+Argument: IP number, filename, or path to the plan file. If empty, infer from conversation context. Parse as `$ARGUMENTS`.
+
+#### Phase 1: Locate the Plan
+
+1. If argument provided, find the matching IP file:
+   - Check `docs/implementationPlans/` for matching file (by IP number, slug, or full path)
+   - If a path was given directly, use that
+2. If no argument, infer from conversation context (most recently discussed IP)
+3. If ambiguous, ask the user
+4. Read the full plan file
+5. If a corresponding task file exists in `docs/tasks/`, read that too
+
+#### Phase 2: Gather Codebase Context
+
+Collect context both reviewers will need:
+
+1. **CLAUDE.md** -- project conventions, tech stack, constraints
+2. **Relevant source files** -- scan the plan's "Files to Create/Modify" or "Files:" fields in tasks, read 3-5 of the most critical existing files
+3. **Data models** -- if the plan references models, find and read their current definitions
+4. **Recent changes** -- `git log --oneline -10` for recent momentum
+
+Keep context focused. Prioritize the plan itself and the most relevant code.
+
+#### Phase 3: Run Both Reviews in Parallel
+
+Launch both reviewers at the same time using parallel tool calls. Do NOT wait for one before starting the other.
+
+##### 3a: Claude Sub-Agent
+
+Use the **Agent tool** with `subagent_type: "general-purpose"`:
+
+Prompt the sub-agent with all gathered context and these instructions:
+
+> You are a senior engineer reviewing an implementation plan. Your goal is to surface issues, gaps, risks, and questions that should be answered before implementation begins.
+>
+> ## The Plan
+>
+> {full plan content}
+>
+> ## Task Breakdown
+>
+> {task list content, if available}
+>
+> ## Codebase Context
+>
+> {CLAUDE.md excerpt -- tech stack, conventions}
+>
+> {relevant source file excerpts}
+>
+> ## Your Review
+>
+> Analyze this plan and produce two outputs:
+>
+> ### Issues & Gaps
+>
+> For each issue found, provide:
+> - **Severity**: CRITICAL / HIGH / MEDIUM / LOW
+> - **Category**: one of: Missing Requirements, Unstated Assumptions, Technical Risks, Security & Data Integrity, Task Breakdown Gaps, Architecture Concerns, Scope Concerns
+> - **Description**: What's wrong or missing -- be specific, cite the plan section
+> - **Suggestion**: How to address it
+>
+> ### Questions for the Author
+>
+> Generate questions that, if answered, would materially improve the plan. Focus on:
+> - Ambiguous requirements that could be interpreted multiple ways
+> - Unstated preferences (e.g., "should this be real-time or batch?")
+> - Tradeoffs where the plan picked one side without discussing alternatives
+> - Missing context that would change the approach
+> - Scale/performance expectations that aren't specified
+> - Integration points with unclear contracts
+> - Rollback/migration strategies that aren't defined
+>
+> For each question:
+> - **Question**: The question itself
+> - **Why it matters**: What changes depending on the answer
+> - **Default assumption**: What the plan currently assumes (if anything)
+>
+> Do NOT ask questions that can be answered by reading the codebase -- use Glob, Grep, and Read to verify before asking. Only ask questions that require human judgment or domain knowledge.
+
+##### 3b: Codex CLI
+
+Build a prompt file at `$TMPDIR/ip-review-prompt.md` with the plan, tasks, and codebase context, then run:
+
+```bash
+codex --model o3 --quiet --approval-mode full-auto "$TMPDIR/ip-review-prompt.md"
+```
+
+The prompt file should contain:
+
+```markdown
+# Implementation Plan Review: {plan title}
+
+You are a senior engineer reviewing an implementation plan. Find issues, gaps, and generate questions for the plan author.
+
+## The Plan
+
+{full plan content}
+
+## Task Breakdown
+
+{task list content, if available}
+
+## Codebase Context
+
+{CLAUDE.md excerpt}
+
+{relevant source file excerpts}
+
+## Your Review
+
+### Part 1: Issues & Gaps
+
+For each issue, provide:
+- **Severity**: CRITICAL / HIGH / MEDIUM / LOW
+- **Category**: Missing Requirements, Unstated Assumptions, Technical Risks, Security & Data Integrity, Task Breakdown Gaps, Architecture Concerns, or Scope Concerns
+- **Description**: Be specific -- cite the plan section and explain exactly what's wrong or missing
+- **Suggestion**: How to fix it
+
+### Part 2: Questions for the Author
+
+Generate questions that require human judgment or domain knowledge to answer. For each:
+- **Question**: The question
+- **Why it matters**: What would change depending on the answer
+- **Default assumption**: What the plan currently assumes
+
+Focus on: ambiguous requirements, unstated tradeoffs, missing scale/performance expectations, unclear integration contracts, and migration/rollback gaps.
+
+Do NOT ask questions answerable from the codebase. Focus on decisions that need human input.
+```
+
+**Model selection:** Use `o3` for strong reasoning. If unavailable, fall back to `o4-mini`.
+
+If `codex` is not installed or fails, report the error and continue with Claude-only results.
+
+Capture the full output.
+
+#### Phase 4: Combine & Deduplicate
+
+After both reviews return:
+
+##### Issues
+
+1. Parse all issues from both reviewers
+2. Deduplicate: if both flagged the same issue (same plan section, similar concern), merge and keep the more detailed description
+3. Tag each with its source:
+   - `[Claude]` -- only Claude found it
+   - `[Codex]` -- only Codex found it
+   - `[Both]` -- both flagged it (higher confidence)
+4. Sort by severity: CRITICAL > HIGH > MEDIUM > LOW
+
+##### Questions
+
+1. Parse all questions from both reviewers
+2. Deduplicate: merge questions asking essentially the same thing
+3. Tag with source (`[Claude]`, `[Codex]`, `[Both]`)
+4. Group by theme (e.g., "Scope", "Architecture", "Data", "Performance", "Migration")
+5. Within each group, sort by impact (questions where the answer would most change the plan come first)
+
+##### Verify Critical Claims
+
+For CRITICAL and HIGH issues, do a quick Glob/Grep/Read to confirm the issue is real. Note which are verified vs unverified.
+
+#### Phase 5: Present Results
+
+Present the combined review:
+
+```
+## IP Review: {plan title}
+
+**Reviewers:** Claude (sub-agent) + OpenAI Codex ({model used})
+**Plan:** {IP file path}
+
+---
+
+### Issues Found
+
+#### Critical
+1. [Both] **{category}** -- {description}
+   → {suggestion}
+
+#### High
+2. [Claude] **{category}** -- {description}
+   → {suggestion}
+
+#### Medium / Low
+3. [Codex] **{category}** -- {description}
+   → {suggestion}
+
+---
+
+### Questions for You
+
+**Scope & Requirements**
+1. [Both] {question}
+   _Why it matters:_ {impact}
+   _Current assumption:_ {what plan assumes}
+
+**Architecture & Design**
+2. [Claude] {question}
+   _Why it matters:_ {impact}
+   _Current assumption:_ {what plan assumes}
+
+**Performance & Scale**
+3. [Codex] {question}
+   _Why it matters:_ {impact}
+
+{...more grouped questions...}
+```
+
+#### Phase 6: Collect Answers
+
+Use **AskUserQuestion** to collect the user's answers. Present the questions in a numbered list and ask the user to answer them. Options:
+
+- Answer all at once (numbered responses)
+- Answer one at a time interactively
+- Skip questions they don't want to address yet (mark as "deferred")
+
+For skipped questions, note the current assumption the plan makes and flag it as an unresolved decision.
+
+#### Phase 7: Update the Plan
+
+After collecting answers:
+
+1. **Read the current IP file** fresh (in case it changed)
+2. **For each answered question**, determine what section(s) of the plan need updating
+3. **For each confirmed issue**, draft the fix
+4. **Draft all changes** and present them to the user as a before/after diff for each section
+5. Ask: "Apply these updates to the plan?"
+6. If yes, edit the IP file with all changes
+7. If a task file exists, update it too if any tasks are affected
+8. Add an "## Review Log" entry at the bottom of the IP file:
+
+```markdown
+## Review Log
+
+### {today's date} -- Dual-Model Review
+- **Reviewers:** Claude + Codex ({model})
+- **Issues found:** {N} ({breakdown by severity})
+- **Questions asked:** {N} ({answered}/{deferred})
+- **Plan updated:** Yes/No
+- **Unresolved:** {list any deferred questions or unverified issues}
+```
+
+#### Cleanup
+
+```bash
+rm -f "$TMPDIR/ip-review-prompt.md"
+```
+
+#### Notes on Review
+
+- The value is **dual perspective** -- Claude and Codex have different biases and catch different things
+- Questions tagged `[Both]` deserve the most attention -- two independent models flagged the same gap
+- Don't pre-filter findings. Present honestly even if they contradict earlier Claude work on the plan
+- This step fits between Step 5 (Generate) and implementation -- use it as a quality gate
+- Can also be run mid-implementation to reassess the plan as understanding deepens
+
+### Step 9: Attack & Adjust
+
+Adversarially red-team the plan and then update it inline based on what comes back. This is the last thing `/ip` does before handing off to implementation.
+
+1. **Locate the plan** — use the file just saved in Step 5 (`docs/implementationPlans/[feature-name].md`). Read it, plus the task file in `docs/tasks/` if present.
+
+2. **Gather focused context** — collect what an external reviewer will need:
+   - `CLAUDE.md` (tech stack, conventions, constraints)
+   - 3–5 of the most critical existing files referenced in the plan's "Files to Create/Modify"
+   - Current definitions of any models the plan touches
+   - `git log --oneline -10` for recent momentum
+
+3. **Build the attack prompt** at `$TMPDIR/ip-attack-prompt.md`:
+
+   ```markdown
+   # Adversarial Review: {plan title}
+
+   You are a senior staff engineer conducting a hostile review of this implementation plan. Find every flaw, gap, risk, and unstated assumption. Be uncharitable — assume nothing works until proven otherwise.
+
+   ## The Plan
+   {full plan content}
+
+   ## Task Breakdown
+   {task list content, if available}
+
+   ## Codebase Context
+   {CLAUDE.md excerpt + relevant source file excerpts}
+
+   ## Your Review
+
+   For each finding, cite the section of the plan and explain exactly what's wrong or missing. Cover:
+
+   1. **Missing Requirements** — what the PRD implies but the plan ignores; uncovered user flows and error states.
+   2. **Unstated Assumptions** — what the plan assumes about codebase/infra/data/scale that isn't verified.
+   3. **Technical Risks** — parts harder than the plan suggests; highest rewrite probability.
+   4. **Security & Data Integrity** — injection, auth gaps, input validation, race conditions.
+   5. **Task Breakdown Gaps** — tasks not actually independent/testable; wrong dependencies; missing setup/migration/testing/docs tasks.
+   6. **Architecture Concerns** — fit with existing patterns; tech debt; simpler approaches overlooked.
+   7. **Verdict** — SHIP IT / REVISE / RETHINK.
+
+   Classify each finding: CRITICAL / HIGH / MEDIUM / LOW.
+   ```
+
+4. **Run the attacker — OpenAI first, Opus fallback:**
+
+   Try OpenAI Codex CLI:
+   ```bash
+   codex --model o3-pro --quiet --approval-mode full-auto "$TMPDIR/ip-attack-prompt.md"
+   ```
+   If `o3-pro` is unavailable or rate-limited, try `o3`, then `o4-mini`.
+
+   If the `codex` CLI is missing or every model fails, fall back to an Opus subagent: spawn a `general-purpose` Agent with `model: "opus"` and pass it the same prompt file contents, telling it to act as the hostile reviewer. Report clearly which path was taken.
+
+5. **Process the findings:**
+   - Deduplicate overlapping issues.
+   - For each CRITICAL/HIGH finding, verify with Glob/Grep/Read before treating it as real — reviewers hallucinate.
+   - Drop anything the plan actually already addresses.
+
+6. **Report to the user** in this shape:
+
+   ```
+   ## Adversarial Review: {plan title}
+
+   **Reviewer:** {OpenAI model used, or "Opus fallback"}
+   **Verdict:** {SHIP IT / REVISE / RETHINK}
+
+   ### Critical / High / Medium / Low
+   {findings grouped by severity, each with a one-line plan-section reference}
+
+   ### Verified vs Unverified
+   - Verified: {confirmed against the codebase}
+   - Unverified: {couldn't confirm — may be false positives}
+   ```
+
+7. **Adjust the plan** — don't stop at reporting. For every verified CRITICAL/HIGH finding, edit the IP file in place: tighten assumptions, add missing tasks, patch acceptance criteria, rewrite risky phases. For MEDIUM/LOW, ask the user which to fold in. Show the diff of your plan edits and ask "Anything else to adjust, or is this ready for implementation?"
+
+If the user provides a `$STEP` argument, skip to that step (assumes prior steps have been completed and context is available in conversation).
+
+## Lifecycle Operations
+
+These operations manage IPs through their lifecycle after creation. Each is self-contained and can be invoked directly by name.
+
+### Lifecycle: Init
+
+Set up the directory structure and tracking index for implementation plans in the current project.
+
+Argument: optional project description or notes (`$ARGUMENTS`).
+
+#### Before Starting
+
+1. Identify the **project root** -- this is the current working directory
+2. Check if IP tracking already exists by looking for `docs/implementationPlans/PLAN_INDEX.md`
+   - If it exists, report what's already set up and ask what to regenerate
+   - If it doesn't exist, proceed with full setup
+
+#### Init Step 1: Infer Project Context
+
+1. Read `CLAUDE.md` if it exists -- note the project name, key conventions, commit style
+2. Check `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, or similar for project name
+3. Look at recent git log for commit message style
+4. Note the primary language and any existing docs structure
+5. Check if `docs/implementationPlans/` already exists with plan files -- if so, scan them for the highest IP number to seed the index
+
+#### Init Step 2: Create Directory Structure
+
+```bash
+mkdir -p docs/implementationPlans/archive
+mkdir -p docs/tasks
+```
+
+#### Init Step 3: Create PLAN_INDEX.md
+
+Create `docs/implementationPlans/PLAN_INDEX.md`:
+
+```markdown
+# Implementation Plan Index
+
+Tracked implementation plans for {project_name}.
+
+See `CLAUDE.md` for IP lifecycle stages and management guidelines.
+
+## Active Plans
+
+| IP | Title | Status | Effort | Priority |
+|----|-------|--------|--------|----------|
+| - | - | - | - | No active plans yet |
+
+## Completed
+
+| IP | Title | Completed | Notes |
+|----|-------|-----------|-------|
+| - | - | - | No completed plans yet |
+
+## Deferred / Closed
+
+| IP | Title | Status | Notes |
+|----|-------|--------|-------|
+| - | - | - | No deferred plans yet |
+
+## Backlog
+
+Low-priority or blocked items. Promote to Active when ready to plan.
+
+| IP | Title | Notes |
+|----|-------|-------|
+| - | - | No backlog items yet |
+```
+
+If existing plan files were found in `docs/implementationPlans/`, populate the Active table with entries for each file, inferring IP numbers from filenames or assigning new ones.
+
+#### Init Step 4: Create IP_TEMPLATE.md
+
+Only create if `docs/implementationPlans/IP_TEMPLATE.md` does not already exist. If it exists, skip this step and report it was found.
+
+Create `docs/implementationPlans/IP_TEMPLATE.md`:
+
+```markdown
+# Implementation Plan: Title
+
+**Status:** Open
+**Priority:** Low | Medium | High
+**Effort:** Small batch (1-2 days) | Big batch (1-2 weeks) | Epic (2+ weeks)
+**IP:** IP-XXX
+
+*When an engineer is assigned to a project but before you begin coding, you should fill in the implementation plan and get feedback from the engineering team.*
+
+## Models
+
+New or modified data models, schemas, relationships.
+
+## APIs
+
+Endpoints, permissions, special queries, bulk operations.
+
+## Notifications
+
+Push, email, in-app alerts -- who, when, what.
+
+## UI
+
+New screens/components, navigation flow, key interactions, states.
+
+## Phases
+
+How to break the work into phases/PRs.
+
+## Feature Flags & Migrations
+
+Feature flags, data migrations, rollout strategy.
+
+## Activity Log & User Updates
+
+What actions get logged, what surfaces as user updates.
+
+## Not Included / Future Work
+
+Explicitly out of scope.
+
+---
+
+## Task List
+
+*Structured task breakdown. Each task should be independently implementable and testable.*
+
+### Phase 1: [Phase Name]
+
+- [ ] **Task 1.1**: [Short title]
+  - Description: [What to implement]
+  - Files: [Expected files to create/modify]
+  - Depends on: [Other task IDs, or "none"]
+  - Acceptance: [How to verify it's done]
+```
+
+#### Init Step 5: Update Project CLAUDE.md
+
+Read the project's `CLAUDE.md`. If it doesn't exist, create it with a minimal header.
+
+**Check if an IP section already exists** by searching for `## Implementation Plan` or `## IP Management`. If found, skip and report.
+
+Otherwise, **append** the following section:
+
+```markdown
+
+---
+
+## Implementation Plan (IP) Management
+
+Implementation plans are tracked in `docs/implementationPlans/`. Each IP has a dedicated file and is indexed in `PLAN_INDEX.md`.
+
+### IP Lifecycle
+
+| Stage | Description |
+|-------|-------------|
+| **Planned** | Identified but not yet designed |
+| **Design** | Actively designing (PRD ingested, shaping) |
+| **Open** | Shaped and ready for implementation |
+| **In Progress** | Currently being implemented |
+| **Pending Verification** | Code complete, awaiting verification |
+| **Complete** | Verified working, ready to archive |
+| **Deferred** | Postponed (low priority or blocked) |
+| **Closed** | Won't implement (superseded or not needed) |
+
+### Conventions
+
+- **IP files**: `docs/implementationPlans/{Title-Case-Name}.md` (e.g. `Zoom-Integration-Mvp.md`)
+- **Template**: `docs/implementationPlans/IP_TEMPLATE.md`
+- **Task files**: `docs/tasks/{feature-name}.md` (created by Step 5: Generate)
+- **Commit format**: `IP-XXX: Brief description`
+- **Numbering**: Next number = highest across all index sections + 1
+- **Source of truth**: IP file status > index (if discrepancy, file wins)
+- **Archive**: Completed IPs move to `docs/implementationPlans/archive/`
+
+### Inline Annotations (`%%`)
+
+Lines starting with `%%` in any file are **inline annotations from the user**. When you encounter them:
+- Treat each `%%` annotation as a direct instruction
+- Address **every** `%%` annotation in the file; do not skip any
+- After acting on an annotation, remove the `%%` line from the file
+- If an annotation is ambiguous, ask for clarification before acting
+```
+
+#### Init Step 6: Init Summary
+
+Report what was created:
+
+```
+## IP Tracking Initialized
+
+### Files Created
+- `docs/implementationPlans/PLAN_INDEX.md` -- Plan index
+- `docs/implementationPlans/IP_TEMPLATE.md` -- IP file template (if not already present)
+- `docs/implementationPlans/archive/` -- Archive directory
+- `docs/tasks/` -- Task files directory
+- `CLAUDE.md` -- Updated with IP conventions
+
+### Next Steps
+1. Run /ip to create your first implementation plan from a PRD
+2. Run the Lifecycle: Status operation to check the current state
+```
+
+### Lifecycle: Explore
+
+General-purpose exploration of any project using the IP system. Uses parallel subagents to quickly build context.
+
+#### Step 1: Launch Parallel Subagents
+
+Launch these THREE subagents IN PARALLEL (single message with multiple Task tool calls):
+
+##### Agent 1: Project Overview
+
+Explore the project root to understand what this project is and how it works:
+
+1. **Read key docs** -- `CLAUDE.md`, `README.md`, any top-level docs
+2. **Directory structure** -- Glob for top-level files and key subdirectories
+3. **Tech stack** -- Identify languages, frameworks, build tools from config files (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `Makefile`, etc.)
+4. **Gotchas** -- Note any warnings, constraints, or non-obvious conventions from CLAUDE.md
+
+Return: project name, purpose, tech stack, directory layout, key gotchas.
+
+##### Agent 2: IP History
+
+Explore the implementation plan system to understand what's been built and what's planned:
+
+1. **Read index** -- `docs/implementationPlans/PLAN_INDEX.md`
+2. **Active IPs** -- Read each active IP file (non-Complete status)
+3. **Archived IPs** -- List files in `docs/implementationPlans/archive/` to understand completed work
+4. **Task files** -- List and scan `docs/tasks/` for active task lists
+5. **Recent IP commits** -- Search git log for commits matching `IP-` pattern (last 20)
+
+Return: active IPs table, count of archived IPs, active tasks summary, recent IP commit summary.
+
+##### Agent 3: Recent Activity
+
+Explore recent development activity to understand current momentum:
+
+1. **Recent commits** -- Last 15 commits with messages
+2. **Modified files** -- Files changed in the last 5 commits
+3. **Branch context** -- Current branch name and how far ahead of main
+4. **Uncommitted work** -- Check git status for staged/unstaged changes
+
+Return: recent commit summary, files in flux, branch status, open work.
+
+#### Step 2: Synthesize Results
+
+Combine all agent outputs into a single briefing:
+
+##### Project Overview
+- Name, purpose, tech stack (from Agent 1)
+- Key gotchas or constraints
+
+##### IP Status
+- Active plans table (from Agent 2)
+- Active tasks and progress
+- Archived count and notable completions
+
+##### Recent Activity
+- What's been happening (from Agent 3)
+- Current branch and open work
+
+##### Quick Reference
+
+| Item | Value |
+|------|-------|
+| **Project** | {name} |
+| **Branch** | {current branch} |
+| **Active IPs** | {count} |
+| **Active Tasks** | {count remaining} |
+| **Recent focus** | {summary of last few commits} |
+
+Use the current working directory as the project root.
+
+### Lifecycle: Deep Analysis
+
+Parallel exploration of a hard problem from multiple angles, inspired by test-time compute scaling. Use when stuck, when the problem is complex enough to benefit from diverse perspectives, or when you need "big brains" on something.
+
+Argument: problem description or context (`$ARGUMENTS`).
+
+#### Phase 1: Understand the Problem
+
+1. **Parse the argument** -- what is the user stuck on? What are they trying to achieve?
+2. **Gather context** -- read conversation history for what's already been tried or discussed
+3. **Check for active IP** -- if there's a relevant implementation plan, read it for design context
+4. **Scan the codebase** -- do a quick targeted search to understand the relevant code area (key files, architecture, constraints). Keep this brief -- the agents will do the deep exploration.
+
+#### Phase 2: Design the Exploration
+
+Based on the problem, design **4 exploration angles**. These are NOT redundant -- each agent gets a **distinct lens** on the problem.
+
+**Before launching, check orthogonality:** Would two of these angles likely explore the same code paths and reach similar conclusions? If so, reframe one to ensure genuine diversity.
+
+**How to choose angles -- infer from the problem type:**
+
+For **performance optimization**:
+- Algorithmic: Can the approach itself be fundamentally different?
+- Structural: Can the data layout, schema, or architecture reduce work?
+- Incremental: Can we avoid redoing work (caching, materialization, deltas)?
+- Environmental: Are we fighting the platform? (query patterns, Python GIL, network topology)
+
+For **architecture/design decisions**:
+- Simplicity: What's the minimal viable approach?
+- Scalability: What happens at 10x/100x current load?
+- Precedent: How do similar systems/libraries solve this?
+- Contrarian: What if the obvious approach is wrong? What's the unconventional path?
+
+For **debugging / "why is this broken"**:
+- Symptoms: Trace the failure path precisely -- what's the chain of events?
+- Environment: What changed? Versions, configs, data, dependencies?
+- Assumptions: What are we assuming that might not be true?
+- Similar: Has this pattern of failure been seen elsewhere in the codebase or in public?
+
+For **anything else** -- choose angles that maximize diversity of insight. Ask: "If these 4 experts were in a room, what different specialties would give me the most useful debate?"
+
+**For each angle, decide:**
+- What codebase areas the agent should explore (specific files, directories, patterns)
+- What question the agent should answer
+- How deep vs. broad the agent should go
+- What existing context (if any) to seed the agent with -- only what's necessary, avoid anchoring
+
+#### Phase 3: Launch Parallel Exploration
+
+**Briefly tell the user** what angles you're exploring (2-3 words each) -- then launch immediately. Don't wait for approval. Speed matters when stuck.
+
+Launch **4 Explore agents IN PARALLEL** (single message with 4 Task tool calls). Use `model: "opus"` explicitly on each agent to ensure heavyweight reasoning. Each agent gets:
+
+```
+You are exploring a specific angle of a hard problem. Your analysis is input to a multi-agent synthesis -- be precise, flag uncertainties, and show your evidence.
+
+## Problem
+{problem description}
+
+## Your Angle
+{specific lens -- what you're looking for, what question you're answering}
+
+## Where to Look (Starting Points)
+{specific files, directories, or search patterns to start with}
+
+These are entry points, not the complete scope. Follow evidence wherever it leads -- if the trail points to related code outside this list, explore it.
+
+## Key Constraint
+You have read-only tools (Glob, Grep, Read). Use them liberally. If you can't verify something exists, don't claim it. Better to say "I couldn't locate a config file for X" than to guess at its name or path.
+
+## Instructions
+- Use Glob, Grep, and Read to thoroughly explore the relevant code
+- Think deeply about your specific angle -- don't try to solve the whole problem
+- Look for evidence, patterns, constraints, and opportunities related to your angle
+- Note anything surprising or that contradicts assumptions
+- Be concrete -- reference specific files, functions, line numbers, data flows
+- If you find something important outside your angle, note it briefly but stay focused
+- Before you finalize: is there evidence that contradicts your recommendation? If yes, address it directly rather than ignore it
+
+## Output
+Return a focused analysis (aim for 600-1000 words):
+
+1. **Key findings** -- specific observations with evidence. For each finding, cite the file/line or code pattern that shows it's true. Avoid vague claims like "this is slow" -- show why.
+
+2. **Implications** -- what this means for the problem. For each implication, explain the logical link: if this finding is true, then we should try X because [reason].
+
+3. **Recommendation** -- your angle's proposed direction:
+   - **Proposed approach:** [specific, actionable idea]
+   - **Why this angle suggests it:** [link findings -> recommendation]
+   - **Tradeoffs:** [what you'd give up]
+   - **Key assumptions:** [what has to be true for this to work]
+   - **Biggest uncertainty:** [what would most change your mind]
+```
+
+#### Phase 4: Verify Key Claims
+
+Before synthesizing, two verification passes:
+
+##### Pass 1: Contradiction Detection
+
+Scan all 4 agent reports for **opposing claims**. Examples:
+- Agent A says "this runs synchronously" while Agent B says "this is async"
+- Agent A says "no index on this column" while Agent C assumes an index exists
+- Two agents recommend opposite directions
+
+Flag contradictions prominently. **Prioritize verifying contradicted claims first** -- these are where the highest-value corrections live.
+
+##### Pass 2: Factual Verification
+
+**Cross-check the most important factual claims** from the agents. Agents can hallucinate file paths, function signatures, config options, or behavioral assumptions.
+
+**What to verify:**
+- **File paths and function names** -- do the files/functions agents referenced actually exist? Spot-check with Glob/Grep.
+- **Behavioral claims** -- "this function does X" or "this config controls Y" -- Read the actual code for the 2-3 most critical claims that the recommendation will hinge on.
+- **Performance/complexity claims** -- if an agent says "this is O(n^2)" or "this query scans the full table," verify against the actual code or query plan.
+- **Assumption checks** -- if agents assumed something about the system (e.g., "this runs synchronously," "this table has an index on X"), verify the ones that matter most.
+
+**How to verify:**
+- Focus on the **top 3-5 claims that would change the recommendation if wrong**. Don't verify everything -- verify what matters.
+- Use Glob, Grep, and Read directly (no subagents -- this should be fast).
+- If a claim is wrong, note the correction. If it's right, move on.
+
+**Output:** Note any corrections or confirmations. Flag anything that was wrong -- this changes the synthesis.
+
+#### Phase 5: Synthesize
+
+After verification, synthesize the agents' findings (with corrections applied) into a single analysis. This is the critical step -- don't just concatenate.
+
+**Synthesis structure:**
+
+##### 1. Agreements
+Where do multiple angles converge? High-confidence insights.
+
+##### 2. Tensions
+Where do angles disagree or present tradeoffs? These are the real design decisions.
+
+##### 3. Surprises
+What did agents find that wasn't expected? Novel insights that change the framing.
+
+##### 4. Corrections
+Any agent claims that were wrong or misleading, and what the truth is. Be transparent -- this builds trust in the analysis.
+
+##### 5. Recommendation
+Your synthesized recommendation. Be opinionated -- rank the options, state which direction you'd go and why. Tag each element with confidence (High/Medium/Low) and a one-line justification. Include:
+- **Proposed approach** -- the synthesized best path forward
+- **Key tradeoffs** -- what you're giving up
+- **Risks** -- what could go wrong
+- **Key assumptions** -- what the recommendation depends on being true
+- **First step** -- the concrete next action
+
+##### 6. Assumption Check
+After drafting the recommendation, note what assumptions it hinges on. Verify those specific assumptions with a quick Glob/Grep/Read check. If any fail, flag them and reassess.
+
+##### 7. If applicable: IP Update
+If there's an active IP related to this problem, propose specific updates to the plan's relevant sections based on the analysis. Don't update the file -- present the proposed changes for the user to approve.
+
+#### Notes on Deep Analysis
+
+- **Agent count**: Always 4. Four distinct angles. No exceptions.
+- **Agent type**: Always use `subagent_type: "Explore"` with `model: "opus"` -- read-only research agents on the heaviest model.
+- **Thoroughness**: Tell agents to be "very thorough" in their Task descriptions.
+- **No anchoring**: Don't give agents each other's angles. They should explore independently.
+- **Speed over perfection**: The user is stuck. A good-enough synthesis in 2 minutes beats a perfect one in 10. Don't over-polish the output.
+
+### Lifecycle: Status
+
+Generate an up-to-date summary of active implementation plans.
+
+#### Fast Path vs Full Grooming
+
+**Decide which path to take based on conversation context:**
+
+##### Fast Path (just print the table)
+Use this when you are **confident the index is up to date** -- for example:
+- You've been working on IPs in this session (closing, creating, updating)
+- You just ran a full grooming pass recently
+- The user just asked you to "print the status"
+
+Simply read `docs/implementationPlans/PLAN_INDEX.md` and each active IP file, then output the table.
+
+##### Full Grooming (first invocation or uncertain state)
+Use this when you have **no context about the current state**:
+- Start of a new conversation
+- You haven't touched any IPs yet
+- The user explicitly asks for a grooming check
+
+Perform these housekeeping checks:
+
+###### 1. Status Sync Check
+- Read each active IP file and compare its `**Status:**` line to the index
+- If discrepancy, update the index to match the file (file is source of truth)
+- Report any discrepancies found and fixed
+
+###### 2. Archive Check
+- Look for IP files in `docs/implementationPlans/` (not in `archive/`) with status: Complete, Deferred, or Closed
+- For each such IP not yet archived:
+  - Move to `docs/implementationPlans/archive/`
+  - Ensure it's in the appropriate section of the index
+- Report any files archived
+
+###### 3. Orphan Check
+- Check if any IPs in the index don't have corresponding files
+- Check if any IP files exist that aren't in the index (exclude IP_TEMPLATE.md and PLAN_INDEX.md)
+- Report any orphans found
+
+###### 4. Task Progress Check
+- For each active IP, check if a corresponding task file exists in `docs/tasks/`
+- Count completed vs total tasks (checked vs unchecked checkboxes)
+- Include task progress in the output table
+
+#### Status Output
+
+Format the output as a markdown table:
+
+    ## Active Implementation Plans
+
+    | IP | Title | Status | Effort | Tasks | Description |
+    |----|-------|--------|--------|-------|-------------|
+    | IP-XXX | Title here | Status | Effort | 3/10 | Brief description |
+
+    **Total:** X active plans (Y design, Z open, W in progress)
+
+If full grooming was performed and changes were made, prepend a grooming report.
+
+Notes:
+- Keep descriptions concise (< 60 chars if possible)
+- Include a count summary at the bottom
+- Task column shows completed/total if task file exists, "-" otherwise
+
+### Lifecycle: Close
+
+Close an IP by marking it complete (or closed/deferred), archiving the file, and updating the index.
+
+Argument should contain:
+- **IP number or name** (required-ish): e.g. `1`, `IP-001`, or the plan filename slug
+- **Disposition** (optional): `complete` (default), `closed`, or `deferred`
+- **Notes** (optional): any additional context
+
+Examples:
+- close 1 -- mark IP-001 as Complete
+- close user-permissions deferred blocked on auth refactor -- mark by name, Deferred
+- close 3 closed superseded by IP-005 -- mark IP-003 as Closed
+- close (no args) -- infer from conversation context
+
+Parse the argument: `$ARGUMENTS`
+
+#### Inferring the IP
+
+If no IP number/name provided, infer from conversation context:
+- Look at which IP was most recently discussed or worked on
+- If exactly one IP is obvious, use it and state which one
+- If ambiguous, ask the user
+
+#### Close Steps
+
+##### 1. Find and read the IP file
+
+- Search `docs/implementationPlans/` for matching file (by IP number, Title-Case filename, or slug)
+- Read to get title, current status
+- If already archived or not found, report and stop
+
+##### 2. Update the IP file
+
+- Set `**Status:**` to `Complete`, `Closed`, or `Deferred`
+- For Complete: add `**Completed:** {today YYYY-MM-DD}` after Status
+- For Closed/Deferred: add `**Closed:** {today}` if not present
+
+##### 3. Update PLAN_INDEX.md
+
+- Read `docs/implementationPlans/PLAN_INDEX.md`
+- Remove IP's row from **Active Plans** table
+- Add to appropriate section:
+  - **Complete** -> add to top of `## Completed` table with date and notes
+  - **Closed/Deferred** -> add to top of `## Deferred / Closed` table with status and notes
+
+##### 4. Archive the files
+
+- Move IP file to `docs/implementationPlans/archive/`
+- If a corresponding task file exists in `docs/tasks/`, move it to `docs/implementationPlans/archive/` as well (or leave in place if tasks are still referenced)
+
+##### 5. Commit
+
+Commit all changes in a single atomic commit:
+- Check `git status` for uncommitted changes related to the IP implementation
+- Stage implementation files, archived IP, deleted original path, `PLAN_INDEX.md`
+- Commit with message: `IP-{number}: {title}`
+
+##### 6. Close Summary
+
+Report:
+- IP number and title
+- Disposition (Complete / Closed / Deferred)
+- Status updated in IP file
+- Moved from Active to the appropriate section in index
+- Archived to `docs/implementationPlans/archive/`
+- Committed: {short hash}
+
+## Submitting the IP
+
+Once the plan is finalized, use `/submit` to commit the IP files, push the branch, and create a PR on the target project's GitHub repo. The worktree is already on a dedicated branch, so `/submit` works directly.
+
+## Arguments
+
+$PROJECT: Project alias or `owner/repo` (required — if omitted, user is prompted to select from the registry)
+$STEP: Optional step to skip to (ingest, research, shape, plan, generate, acceptance, e2e, review, attack). Note: Step 0 (project setup) always runs regardless of $STEP.
+$PRD: Optional path to a PRD markdown file (skips the paste prompt in ingest step)

--- a/.cursor/skills/mongoose-schema-safety/SKILL.md
+++ b/.cursor/skills/mongoose-schema-safety/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: mongoose-schema-safety
+description: 'Invoke when making any Mongoose schema change: adding/removing/renaming fields, creating a new model, adding indexes, or writing a backfill migration. Provides the five-type pattern, risk matrix, type file checklist, and rollout safety steps for terreno backends.'
+---
+# Mongoose Schema Safety — Terreno
+
+## Where Schemas and Types Live
+
+| Package | Schemas | Types |
+|---------|---------|-------|
+| `@terreno/api` (built-in models like `User`, `ConsentForm`) | `api/src/models/*.ts` | `api/src/types/*.ts` (or co-located in the model file via `mongoose.Schema<Doc, Model, Methods>` generics) |
+| `example-backend` (`User`, `Todo`, `Configuration`) | `example-backend/src/models/*.ts` | `example-backend/src/types/models/*.ts` (`userTypes.ts`, `todoTypes.ts`, …) |
+| `@terreno/ai` (`AIRequest`, `GptHistory`) | `ai/src/models/*.ts` | `ai/src/types/index.ts` |
+
+Every field in every schema **must** have a `description` (see the API rule `01-model-field-descriptions.md`). Descriptions flow through to the OpenAPI spec via `mongoose-to-swagger`.
+
+## The Five-Type Pattern
+
+Every model has manually-maintained TypeScript types. **Types are NOT auto-generated** — every schema change must include a matching type update in the same commit/PR.
+
+```typescript
+import type {DefaultDoc, DefaultModel, DefaultStatics} from "@terreno/api";
+
+// 1. Instance methods (on the document)
+export type YourModelMethods = {
+  customMethod: (this: YourModelDocument, param: string) => Promise<void>;
+};
+
+// 2. Static methods (on the model class) — extend DefaultStatics for findExactlyOne / findOneOrNone
+export type YourModelStatics = DefaultStatics<YourModelDocument> & {
+  customStatic: (this: YourModelModel, param: string) => Promise<YourModelDocument>;
+};
+
+// 3. Model type combining document + statics
+export type YourModelModel = DefaultModel<YourModelDocument> & YourModelStatics;
+
+// 4. Schema type
+export type YourModelSchema = mongoose.Schema<YourModelDocument, YourModelModel, YourModelMethods>;
+
+// 5. Document type (the shape of a single record)
+export type YourModelDocument = DefaultDoc & YourModelMethods & {
+  fieldName: string;
+  optionalField?: number;
+  enumField: "value1" | "value2";
+};
+```
+
+Follow existing type files in `example-backend/src/types/models/` and `ai/src/types/index.ts` for naming and structure.
+
+## Statics & Methods — Direct Assignment
+
+Define statics and methods by direct assignment on the schema — not via `.method()` / `.static()` / `.add()`:
+
+```typescript
+schema.methods = {
+  getDisplayName(this: YourModelDocument): string { return this.name; },
+};
+schema.statics = {
+  async findByEmail(this: YourModelModel, email: string) { return this.findOne({email}); },
+};
+```
+
+## Critical Mongoose Rules
+
+- **Never use `Model.findOne`** — use `Model.findExactlyOne` (throws on 0 or many) or `Model.findOneOrNone` (throws on many). These come from the `findExactlyOne` / `findOneOrNone` plugins in `@terreno/api`.
+- Apply the standard plugins (`createdUpdatedPlugin`, `isDeletedPlugin`, `findOneOrNone`, `findExactlyOne`) on every new model. Most existing models go through `addDefaultPlugins`.
+- `checkModelsStrict()` runs at non-prod startup (`server.ts`) and validates schema consistency — keep it passing.
+
+## Schema Change Risk Matrix
+
+| Change Type | Risk Level | Required Mitigation |
+|-------------|-----------|---------------------|
+| Add optional field | Low | Safe to ship directly (still requires `description`) |
+| Add required field | High | Must provide a default value, OR write a backfill migration script first |
+| Remove field | Medium | Soft-remove first (mark optional, stop writing); hard-remove in next PR after deploys settle |
+| Rename field | High | Three-step: add new → backfill → remove old (separate PRs) |
+| Change field type | Critical | Treat as rename: new field + migration + remove old |
+| Add index | Medium | Safe in code, but build can slow writes on large collections — coordinate with ops |
+| Remove index | Low | Safe to ship directly |
+| Add unique index | High | Dedup migration must run first; otherwise the index build fails on existing duplicates |
+
+## Migration Scripts
+
+Migration / backfill scripts live in `example-backend/src/scripts/` (e.g. `syncConsents.ts`, `seedConsents.ts`). They use the `ScriptRunner` type and `BackgroundTask` model from `@terreno/api` (`api/src/scriptRunner.ts`):
+
+```typescript
+import type {ScriptContext, ScriptResult, ScriptRunner} from "@terreno/api";
+
+export const run: ScriptRunner = async (wetRun, ctx) => {
+  const results: string[] = [];
+  // ... do work ...
+  if (wetRun) {
+    // commit changes
+  }
+  return {success: true, results};
+};
+```
+
+Always run with `wetRun = false` first to verify the dry-run output. Use `ctx.checkCancellation()`, `ctx.addLog()`, and `ctx.updateProgress()` for long-running tasks.
+
+## Cross-Package Ripple
+
+A schema change in one place often ripples:
+
+- **API surface affected?** Regenerate the SDK with `cd example-frontend && bun run sdk` (or invoke the `generate-sdk` skill). The OpenAPI spec is derived from the schema, so the frontend hooks will go stale otherwise.
+- **`modelRouter` config?** If you added/removed a field, update `queryFields`, `populatePaths`, and `responseHandler` for any router that touches the model.
+- **Admin panel?** If the model is registered in `AdminApp`, update `listFields` so the table reflects the new shape.
+- **Populated refs?** If another model references this one via `ObjectId` + `ref`, and the referenced document shape changed, the consumer's populated type may need updating.
+
+## Post-Change Checklist
+
+- [ ] All new fields have a `description` (flows to OpenAPI)
+- [ ] Type file updated in the same commit/PR — field names, optionality, enum values, array types, refs, statics/methods all match the schema
+- [ ] For a new model: all five types (`Document`, `Methods`, `Statics`, `Model`, `Schema`) created
+- [ ] Statics/methods assigned directly on schema (`schema.statics = {...}`, `schema.methods = {...}`) — not `.static()` / `.method()`
+- [ ] Other model type files checked — any model that populates this one updated if its shape changed
+- [ ] Migration script written (and dry-run verified with `wetRun = false`) for any backfill
+- [ ] `modelRouter` config updated (`queryFields`, `populatePaths`, `responseHandler`) if needed
+- [ ] `AdminApp` `listFields` updated if the model is in the admin panel
+- [ ] `bun run sdk` run from `example-frontend/` if the API response shape changed
+- [ ] Test covers old-format document behavior (missing new field) if the change rolls out before a backfill
+- [ ] Unique index: dedup migration written and run before the index is added
+- [ ] `checkModelsStrict()` still passes (it runs on non-prod startup)
+- [ ] No `Model.findOne` introduced — use `findExactlyOne` / `findOneOrNone`
+
+## Common Pitfalls
+
+- Adding a required field without a default — first deploy fails for documents that pre-date the field
+- Skipping the type file update — TS happily compiles older callers but new ones break at runtime
+- Adding a `unique` index without dedup — index build fails on collections with existing duplicates
+- Renaming a field in one PR — frontend gets old field, backend writes new field, neither side is happy
+- Forgetting to regenerate the SDK after a shape change — frontend types drift from reality
+- Using `.method()` / `.static()` API — terreno's convention is direct assignment, and mixing styles makes types hard to maintain

--- a/.cursor/skills/respond-to-review/SKILL.md
+++ b/.cursor/skills/respond-to-review/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: respond-to-review
+description: Review PR comments, plan fixes, and implement — auto-submitting when no clarifications are needed
+---
+# PR Review Response Workflow
+
+Review comments on PR #$ARGUMENTS and plan fixes. If the plan has open questions for the user, pause for confirmation; otherwise implement, commit, and run `/submit` automatically without prompting.
+
+## Step 1: Setup Working Directory
+
+1. Check if we're already in a git worktree:
+   ```bash
+   git rev-parse --show-toplevel
+   git worktree list
+   ```
+
+2. **If already in a worktree**, use the current directory — skip to Step 2.
+
+3. **If NOT in a worktree**, set one up:
+
+   a. Get the repo name:
+      ```bash
+      basename $(git rev-parse --show-toplevel)
+      ```
+
+   b. Fetch PR details and branch name:
+      ```bash
+      gh pr view $ARGUMENTS --json headRefName,number,title,url,author
+      ```
+
+   c. Fetch the PR branch:
+      ```bash
+      git fetch origin pull/$ARGUMENTS/head
+      ```
+
+   d. Create worktree at `~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS`:
+      ```bash
+      git worktree add ~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS FETCH_HEAD
+      ```
+
+   e. Change to the worktree directory:
+      ```bash
+      cd ~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS
+      ```
+
+   f. Set up tracking for the PR branch:
+      ```bash
+      git checkout -B <branch-name> FETCH_HEAD
+      git branch --set-upstream-to=origin/<branch-name>
+      ```
+
+**Important**: All subsequent work happens in the working directory (worktree or current).
+
+## Step 2: Find the Reviews
+
+1. Get review threads with resolution status using GraphQL. **Important**: capture the thread `id` for each unresolved thread so you can resolve them later.
+   ```bash
+   gh api graphql -f query='
+     query($owner: String!, $repo: String!, $pr: Int!) {
+       repository(owner: $owner, name: $repo) {
+         pullRequest(number: $pr) {
+           reviewThreads(first: 100) {
+             nodes {
+               id
+               isResolved
+               comments(first: 50) {
+                 nodes {
+                   author { login }
+                   body
+                   path
+                   line
+                   createdAt
+                 }
+               }
+             }
+           }
+           reviews(first: 50) {
+             nodes {
+               author { login }
+               state
+               body
+             }
+           }
+         }
+       }
+     }' -F owner=':owner' -F repo=':repo' -F pr=$ARGUMENTS
+   ```
+
+2. **Ignore resolved threads entirely** — only process threads where `isResolved` is `false`
+
+3. Filter to comments from other users (not the PR author)
+
+4. Identify which remaining comments are:
+   - Blocking (CHANGES_REQUESTED) vs suggestions
+   - Inline code comments vs general comments
+
+## Step 3: Decide What To Do & Propose a Plan
+
+Decide the right action for each unresolved comment (fix, skip, ask), then present a structured plan organized by priority:
+
+```
+## PR #$ARGUMENTS Review Comments Plan
+
+### 🔴 Must Fix (Blocking)
+1. [file:line] @reviewer: "comment text"
+   → Proposed fix: <description>
+
+### ⚠️ Should Address (Suggestions)
+2. [file:line] @reviewer: "comment text"
+   → Proposed fix: <description>
+
+### 💬 Questions/Clarifications Needed
+- Comment X: Need your input on approach
+- Comment Y: Conflicts with existing pattern, which to use?
+
+### 📝 Will Skip (N/A or out of scope)
+- Comment Z: Not applicable or out of scope
+
+### 💬 Suggested Replies to Human Commenters
+For any comments that warrant a reply (e.g., to clarify a decision or thank a reviewer):
+- **Print the suggested reply text** so the user can see it
+- **Never post replies** via `gh pr comment`, `gh api`, or any other method — leave posting to the user
+```
+
+## Step 4: Confirmation (only if there are open questions)
+
+**If the plan has any items under 💬 Questions/Clarifications Needed:**
+Ask: **"Need your input on the questions above. Anything else to change before I implement?"**
+- Wait for explicit approval before making any changes
+- Incorporate any feedback
+- Re-present plan if significant changes requested
+
+**If there are no open questions:** skip confirmation entirely. Proceed directly to Step 5 — implement, commit, run `/submit`, and resolve threads without further prompts. Do not ask the user for plan approval in this case.
+
+## Step 5: Make the Fix
+
+After approval:
+
+1. Implement fixes one at a time, in priority order
+2. After each fix, briefly confirm what was changed
+
+## Step 6: Show the diff
+
+Show the complete diff so the user can scan what was implemented:
+```bash
+git diff
+git diff --stat
+```
+
+Do **not** commit here. `/submit` (next step) handles pre-commit checks, staging, commit, push, and PR updates — running pre-commit *before* the commit, which is the correct order. Committing here would invert that order and leave broken code committed locally if pre-commit fails.
+
+## Step 7: Run /submit
+
+Invoke the `/submit` skill to handle pre-commit checks, commit, push, and PR updates. This will also launch the CI check-watcher in the background. Pass a `$DESCRIPTION` summarizing what review comments were addressed so the commit message reflects the work.
+
+## Step 8: Resolve Addressed Threads
+
+After `/submit` completes, resolve each review thread that was addressed in the implementation. Use the thread `id` captured in Step 2.
+
+For each thread that was fixed or addressed (from the "Must Fix" and "Should Address" categories in the plan):
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }' -f threadId="<thread_id>"
+```
+
+Do NOT resolve threads that were:
+- Skipped (marked as N/A or out of scope)
+- Questions/clarifications that were not answered by code changes
+- Threads where the user decided not to take action
+
+Report which threads were resolved and which were left open.
+
+---
+
+## Error Handling
+
+- If worktree already exists, ask if user wants to reset it or use existing
+- If PR not found, show error and available PRs: `gh pr list`
+- If no comments found, inform user and ask if they want to proceed anyway
+- If merge conflicts occur during implementation, pause and ask for guidance
+
+## Cleanup Reminder
+
+If a new worktree was created, remind user:
+```
+To remove this worktree later:
+  git worktree remove ~/.claude-worktrees/<repo>/pr-$ARGUMENTS
+
+Or to keep working on it, you can open a new Claude session in:
+  cd ~/.claude-worktrees/<repo>/pr-$ARGUMENTS
+```

--- a/.cursor/skills/submit/SKILL.md
+++ b/.cursor/skills/submit/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: submit
+description: Lightweight pre-commit + commit + push + create/update PR, then spawn check-watcher in the background. Use /fullsend for the full pipeline with code review.
+---
+# Submit: Quick Commit & PR
+
+Lightweight path to run pre-commit checks, commit, push, and monitor CI. After pushing, this skill launches `/check-watcher` as a background sub-agent so CI is watched without blocking. Use `/fullsend` for the full pipeline that also includes code review.
+
+## Step 1: Assess Changes
+
+```bash
+git status && git diff --stat
+```
+
+```bash
+gh pr view --json number -q .number 2>/dev/null || echo "no-pr"
+```
+
+## Step 1.5: Pre-Commit Checks
+
+Delegate lint, type check, and related tests to the `pre-commit` subagent before committing.
+
+Use the `Agent` tool:
+- `subagent_type`: `pre-commit`
+- `description`: `Run pre-commit checks`
+- `prompt`: instruct it to run lint, compile, and related tests for the current project, fix any issues, and report back. Mention this is being run as part of `/submit` for an upcoming commit.
+
+Wait for the subagent to return its Pre-Commit Report. If it surfaces unfixable failures, STOP and report them — do not commit or push.
+
+If invoked from `/fullsend` (which already ran pre-commit), skip this step.
+
+## Step 2: Commit
+
+Stage and commit:
+- Review the diff to write an accurate message
+- Keep first line under 72 characters
+- No conventional commit prefixes
+- No AI attribution
+
+## Step 3: Push
+
+```bash
+git push origin HEAD
+```
+
+## Step 4: Create or Update PR
+
+### If no PR exists
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+[What changed and why — 2-4 sentences]
+
+## Human Testing Steps
+- [ ] [Step-by-step verification instructions]
+
+## Changes
+- [Bullet list of specific changes]
+
+## Automated Tests
+- [Tests that ran and passed, or "None"]
+EOF
+)" --draft
+```
+
+### If a PR already exists
+
+Read the current title and body, then compare against the full set of commits on the branch:
+
+```bash
+gh pr view --json title,body,baseRefName
+git log $(gh pr view --json baseRefName -q .baseRefName)..HEAD --oneline
+git diff $(gh pr view --json baseRefName -q .baseRefName)...HEAD --stat
+```
+
+Decide whether the description still reflects what's on the branch — pay attention to commits added since the PR was opened:
+- **Summary** still matches the actual goal of the changes
+- **Changes** list covers the new commits, not just the original ones
+- **Human Testing Steps** still cover what reviewers need to verify
+- **Automated Tests** section reflects current test state
+
+If the description is stale or incomplete, update it. Preserve sections the user has clearly edited by hand — only rewrite what's actually out of date, and merge new bullets into existing lists rather than replacing them wholesale:
+
+```bash
+gh pr edit --title "<title>" --body "$(cat <<'EOF'
+<updated body>
+EOF
+)"
+```
+
+If the description is already accurate, skip the edit and note that it's up to date.
+
+## Step 5: Print PR Link
+
+```bash
+gh pr view --json title,url -q '"**\(.title)** — \(.url)"'
+```
+
+## Step 6: Launch Check Watcher Sub-Agent
+
+Spawn `/check-watcher` as a **background sub-agent** so CI monitoring runs autonomously without blocking the parent conversation. Use the `Agent` tool with `run_in_background: true`.
+
+- `subagent_type`: `general-purpose`
+- `description`: `Watch CI for current PR`
+- `run_in_background`: `true`
+- `prompt`: instruct the sub-agent to invoke the `/check-watcher` skill for the current PR, fix any failures, and report back when checks are green or max attempts are hit. Include the PR number/URL from Step 5 so the sub-agent has context.
+
+Do **not** wait on the sub-agent — return control immediately after spawning. The user will be notified when it completes.
+
+By the time you reach this step, a PR is guaranteed to exist — either it pre-existed (from Step 1) or Step 4 just created it. Always spawn check-watcher.
+
+## Arguments
+
+$DESCRIPTION: Optional description to guide the commit message and PR

--- a/.github/skills/ai-prompt-governance/SKILL.md
+++ b/.github/skills/ai-prompt-governance/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: ai-prompt-governance
+description: >-
+  Invoke when adding, modifying, or reviewing any prompt used by `@terreno/ai`
+  (AIService methods, system prompts, helpers). Provides prompt-as-constant
+  rules, temperature preset guidance, logging requirements, and a testing
+  checklist.
+---
+# AI Prompt Governance — `@terreno/ai`
+
+`@terreno/ai` is a backend-only, provider-agnostic AI layer built on the Vercel AI SDK. Consuming apps inject a `LanguageModel` (Google, Anthropic, OpenAI, etc.) and call `AIService` methods. All requests are logged through the `AIRequest` model.
+
+See `ai/src/service/aiService.ts` and `ai/src/service/prompts.ts` for the canonical implementation.
+
+## Prompt Writing Rules
+
+1. **Always a named constant** — Define prompts in `ai/src/service/prompts.ts` (or the consuming app's equivalent constants file). Never inline prompt strings in route handlers, services, or `AIService` method bodies.
+2. **Self-contained** — A prompt should read coherently on its own. If you must inject runtime context, document why in a comment above the constant.
+3. **Typed return** — If the prompt asks for structured JSON, define a matching TypeScript interface in `ai/src/types/index.ts` and parse against it on every response.
+4. **Don't bake user-identifiable data into the prompt template itself** — inject it at call time as runtime parameters, never as defaults in the constant.
+
+## Temperature Preset Guidance
+
+Use the presets exported from `@terreno/ai`:
+
+| Preset | Value | When to use |
+|--------|-------|-------------|
+| `DETERMINISTIC` | 0 | Structured extraction, classification, deterministic transforms |
+| `LOW` | 0.3 | Summarization, translation, faithful rewording |
+| `BALANCED` | 0.7 | General Q&A, balanced creativity |
+| `DEFAULT` | 1.0 | Chat, open-ended responses |
+| `HIGH` | 1.5 | Brainstorming, creative variation |
+| `MAXIMUM` | 2.0 | Maximum variability — rarely the right choice |
+
+Pick the lowest temperature that still produces good results. Don't override the default unless you can name a reason in the call site.
+
+## Logging
+
+Every `AIService` method already logs to the `AIRequest` model via the internal `logRequest()` call. Do not bypass `AIService` and call the Vercel SDK directly from routes — you lose request logging, error capture, and the `requestType` taxonomy.
+
+Current `AIRequest.requestType` values: `"general" | "remix" | "summarization" | "translation"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
+
+Logging failures must never break the main flow — the existing pattern catches and logs internally. Preserve that behavior.
+
+## Testing a Prompt Change
+
+`@terreno/ai` tests inject a mock `LanguageModel` with `doGenerate` / `doStream` methods. See the mock pattern in `ai/src/aiApp.test.ts`. Never hit a live provider in unit tests.
+
+1. Add or update a unit test that mocks `doGenerate` / `doStream` and asserts the prompt your code sends matches expectations.
+2. Run against at least 3 inputs:
+   - A normal/expected case
+   - An edge case (empty input, very long input, missing optional fields)
+   - An adversarial case that could break structured JSON output
+3. For structured JSON: assert the response parses against the typed return interface.
+4. If the prompt affects streaming behavior, mock `doStream` and assert the emitted chunks.
+
+For a one-off manual smoke against a real provider, temporarily add `logger.debug("prompt test", {prompt, response})` in the `AIService` method, run locally, then remove the log before committing.
+
+## Prompt Change Checklist
+
+- [ ] Prompt is a named constant in `prompts.ts` (or app equivalent) — not inlined
+- [ ] Prompt still produces valid, parseable structured JSON if applicable (tested with 3+ inputs)
+- [ ] Temperature preset is appropriate (lowest viable for the task)
+- [ ] Call goes through `AIService` (so `AIRequest` logging fires) — no direct Vercel SDK calls from routes
+- [ ] If `requestType` taxonomy changed, the type union and admin explorer filters were updated
+- [ ] No user-identifiable data baked into the prompt template (only injected at call time)
+- [ ] Unit test added/updated with a mock model
+- [ ] Commit message explains the behavioral change (the prompt is the behavior)
+
+## Adding a New AI Feature
+
+1. Define prompt(s) as named constants in `ai/src/service/prompts.ts`.
+2. If structured JSON output, define the TypeScript interface for the return shape in `ai/src/types/index.ts`.
+3. Add a method to `AIService` (or a new service class) that calls `generateText` / `generateTextStream` and goes through the existing logging path.
+4. If exposing via HTTP, add a route in `ai/src/routes/` following the patterns in `gpt.ts` / `gptHistories.ts`. Use `createOpenApiBuilder` for OpenAPI docs.
+5. Add an integration test with a mock model that verifies:
+   - The prompt sent to the model matches the constant
+   - The structured JSON return parses against the typed interface
+   - `AIRequest.logRequest` is called with the correct `requestType`
+
+## Common Pitfalls
+
+- Calling the Vercel SDK directly from a route — bypasses logging and request typing
+- Inlining a prompt string in a route handler — makes future changes invisible and untestable
+- Using the wrong `requestType` value (or `"general"` as a catch-all) — degrades the admin explorer
+- Setting `temperature` numerically instead of via a preset — drifts away from the documented presets
+- Forgetting to type the JSON return — runtime parse failures show up later as confusing errors

--- a/.github/skills/backend-test-env/SKILL.md
+++ b/.github/skills/backend-test-env/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: backend-test-env
+description: >-
+  Invoke when writing tests that mutate `process.env` in `@terreno/api`,
+  `@terreno/ai`, or `example-backend` — feature flags, auth secrets, integration
+  toggles. Covers the preload contract, `setupEnvironment()`, and safe mutation
+  patterns.
+---
+# Backend Test — `process.env` Contract
+
+Bun's test runner preloads a per-package setup file (configured in each package's `bunfig.toml` under `[test].preload`):
+
+| Package | Preload file |
+|---------|--------------|
+| `@terreno/api` | `api/src/tests/bunSetup.ts` |
+| `@terreno/ai` | `ai/src/tests/bunSetup.ts` |
+| `example-backend` | `example-backend/src/tests/setup.ts` |
+
+The `@terreno/api` preload uses a global `beforeEach` to (1) reset the canonical auth secrets, (2) call `setupEnvironment()` (exported from `expressServer.ts`) for the wider baseline, and (3) re-silence the winston loggers. The next test always starts from the canonical baseline — you normally **do not** need to re-call `setupEnvironment()` in a file-level `beforeEach`.
+
+## Default — Rely on the Preload
+
+- Do not assume a toggle left by another file. Treat the preload's `beforeEach` as the source of truth for the canonical baseline.
+- Set only the keys this test needs in its own `beforeEach` or test body.
+- Don't reach in and call `setupEnvironment()` again unless you're explicitly testing env-driven behavior that the preload didn't cover.
+
+## When a Test Mutates `process.env`
+
+1. **Add the key to the preload's reset list** if it should always start from a fixed test value. Otherwise it leaks into the next test in the same worker.
+2. **Set only what this case needs** in the test body — avoid redundant manual restore if the preload already resets that key in `beforeEach`.
+3. **For keys that should be absent (unset)**, use **`Reflect.deleteProperty(process.env, "KEY")`**. Avoid `process.env.KEY = ""` to mean "unset" — on some platforms empty string and unset behave differently and can make tests flaky.
+4. **Avoid whole-env snapshots** (`const OLD_ENV = process.env; ...; process.env = OLD_ENV;`). This pattern exists in some older test files (`auth.test.ts`) — don't propagate it. It captures pre-`beforeEach` state and breaks ordering guarantees if the preload's `beforeEach` runs in between. Use targeted mutations + the preload's reset instead.
+
+## Adding a New Required Env Var
+
+If you introduce a new `process.env.FOO` that backend code reads at startup:
+
+1. Add `FOO` to `setupEnvironment()` in `api/src/expressServer.ts` so every package picks it up via the preload's `setupEnvironment()` call.
+2. If `example-backend` has its own startup needs for it, also add to `example-backend/src/tests/setup.ts`'s `beforeAll`.
+3. If a test needs to mutate it, follow the rules above — don't snapshot the whole env.
+
+## Auth-Related Keys
+
+`api/src/tests/bunSetup.ts` resets four auth keys in `beforeEach`: `TOKEN_SECRET`, `TOKEN_ISSUER`, `SESSION_SECRET`, `REFRESH_TOKEN_SECRET`. If your test changes any of these, you do not need to restore — the next `beforeEach` already does. If your test relies on them being **absent** for a code path, use `Reflect.deleteProperty` within the test, knowing the next `beforeEach` will restore.
+
+`auth.test.ts` is the established home for env-driven auth assertions; mirror its newer patterns (per-test `beforeEach` setting only what changes) rather than its older whole-env-snapshot blocks.
+
+## Log Capture & Sentry
+
+The preload silences winston and `console.*` and captures into an in-memory buffer (cleared in `beforeEach`/`afterEach`). It also mocks `@sentry/bun`. Don't re-mock Sentry inside individual tests — the preload's mock is shared and reset across tests.
+
+## Checklist
+
+- [ ] New env var added to `setupEnvironment()` and (if needed) `example-backend/src/tests/setup.ts`
+- [ ] Test mutations are targeted — no whole-env snapshots
+- [ ] "Unset" expressed as `Reflect.deleteProperty(process.env, "KEY")`, not `= ""`
+- [ ] No manual restore that duplicates the preload's `beforeEach` reset
+- [ ] No re-mock of `@sentry/bun` — the preload's mock is already in place
+- [ ] If you added an env-driven branch in code, a test covers both the set and the unset case

--- a/.github/skills/check-watcher/SKILL.md
+++ b/.github/skills/check-watcher/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: check-watcher
+description: Monitor GitHub Actions checks and automatically fix failures
+---
+# Check Watcher
+
+Monitor GitHub Actions checks and auto-fix failures. Designed to be called standalone or from other skills.
+
+## Instructions
+
+1. Get the PR number:
+   ```bash
+   gh pr view --json number -q .number
+   ```
+   If no PR exists, inform the user and exit.
+
+2. Wait for CI to finish using `--watch` (no manual polling):
+   ```bash
+   gh pr checks --watch --fail-fast
+   ```
+   - All passing → go to step 6
+   - Failed → continue to step 3
+
+3. Get failure details:
+   ```bash
+   gh run view <run-id> --log-failed
+   ```
+
+4. Determine if flaky or real:
+   - Compare failed files/tests against `gh pr diff` — is the failure in code you changed?
+   - Check for flaky signals: timeouts, race conditions, ECONNRESET, intermittent assertions
+   - If flaky (not in your code + flaky signals), rerun once: `gh run rerun <run-id> --failed`
+   - Run `gh pr checks --watch --fail-fast` again. If still failing, file an issue and move on:
+     ```bash
+     gh issue create --title "Flaky test: <test name>" --body "<error details and job link>"
+     ```
+
+5. If failure IS related to PR changes:
+   - Fix the code
+   - Run lint and compile locally to validate
+   - Commit and push (no AI attribution, no conventional prefixes)
+   - Return to step 2
+
+6. When all checks pass, check for bot review comments:
+   ```bash
+   gh api repos/:owner/:repo/pulls/<pr_number>/comments --jq '.[] | select(.user.type == "Bot") | "\(.path):\(.line) @\(.user.login): \(.body)"'
+   ```
+   Report any actionable bot comments found. Do NOT auto-fix — just report them.
+
+7. Print the PR link:
+   ```bash
+   gh pr view --json title,url -q '"**\(.title)** — \(.url)"'
+   ```
+
+Cap fix attempts at $MAX_ATTEMPTS (default: 5).
+
+## Arguments
+
+$MAX_ATTEMPTS: Optional max fix attempts before stopping (default: 5)

--- a/.github/skills/commit/SKILL.md
+++ b/.github/skills/commit/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: commit
+description: >-
+  Create a commit for the current staged/unstaged changes with a clear, accurate
+  message
+---
+# Commit Changes
+
+Create a commit for the current staged/unstaged changes.
+
+## Instructions
+
+1. Check git status and diff to understand what changed:
+   ```
+   git status
+   git diff
+   git diff --cached
+   ```
+
+
+2. Stage changes appropriately and create a commit:
+   - Review the actual changes to write an accurate commit message
+
+   **Message Format:**
+   - The first line must be under 72 characters
+   - Add a body if more context is needed
+   - Exclude conventional commit prefixes (feat:, fix:, chore:, etc.)
+
+   **Content Restrictions:**
+   - Exclude any mention of AI, Claude, or any AI assistant
+   - Exclude making the commit coauthored by any AI
+   - Exclude adding "Co-Authored-By" trailers
+
+   *If constraints conflict, prioritize Message Format for clarity and readability.*
+
+3. Never push unless explicitly asked.
+
+## Arguments
+
+$DESCRIPTION: Optional description to guide the commit message

--- a/.github/skills/create-pr/SKILL.md
+++ b/.github/skills/create-pr/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: create-pr
+description: Create a draft pull request for the current branch
+---
+# Create Pull Request
+
+Create a pull request for the current branch.
+
+## Instructions
+
+1. First ensure changes are committed and pushed:
+   ```
+   git status
+   git log origin/master..HEAD --oneline
+   ```
+
+2. If there are uncommitted changes, commit them first (run `/commit` command).
+
+3. Push the branch if not already pushed:
+   ```
+   git push origin HEAD
+   ```
+
+4. Create the pull request:
+   ```
+   gh pr create --title "<title>" --body "<body>" --draft
+   ```
+
+   Guidelines for the PR:
+   - Title: Clear, concise summary of the changes
+   - Do not use prefix commit format (feat:, fix:, chore:, etc.)
+   - Do not mention AI, Claude, or any AI assistant in the title or body
+   - Do not add "Generated with Claude" or similar footers
+   - Always create as draft
+
+   **PR Body Structure:**
+
+   ```markdown
+   ## Summary
+
+   [What changed and why — 2-4 sentences]
+
+   ## Human Testing Steps
+
+   - [ ] [Step-by-step instructions a reviewer can follow to verify the change works]
+   - [ ] [Cover happy path and at least one edge case]
+
+   ## Changes
+
+   - [Bullet list of specific changes]
+
+   ## Automated Tests
+
+   - [Tests that ran and passed, or "No automated tests"]
+   ```
+
+5. Return the PR URL to the user.
+
+## Arguments
+
+$DESCRIPTION: Optional description for the PR title and body

--- a/.github/skills/fix-conflicts/SKILL.md
+++ b/.github/skills/fix-conflicts/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: fix-conflicts
+description: >-
+  Pull latest from master, resolve merge conflicts, validate with lint/compile
+  checks, and monitor CI
+---
+# Fix Conflicts
+
+Pull latest from master, resolve merge conflicts, validate with lint/compile checks, and monitor CI.
+
+## Instructions
+
+1. Ensure the working tree is clean before starting:
+   ```
+   git status
+   ```
+   - If there are uncommitted changes, ask the user whether to stash them or abort
+
+2. Fetch and merge the latest master into the current branch:
+   ```
+   git fetch origin master
+   git merge origin/master
+   ```
+   - If the fetch or merge fails, check network connectivity and repository access permissions. Notify the user if the issue persists.
+
+3. Check for merge conflicts:
+   ```
+   git diff --name-only --diff-filter=U
+   ```
+   - If there are no conflicts, skip to step 5
+
+4. For each conflicted file:
+    - Read the file and understand both sides of the conflict
+    - Resolve the conflict by combining changes in a way that retains the functionality and purpose of both sets of changes, ensuring no critical information is lost.
+    - If the conflict cannot be resolved automatically, notify the user and provide a summary of the conflicting changes.
+    - After resolving all conflicts in a file, stage it:
+       ```
+       git add <file>
+       ```
+    - After all conflicts are resolved, complete the merge:
+       ```
+       git commit --no-edit
+       ```
+
+## Running Checks
+
+5. Run lint and compile checks at the project root:
+    ```
+    git rev-parse --show-toplevel
+    ```
+    - Run linting:
+       ```
+       cd <project-root> && bun run lint
+       ```
+       - If linting fails, fix the issues and re-run until passing
+    - Run type compilation/checking:
+       ```
+       cd <project-root> && bun run compile
+       ```
+       - If compilation fails, fix the type errors and re-run until passing
+    - If linting or compilation fails repeatedly and cannot be resolved, notify the user with the error details and suggest seeking assistance.
+
+## Handling Fixes and Commits
+
+6. If any fixes were needed in step 5, stage and commit them:
+   - Review the changes made
+   - Create a commit with a clear message describing what was fixed
+   - In step 6, do not use prefix commit format (feat:, fix:, chore:, etc.) for the commit message.
+   - Do not mention AI, Claude, or any AI assistant
+
+7. Push the changes:
+   ```
+   git push origin HEAD
+   ```
+
+8. Run check-watcher by invoking `/check-watcher`:
+   - This monitors GitHub Actions checks
+   - If checks fail, it will automatically read failures, fix them, and push again
+   - Continue until all checks pass
+
+## Arguments
+
+None

--- a/.github/skills/implement/SKILL.md
+++ b/.github/skills/implement/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: implement
+description: >-
+  Test-driven implementation execution skill for applying implementation plans
+  directly in code
+---
+# Implementation Execution Skill
+
+Use this skill when an Implementation Plan (IP) or implementation requirements are provided.
+
+
+The goal of this skill is to execute the implementation directly in code using test-driven development.
+
+If the implementation plan is incomplete or contains contradictions, highlight the conflicts and request clarification before proceeding.
+
+Do not stop after analysis or task generation unless blocked by material ambiguity.
+
+## Primary Behavior
+
+When an IP is provided:
+
+1. Read the full IP carefully.
+2. Determine implementation scope.
+3. Identify the smallest meaningful automated test coverage that should fail for the requested behavior.
+4. Write or update the failing tests before implementation code.
+5. Run the targeted tests and confirm they fail for the expected product reason, not because of syntax, setup, or unrelated failures.
+6. Implement the requested changes directly.
+7. Run the previously failing tests until they pass.
+8. Run relevant validation or broader test commands when available.
+9. Summarize completed work, assumptions, and remaining risks.
+
+Exclude generating a separate implementation plan unless explicitly requested.
+
+## Scope Detection
+
+Determine whether the implementation is:
+
+- backend only
+- frontend only
+- full stack
+- phased implementation
+- rollout-gated
+- migration-dependent
+
+
+// --- Assumption Rules ---
+Use best-effort assumptions when the assumption does not affect compliance, data integrity, or user experience.
+
+If the correct scope is unclear and could materially change implementation, ask concise clarifying questions before coding.
+
+## Clarifying Question Rules
+
+Only ask questions if missing information would materially affect:
+
+- architecture
+- data model behavior
+- API contracts
+- permissions/access control
+- user/admin visibility
+- rollout sequencing
+- migration/backfill behavior
+- destructive operations
+- compliance-sensitive behavior
+- whether implementation should be backend only, frontend only, phased, or full stack
+
+// --- Clarifying Question Exclusions ---
+Exclude asking questions for implementation details that do not affect functionality, performance, or compliance, and can reasonably be inferred.
+
+
+## Execution Expectations
+
+Implement the requested behavior directly in the codebase.
+
+### Test-Driven Development Flow
+
+Default to red/green/refactor:
+
+- red: write the focused failing test or regression test first
+- green: implement only enough production code to satisfy the requested behavior
+- refactor: clean up the implementation while preserving passing tests
+
+If no meaningful automated test can be written for the change, document why before implementation and use the strongest available manual or static validation instead.
+
+### Implementation Steps
+- update or add focused failing tests
+- update schemas/models
+- update services/controllers/routes
+- update validation
+- update frontend UI
+- update state management/API hooks
+- update OpenAPI/types
+- update permissions/visibility logic
+- update feature flags
+- update fixtures/mocks
+- rerun the focused tests that failed first
+- run broader validation when appropriate
+- preserve existing behavior unless the IP explicitly changes it
+
+## Phased Implementations
+
+If the IP implies phased implementation:
+
+- determine whether backend and frontend should be separated
+- determine whether rollout gating is required
+- determine whether app-version compatibility matters
+
+If phase requirements are unclear and could affect implementation safety, ask before coding.
+
+Otherwise proceed with best-effort assumptions.
+
+## Testing Requirements
+
+Add or update relevant tests before production implementation whenever applicable.
+
+Possible test types include:
+
+- backend unit tests
+- backend integration tests
+- API tests
+- frontend component tests
+- frontend flow tests
+- regression tests
+
+Run the most targeted available tests first and capture the initial failure before writing production code. After implementation, rerun the same focused tests to confirm the red-to-green transition.
+
+If full test execution is not practical, run the closest focused validation possible and document what was not run.
+
+## File Modification Rules
+
+Prefer modifying existing patterns consistently with the codebase.
+
+Avoid introducing new architectural patterns unless required.
+
+Do not invent exact file paths unless strongly implied by the repository structure.
+
+Prefer consistency over novelty.
+
+## Safety Rules
+
+Do not make destructive or irreversible changes without clear instruction.
+
+Do not silently change existing product behavior outside the requested scope.
+
+If implementation could create compliance, privacy, permission, or rollout risk, explicitly call it out in the final response.
+
+## Final Response Requirements
+
+At completion, summarize:
+
+- implementation scope
+- major code changes
+- assumptions made
+- tests updated/run
+- remaining risks or follow-up work
+
+Keep the summary concise and implementation-focused.

--- a/.github/skills/improve-rulesync/SKILL.md
+++ b/.github/skills/improve-rulesync/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: improve-rulesync
+description: >-
+  Invoke at the end of a session to evaluate whether any skills or rules were
+  misleading, incorrect, or missing — and fix or create them. Trigger with
+  /improve-rulesync.
+---
+# Improve Rulesync
+
+### Trigger
+Invoke explicitly at the end of a session with `/improve-rulesync`.
+
+### Behavior
+Review the current conversation session and evaluate the skills and rules in `.rulesync/`. Identify any that:
+- Gave misleading or incorrect guidance that caused errors or rework
+- Were missing and would have prevented incorrect behavior
+- Need to be updated to reflect decisions or patterns established in this session
+
+Then make the changes directly.
+
+### Step 1 — Session Review
+Scan the session for:
+- Moments where a skill or rule was followed but produced a wrong or suboptimal result
+- User corrections or decisions about AI model behavior (these indicate a gap or error in the rules)
+- New patterns, decisions, or constraints established that should be codified
+
+### Step 2 — Rules Audit
+Check `.rulesync/` for relevant existing rules and skills. Evaluate:
+- Are trigger conditions accurate?
+- Is the guidance still correct given what happened this session?
+- Are there gaps that caused confusion?
+
+### Step 3 — Make Changes
+For each issue found:
+- **Incorrect/misleading**: Edit the existing file to fix it
+- **Missing**: Create a new skill or rule file in `.rulesync/skills/` or `.rulesync/rules/`
+- **Outdated**: Update or remove the stale content
+
+Always edit `.rulesync/` as the source of truth.
+
+### Step 4 — Sync
+After all changes, run `bun run rules` to sync to all AI tool directories.
+
+### Step 5 — Summary
+Output a brief summary of what was changed and why. Format:
+- **Fixed**: [file] — [what was wrong and what was corrected]
+- **Created**: [file] — [what gap it fills]
+- **No changes needed**: [reason]

--- a/.github/skills/ip/SKILL.md
+++ b/.github/skills/ip/SKILL.md
@@ -1,0 +1,1559 @@
+---
+name: ip
+description: >-
+  Implementation Plan (/ip) — build an implementation plan from a PRD through an
+  interactive, multi-step process
+---
+# Implementation Plan (/ip)
+
+Build an implementation plan from a PRD through an interactive, multi-step process. Produces both a human-readable implementation plan and a structured task list for bot consumption.
+
+## Overview
+
+This skill walks through the Shape Up-inspired process of turning a raw PRD into a concrete implementation plan. Each step is a self-contained section in this file — you can re-run individual steps if needed by jumping to the matching section.
+
+**Every IP targets a specific project.** The project must be specified via the `$PROJECT` argument or selected interactively.
+
+## Project Registry
+
+| Alias(es) | GitHub Repo | Local Dir |
+|-----------|-------------|-----------|
+| `ter`, `terreno` | `flourishhealth/terreno` | `~/src/terreno` |
+
+Local Dir is derived from the repo name (the part after `/`). All repos clone into `~/src/`.
+
+If a project isn't in the registry, attempt to resolve it via `gh repo view <input>`. If found, use it. If not, ask the user for the full `owner/repo`.
+
+## Planning Workflow
+
+Run the following steps in order. Each step builds on the previous one.
+
+### Step 0: Project Setup (always runs first)
+
+This step is **mandatory** and runs before everything else, even when `$STEP` is provided.
+
+#### 0a. GitHub Auth Check
+
+```bash
+gh auth status
+```
+
+If not authenticated, tell the user:
+> You need to authenticate with GitHub. Run this in your terminal:
+> `! gh auth login --web`
+> Follow the prompts to open the browser link and enter the code.
+
+Then **stop** — do not proceed until the user confirms auth is complete.
+
+#### 0b. Resolve Project
+
+If `$PROJECT` was provided, match it against the registry aliases (case-insensitive). If no `$PROJECT`, show the registry table and ask the user to pick one.
+
+#### 0c. Clone if Needed
+
+Check if the local directory exists:
+```bash
+ls -d ~/src/{repo-name} 2>/dev/null
+```
+
+If it doesn't exist, clone it:
+```bash
+gh repo clone {owner/repo} ~/src/{repo-name}
+```
+
+#### 0d. Fetch Latest & Enter Worktree
+
+Navigate to the repo and ensure we have the latest code:
+```bash
+cd ~/src/{repo-name} && git fetch origin && git checkout master && git pull origin master
+```
+
+(If the default branch is `main` instead of `master`, detect it with `git remote show origin | grep 'HEAD branch'` and use that.)
+
+Then create a worktree for this IP using the `EnterWorktree` tool:
+- **name**: `ip-{feature-slug}` (derive from the PRD title once known, or use a temporary name like `ip-draft` and note that it can be renamed)
+
+Since the PRD title isn't known yet at this point, use `ip-draft` as the worktree name. After Step 1 (Ingest), if the worktree name doesn't match the feature, note the mismatch but continue — the branch can be renamed later.
+
+#### 0e. Confirm Ready
+
+Print a summary:
+```
+Project: {repo-name} ({owner/repo})
+Branch: {worktree-branch}
+Working dir: {worktree-path}
+Latest master: {short SHA + date of HEAD}
+```
+
+Proceed to Step 1.
+
+### Step 1: Ingest PRD
+
+Collect the PRD (Product Requirements Document) that will drive the implementation plan.
+
+1. `$PRD` is **required**. If it was not provided, stop immediately and tell the user: **"Error: /ip requires a PRD as the first argument (either a file path or the inline PRD text). Please re-run as `/ip <path-or-text>`."** Do not prompt for it interactively.
+
+2. Determine what the user provided:
+   - If it looks like a file path (e.g., ends in `.md`, `.txt`, contains `/` or `\`, or matches an existing file), read that file and use its contents as the PRD.
+   - Otherwise, treat the input as the PRD text itself.
+
+3. The PRD should contain at minimum a **Problem** section and ideally a **Business Case** section. If either is missing, note what's missing but proceed anyway.
+
+4. Display a brief summary of what you understood from the PRD:
+   - The core problem (1-2 sentences)
+   - The business impact (1-2 sentences)
+   - Key stakeholders or affected teams
+   - Any constraints or requirements called out
+
+5. Ask: "Does this summary capture the intent? Anything to add or correct?" and let the user adjust before moving on.
+
+6. Once confirmed, say: **"PRD ingested. Moving to research phase..."** and proceed to Step 2.
+
+### Step 2: Research Context
+
+Investigate the codebase and gather context for the PRD topic. Do this inline — do not invoke `/research` via the Skill tool. Follow this procedure:
+
+1. **Scope** — restate the topic in one sentence and tell the user what you plan to investigate. Ask if they want anything specific covered.
+2. **Codebase deep dive** — read relevant source files in depth (models, routes, screens, components, configs, tests). Search for existing patterns, conventions, and dependencies. Check `docs/`, `README.md`, `CLAUDE.md`, and any feature documentation. Note file paths, function names, and line numbers as you go.
+3. **External research** — search the web for any APIs, libraries, or best practices that aren't already in the codebase.
+4. **Present findings** — output a complete research document in chat with: Summary, Context, Findings (with file paths and snippets), Options Considered (table with pros/cons/effort), Recommendation (be opinionated), Open Questions, References.
+5. **Iterate** — ask "Anything you want me to dig deeper on, adjust, or investigate further?" If the user gives feedback, investigate and re-output the **full** updated document.
+6. **Save** — once the user is satisfied, write the final version to `research.md` in the project root and continue to Step 3.
+
+Be specific (file paths, line numbers, code snippets) and opinionated (recommend an approach, don't just list options).
+
+### Step 3: Shape & Question
+
+This is the core shaping step inspired by the Shape Up methodology. The goal is to narrow the solution from a raw idea to a well-defined approach with clear boundaries.
+
+#### Phase 1: Models & APIs (get alignment first)
+
+This is the most important part. Models and APIs define the shape of the feature — everything else follows from them.
+
+1. **Draft the data model** based on the PRD and research:
+   - Mongoose schemas with types, required fields, enums, defaults
+   - Relationships to existing models (refs)
+   - Indexes if relevant
+   - Plugins (soft delete, timestamps, etc.) based on existing patterns
+
+2. **Draft the API surface**:
+   - List each endpoint (method, path, description)
+   - Note if it's a standard CRUD modelRouter or custom
+   - Specify permissions for each endpoint
+   - Call out any special query parameters, filters, or bulk operations
+
+3. **Present both together** and ask the user: "Are these models and APIs the right approach?" Use AskUserQuestion.
+
+4. **Iterate** until the user confirms the models and APIs are right. This is the foundation — don't move on until it's solid.
+
+#### Phase 2: Everything Else (flows from models/APIs)
+
+Once models and APIs are confirmed, draft the remaining concerns in a single pass. These should follow naturally from the model/API decisions:
+
+- **Notifications**: Push, email, in-app — who gets notified, when, what content. If none needed, say so.
+- **Activity Log**: What actions get logged, which surface as User Updates, which user groups see them. If none, say so.
+- **Permissions & Access**: Role-based differences beyond what's already covered in API permissions.
+- **UI**: New screens/components, navigation flow, key interactions and states, reusable vs new components.
+- **Feature Flags & Migration**: Whether a flag is needed, any data migrations, rollout strategy.
+- **Phases**: How to break the work into PRs (Phase 1: models + APIs, Phase 2: core UI, Phase 3: polish). If small enough, say "single phase."
+- **Not Included / Future Work**: Compile out-of-scope items and deferred ideas.
+
+Present all of this as a single shaped solution summary:
+
+```
+## Shaped Solution
+
+### Core Concept
+[1-2 sentence description of the approach]
+
+### Models
+[schemas from Phase 1]
+
+### APIs
+[endpoints from Phase 1]
+
+### Notifications
+[notification plan or "none needed"]
+
+### Activity Log
+[logging plan or "none needed"]
+
+### UI
+[screens, flows, interactions]
+
+### Phases
+[implementation phases]
+
+### Not Included
+[explicitly excluded items]
+
+### Risks & Mitigations
+- [risk]: [mitigation approach]
+```
+
+Surface any **risks and rabbit holes** inline:
+- Technical risks: things that might be harder than they look
+- Scope risks: features that could balloon if not bounded
+- For each risk, suggest a mitigation or simpler fallback
+
+Ask: "Does this shaped solution look right? Any decisions you want to revisit?"
+
+Once confirmed, say: **"Solution shaped. Moving to plan sections..."** and proceed to Step 4.
+
+### Step 4: Plan Sections (optional deep pass)
+
+Optional interactive walk-through of each plan section, useful when Step 3 left details fuzzy. For each section: present a draft, ask the user if it looks right, let them refine, then move on.
+
+#### Section 1: Models
+
+1. Draft Mongoose schemas based on the shaped solution. Include:
+   - Full schema code blocks with types, required fields, enums, defaults
+   - Relationships to existing models (refs)
+   - Indexes if relevant
+   - Plugins (soft delete, timestamps, etc.) based on existing patterns found in research
+
+2. Present the schemas and ask:
+   - "Do these models look right?"
+   - "Any fields missing or that should be changed?"
+   - "Should any of these fields be optional vs required?"
+
+#### Section 2: APIs
+
+1. Draft the API surface:
+   - List each endpoint (method, path, description)
+   - Note if it's a standard CRUD modelRouter or custom
+   - Specify permissions for each endpoint
+   - Call out any special query parameters, filters, or bulk operations
+   - Note any webhook or external API integrations
+
+2. Present and ask: "Any endpoints missing? Do the permissions look right?"
+
+#### Section 3: Notifications
+
+1. Based on the shaped solution, list:
+   - Push notifications (who, when, what content)
+   - Email/text notifications
+   - In-app notifications or alerts
+   - If none needed, explicitly state "No notifications required for this feature"
+
+2. Present and confirm with user.
+
+#### Section 4: UI
+
+1. Draft the UI plan:
+   - List new screens/components
+   - Describe navigation flow (how users get there)
+   - Describe key interactions and states
+   - Note any reusable components that already exist vs need to be created
+   - Suggest fat-marker sketches if the UI is complex (describe what should be sketched)
+
+2. Present and ask: "Does this UI approach make sense? Any screens or interactions missing?"
+
+#### Section 5: Phases
+
+1. Propose how to break the work into phases/PRs:
+   - Phase 1: Usually models + basic APIs
+   - Phase 2: Core UI and integrations
+   - Phase 3: Polish, notifications, edge cases
+   - If the feature is small enough, note "Single phase - no need to break up"
+
+2. For each phase, list what's included and what the deliverable looks like.
+
+3. Present and ask: "Does this phasing make sense? Want to adjust?"
+
+#### Section 6: Feature Flags & Migrations
+
+1. Based on the shaped solution, recommend:
+   - Whether a feature flag is needed (and what it controls)
+   - Any data migrations required
+   - Rollout strategy
+
+2. Present and confirm.
+
+#### Section 7: Activity Log & User Updates
+
+1. List:
+   - What actions get logged to the activity log
+   - Which of those surface as User Updates
+   - Which user groups see the updates
+
+2. If no activity logging is needed, say so explicitly.
+
+#### Section 8: Not Included / Future Work
+
+1. Compile the "out of scope" items from shaping into this section
+2. Add any ideas that came up during planning but were deferred
+3. Present and confirm.
+
+After all sections are finalized, say: **"All sections planned. Moving to output generation..."** and proceed to Step 5.
+
+### Step 5: Generate Output
+
+Produce the final implementation plan document and a structured task list, then save them.
+
+1. **Generate the Implementation Plan** in the standard format:
+
+   ```markdown
+   # Implementation Plan: [Feature Name]
+
+   *When an engineer is assigned to a project but before you begin coding, you should fill in the implementation plan and get feedback from the engineering team. Once you have finished or you make any changes, tag Josh with the @ symbol so he can review. Also tag anyone else that needs to be notified, has conflicting work, etc.*
+
+   ## **Models**
+   [Content from plan step]
+
+   ## **APIs**
+   [Content from plan step]
+
+   ## **Notifications**
+   [Content from plan step]
+
+   ## **UI**
+   [Content from plan step]
+
+   ## Phases
+   [Content from plan step]
+
+   ## Feature Flags & Migrations
+   [Content from plan step]
+
+   ## Activity Log & User Updates
+   [Content from plan step]
+
+   ## **Not included/Future work**
+   [Content from plan step]
+
+   ## Acceptance Criteria
+   [If criteria exist from the PRD or shaping, include them here. Otherwise, leave a placeholder noting to run Step 6 (Acceptance Criteria) to generate them.]
+   ```
+
+2. **Generate the Task List** as a structured section at the bottom of the document:
+
+   ```markdown
+   ---
+
+   ## Task List (Bot Consumption)
+
+   *Structured task breakdown for automated implementation. Each task should be independently implementable and testable.*
+
+   ### Phase 1: [Phase Name]
+
+   - [ ] **Task 1.1**: [Short title]
+     - Description: [What to implement]
+     - Files: [Expected files to create/modify]
+     - Depends on: [Other task IDs, or "none"]
+     - Acceptance: [How to verify it's done]
+
+   - [ ] **Task 1.2**: [Short title]
+     ...
+
+   ### Phase 2: [Phase Name]
+   ...
+   ```
+
+   Tasks should be:
+   - Small enough to be a single PR or commit
+   - Ordered by dependency (models first, then APIs, then UI)
+   - Specific about which files to create/modify
+   - Clear about acceptance criteria
+
+3. **Ask the user for the feature name** to use in the filename (suggest one based on the PRD). The filename should be kebab-case.
+
+4. **Save the implementation plan:**
+   - Ensure `docs/implementationPlans/` directory exists (create if needed)
+   - Save to `docs/implementationPlans/[feature-name].md`
+   - Confirm the file was saved and show the path
+
+5. **Save the task plan:**
+   - Ensure `docs/tasks/` directory exists (create if needed)
+   - Save to `docs/tasks/[feature-name].md`
+   - Confirm the file was saved and show the path
+
+6. **Final summary:**
+
+   ```
+   ## Implementation Plan Complete
+
+   **Saved to**: docs/implementationPlans/[feature-name].md
+
+   ### Quick Stats
+   - Models: [count] new/modified
+   - API Endpoints: [count]
+   - Screens: [count]
+   - Phases: [count]
+   - Tasks: [count] total
+
+   ### Next Steps
+   1. Share with the engineering team for review
+   2. Tag @Josh and relevant stakeholders
+   3. Once approved, tasks can be loaded for implementation
+   ```
+
+7. Ask: "Want to make any final changes, or is this ready to share?"
+
+### Step 6: Acceptance Criteria
+
+Generate structured acceptance criteria for an implementation plan. The criteria should be specific enough for a human to manually test AND for a bot to translate into Playwright E2E tests.
+
+`$IP` (optional): path to an existing IP file. If not provided, look for the IP in the current conversation context or ask the user which IP to use.
+
+#### 1. Load the IP
+
+- If `$IP` is provided, read the file
+- Otherwise, check if an IP was generated in the current conversation
+- If neither, list available IPs from `docs/implementationPlans/` and ask which one to use
+
+#### 2. Check for existing acceptance criteria
+
+- If the PRD or IP already has an `## Acceptance Criteria` section, read it carefully
+- Also check each task in the Task List for `Acceptance:` lines
+- These are your starting point — you'll expand and formalize them, not replace them
+
+#### 3. Analyze the IP to identify testable behaviors
+
+Walk through each section of the IP and identify user-facing behaviors:
+
+- **Models & APIs**: What responses should the API return? What validation errors should occur?
+- **UI**: What should the user see? What happens when they interact with elements?
+- **Notifications**: What triggers them? What content appears?
+- **Permissions**: What should different roles see/not see?
+- **Error states**: What happens when things fail?
+- **Edge cases**: Empty states, boundary values, concurrent actions
+
+#### 4. Write acceptance criteria
+
+Write criteria in a dual-format that works for both humans and bots:
+
+```markdown
+## Acceptance Criteria
+
+### Feature: [Feature area name]
+
+#### AC-1: [Short descriptive title]
+**Priority:** P0 | P1 | P2
+**Screen:** [screen name, e.g., "Login Screen"]
+**Preconditions:**
+- [Any setup needed before testing, e.g., "User is logged in", "At least 3 items exist"]
+
+**Steps:**
+1. [Navigate to / open / tap specific element]
+2. [Perform action — be specific about what to type, tap, select]
+3. [Observe result]
+
+**Expected results:**
+- [ ] [Specific, observable outcome — what the user sees]
+- [ ] [Another expected outcome]
+
+**testIDs needed:** `screen-element-qualifier`, `screen-another-element`
+
+---
+```
+
+Format rules:
+
+- **Steps must reference specific UI elements** using the `{screen}-{element}-{qualifier}` testID naming convention
+- **Expected results must be visually verifiable** — things a human can see AND a bot can assert (`toBeVisible`, `toHaveText`, `toHaveCount`, etc.)
+- **Include the `testIDs needed` line** listing every testID the test will need. This serves as a checklist for the developer to add testIDs to components before tests can run.
+- **Priority levels:**
+  - **P0**: Core happy path — feature is broken without this
+  - **P1**: Important flows — error handling, validation, key edge cases
+  - **P2**: Nice-to-have — polish, edge cases, minor interactions
+- **Group by feature area** (e.g., "User Authentication", "Item Management", "Notifications")
+
+#### 5. Cover these categories
+
+Ensure you have at least one criterion for each:
+
+- **Happy path**: The main flow works end to end
+- **Validation**: Required fields, format checks, boundary values
+- **Error handling**: Network errors, server errors, invalid states
+- **Empty states**: What shows when there's no data?
+- **Permissions** (if applicable): Different roles see different things
+- **Navigation**: Moving between screens works correctly
+- **Data persistence**: Changes are saved and visible after refresh
+
+#### 6. Add the section to the IP
+
+Insert the `## Acceptance Criteria` section into the IP file, after the main plan sections but before the `## Task List` section.
+
+#### 7. Summary
+
+Present a summary:
+
+```
+## Acceptance Criteria Generated
+
+**Added to**: [IP file path]
+
+### Coverage
+- P0 (critical): [count] criteria
+- P1 (important): [count] criteria
+- P2 (nice-to-have): [count] criteria
+- Total testIDs needed: [count]
+
+### Next Steps
+1. Review criteria with the team
+2. Ensure all listed testIDs are added to components
+3. Run Step 7 (E2E Tests) to generate Playwright tests from these criteria
+```
+
+Ask: "Want to adjust any criteria or add coverage for something I missed?"
+
+### Step 7: E2E Tests (optional)
+
+Generate Playwright end-to-end tests from an IP's acceptance criteria. Uses the project's Playwright skill and testing conventions.
+
+`$IP` (optional): path to an IP file with acceptance criteria. If not provided, look for the IP in the current conversation context or ask the user which IP to use.
+
+#### 1. Load the IP and acceptance criteria
+
+- If `$IP` is provided, read the file
+- Otherwise, check if an IP was loaded in the current conversation
+- If neither, list available IPs from `docs/implementationPlans/` and ask which one to use
+- The IP **must** have an `## Acceptance Criteria` section. If it doesn't, tell the user to run Step 6 (Acceptance Criteria) first.
+
+#### 2. Research the codebase
+
+Before writing tests, understand the existing test setup:
+
+- Check if `playwright.config.ts` exists — if not, note that it needs to be created
+- Check if `e2e/` directory exists and what tests are already there
+- Check for `e2e/helpers/` and `e2e/fixtures/` for reusable utilities
+- Check for `e2e/auth.setup.ts` to understand auth patterns
+- Look at existing test files to match the style and patterns in use
+- Check if the testIDs listed in acceptance criteria already exist in the component code
+
+#### 3. Plan the test files
+
+Map acceptance criteria to test files:
+
+- **One test file per feature area** (matching the `### Feature:` groups in acceptance criteria)
+- File naming: `e2e/{feature-name}.spec.ts` (kebab-case)
+- Group related ACs into `test.describe()` blocks
+
+Present the plan to the user:
+
+```
+## E2E Test Plan
+
+### Files to create:
+- `e2e/feature-name.spec.ts` — [count] tests from [AC numbers]
+- `e2e/another-feature.spec.ts` — [count] tests from [AC numbers]
+
+### Missing testIDs (must be added to components first):
+- `screen-element-name` — [component file if known]
+- ...
+
+### Missing infrastructure:
+- [ ] playwright.config.ts (will create)
+- [ ] e2e/helpers/auth.ts (will create)
+- ...
+```
+
+Ask: "Should I generate these test files? Any changes to the plan?"
+
+#### 4. Generate test files
+
+For each test file, follow these rules strictly:
+
+**Structure:**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Feature: [Feature Name]', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to starting screen
+    // Wait for screen to be visible
+  });
+
+  // One test per acceptance criterion
+  test('[AC title — as user behavior]', async ({ page }) => {
+    // Steps from the AC, translated to Playwright actions
+    // Expected results as assertions
+  });
+});
+```
+
+**Translation rules (AC → Playwright):**
+
+| AC Step | Playwright Code |
+|---------|----------------|
+| Navigate to [screen] | `await page.goto('/path'); await page.getByTestId('screen-name').waitFor({ state: 'visible' });` |
+| Tap / click [element] | `await page.getByTestId('testid').click();` |
+| Type [text] into [field] | `await page.getByTestId('testid').fill('text');` |
+| Toggle [switch] | `await page.getByTestId('testid').click();` |
+| See [text/element] | `await expect(page.getByTestId('testid')).toBeVisible();` |
+| See text [content] | `await expect(page.getByTestId('testid')).toHaveText(/content/i);` |
+| Don't see [element] | `await expect(page.getByTestId('testid')).not.toBeVisible();` |
+| See [N] items in list | `await expect(page.getByTestId('list').getByTestId(/^item-/)).toHaveCount(N);` |
+| Wait for loading | `await page.getByTestId('loading-indicator').waitFor({ state: 'hidden' });` |
+| Page URL contains [path] | `await expect(page).toHaveURL(/path/);` |
+
+**Mandatory rules:**
+- Use `getByTestId()` as primary selector — never class names or deep selectors
+- Never use `waitForTimeout()` — always wait for element state
+- Wait for screen visibility after every navigation
+- Wait for `networkidle` after data-fetching actions when appropriate
+- Add `// AC-N: [title]` comment above each test for traceability
+- Mark tests that need auth setup with the appropriate Playwright project dependency
+- Use `test.skip()` with a reason for any AC that can't be automated yet (e.g., requires native device features)
+
+#### 5. Report missing testIDs
+
+After generating tests, produce a checklist of testIDs that need to be added to components:
+
+```markdown
+## testIDs to Add
+
+These testIDs are referenced in the generated tests but may not exist in the app yet.
+Add them before running the tests.
+
+### [Screen Name]
+- [ ] `screen-element-name` on `<ComponentType>` — [purpose]
+- [ ] `screen-another-element` on `<ComponentType>` — [purpose]
+```
+
+If you can identify the component files where testIDs should be added, include the file paths.
+
+#### 6. E2E Summary
+
+```
+## E2E Tests Generated
+
+### Files created:
+- `e2e/feature-name.spec.ts` — [count] tests
+- ...
+
+### Coverage:
+- P0 criteria covered: [count]/[total]
+- P1 criteria covered: [count]/[total]
+- P2 criteria covered: [count]/[total]
+- Skipped (not automatable): [count] — [reasons]
+
+### Before running tests:
+1. Add missing testIDs to components (see checklist above)
+2. Ensure `playwright.config.ts` is configured
+3. Start the dev server
+4. Run: `bunx playwright test`
+
+### After tests pass:
+Run `/verify` to verify the full implementation
+```
+
+### Step 8: Review (optional, dual-model)
+
+Review an implementation plan using both Claude (sub-agent) and OpenAI Codex in parallel. Each reviewer independently identifies issues, gaps, and questions. Results are combined, deduplicated, and presented as a structured question list for the user. After the user answers, the IP is updated.
+
+Argument: IP number, filename, or path to the plan file. If empty, infer from conversation context. Parse as `$ARGUMENTS`.
+
+#### Phase 1: Locate the Plan
+
+1. If argument provided, find the matching IP file:
+   - Check `docs/implementationPlans/` for matching file (by IP number, slug, or full path)
+   - If a path was given directly, use that
+2. If no argument, infer from conversation context (most recently discussed IP)
+3. If ambiguous, ask the user
+4. Read the full plan file
+5. If a corresponding task file exists in `docs/tasks/`, read that too
+
+#### Phase 2: Gather Codebase Context
+
+Collect context both reviewers will need:
+
+1. **CLAUDE.md** -- project conventions, tech stack, constraints
+2. **Relevant source files** -- scan the plan's "Files to Create/Modify" or "Files:" fields in tasks, read 3-5 of the most critical existing files
+3. **Data models** -- if the plan references models, find and read their current definitions
+4. **Recent changes** -- `git log --oneline -10` for recent momentum
+
+Keep context focused. Prioritize the plan itself and the most relevant code.
+
+#### Phase 3: Run Both Reviews in Parallel
+
+Launch both reviewers at the same time using parallel tool calls. Do NOT wait for one before starting the other.
+
+##### 3a: Claude Sub-Agent
+
+Use the **Agent tool** with `subagent_type: "general-purpose"`:
+
+Prompt the sub-agent with all gathered context and these instructions:
+
+> You are a senior engineer reviewing an implementation plan. Your goal is to surface issues, gaps, risks, and questions that should be answered before implementation begins.
+>
+> ## The Plan
+>
+> {full plan content}
+>
+> ## Task Breakdown
+>
+> {task list content, if available}
+>
+> ## Codebase Context
+>
+> {CLAUDE.md excerpt -- tech stack, conventions}
+>
+> {relevant source file excerpts}
+>
+> ## Your Review
+>
+> Analyze this plan and produce two outputs:
+>
+> ### Issues & Gaps
+>
+> For each issue found, provide:
+> - **Severity**: CRITICAL / HIGH / MEDIUM / LOW
+> - **Category**: one of: Missing Requirements, Unstated Assumptions, Technical Risks, Security & Data Integrity, Task Breakdown Gaps, Architecture Concerns, Scope Concerns
+> - **Description**: What's wrong or missing -- be specific, cite the plan section
+> - **Suggestion**: How to address it
+>
+> ### Questions for the Author
+>
+> Generate questions that, if answered, would materially improve the plan. Focus on:
+> - Ambiguous requirements that could be interpreted multiple ways
+> - Unstated preferences (e.g., "should this be real-time or batch?")
+> - Tradeoffs where the plan picked one side without discussing alternatives
+> - Missing context that would change the approach
+> - Scale/performance expectations that aren't specified
+> - Integration points with unclear contracts
+> - Rollback/migration strategies that aren't defined
+>
+> For each question:
+> - **Question**: The question itself
+> - **Why it matters**: What changes depending on the answer
+> - **Default assumption**: What the plan currently assumes (if anything)
+>
+> Do NOT ask questions that can be answered by reading the codebase -- use Glob, Grep, and Read to verify before asking. Only ask questions that require human judgment or domain knowledge.
+
+##### 3b: Codex CLI
+
+Build a prompt file at `$TMPDIR/ip-review-prompt.md` with the plan, tasks, and codebase context, then run:
+
+```bash
+codex --model o3 --quiet --approval-mode full-auto "$TMPDIR/ip-review-prompt.md"
+```
+
+The prompt file should contain:
+
+```markdown
+# Implementation Plan Review: {plan title}
+
+You are a senior engineer reviewing an implementation plan. Find issues, gaps, and generate questions for the plan author.
+
+## The Plan
+
+{full plan content}
+
+## Task Breakdown
+
+{task list content, if available}
+
+## Codebase Context
+
+{CLAUDE.md excerpt}
+
+{relevant source file excerpts}
+
+## Your Review
+
+### Part 1: Issues & Gaps
+
+For each issue, provide:
+- **Severity**: CRITICAL / HIGH / MEDIUM / LOW
+- **Category**: Missing Requirements, Unstated Assumptions, Technical Risks, Security & Data Integrity, Task Breakdown Gaps, Architecture Concerns, or Scope Concerns
+- **Description**: Be specific -- cite the plan section and explain exactly what's wrong or missing
+- **Suggestion**: How to fix it
+
+### Part 2: Questions for the Author
+
+Generate questions that require human judgment or domain knowledge to answer. For each:
+- **Question**: The question
+- **Why it matters**: What would change depending on the answer
+- **Default assumption**: What the plan currently assumes
+
+Focus on: ambiguous requirements, unstated tradeoffs, missing scale/performance expectations, unclear integration contracts, and migration/rollback gaps.
+
+Do NOT ask questions answerable from the codebase. Focus on decisions that need human input.
+```
+
+**Model selection:** Use `o3` for strong reasoning. If unavailable, fall back to `o4-mini`.
+
+If `codex` is not installed or fails, report the error and continue with Claude-only results.
+
+Capture the full output.
+
+#### Phase 4: Combine & Deduplicate
+
+After both reviews return:
+
+##### Issues
+
+1. Parse all issues from both reviewers
+2. Deduplicate: if both flagged the same issue (same plan section, similar concern), merge and keep the more detailed description
+3. Tag each with its source:
+   - `[Claude]` -- only Claude found it
+   - `[Codex]` -- only Codex found it
+   - `[Both]` -- both flagged it (higher confidence)
+4. Sort by severity: CRITICAL > HIGH > MEDIUM > LOW
+
+##### Questions
+
+1. Parse all questions from both reviewers
+2. Deduplicate: merge questions asking essentially the same thing
+3. Tag with source (`[Claude]`, `[Codex]`, `[Both]`)
+4. Group by theme (e.g., "Scope", "Architecture", "Data", "Performance", "Migration")
+5. Within each group, sort by impact (questions where the answer would most change the plan come first)
+
+##### Verify Critical Claims
+
+For CRITICAL and HIGH issues, do a quick Glob/Grep/Read to confirm the issue is real. Note which are verified vs unverified.
+
+#### Phase 5: Present Results
+
+Present the combined review:
+
+```
+## IP Review: {plan title}
+
+**Reviewers:** Claude (sub-agent) + OpenAI Codex ({model used})
+**Plan:** {IP file path}
+
+---
+
+### Issues Found
+
+#### Critical
+1. [Both] **{category}** -- {description}
+   → {suggestion}
+
+#### High
+2. [Claude] **{category}** -- {description}
+   → {suggestion}
+
+#### Medium / Low
+3. [Codex] **{category}** -- {description}
+   → {suggestion}
+
+---
+
+### Questions for You
+
+**Scope & Requirements**
+1. [Both] {question}
+   _Why it matters:_ {impact}
+   _Current assumption:_ {what plan assumes}
+
+**Architecture & Design**
+2. [Claude] {question}
+   _Why it matters:_ {impact}
+   _Current assumption:_ {what plan assumes}
+
+**Performance & Scale**
+3. [Codex] {question}
+   _Why it matters:_ {impact}
+
+{...more grouped questions...}
+```
+
+#### Phase 6: Collect Answers
+
+Use **AskUserQuestion** to collect the user's answers. Present the questions in a numbered list and ask the user to answer them. Options:
+
+- Answer all at once (numbered responses)
+- Answer one at a time interactively
+- Skip questions they don't want to address yet (mark as "deferred")
+
+For skipped questions, note the current assumption the plan makes and flag it as an unresolved decision.
+
+#### Phase 7: Update the Plan
+
+After collecting answers:
+
+1. **Read the current IP file** fresh (in case it changed)
+2. **For each answered question**, determine what section(s) of the plan need updating
+3. **For each confirmed issue**, draft the fix
+4. **Draft all changes** and present them to the user as a before/after diff for each section
+5. Ask: "Apply these updates to the plan?"
+6. If yes, edit the IP file with all changes
+7. If a task file exists, update it too if any tasks are affected
+8. Add an "## Review Log" entry at the bottom of the IP file:
+
+```markdown
+## Review Log
+
+### {today's date} -- Dual-Model Review
+- **Reviewers:** Claude + Codex ({model})
+- **Issues found:** {N} ({breakdown by severity})
+- **Questions asked:** {N} ({answered}/{deferred})
+- **Plan updated:** Yes/No
+- **Unresolved:** {list any deferred questions or unverified issues}
+```
+
+#### Cleanup
+
+```bash
+rm -f "$TMPDIR/ip-review-prompt.md"
+```
+
+#### Notes on Review
+
+- The value is **dual perspective** -- Claude and Codex have different biases and catch different things
+- Questions tagged `[Both]` deserve the most attention -- two independent models flagged the same gap
+- Don't pre-filter findings. Present honestly even if they contradict earlier Claude work on the plan
+- This step fits between Step 5 (Generate) and implementation -- use it as a quality gate
+- Can also be run mid-implementation to reassess the plan as understanding deepens
+
+### Step 9: Attack & Adjust
+
+Adversarially red-team the plan and then update it inline based on what comes back. This is the last thing `/ip` does before handing off to implementation.
+
+1. **Locate the plan** — use the file just saved in Step 5 (`docs/implementationPlans/[feature-name].md`). Read it, plus the task file in `docs/tasks/` if present.
+
+2. **Gather focused context** — collect what an external reviewer will need:
+   - `CLAUDE.md` (tech stack, conventions, constraints)
+   - 3–5 of the most critical existing files referenced in the plan's "Files to Create/Modify"
+   - Current definitions of any models the plan touches
+   - `git log --oneline -10` for recent momentum
+
+3. **Build the attack prompt** at `$TMPDIR/ip-attack-prompt.md`:
+
+   ```markdown
+   # Adversarial Review: {plan title}
+
+   You are a senior staff engineer conducting a hostile review of this implementation plan. Find every flaw, gap, risk, and unstated assumption. Be uncharitable — assume nothing works until proven otherwise.
+
+   ## The Plan
+   {full plan content}
+
+   ## Task Breakdown
+   {task list content, if available}
+
+   ## Codebase Context
+   {CLAUDE.md excerpt + relevant source file excerpts}
+
+   ## Your Review
+
+   For each finding, cite the section of the plan and explain exactly what's wrong or missing. Cover:
+
+   1. **Missing Requirements** — what the PRD implies but the plan ignores; uncovered user flows and error states.
+   2. **Unstated Assumptions** — what the plan assumes about codebase/infra/data/scale that isn't verified.
+   3. **Technical Risks** — parts harder than the plan suggests; highest rewrite probability.
+   4. **Security & Data Integrity** — injection, auth gaps, input validation, race conditions.
+   5. **Task Breakdown Gaps** — tasks not actually independent/testable; wrong dependencies; missing setup/migration/testing/docs tasks.
+   6. **Architecture Concerns** — fit with existing patterns; tech debt; simpler approaches overlooked.
+   7. **Verdict** — SHIP IT / REVISE / RETHINK.
+
+   Classify each finding: CRITICAL / HIGH / MEDIUM / LOW.
+   ```
+
+4. **Run the attacker — OpenAI first, Opus fallback:**
+
+   Try OpenAI Codex CLI:
+   ```bash
+   codex --model o3-pro --quiet --approval-mode full-auto "$TMPDIR/ip-attack-prompt.md"
+   ```
+   If `o3-pro` is unavailable or rate-limited, try `o3`, then `o4-mini`.
+
+   If the `codex` CLI is missing or every model fails, fall back to an Opus subagent: spawn a `general-purpose` Agent with `model: "opus"` and pass it the same prompt file contents, telling it to act as the hostile reviewer. Report clearly which path was taken.
+
+5. **Process the findings:**
+   - Deduplicate overlapping issues.
+   - For each CRITICAL/HIGH finding, verify with Glob/Grep/Read before treating it as real — reviewers hallucinate.
+   - Drop anything the plan actually already addresses.
+
+6. **Report to the user** in this shape:
+
+   ```
+   ## Adversarial Review: {plan title}
+
+   **Reviewer:** {OpenAI model used, or "Opus fallback"}
+   **Verdict:** {SHIP IT / REVISE / RETHINK}
+
+   ### Critical / High / Medium / Low
+   {findings grouped by severity, each with a one-line plan-section reference}
+
+   ### Verified vs Unverified
+   - Verified: {confirmed against the codebase}
+   - Unverified: {couldn't confirm — may be false positives}
+   ```
+
+7. **Adjust the plan** — don't stop at reporting. For every verified CRITICAL/HIGH finding, edit the IP file in place: tighten assumptions, add missing tasks, patch acceptance criteria, rewrite risky phases. For MEDIUM/LOW, ask the user which to fold in. Show the diff of your plan edits and ask "Anything else to adjust, or is this ready for implementation?"
+
+If the user provides a `$STEP` argument, skip to that step (assumes prior steps have been completed and context is available in conversation).
+
+## Lifecycle Operations
+
+These operations manage IPs through their lifecycle after creation. Each is self-contained and can be invoked directly by name.
+
+### Lifecycle: Init
+
+Set up the directory structure and tracking index for implementation plans in the current project.
+
+Argument: optional project description or notes (`$ARGUMENTS`).
+
+#### Before Starting
+
+1. Identify the **project root** -- this is the current working directory
+2. Check if IP tracking already exists by looking for `docs/implementationPlans/PLAN_INDEX.md`
+   - If it exists, report what's already set up and ask what to regenerate
+   - If it doesn't exist, proceed with full setup
+
+#### Init Step 1: Infer Project Context
+
+1. Read `CLAUDE.md` if it exists -- note the project name, key conventions, commit style
+2. Check `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, or similar for project name
+3. Look at recent git log for commit message style
+4. Note the primary language and any existing docs structure
+5. Check if `docs/implementationPlans/` already exists with plan files -- if so, scan them for the highest IP number to seed the index
+
+#### Init Step 2: Create Directory Structure
+
+```bash
+mkdir -p docs/implementationPlans/archive
+mkdir -p docs/tasks
+```
+
+#### Init Step 3: Create PLAN_INDEX.md
+
+Create `docs/implementationPlans/PLAN_INDEX.md`:
+
+```markdown
+# Implementation Plan Index
+
+Tracked implementation plans for {project_name}.
+
+See `CLAUDE.md` for IP lifecycle stages and management guidelines.
+
+## Active Plans
+
+| IP | Title | Status | Effort | Priority |
+|----|-------|--------|--------|----------|
+| - | - | - | - | No active plans yet |
+
+## Completed
+
+| IP | Title | Completed | Notes |
+|----|-------|-----------|-------|
+| - | - | - | No completed plans yet |
+
+## Deferred / Closed
+
+| IP | Title | Status | Notes |
+|----|-------|--------|-------|
+| - | - | - | No deferred plans yet |
+
+## Backlog
+
+Low-priority or blocked items. Promote to Active when ready to plan.
+
+| IP | Title | Notes |
+|----|-------|-------|
+| - | - | No backlog items yet |
+```
+
+If existing plan files were found in `docs/implementationPlans/`, populate the Active table with entries for each file, inferring IP numbers from filenames or assigning new ones.
+
+#### Init Step 4: Create IP_TEMPLATE.md
+
+Only create if `docs/implementationPlans/IP_TEMPLATE.md` does not already exist. If it exists, skip this step and report it was found.
+
+Create `docs/implementationPlans/IP_TEMPLATE.md`:
+
+```markdown
+# Implementation Plan: Title
+
+**Status:** Open
+**Priority:** Low | Medium | High
+**Effort:** Small batch (1-2 days) | Big batch (1-2 weeks) | Epic (2+ weeks)
+**IP:** IP-XXX
+
+*When an engineer is assigned to a project but before you begin coding, you should fill in the implementation plan and get feedback from the engineering team.*
+
+## Models
+
+New or modified data models, schemas, relationships.
+
+## APIs
+
+Endpoints, permissions, special queries, bulk operations.
+
+## Notifications
+
+Push, email, in-app alerts -- who, when, what.
+
+## UI
+
+New screens/components, navigation flow, key interactions, states.
+
+## Phases
+
+How to break the work into phases/PRs.
+
+## Feature Flags & Migrations
+
+Feature flags, data migrations, rollout strategy.
+
+## Activity Log & User Updates
+
+What actions get logged, what surfaces as user updates.
+
+## Not Included / Future Work
+
+Explicitly out of scope.
+
+---
+
+## Task List
+
+*Structured task breakdown. Each task should be independently implementable and testable.*
+
+### Phase 1: [Phase Name]
+
+- [ ] **Task 1.1**: [Short title]
+  - Description: [What to implement]
+  - Files: [Expected files to create/modify]
+  - Depends on: [Other task IDs, or "none"]
+  - Acceptance: [How to verify it's done]
+```
+
+#### Init Step 5: Update Project CLAUDE.md
+
+Read the project's `CLAUDE.md`. If it doesn't exist, create it with a minimal header.
+
+**Check if an IP section already exists** by searching for `## Implementation Plan` or `## IP Management`. If found, skip and report.
+
+Otherwise, **append** the following section:
+
+```markdown
+
+---
+
+## Implementation Plan (IP) Management
+
+Implementation plans are tracked in `docs/implementationPlans/`. Each IP has a dedicated file and is indexed in `PLAN_INDEX.md`.
+
+### IP Lifecycle
+
+| Stage | Description |
+|-------|-------------|
+| **Planned** | Identified but not yet designed |
+| **Design** | Actively designing (PRD ingested, shaping) |
+| **Open** | Shaped and ready for implementation |
+| **In Progress** | Currently being implemented |
+| **Pending Verification** | Code complete, awaiting verification |
+| **Complete** | Verified working, ready to archive |
+| **Deferred** | Postponed (low priority or blocked) |
+| **Closed** | Won't implement (superseded or not needed) |
+
+### Conventions
+
+- **IP files**: `docs/implementationPlans/{Title-Case-Name}.md` (e.g. `Zoom-Integration-Mvp.md`)
+- **Template**: `docs/implementationPlans/IP_TEMPLATE.md`
+- **Task files**: `docs/tasks/{feature-name}.md` (created by Step 5: Generate)
+- **Commit format**: `IP-XXX: Brief description`
+- **Numbering**: Next number = highest across all index sections + 1
+- **Source of truth**: IP file status > index (if discrepancy, file wins)
+- **Archive**: Completed IPs move to `docs/implementationPlans/archive/`
+
+### Inline Annotations (`%%`)
+
+Lines starting with `%%` in any file are **inline annotations from the user**. When you encounter them:
+- Treat each `%%` annotation as a direct instruction
+- Address **every** `%%` annotation in the file; do not skip any
+- After acting on an annotation, remove the `%%` line from the file
+- If an annotation is ambiguous, ask for clarification before acting
+```
+
+#### Init Step 6: Init Summary
+
+Report what was created:
+
+```
+## IP Tracking Initialized
+
+### Files Created
+- `docs/implementationPlans/PLAN_INDEX.md` -- Plan index
+- `docs/implementationPlans/IP_TEMPLATE.md` -- IP file template (if not already present)
+- `docs/implementationPlans/archive/` -- Archive directory
+- `docs/tasks/` -- Task files directory
+- `CLAUDE.md` -- Updated with IP conventions
+
+### Next Steps
+1. Run /ip to create your first implementation plan from a PRD
+2. Run the Lifecycle: Status operation to check the current state
+```
+
+### Lifecycle: Explore
+
+General-purpose exploration of any project using the IP system. Uses parallel subagents to quickly build context.
+
+#### Step 1: Launch Parallel Subagents
+
+Launch these THREE subagents IN PARALLEL (single message with multiple Task tool calls):
+
+##### Agent 1: Project Overview
+
+Explore the project root to understand what this project is and how it works:
+
+1. **Read key docs** -- `CLAUDE.md`, `README.md`, any top-level docs
+2. **Directory structure** -- Glob for top-level files and key subdirectories
+3. **Tech stack** -- Identify languages, frameworks, build tools from config files (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `Makefile`, etc.)
+4. **Gotchas** -- Note any warnings, constraints, or non-obvious conventions from CLAUDE.md
+
+Return: project name, purpose, tech stack, directory layout, key gotchas.
+
+##### Agent 2: IP History
+
+Explore the implementation plan system to understand what's been built and what's planned:
+
+1. **Read index** -- `docs/implementationPlans/PLAN_INDEX.md`
+2. **Active IPs** -- Read each active IP file (non-Complete status)
+3. **Archived IPs** -- List files in `docs/implementationPlans/archive/` to understand completed work
+4. **Task files** -- List and scan `docs/tasks/` for active task lists
+5. **Recent IP commits** -- Search git log for commits matching `IP-` pattern (last 20)
+
+Return: active IPs table, count of archived IPs, active tasks summary, recent IP commit summary.
+
+##### Agent 3: Recent Activity
+
+Explore recent development activity to understand current momentum:
+
+1. **Recent commits** -- Last 15 commits with messages
+2. **Modified files** -- Files changed in the last 5 commits
+3. **Branch context** -- Current branch name and how far ahead of main
+4. **Uncommitted work** -- Check git status for staged/unstaged changes
+
+Return: recent commit summary, files in flux, branch status, open work.
+
+#### Step 2: Synthesize Results
+
+Combine all agent outputs into a single briefing:
+
+##### Project Overview
+- Name, purpose, tech stack (from Agent 1)
+- Key gotchas or constraints
+
+##### IP Status
+- Active plans table (from Agent 2)
+- Active tasks and progress
+- Archived count and notable completions
+
+##### Recent Activity
+- What's been happening (from Agent 3)
+- Current branch and open work
+
+##### Quick Reference
+
+| Item | Value |
+|------|-------|
+| **Project** | {name} |
+| **Branch** | {current branch} |
+| **Active IPs** | {count} |
+| **Active Tasks** | {count remaining} |
+| **Recent focus** | {summary of last few commits} |
+
+Use the current working directory as the project root.
+
+### Lifecycle: Deep Analysis
+
+Parallel exploration of a hard problem from multiple angles, inspired by test-time compute scaling. Use when stuck, when the problem is complex enough to benefit from diverse perspectives, or when you need "big brains" on something.
+
+Argument: problem description or context (`$ARGUMENTS`).
+
+#### Phase 1: Understand the Problem
+
+1. **Parse the argument** -- what is the user stuck on? What are they trying to achieve?
+2. **Gather context** -- read conversation history for what's already been tried or discussed
+3. **Check for active IP** -- if there's a relevant implementation plan, read it for design context
+4. **Scan the codebase** -- do a quick targeted search to understand the relevant code area (key files, architecture, constraints). Keep this brief -- the agents will do the deep exploration.
+
+#### Phase 2: Design the Exploration
+
+Based on the problem, design **4 exploration angles**. These are NOT redundant -- each agent gets a **distinct lens** on the problem.
+
+**Before launching, check orthogonality:** Would two of these angles likely explore the same code paths and reach similar conclusions? If so, reframe one to ensure genuine diversity.
+
+**How to choose angles -- infer from the problem type:**
+
+For **performance optimization**:
+- Algorithmic: Can the approach itself be fundamentally different?
+- Structural: Can the data layout, schema, or architecture reduce work?
+- Incremental: Can we avoid redoing work (caching, materialization, deltas)?
+- Environmental: Are we fighting the platform? (query patterns, Python GIL, network topology)
+
+For **architecture/design decisions**:
+- Simplicity: What's the minimal viable approach?
+- Scalability: What happens at 10x/100x current load?
+- Precedent: How do similar systems/libraries solve this?
+- Contrarian: What if the obvious approach is wrong? What's the unconventional path?
+
+For **debugging / "why is this broken"**:
+- Symptoms: Trace the failure path precisely -- what's the chain of events?
+- Environment: What changed? Versions, configs, data, dependencies?
+- Assumptions: What are we assuming that might not be true?
+- Similar: Has this pattern of failure been seen elsewhere in the codebase or in public?
+
+For **anything else** -- choose angles that maximize diversity of insight. Ask: "If these 4 experts were in a room, what different specialties would give me the most useful debate?"
+
+**For each angle, decide:**
+- What codebase areas the agent should explore (specific files, directories, patterns)
+- What question the agent should answer
+- How deep vs. broad the agent should go
+- What existing context (if any) to seed the agent with -- only what's necessary, avoid anchoring
+
+#### Phase 3: Launch Parallel Exploration
+
+**Briefly tell the user** what angles you're exploring (2-3 words each) -- then launch immediately. Don't wait for approval. Speed matters when stuck.
+
+Launch **4 Explore agents IN PARALLEL** (single message with 4 Task tool calls). Use `model: "opus"` explicitly on each agent to ensure heavyweight reasoning. Each agent gets:
+
+```
+You are exploring a specific angle of a hard problem. Your analysis is input to a multi-agent synthesis -- be precise, flag uncertainties, and show your evidence.
+
+## Problem
+{problem description}
+
+## Your Angle
+{specific lens -- what you're looking for, what question you're answering}
+
+## Where to Look (Starting Points)
+{specific files, directories, or search patterns to start with}
+
+These are entry points, not the complete scope. Follow evidence wherever it leads -- if the trail points to related code outside this list, explore it.
+
+## Key Constraint
+You have read-only tools (Glob, Grep, Read). Use them liberally. If you can't verify something exists, don't claim it. Better to say "I couldn't locate a config file for X" than to guess at its name or path.
+
+## Instructions
+- Use Glob, Grep, and Read to thoroughly explore the relevant code
+- Think deeply about your specific angle -- don't try to solve the whole problem
+- Look for evidence, patterns, constraints, and opportunities related to your angle
+- Note anything surprising or that contradicts assumptions
+- Be concrete -- reference specific files, functions, line numbers, data flows
+- If you find something important outside your angle, note it briefly but stay focused
+- Before you finalize: is there evidence that contradicts your recommendation? If yes, address it directly rather than ignore it
+
+## Output
+Return a focused analysis (aim for 600-1000 words):
+
+1. **Key findings** -- specific observations with evidence. For each finding, cite the file/line or code pattern that shows it's true. Avoid vague claims like "this is slow" -- show why.
+
+2. **Implications** -- what this means for the problem. For each implication, explain the logical link: if this finding is true, then we should try X because [reason].
+
+3. **Recommendation** -- your angle's proposed direction:
+   - **Proposed approach:** [specific, actionable idea]
+   - **Why this angle suggests it:** [link findings -> recommendation]
+   - **Tradeoffs:** [what you'd give up]
+   - **Key assumptions:** [what has to be true for this to work]
+   - **Biggest uncertainty:** [what would most change your mind]
+```
+
+#### Phase 4: Verify Key Claims
+
+Before synthesizing, two verification passes:
+
+##### Pass 1: Contradiction Detection
+
+Scan all 4 agent reports for **opposing claims**. Examples:
+- Agent A says "this runs synchronously" while Agent B says "this is async"
+- Agent A says "no index on this column" while Agent C assumes an index exists
+- Two agents recommend opposite directions
+
+Flag contradictions prominently. **Prioritize verifying contradicted claims first** -- these are where the highest-value corrections live.
+
+##### Pass 2: Factual Verification
+
+**Cross-check the most important factual claims** from the agents. Agents can hallucinate file paths, function signatures, config options, or behavioral assumptions.
+
+**What to verify:**
+- **File paths and function names** -- do the files/functions agents referenced actually exist? Spot-check with Glob/Grep.
+- **Behavioral claims** -- "this function does X" or "this config controls Y" -- Read the actual code for the 2-3 most critical claims that the recommendation will hinge on.
+- **Performance/complexity claims** -- if an agent says "this is O(n^2)" or "this query scans the full table," verify against the actual code or query plan.
+- **Assumption checks** -- if agents assumed something about the system (e.g., "this runs synchronously," "this table has an index on X"), verify the ones that matter most.
+
+**How to verify:**
+- Focus on the **top 3-5 claims that would change the recommendation if wrong**. Don't verify everything -- verify what matters.
+- Use Glob, Grep, and Read directly (no subagents -- this should be fast).
+- If a claim is wrong, note the correction. If it's right, move on.
+
+**Output:** Note any corrections or confirmations. Flag anything that was wrong -- this changes the synthesis.
+
+#### Phase 5: Synthesize
+
+After verification, synthesize the agents' findings (with corrections applied) into a single analysis. This is the critical step -- don't just concatenate.
+
+**Synthesis structure:**
+
+##### 1. Agreements
+Where do multiple angles converge? High-confidence insights.
+
+##### 2. Tensions
+Where do angles disagree or present tradeoffs? These are the real design decisions.
+
+##### 3. Surprises
+What did agents find that wasn't expected? Novel insights that change the framing.
+
+##### 4. Corrections
+Any agent claims that were wrong or misleading, and what the truth is. Be transparent -- this builds trust in the analysis.
+
+##### 5. Recommendation
+Your synthesized recommendation. Be opinionated -- rank the options, state which direction you'd go and why. Tag each element with confidence (High/Medium/Low) and a one-line justification. Include:
+- **Proposed approach** -- the synthesized best path forward
+- **Key tradeoffs** -- what you're giving up
+- **Risks** -- what could go wrong
+- **Key assumptions** -- what the recommendation depends on being true
+- **First step** -- the concrete next action
+
+##### 6. Assumption Check
+After drafting the recommendation, note what assumptions it hinges on. Verify those specific assumptions with a quick Glob/Grep/Read check. If any fail, flag them and reassess.
+
+##### 7. If applicable: IP Update
+If there's an active IP related to this problem, propose specific updates to the plan's relevant sections based on the analysis. Don't update the file -- present the proposed changes for the user to approve.
+
+#### Notes on Deep Analysis
+
+- **Agent count**: Always 4. Four distinct angles. No exceptions.
+- **Agent type**: Always use `subagent_type: "Explore"` with `model: "opus"` -- read-only research agents on the heaviest model.
+- **Thoroughness**: Tell agents to be "very thorough" in their Task descriptions.
+- **No anchoring**: Don't give agents each other's angles. They should explore independently.
+- **Speed over perfection**: The user is stuck. A good-enough synthesis in 2 minutes beats a perfect one in 10. Don't over-polish the output.
+
+### Lifecycle: Status
+
+Generate an up-to-date summary of active implementation plans.
+
+#### Fast Path vs Full Grooming
+
+**Decide which path to take based on conversation context:**
+
+##### Fast Path (just print the table)
+Use this when you are **confident the index is up to date** -- for example:
+- You've been working on IPs in this session (closing, creating, updating)
+- You just ran a full grooming pass recently
+- The user just asked you to "print the status"
+
+Simply read `docs/implementationPlans/PLAN_INDEX.md` and each active IP file, then output the table.
+
+##### Full Grooming (first invocation or uncertain state)
+Use this when you have **no context about the current state**:
+- Start of a new conversation
+- You haven't touched any IPs yet
+- The user explicitly asks for a grooming check
+
+Perform these housekeeping checks:
+
+###### 1. Status Sync Check
+- Read each active IP file and compare its `**Status:**` line to the index
+- If discrepancy, update the index to match the file (file is source of truth)
+- Report any discrepancies found and fixed
+
+###### 2. Archive Check
+- Look for IP files in `docs/implementationPlans/` (not in `archive/`) with status: Complete, Deferred, or Closed
+- For each such IP not yet archived:
+  - Move to `docs/implementationPlans/archive/`
+  - Ensure it's in the appropriate section of the index
+- Report any files archived
+
+###### 3. Orphan Check
+- Check if any IPs in the index don't have corresponding files
+- Check if any IP files exist that aren't in the index (exclude IP_TEMPLATE.md and PLAN_INDEX.md)
+- Report any orphans found
+
+###### 4. Task Progress Check
+- For each active IP, check if a corresponding task file exists in `docs/tasks/`
+- Count completed vs total tasks (checked vs unchecked checkboxes)
+- Include task progress in the output table
+
+#### Status Output
+
+Format the output as a markdown table:
+
+    ## Active Implementation Plans
+
+    | IP | Title | Status | Effort | Tasks | Description |
+    |----|-------|--------|--------|-------|-------------|
+    | IP-XXX | Title here | Status | Effort | 3/10 | Brief description |
+
+    **Total:** X active plans (Y design, Z open, W in progress)
+
+If full grooming was performed and changes were made, prepend a grooming report.
+
+Notes:
+- Keep descriptions concise (< 60 chars if possible)
+- Include a count summary at the bottom
+- Task column shows completed/total if task file exists, "-" otherwise
+
+### Lifecycle: Close
+
+Close an IP by marking it complete (or closed/deferred), archiving the file, and updating the index.
+
+Argument should contain:
+- **IP number or name** (required-ish): e.g. `1`, `IP-001`, or the plan filename slug
+- **Disposition** (optional): `complete` (default), `closed`, or `deferred`
+- **Notes** (optional): any additional context
+
+Examples:
+- close 1 -- mark IP-001 as Complete
+- close user-permissions deferred blocked on auth refactor -- mark by name, Deferred
+- close 3 closed superseded by IP-005 -- mark IP-003 as Closed
+- close (no args) -- infer from conversation context
+
+Parse the argument: `$ARGUMENTS`
+
+#### Inferring the IP
+
+If no IP number/name provided, infer from conversation context:
+- Look at which IP was most recently discussed or worked on
+- If exactly one IP is obvious, use it and state which one
+- If ambiguous, ask the user
+
+#### Close Steps
+
+##### 1. Find and read the IP file
+
+- Search `docs/implementationPlans/` for matching file (by IP number, Title-Case filename, or slug)
+- Read to get title, current status
+- If already archived or not found, report and stop
+
+##### 2. Update the IP file
+
+- Set `**Status:**` to `Complete`, `Closed`, or `Deferred`
+- For Complete: add `**Completed:** {today YYYY-MM-DD}` after Status
+- For Closed/Deferred: add `**Closed:** {today}` if not present
+
+##### 3. Update PLAN_INDEX.md
+
+- Read `docs/implementationPlans/PLAN_INDEX.md`
+- Remove IP's row from **Active Plans** table
+- Add to appropriate section:
+  - **Complete** -> add to top of `## Completed` table with date and notes
+  - **Closed/Deferred** -> add to top of `## Deferred / Closed` table with status and notes
+
+##### 4. Archive the files
+
+- Move IP file to `docs/implementationPlans/archive/`
+- If a corresponding task file exists in `docs/tasks/`, move it to `docs/implementationPlans/archive/` as well (or leave in place if tasks are still referenced)
+
+##### 5. Commit
+
+Commit all changes in a single atomic commit:
+- Check `git status` for uncommitted changes related to the IP implementation
+- Stage implementation files, archived IP, deleted original path, `PLAN_INDEX.md`
+- Commit with message: `IP-{number}: {title}`
+
+##### 6. Close Summary
+
+Report:
+- IP number and title
+- Disposition (Complete / Closed / Deferred)
+- Status updated in IP file
+- Moved from Active to the appropriate section in index
+- Archived to `docs/implementationPlans/archive/`
+- Committed: {short hash}
+
+## Submitting the IP
+
+Once the plan is finalized, use `/submit` to commit the IP files, push the branch, and create a PR on the target project's GitHub repo. The worktree is already on a dedicated branch, so `/submit` works directly.
+
+## Arguments
+
+$PROJECT: Project alias or `owner/repo` (required — if omitted, user is prompted to select from the registry)
+$STEP: Optional step to skip to (ingest, research, shape, plan, generate, acceptance, e2e, review, attack). Note: Step 0 (project setup) always runs regardless of $STEP.
+$PRD: Optional path to a PRD markdown file (skips the paste prompt in ingest step)

--- a/.github/skills/mongoose-schema-safety/SKILL.md
+++ b/.github/skills/mongoose-schema-safety/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: mongoose-schema-safety
+description: >-
+  Invoke when making any Mongoose schema change: adding/removing/renaming
+  fields, creating a new model, adding indexes, or writing a backfill migration.
+  Provides the five-type pattern, risk matrix, type file checklist, and rollout
+  safety steps for terreno backends.
+---
+# Mongoose Schema Safety — Terreno
+
+## Where Schemas and Types Live
+
+| Package | Schemas | Types |
+|---------|---------|-------|
+| `@terreno/api` (built-in models like `User`, `ConsentForm`) | `api/src/models/*.ts` | `api/src/types/*.ts` (or co-located in the model file via `mongoose.Schema<Doc, Model, Methods>` generics) |
+| `example-backend` (`User`, `Todo`, `Configuration`) | `example-backend/src/models/*.ts` | `example-backend/src/types/models/*.ts` (`userTypes.ts`, `todoTypes.ts`, …) |
+| `@terreno/ai` (`AIRequest`, `GptHistory`) | `ai/src/models/*.ts` | `ai/src/types/index.ts` |
+
+Every field in every schema **must** have a `description` (see the API rule `01-model-field-descriptions.md`). Descriptions flow through to the OpenAPI spec via `mongoose-to-swagger`.
+
+## The Five-Type Pattern
+
+Every model has manually-maintained TypeScript types. **Types are NOT auto-generated** — every schema change must include a matching type update in the same commit/PR.
+
+```typescript
+import type {DefaultDoc, DefaultModel, DefaultStatics} from "@terreno/api";
+
+// 1. Instance methods (on the document)
+export type YourModelMethods = {
+  customMethod: (this: YourModelDocument, param: string) => Promise<void>;
+};
+
+// 2. Static methods (on the model class) — extend DefaultStatics for findExactlyOne / findOneOrNone
+export type YourModelStatics = DefaultStatics<YourModelDocument> & {
+  customStatic: (this: YourModelModel, param: string) => Promise<YourModelDocument>;
+};
+
+// 3. Model type combining document + statics
+export type YourModelModel = DefaultModel<YourModelDocument> & YourModelStatics;
+
+// 4. Schema type
+export type YourModelSchema = mongoose.Schema<YourModelDocument, YourModelModel, YourModelMethods>;
+
+// 5. Document type (the shape of a single record)
+export type YourModelDocument = DefaultDoc & YourModelMethods & {
+  fieldName: string;
+  optionalField?: number;
+  enumField: "value1" | "value2";
+};
+```
+
+Follow existing type files in `example-backend/src/types/models/` and `ai/src/types/index.ts` for naming and structure.
+
+## Statics & Methods — Direct Assignment
+
+Define statics and methods by direct assignment on the schema — not via `.method()` / `.static()` / `.add()`:
+
+```typescript
+schema.methods = {
+  getDisplayName(this: YourModelDocument): string { return this.name; },
+};
+schema.statics = {
+  async findByEmail(this: YourModelModel, email: string) { return this.findOne({email}); },
+};
+```
+
+## Critical Mongoose Rules
+
+- **Never use `Model.findOne`** — use `Model.findExactlyOne` (throws on 0 or many) or `Model.findOneOrNone` (throws on many). These come from the `findExactlyOne` / `findOneOrNone` plugins in `@terreno/api`.
+- Apply the standard plugins (`createdUpdatedPlugin`, `isDeletedPlugin`, `findOneOrNone`, `findExactlyOne`) on every new model. Most existing models go through `addDefaultPlugins`.
+- `checkModelsStrict()` runs at non-prod startup (`server.ts`) and validates schema consistency — keep it passing.
+
+## Schema Change Risk Matrix
+
+| Change Type | Risk Level | Required Mitigation |
+|-------------|-----------|---------------------|
+| Add optional field | Low | Safe to ship directly (still requires `description`) |
+| Add required field | High | Must provide a default value, OR write a backfill migration script first |
+| Remove field | Medium | Soft-remove first (mark optional, stop writing); hard-remove in next PR after deploys settle |
+| Rename field | High | Three-step: add new → backfill → remove old (separate PRs) |
+| Change field type | Critical | Treat as rename: new field + migration + remove old |
+| Add index | Medium | Safe in code, but build can slow writes on large collections — coordinate with ops |
+| Remove index | Low | Safe to ship directly |
+| Add unique index | High | Dedup migration must run first; otherwise the index build fails on existing duplicates |
+
+## Migration Scripts
+
+Migration / backfill scripts live in `example-backend/src/scripts/` (e.g. `syncConsents.ts`, `seedConsents.ts`). They use the `ScriptRunner` type and `BackgroundTask` model from `@terreno/api` (`api/src/scriptRunner.ts`):
+
+```typescript
+import type {ScriptContext, ScriptResult, ScriptRunner} from "@terreno/api";
+
+export const run: ScriptRunner = async (wetRun, ctx) => {
+  const results: string[] = [];
+  // ... do work ...
+  if (wetRun) {
+    // commit changes
+  }
+  return {success: true, results};
+};
+```
+
+Always run with `wetRun = false` first to verify the dry-run output. Use `ctx.checkCancellation()`, `ctx.addLog()`, and `ctx.updateProgress()` for long-running tasks.
+
+## Cross-Package Ripple
+
+A schema change in one place often ripples:
+
+- **API surface affected?** Regenerate the SDK with `cd example-frontend && bun run sdk` (or invoke the `generate-sdk` skill). The OpenAPI spec is derived from the schema, so the frontend hooks will go stale otherwise.
+- **`modelRouter` config?** If you added/removed a field, update `queryFields`, `populatePaths`, and `responseHandler` for any router that touches the model.
+- **Admin panel?** If the model is registered in `AdminApp`, update `listFields` so the table reflects the new shape.
+- **Populated refs?** If another model references this one via `ObjectId` + `ref`, and the referenced document shape changed, the consumer's populated type may need updating.
+
+## Post-Change Checklist
+
+- [ ] All new fields have a `description` (flows to OpenAPI)
+- [ ] Type file updated in the same commit/PR — field names, optionality, enum values, array types, refs, statics/methods all match the schema
+- [ ] For a new model: all five types (`Document`, `Methods`, `Statics`, `Model`, `Schema`) created
+- [ ] Statics/methods assigned directly on schema (`schema.statics = {...}`, `schema.methods = {...}`) — not `.static()` / `.method()`
+- [ ] Other model type files checked — any model that populates this one updated if its shape changed
+- [ ] Migration script written (and dry-run verified with `wetRun = false`) for any backfill
+- [ ] `modelRouter` config updated (`queryFields`, `populatePaths`, `responseHandler`) if needed
+- [ ] `AdminApp` `listFields` updated if the model is in the admin panel
+- [ ] `bun run sdk` run from `example-frontend/` if the API response shape changed
+- [ ] Test covers old-format document behavior (missing new field) if the change rolls out before a backfill
+- [ ] Unique index: dedup migration written and run before the index is added
+- [ ] `checkModelsStrict()` still passes (it runs on non-prod startup)
+- [ ] No `Model.findOne` introduced — use `findExactlyOne` / `findOneOrNone`
+
+## Common Pitfalls
+
+- Adding a required field without a default — first deploy fails for documents that pre-date the field
+- Skipping the type file update — TS happily compiles older callers but new ones break at runtime
+- Adding a `unique` index without dedup — index build fails on collections with existing duplicates
+- Renaming a field in one PR — frontend gets old field, backend writes new field, neither side is happy
+- Forgetting to regenerate the SDK after a shape change — frontend types drift from reality
+- Using `.method()` / `.static()` API — terreno's convention is direct assignment, and mixing styles makes types hard to maintain

--- a/.github/skills/respond-to-review/SKILL.md
+++ b/.github/skills/respond-to-review/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: respond-to-review
+description: >-
+  Review PR comments, plan fixes, and implement — auto-submitting when no
+  clarifications are needed
+---
+# PR Review Response Workflow
+
+Review comments on PR #$ARGUMENTS and plan fixes. If the plan has open questions for the user, pause for confirmation; otherwise implement, commit, and run `/submit` automatically without prompting.
+
+## Step 1: Setup Working Directory
+
+1. Check if we're already in a git worktree:
+   ```bash
+   git rev-parse --show-toplevel
+   git worktree list
+   ```
+
+2. **If already in a worktree**, use the current directory — skip to Step 2.
+
+3. **If NOT in a worktree**, set one up:
+
+   a. Get the repo name:
+      ```bash
+      basename $(git rev-parse --show-toplevel)
+      ```
+
+   b. Fetch PR details and branch name:
+      ```bash
+      gh pr view $ARGUMENTS --json headRefName,number,title,url,author
+      ```
+
+   c. Fetch the PR branch:
+      ```bash
+      git fetch origin pull/$ARGUMENTS/head
+      ```
+
+   d. Create worktree at `~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS`:
+      ```bash
+      git worktree add ~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS FETCH_HEAD
+      ```
+
+   e. Change to the worktree directory:
+      ```bash
+      cd ~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS
+      ```
+
+   f. Set up tracking for the PR branch:
+      ```bash
+      git checkout -B <branch-name> FETCH_HEAD
+      git branch --set-upstream-to=origin/<branch-name>
+      ```
+
+**Important**: All subsequent work happens in the working directory (worktree or current).
+
+## Step 2: Find the Reviews
+
+1. Get review threads with resolution status using GraphQL. **Important**: capture the thread `id` for each unresolved thread so you can resolve them later.
+   ```bash
+   gh api graphql -f query='
+     query($owner: String!, $repo: String!, $pr: Int!) {
+       repository(owner: $owner, name: $repo) {
+         pullRequest(number: $pr) {
+           reviewThreads(first: 100) {
+             nodes {
+               id
+               isResolved
+               comments(first: 50) {
+                 nodes {
+                   author { login }
+                   body
+                   path
+                   line
+                   createdAt
+                 }
+               }
+             }
+           }
+           reviews(first: 50) {
+             nodes {
+               author { login }
+               state
+               body
+             }
+           }
+         }
+       }
+     }' -F owner=':owner' -F repo=':repo' -F pr=$ARGUMENTS
+   ```
+
+2. **Ignore resolved threads entirely** — only process threads where `isResolved` is `false`
+
+3. Filter to comments from other users (not the PR author)
+
+4. Identify which remaining comments are:
+   - Blocking (CHANGES_REQUESTED) vs suggestions
+   - Inline code comments vs general comments
+
+## Step 3: Decide What To Do & Propose a Plan
+
+Decide the right action for each unresolved comment (fix, skip, ask), then present a structured plan organized by priority:
+
+```
+## PR #$ARGUMENTS Review Comments Plan
+
+### 🔴 Must Fix (Blocking)
+1. [file:line] @reviewer: "comment text"
+   → Proposed fix: <description>
+
+### ⚠️ Should Address (Suggestions)
+2. [file:line] @reviewer: "comment text"
+   → Proposed fix: <description>
+
+### 💬 Questions/Clarifications Needed
+- Comment X: Need your input on approach
+- Comment Y: Conflicts with existing pattern, which to use?
+
+### 📝 Will Skip (N/A or out of scope)
+- Comment Z: Not applicable or out of scope
+
+### 💬 Suggested Replies to Human Commenters
+For any comments that warrant a reply (e.g., to clarify a decision or thank a reviewer):
+- **Print the suggested reply text** so the user can see it
+- **Never post replies** via `gh pr comment`, `gh api`, or any other method — leave posting to the user
+```
+
+## Step 4: Confirmation (only if there are open questions)
+
+**If the plan has any items under 💬 Questions/Clarifications Needed:**
+Ask: **"Need your input on the questions above. Anything else to change before I implement?"**
+- Wait for explicit approval before making any changes
+- Incorporate any feedback
+- Re-present plan if significant changes requested
+
+**If there are no open questions:** skip confirmation entirely. Proceed directly to Step 5 — implement, commit, run `/submit`, and resolve threads without further prompts. Do not ask the user for plan approval in this case.
+
+## Step 5: Make the Fix
+
+After approval:
+
+1. Implement fixes one at a time, in priority order
+2. After each fix, briefly confirm what was changed
+
+## Step 6: Show the diff
+
+Show the complete diff so the user can scan what was implemented:
+```bash
+git diff
+git diff --stat
+```
+
+Do **not** commit here. `/submit` (next step) handles pre-commit checks, staging, commit, push, and PR updates — running pre-commit *before* the commit, which is the correct order. Committing here would invert that order and leave broken code committed locally if pre-commit fails.
+
+## Step 7: Run /submit
+
+Invoke the `/submit` skill to handle pre-commit checks, commit, push, and PR updates. This will also launch the CI check-watcher in the background. Pass a `$DESCRIPTION` summarizing what review comments were addressed so the commit message reflects the work.
+
+## Step 8: Resolve Addressed Threads
+
+After `/submit` completes, resolve each review thread that was addressed in the implementation. Use the thread `id` captured in Step 2.
+
+For each thread that was fixed or addressed (from the "Must Fix" and "Should Address" categories in the plan):
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }' -f threadId="<thread_id>"
+```
+
+Do NOT resolve threads that were:
+- Skipped (marked as N/A or out of scope)
+- Questions/clarifications that were not answered by code changes
+- Threads where the user decided not to take action
+
+Report which threads were resolved and which were left open.
+
+---
+
+## Error Handling
+
+- If worktree already exists, ask if user wants to reset it or use existing
+- If PR not found, show error and available PRs: `gh pr list`
+- If no comments found, inform user and ask if they want to proceed anyway
+- If merge conflicts occur during implementation, pause and ask for guidance
+
+## Cleanup Reminder
+
+If a new worktree was created, remind user:
+```
+To remove this worktree later:
+  git worktree remove ~/.claude-worktrees/<repo>/pr-$ARGUMENTS
+
+Or to keep working on it, you can open a new Claude session in:
+  cd ~/.claude-worktrees/<repo>/pr-$ARGUMENTS
+```

--- a/.github/skills/submit/SKILL.md
+++ b/.github/skills/submit/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: submit
+description: >-
+  Lightweight pre-commit + commit + push + create/update PR, then spawn
+  check-watcher in the background. Use /fullsend for the full pipeline with code
+  review.
+---
+# Submit: Quick Commit & PR
+
+Lightweight path to run pre-commit checks, commit, push, and monitor CI. After pushing, this skill launches `/check-watcher` as a background sub-agent so CI is watched without blocking. Use `/fullsend` for the full pipeline that also includes code review.
+
+## Step 1: Assess Changes
+
+```bash
+git status && git diff --stat
+```
+
+```bash
+gh pr view --json number -q .number 2>/dev/null || echo "no-pr"
+```
+
+## Step 1.5: Pre-Commit Checks
+
+Delegate lint, type check, and related tests to the `pre-commit` subagent before committing.
+
+Use the `Agent` tool:
+- `subagent_type`: `pre-commit`
+- `description`: `Run pre-commit checks`
+- `prompt`: instruct it to run lint, compile, and related tests for the current project, fix any issues, and report back. Mention this is being run as part of `/submit` for an upcoming commit.
+
+Wait for the subagent to return its Pre-Commit Report. If it surfaces unfixable failures, STOP and report them — do not commit or push.
+
+If invoked from `/fullsend` (which already ran pre-commit), skip this step.
+
+## Step 2: Commit
+
+Stage and commit:
+- Review the diff to write an accurate message
+- Keep first line under 72 characters
+- No conventional commit prefixes
+- No AI attribution
+
+## Step 3: Push
+
+```bash
+git push origin HEAD
+```
+
+## Step 4: Create or Update PR
+
+### If no PR exists
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+[What changed and why — 2-4 sentences]
+
+## Human Testing Steps
+- [ ] [Step-by-step verification instructions]
+
+## Changes
+- [Bullet list of specific changes]
+
+## Automated Tests
+- [Tests that ran and passed, or "None"]
+EOF
+)" --draft
+```
+
+### If a PR already exists
+
+Read the current title and body, then compare against the full set of commits on the branch:
+
+```bash
+gh pr view --json title,body,baseRefName
+git log $(gh pr view --json baseRefName -q .baseRefName)..HEAD --oneline
+git diff $(gh pr view --json baseRefName -q .baseRefName)...HEAD --stat
+```
+
+Decide whether the description still reflects what's on the branch — pay attention to commits added since the PR was opened:
+- **Summary** still matches the actual goal of the changes
+- **Changes** list covers the new commits, not just the original ones
+- **Human Testing Steps** still cover what reviewers need to verify
+- **Automated Tests** section reflects current test state
+
+If the description is stale or incomplete, update it. Preserve sections the user has clearly edited by hand — only rewrite what's actually out of date, and merge new bullets into existing lists rather than replacing them wholesale:
+
+```bash
+gh pr edit --title "<title>" --body "$(cat <<'EOF'
+<updated body>
+EOF
+)"
+```
+
+If the description is already accurate, skip the edit and note that it's up to date.
+
+## Step 5: Print PR Link
+
+```bash
+gh pr view --json title,url -q '"**\(.title)** — \(.url)"'
+```
+
+## Step 6: Launch Check Watcher Sub-Agent
+
+Spawn `/check-watcher` as a **background sub-agent** so CI monitoring runs autonomously without blocking the parent conversation. Use the `Agent` tool with `run_in_background: true`.
+
+- `subagent_type`: `general-purpose`
+- `description`: `Watch CI for current PR`
+- `run_in_background`: `true`
+- `prompt`: instruct the sub-agent to invoke the `/check-watcher` skill for the current PR, fix any failures, and report back when checks are green or max attempts are hit. Include the PR number/URL from Step 5 so the sub-agent has context.
+
+Do **not** wait on the sub-agent — return control immediately after spawning. The user will be notified when it completes.
+
+By the time you reach this step, a PR is guaranteed to exist — either it pre-existed (from Step 1) or Step 4 just created it. Always spawn check-watcher.
+
+## Arguments
+
+$DESCRIPTION: Optional description to guide the commit message and PR

--- a/.rulesync/skills/ai-prompt-governance/SKILL.md
+++ b/.rulesync/skills/ai-prompt-governance/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: ai-prompt-governance
+description: >-
+  Invoke when adding, modifying, or reviewing any prompt used by `@terreno/ai`
+  (AIService methods, system prompts, helpers). Provides prompt-as-constant
+  rules, temperature preset guidance, logging requirements, and a testing
+  checklist.
+---
+# AI Prompt Governance — `@terreno/ai`
+
+`@terreno/ai` is a backend-only, provider-agnostic AI layer built on the Vercel AI SDK. Consuming apps inject a `LanguageModel` (Google, Anthropic, OpenAI, etc.) and call `AIService` methods. All requests are logged through the `AIRequest` model.
+
+See `ai/src/service/aiService.ts` and `ai/src/service/prompts.ts` for the canonical implementation.
+
+## Prompt Writing Rules
+
+1. **Always a named constant** — Define prompts in `ai/src/service/prompts.ts` (or the consuming app's equivalent constants file). Never inline prompt strings in route handlers, services, or `AIService` method bodies.
+2. **Self-contained** — A prompt should read coherently on its own. If you must inject runtime context, document why in a comment above the constant.
+3. **Typed return** — If the prompt asks for structured JSON, define a matching TypeScript interface in `ai/src/types/index.ts` and parse against it on every response.
+4. **Don't bake user-identifiable data into the prompt template itself** — inject it at call time as runtime parameters, never as defaults in the constant.
+
+## Temperature Preset Guidance
+
+Use the presets exported from `@terreno/ai`:
+
+| Preset | Value | When to use |
+|--------|-------|-------------|
+| `DETERMINISTIC` | 0 | Structured extraction, classification, deterministic transforms |
+| `LOW` | 0.3 | Summarization, translation, faithful rewording |
+| `BALANCED` | 0.7 | General Q&A, balanced creativity |
+| `DEFAULT` | 1.0 | Chat, open-ended responses |
+| `HIGH` | 1.5 | Brainstorming, creative variation |
+| `MAXIMUM` | 2.0 | Maximum variability — rarely the right choice |
+
+Pick the lowest temperature that still produces good results. Don't override the default unless you can name a reason in the call site.
+
+## Logging
+
+Every `AIService` method already logs to the `AIRequest` model via the internal `logRequest()` call. Do not bypass `AIService` and call the Vercel SDK directly from routes — you lose request logging, error capture, and the `requestType` taxonomy.
+
+Current `AIRequest.requestType` values: `"general" | "remix" | "summarization" | "translation"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
+
+Logging failures must never break the main flow — the existing pattern catches and logs internally. Preserve that behavior.
+
+## Testing a Prompt Change
+
+`@terreno/ai` tests inject a mock `LanguageModel` with `doGenerate` / `doStream` methods. See the mock pattern in `ai/src/aiApp.test.ts`. Never hit a live provider in unit tests.
+
+1. Add or update a unit test that mocks `doGenerate` / `doStream` and asserts the prompt your code sends matches expectations.
+2. Run against at least 3 inputs:
+   - A normal/expected case
+   - An edge case (empty input, very long input, missing optional fields)
+   - An adversarial case that could break structured JSON output
+3. For structured JSON: assert the response parses against the typed return interface.
+4. If the prompt affects streaming behavior, mock `doStream` and assert the emitted chunks.
+
+For a one-off manual smoke against a real provider, temporarily add `logger.debug("prompt test", {prompt, response})` in the `AIService` method, run locally, then remove the log before committing.
+
+## Prompt Change Checklist
+
+- [ ] Prompt is a named constant in `prompts.ts` (or app equivalent) — not inlined
+- [ ] Prompt still produces valid, parseable structured JSON if applicable (tested with 3+ inputs)
+- [ ] Temperature preset is appropriate (lowest viable for the task)
+- [ ] Call goes through `AIService` (so `AIRequest` logging fires) — no direct Vercel SDK calls from routes
+- [ ] If `requestType` taxonomy changed, the type union and admin explorer filters were updated
+- [ ] No user-identifiable data baked into the prompt template (only injected at call time)
+- [ ] Unit test added/updated with a mock model
+- [ ] Commit message explains the behavioral change (the prompt is the behavior)
+
+## Adding a New AI Feature
+
+1. Define prompt(s) as named constants in `ai/src/service/prompts.ts`.
+2. If structured JSON output, define the TypeScript interface for the return shape in `ai/src/types/index.ts`.
+3. Add a method to `AIService` (or a new service class) that calls `generateText` / `generateTextStream` and goes through the existing logging path.
+4. If exposing via HTTP, add a route in `ai/src/routes/` following the patterns in `gpt.ts` / `gptHistories.ts`. Use `createOpenApiBuilder` for OpenAPI docs.
+5. Add an integration test with a mock model that verifies:
+   - The prompt sent to the model matches the constant
+   - The structured JSON return parses against the typed interface
+   - `AIRequest.logRequest` is called with the correct `requestType`
+
+## Common Pitfalls
+
+- Calling the Vercel SDK directly from a route — bypasses logging and request typing
+- Inlining a prompt string in a route handler — makes future changes invisible and untestable
+- Using the wrong `requestType` value (or `"general"` as a catch-all) — degrades the admin explorer
+- Setting `temperature` numerically instead of via a preset — drifts away from the documented presets
+- Forgetting to type the JSON return — runtime parse failures show up later as confusing errors

--- a/.rulesync/skills/backend-test-env/SKILL.md
+++ b/.rulesync/skills/backend-test-env/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: backend-test-env
+description: >-
+  Invoke when writing tests that mutate `process.env` in `@terreno/api`,
+  `@terreno/ai`, or `example-backend` — feature flags, auth secrets, integration
+  toggles. Covers the preload contract, `setupEnvironment()`, and safe mutation
+  patterns.
+---
+# Backend Test — `process.env` Contract
+
+Bun's test runner preloads a per-package setup file (configured in each package's `bunfig.toml` under `[test].preload`):
+
+| Package | Preload file |
+|---------|--------------|
+| `@terreno/api` | `api/src/tests/bunSetup.ts` |
+| `@terreno/ai` | `ai/src/tests/bunSetup.ts` |
+| `example-backend` | `example-backend/src/tests/setup.ts` |
+
+The `@terreno/api` preload uses a global `beforeEach` to (1) reset the canonical auth secrets, (2) call `setupEnvironment()` (exported from `expressServer.ts`) for the wider baseline, and (3) re-silence the winston loggers. The next test always starts from the canonical baseline — you normally **do not** need to re-call `setupEnvironment()` in a file-level `beforeEach`.
+
+## Default — Rely on the Preload
+
+- Do not assume a toggle left by another file. Treat the preload's `beforeEach` as the source of truth for the canonical baseline.
+- Set only the keys this test needs in its own `beforeEach` or test body.
+- Don't reach in and call `setupEnvironment()` again unless you're explicitly testing env-driven behavior that the preload didn't cover.
+
+## When a Test Mutates `process.env`
+
+1. **Add the key to the preload's reset list** if it should always start from a fixed test value. Otherwise it leaks into the next test in the same worker.
+2. **Set only what this case needs** in the test body — avoid redundant manual restore if the preload already resets that key in `beforeEach`.
+3. **For keys that should be absent (unset)**, use **`Reflect.deleteProperty(process.env, "KEY")`**. Avoid `process.env.KEY = ""` to mean "unset" — on some platforms empty string and unset behave differently and can make tests flaky.
+4. **Avoid whole-env snapshots** (`const OLD_ENV = process.env; ...; process.env = OLD_ENV;`). This pattern exists in some older test files (`auth.test.ts`) — don't propagate it. It captures pre-`beforeEach` state and breaks ordering guarantees if the preload's `beforeEach` runs in between. Use targeted mutations + the preload's reset instead.
+
+## Adding a New Required Env Var
+
+If you introduce a new `process.env.FOO` that backend code reads at startup:
+
+1. Add `FOO` to `setupEnvironment()` in `api/src/expressServer.ts` so every package picks it up via the preload's `setupEnvironment()` call.
+2. If `example-backend` has its own startup needs for it, also add to `example-backend/src/tests/setup.ts`'s `beforeAll`.
+3. If a test needs to mutate it, follow the rules above — don't snapshot the whole env.
+
+## Auth-Related Keys
+
+`api/src/tests/bunSetup.ts` resets four auth keys in `beforeEach`: `TOKEN_SECRET`, `TOKEN_ISSUER`, `SESSION_SECRET`, `REFRESH_TOKEN_SECRET`. If your test changes any of these, you do not need to restore — the next `beforeEach` already does. If your test relies on them being **absent** for a code path, use `Reflect.deleteProperty` within the test, knowing the next `beforeEach` will restore.
+
+`auth.test.ts` is the established home for env-driven auth assertions; mirror its newer patterns (per-test `beforeEach` setting only what changes) rather than its older whole-env-snapshot blocks.
+
+## Log Capture & Sentry
+
+The preload silences winston and `console.*` and captures into an in-memory buffer (cleared in `beforeEach`/`afterEach`). It also mocks `@sentry/bun`. Don't re-mock Sentry inside individual tests — the preload's mock is shared and reset across tests.
+
+## Checklist
+
+- [ ] New env var added to `setupEnvironment()` and (if needed) `example-backend/src/tests/setup.ts`
+- [ ] Test mutations are targeted — no whole-env snapshots
+- [ ] "Unset" expressed as `Reflect.deleteProperty(process.env, "KEY")`, not `= ""`
+- [ ] No manual restore that duplicates the preload's `beforeEach` reset
+- [ ] No re-mock of `@sentry/bun` — the preload's mock is already in place
+- [ ] If you added an env-driven branch in code, a test covers both the set and the unset case

--- a/.rulesync/skills/check-watcher/SKILL.md
+++ b/.rulesync/skills/check-watcher/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: check-watcher
+description: Monitor GitHub Actions checks and automatically fix failures
+disable-model-invocation: true
+model: sonnet
+---
+
+# Check Watcher
+
+Monitor GitHub Actions checks and auto-fix failures. Designed to be called standalone or from other skills.
+
+## Instructions
+
+1. Get the PR number:
+   ```bash
+   gh pr view --json number -q .number
+   ```
+   If no PR exists, inform the user and exit.
+
+2. Wait for CI to finish using `--watch` (no manual polling):
+   ```bash
+   gh pr checks --watch --fail-fast
+   ```
+   - All passing → go to step 6
+   - Failed → continue to step 3
+
+3. Get failure details:
+   ```bash
+   gh run view <run-id> --log-failed
+   ```
+
+4. Determine if flaky or real:
+   - Compare failed files/tests against `gh pr diff` — is the failure in code you changed?
+   - Check for flaky signals: timeouts, race conditions, ECONNRESET, intermittent assertions
+   - If flaky (not in your code + flaky signals), rerun once: `gh run rerun <run-id> --failed`
+   - Run `gh pr checks --watch --fail-fast` again. If still failing, file an issue and move on:
+     ```bash
+     gh issue create --title "Flaky test: <test name>" --body "<error details and job link>"
+     ```
+
+5. If failure IS related to PR changes:
+   - Fix the code
+   - Run lint and compile locally to validate
+   - Commit and push (no AI attribution, no conventional prefixes)
+   - Return to step 2
+
+6. When all checks pass, check for bot review comments:
+   ```bash
+   gh api repos/:owner/:repo/pulls/<pr_number>/comments --jq '.[] | select(.user.type == "Bot") | "\(.path):\(.line) @\(.user.login): \(.body)"'
+   ```
+   Report any actionable bot comments found. Do NOT auto-fix — just report them.
+
+7. Print the PR link:
+   ```bash
+   gh pr view --json title,url -q '"**\(.title)** — \(.url)"'
+   ```
+
+Cap fix attempts at $MAX_ATTEMPTS (default: 5).
+
+## Arguments
+
+$MAX_ATTEMPTS: Optional max fix attempts before stopping (default: 5)

--- a/.rulesync/skills/commit/SKILL.md
+++ b/.rulesync/skills/commit/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: commit
+description: Create a commit for the current staged/unstaged changes with a clear, accurate message
+disable-model-invocation: true
+model: sonnet
+---
+
+# Commit Changes
+
+Create a commit for the current staged/unstaged changes.
+
+## Instructions
+
+1. Check git status and diff to understand what changed:
+   ```
+   git status
+   git diff
+   git diff --cached
+   ```
+
+
+2. Stage changes appropriately and create a commit:
+   - Review the actual changes to write an accurate commit message
+
+   **Message Format:**
+   - The first line must be under 72 characters
+   - Add a body if more context is needed
+   - Exclude conventional commit prefixes (feat:, fix:, chore:, etc.)
+
+   **Content Restrictions:**
+   - Exclude any mention of AI, Claude, or any AI assistant
+   - Exclude making the commit coauthored by any AI
+   - Exclude adding "Co-Authored-By" trailers
+
+   *If constraints conflict, prioritize Message Format for clarity and readability.*
+
+3. Never push unless explicitly asked.
+
+## Arguments
+
+$DESCRIPTION: Optional description to guide the commit message

--- a/.rulesync/skills/create-pr/SKILL.md
+++ b/.rulesync/skills/create-pr/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: create-pr
+description: Create a draft pull request for the current branch
+disable-model-invocation: true
+model: sonnet
+---
+
+# Create Pull Request
+
+Create a pull request for the current branch.
+
+## Instructions
+
+1. First ensure changes are committed and pushed:
+   ```
+   git status
+   git log origin/master..HEAD --oneline
+   ```
+
+2. If there are uncommitted changes, commit them first (run `/commit` command).
+
+3. Push the branch if not already pushed:
+   ```
+   git push origin HEAD
+   ```
+
+4. Create the pull request:
+   ```
+   gh pr create --title "<title>" --body "<body>" --draft
+   ```
+
+   Guidelines for the PR:
+   - Title: Clear, concise summary of the changes
+   - Do not use prefix commit format (feat:, fix:, chore:, etc.)
+   - Do not mention AI, Claude, or any AI assistant in the title or body
+   - Do not add "Generated with Claude" or similar footers
+   - Always create as draft
+
+   **PR Body Structure:**
+
+   ```markdown
+   ## Summary
+
+   [What changed and why — 2-4 sentences]
+
+   ## Human Testing Steps
+
+   - [ ] [Step-by-step instructions a reviewer can follow to verify the change works]
+   - [ ] [Cover happy path and at least one edge case]
+
+   ## Changes
+
+   - [Bullet list of specific changes]
+
+   ## Automated Tests
+
+   - [Tests that ran and passed, or "No automated tests"]
+   ```
+
+5. Return the PR URL to the user.
+
+## Arguments
+
+$DESCRIPTION: Optional description for the PR title and body

--- a/.rulesync/skills/fix-conflicts/SKILL.md
+++ b/.rulesync/skills/fix-conflicts/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: fix-conflicts
+description: Pull latest from master, resolve merge conflicts, validate with lint/compile checks, and monitor CI
+disable-model-invocation: true
+---
+
+# Fix Conflicts
+
+Pull latest from master, resolve merge conflicts, validate with lint/compile checks, and monitor CI.
+
+## Instructions
+
+1. Ensure the working tree is clean before starting:
+   ```
+   git status
+   ```
+   - If there are uncommitted changes, ask the user whether to stash them or abort
+
+2. Fetch and merge the latest master into the current branch:
+   ```
+   git fetch origin master
+   git merge origin/master
+   ```
+   - If the fetch or merge fails, check network connectivity and repository access permissions. Notify the user if the issue persists.
+
+3. Check for merge conflicts:
+   ```
+   git diff --name-only --diff-filter=U
+   ```
+   - If there are no conflicts, skip to step 5
+
+4. For each conflicted file:
+    - Read the file and understand both sides of the conflict
+    - Resolve the conflict by combining changes in a way that retains the functionality and purpose of both sets of changes, ensuring no critical information is lost.
+    - If the conflict cannot be resolved automatically, notify the user and provide a summary of the conflicting changes.
+    - After resolving all conflicts in a file, stage it:
+       ```
+       git add <file>
+       ```
+    - After all conflicts are resolved, complete the merge:
+       ```
+       git commit --no-edit
+       ```
+
+## Running Checks
+
+5. Run lint and compile checks at the project root:
+    ```
+    git rev-parse --show-toplevel
+    ```
+    - Run linting:
+       ```
+       cd <project-root> && bun run lint
+       ```
+       - If linting fails, fix the issues and re-run until passing
+    - Run type compilation/checking:
+       ```
+       cd <project-root> && bun run compile
+       ```
+       - If compilation fails, fix the type errors and re-run until passing
+    - If linting or compilation fails repeatedly and cannot be resolved, notify the user with the error details and suggest seeking assistance.
+
+## Handling Fixes and Commits
+
+6. If any fixes were needed in step 5, stage and commit them:
+   - Review the changes made
+   - Create a commit with a clear message describing what was fixed
+   - In step 6, do not use prefix commit format (feat:, fix:, chore:, etc.) for the commit message.
+   - Do not mention AI, Claude, or any AI assistant
+
+7. Push the changes:
+   ```
+   git push origin HEAD
+   ```
+
+8. Run check-watcher by invoking `/check-watcher`:
+   - This monitors GitHub Actions checks
+   - If checks fail, it will automatically read failures, fix them, and push again
+   - Continue until all checks pass
+
+## Arguments
+
+None

--- a/.rulesync/skills/implement/SKILL.md
+++ b/.rulesync/skills/implement/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: implement
+description: Test-driven implementation execution skill for applying implementation plans directly in code
+---
+# Implementation Execution Skill
+
+Use this skill when an Implementation Plan (IP) or implementation requirements are provided.
+
+
+The goal of this skill is to execute the implementation directly in code using test-driven development.
+
+If the implementation plan is incomplete or contains contradictions, highlight the conflicts and request clarification before proceeding.
+
+Do not stop after analysis or task generation unless blocked by material ambiguity.
+
+## Primary Behavior
+
+When an IP is provided:
+
+1. Read the full IP carefully.
+2. Determine implementation scope.
+3. Identify the smallest meaningful automated test coverage that should fail for the requested behavior.
+4. Write or update the failing tests before implementation code.
+5. Run the targeted tests and confirm they fail for the expected product reason, not because of syntax, setup, or unrelated failures.
+6. Implement the requested changes directly.
+7. Run the previously failing tests until they pass.
+8. Run relevant validation or broader test commands when available.
+9. Summarize completed work, assumptions, and remaining risks.
+
+Exclude generating a separate implementation plan unless explicitly requested.
+
+## Scope Detection
+
+Determine whether the implementation is:
+
+- backend only
+- frontend only
+- full stack
+- phased implementation
+- rollout-gated
+- migration-dependent
+
+
+// --- Assumption Rules ---
+Use best-effort assumptions when the assumption does not affect compliance, data integrity, or user experience.
+
+If the correct scope is unclear and could materially change implementation, ask concise clarifying questions before coding.
+
+## Clarifying Question Rules
+
+Only ask questions if missing information would materially affect:
+
+- architecture
+- data model behavior
+- API contracts
+- permissions/access control
+- user/admin visibility
+- rollout sequencing
+- migration/backfill behavior
+- destructive operations
+- compliance-sensitive behavior
+- whether implementation should be backend only, frontend only, phased, or full stack
+
+// --- Clarifying Question Exclusions ---
+Exclude asking questions for implementation details that do not affect functionality, performance, or compliance, and can reasonably be inferred.
+
+
+## Execution Expectations
+
+Implement the requested behavior directly in the codebase.
+
+### Test-Driven Development Flow
+
+Default to red/green/refactor:
+
+- red: write the focused failing test or regression test first
+- green: implement only enough production code to satisfy the requested behavior
+- refactor: clean up the implementation while preserving passing tests
+
+If no meaningful automated test can be written for the change, document why before implementation and use the strongest available manual or static validation instead.
+
+### Implementation Steps
+- update or add focused failing tests
+- update schemas/models
+- update services/controllers/routes
+- update validation
+- update frontend UI
+- update state management/API hooks
+- update OpenAPI/types
+- update permissions/visibility logic
+- update feature flags
+- update fixtures/mocks
+- rerun the focused tests that failed first
+- run broader validation when appropriate
+- preserve existing behavior unless the IP explicitly changes it
+
+## Phased Implementations
+
+If the IP implies phased implementation:
+
+- determine whether backend and frontend should be separated
+- determine whether rollout gating is required
+- determine whether app-version compatibility matters
+
+If phase requirements are unclear and could affect implementation safety, ask before coding.
+
+Otherwise proceed with best-effort assumptions.
+
+## Testing Requirements
+
+Add or update relevant tests before production implementation whenever applicable.
+
+Possible test types include:
+
+- backend unit tests
+- backend integration tests
+- API tests
+- frontend component tests
+- frontend flow tests
+- regression tests
+
+Run the most targeted available tests first and capture the initial failure before writing production code. After implementation, rerun the same focused tests to confirm the red-to-green transition.
+
+If full test execution is not practical, run the closest focused validation possible and document what was not run.
+
+## File Modification Rules
+
+Prefer modifying existing patterns consistently with the codebase.
+
+Avoid introducing new architectural patterns unless required.
+
+Do not invent exact file paths unless strongly implied by the repository structure.
+
+Prefer consistency over novelty.
+
+## Safety Rules
+
+Do not make destructive or irreversible changes without clear instruction.
+
+Do not silently change existing product behavior outside the requested scope.
+
+If implementation could create compliance, privacy, permission, or rollout risk, explicitly call it out in the final response.
+
+## Final Response Requirements
+
+At completion, summarize:
+
+- implementation scope
+- major code changes
+- assumptions made
+- tests updated/run
+- remaining risks or follow-up work
+
+Keep the summary concise and implementation-focused.

--- a/.rulesync/skills/improve-rulesync/SKILL.md
+++ b/.rulesync/skills/improve-rulesync/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: improve-rulesync
+description: >-
+  Invoke at the end of a session to evaluate whether any skills or rules were
+  misleading, incorrect, or missing — and fix or create them. Trigger with
+  /improve-rulesync.
+---
+# Improve Rulesync
+
+### Trigger
+Invoke explicitly at the end of a session with `/improve-rulesync`.
+
+### Behavior
+Review the current conversation session and evaluate the skills and rules in `.rulesync/`. Identify any that:
+- Gave misleading or incorrect guidance that caused errors or rework
+- Were missing and would have prevented incorrect behavior
+- Need to be updated to reflect decisions or patterns established in this session
+
+Then make the changes directly.
+
+### Step 1 — Session Review
+Scan the session for:
+- Moments where a skill or rule was followed but produced a wrong or suboptimal result
+- User corrections or decisions about AI model behavior (these indicate a gap or error in the rules)
+- New patterns, decisions, or constraints established that should be codified
+
+### Step 2 — Rules Audit
+Check `.rulesync/` for relevant existing rules and skills. Evaluate:
+- Are trigger conditions accurate?
+- Is the guidance still correct given what happened this session?
+- Are there gaps that caused confusion?
+
+### Step 3 — Make Changes
+For each issue found:
+- **Incorrect/misleading**: Edit the existing file to fix it
+- **Missing**: Create a new skill or rule file in `.rulesync/skills/` or `.rulesync/rules/`
+- **Outdated**: Update or remove the stale content
+
+Always edit `.rulesync/` as the source of truth.
+
+### Step 4 — Sync
+After all changes, run `bun run rules` to sync to all AI tool directories.
+
+### Step 5 — Summary
+Output a brief summary of what was changed and why. Format:
+- **Fixed**: [file] — [what was wrong and what was corrected]
+- **Created**: [file] — [what gap it fills]
+- **No changes needed**: [reason]

--- a/.rulesync/skills/ip/SKILL.md
+++ b/.rulesync/skills/ip/SKILL.md
@@ -1,0 +1,1559 @@
+---
+name: ip
+description: "Implementation Plan (/ip) — build an implementation plan from a PRD through an interactive, multi-step process"
+disable-model-invocation: true
+---
+
+# Implementation Plan (/ip)
+
+Build an implementation plan from a PRD through an interactive, multi-step process. Produces both a human-readable implementation plan and a structured task list for bot consumption.
+
+## Overview
+
+This skill walks through the Shape Up-inspired process of turning a raw PRD into a concrete implementation plan. Each step is a self-contained section in this file — you can re-run individual steps if needed by jumping to the matching section.
+
+**Every IP targets a specific project.** The project must be specified via the `$PROJECT` argument or selected interactively.
+
+## Project Registry
+
+| Alias(es) | GitHub Repo | Local Dir |
+|-----------|-------------|-----------|
+| `ter`, `terreno` | `flourishhealth/terreno` | `~/src/terreno` |
+
+Local Dir is derived from the repo name (the part after `/`). All repos clone into `~/src/`.
+
+If a project isn't in the registry, attempt to resolve it via `gh repo view <input>`. If found, use it. If not, ask the user for the full `owner/repo`.
+
+## Planning Workflow
+
+Run the following steps in order. Each step builds on the previous one.
+
+### Step 0: Project Setup (always runs first)
+
+This step is **mandatory** and runs before everything else, even when `$STEP` is provided.
+
+#### 0a. GitHub Auth Check
+
+```bash
+gh auth status
+```
+
+If not authenticated, tell the user:
+> You need to authenticate with GitHub. Run this in your terminal:
+> `! gh auth login --web`
+> Follow the prompts to open the browser link and enter the code.
+
+Then **stop** — do not proceed until the user confirms auth is complete.
+
+#### 0b. Resolve Project
+
+If `$PROJECT` was provided, match it against the registry aliases (case-insensitive). If no `$PROJECT`, show the registry table and ask the user to pick one.
+
+#### 0c. Clone if Needed
+
+Check if the local directory exists:
+```bash
+ls -d ~/src/{repo-name} 2>/dev/null
+```
+
+If it doesn't exist, clone it:
+```bash
+gh repo clone {owner/repo} ~/src/{repo-name}
+```
+
+#### 0d. Fetch Latest & Enter Worktree
+
+Navigate to the repo and ensure we have the latest code:
+```bash
+cd ~/src/{repo-name} && git fetch origin && git checkout master && git pull origin master
+```
+
+(If the default branch is `main` instead of `master`, detect it with `git remote show origin | grep 'HEAD branch'` and use that.)
+
+Then create a worktree for this IP using the `EnterWorktree` tool:
+- **name**: `ip-{feature-slug}` (derive from the PRD title once known, or use a temporary name like `ip-draft` and note that it can be renamed)
+
+Since the PRD title isn't known yet at this point, use `ip-draft` as the worktree name. After Step 1 (Ingest), if the worktree name doesn't match the feature, note the mismatch but continue — the branch can be renamed later.
+
+#### 0e. Confirm Ready
+
+Print a summary:
+```
+Project: {repo-name} ({owner/repo})
+Branch: {worktree-branch}
+Working dir: {worktree-path}
+Latest master: {short SHA + date of HEAD}
+```
+
+Proceed to Step 1.
+
+### Step 1: Ingest PRD
+
+Collect the PRD (Product Requirements Document) that will drive the implementation plan.
+
+1. `$PRD` is **required**. If it was not provided, stop immediately and tell the user: **"Error: /ip requires a PRD as the first argument (either a file path or the inline PRD text). Please re-run as `/ip <path-or-text>`."** Do not prompt for it interactively.
+
+2. Determine what the user provided:
+   - If it looks like a file path (e.g., ends in `.md`, `.txt`, contains `/` or `\`, or matches an existing file), read that file and use its contents as the PRD.
+   - Otherwise, treat the input as the PRD text itself.
+
+3. The PRD should contain at minimum a **Problem** section and ideally a **Business Case** section. If either is missing, note what's missing but proceed anyway.
+
+4. Display a brief summary of what you understood from the PRD:
+   - The core problem (1-2 sentences)
+   - The business impact (1-2 sentences)
+   - Key stakeholders or affected teams
+   - Any constraints or requirements called out
+
+5. Ask: "Does this summary capture the intent? Anything to add or correct?" and let the user adjust before moving on.
+
+6. Once confirmed, say: **"PRD ingested. Moving to research phase..."** and proceed to Step 2.
+
+### Step 2: Research Context
+
+Investigate the codebase and gather context for the PRD topic. Do this inline — do not invoke `/research` via the Skill tool. Follow this procedure:
+
+1. **Scope** — restate the topic in one sentence and tell the user what you plan to investigate. Ask if they want anything specific covered.
+2. **Codebase deep dive** — read relevant source files in depth (models, routes, screens, components, configs, tests). Search for existing patterns, conventions, and dependencies. Check `docs/`, `README.md`, `CLAUDE.md`, and any feature documentation. Note file paths, function names, and line numbers as you go.
+3. **External research** — search the web for any APIs, libraries, or best practices that aren't already in the codebase.
+4. **Present findings** — output a complete research document in chat with: Summary, Context, Findings (with file paths and snippets), Options Considered (table with pros/cons/effort), Recommendation (be opinionated), Open Questions, References.
+5. **Iterate** — ask "Anything you want me to dig deeper on, adjust, or investigate further?" If the user gives feedback, investigate and re-output the **full** updated document.
+6. **Save** — once the user is satisfied, write the final version to `research.md` in the project root and continue to Step 3.
+
+Be specific (file paths, line numbers, code snippets) and opinionated (recommend an approach, don't just list options).
+
+### Step 3: Shape & Question
+
+This is the core shaping step inspired by the Shape Up methodology. The goal is to narrow the solution from a raw idea to a well-defined approach with clear boundaries.
+
+#### Phase 1: Models & APIs (get alignment first)
+
+This is the most important part. Models and APIs define the shape of the feature — everything else follows from them.
+
+1. **Draft the data model** based on the PRD and research:
+   - Mongoose schemas with types, required fields, enums, defaults
+   - Relationships to existing models (refs)
+   - Indexes if relevant
+   - Plugins (soft delete, timestamps, etc.) based on existing patterns
+
+2. **Draft the API surface**:
+   - List each endpoint (method, path, description)
+   - Note if it's a standard CRUD modelRouter or custom
+   - Specify permissions for each endpoint
+   - Call out any special query parameters, filters, or bulk operations
+
+3. **Present both together** and ask the user: "Are these models and APIs the right approach?" Use AskUserQuestion.
+
+4. **Iterate** until the user confirms the models and APIs are right. This is the foundation — don't move on until it's solid.
+
+#### Phase 2: Everything Else (flows from models/APIs)
+
+Once models and APIs are confirmed, draft the remaining concerns in a single pass. These should follow naturally from the model/API decisions:
+
+- **Notifications**: Push, email, in-app — who gets notified, when, what content. If none needed, say so.
+- **Activity Log**: What actions get logged, which surface as User Updates, which user groups see them. If none, say so.
+- **Permissions & Access**: Role-based differences beyond what's already covered in API permissions.
+- **UI**: New screens/components, navigation flow, key interactions and states, reusable vs new components.
+- **Feature Flags & Migration**: Whether a flag is needed, any data migrations, rollout strategy.
+- **Phases**: How to break the work into PRs (Phase 1: models + APIs, Phase 2: core UI, Phase 3: polish). If small enough, say "single phase."
+- **Not Included / Future Work**: Compile out-of-scope items and deferred ideas.
+
+Present all of this as a single shaped solution summary:
+
+```
+## Shaped Solution
+
+### Core Concept
+[1-2 sentence description of the approach]
+
+### Models
+[schemas from Phase 1]
+
+### APIs
+[endpoints from Phase 1]
+
+### Notifications
+[notification plan or "none needed"]
+
+### Activity Log
+[logging plan or "none needed"]
+
+### UI
+[screens, flows, interactions]
+
+### Phases
+[implementation phases]
+
+### Not Included
+[explicitly excluded items]
+
+### Risks & Mitigations
+- [risk]: [mitigation approach]
+```
+
+Surface any **risks and rabbit holes** inline:
+- Technical risks: things that might be harder than they look
+- Scope risks: features that could balloon if not bounded
+- For each risk, suggest a mitigation or simpler fallback
+
+Ask: "Does this shaped solution look right? Any decisions you want to revisit?"
+
+Once confirmed, say: **"Solution shaped. Moving to plan sections..."** and proceed to Step 4.
+
+### Step 4: Plan Sections (optional deep pass)
+
+Optional interactive walk-through of each plan section, useful when Step 3 left details fuzzy. For each section: present a draft, ask the user if it looks right, let them refine, then move on.
+
+#### Section 1: Models
+
+1. Draft Mongoose schemas based on the shaped solution. Include:
+   - Full schema code blocks with types, required fields, enums, defaults
+   - Relationships to existing models (refs)
+   - Indexes if relevant
+   - Plugins (soft delete, timestamps, etc.) based on existing patterns found in research
+
+2. Present the schemas and ask:
+   - "Do these models look right?"
+   - "Any fields missing or that should be changed?"
+   - "Should any of these fields be optional vs required?"
+
+#### Section 2: APIs
+
+1. Draft the API surface:
+   - List each endpoint (method, path, description)
+   - Note if it's a standard CRUD modelRouter or custom
+   - Specify permissions for each endpoint
+   - Call out any special query parameters, filters, or bulk operations
+   - Note any webhook or external API integrations
+
+2. Present and ask: "Any endpoints missing? Do the permissions look right?"
+
+#### Section 3: Notifications
+
+1. Based on the shaped solution, list:
+   - Push notifications (who, when, what content)
+   - Email/text notifications
+   - In-app notifications or alerts
+   - If none needed, explicitly state "No notifications required for this feature"
+
+2. Present and confirm with user.
+
+#### Section 4: UI
+
+1. Draft the UI plan:
+   - List new screens/components
+   - Describe navigation flow (how users get there)
+   - Describe key interactions and states
+   - Note any reusable components that already exist vs need to be created
+   - Suggest fat-marker sketches if the UI is complex (describe what should be sketched)
+
+2. Present and ask: "Does this UI approach make sense? Any screens or interactions missing?"
+
+#### Section 5: Phases
+
+1. Propose how to break the work into phases/PRs:
+   - Phase 1: Usually models + basic APIs
+   - Phase 2: Core UI and integrations
+   - Phase 3: Polish, notifications, edge cases
+   - If the feature is small enough, note "Single phase - no need to break up"
+
+2. For each phase, list what's included and what the deliverable looks like.
+
+3. Present and ask: "Does this phasing make sense? Want to adjust?"
+
+#### Section 6: Feature Flags & Migrations
+
+1. Based on the shaped solution, recommend:
+   - Whether a feature flag is needed (and what it controls)
+   - Any data migrations required
+   - Rollout strategy
+
+2. Present and confirm.
+
+#### Section 7: Activity Log & User Updates
+
+1. List:
+   - What actions get logged to the activity log
+   - Which of those surface as User Updates
+   - Which user groups see the updates
+
+2. If no activity logging is needed, say so explicitly.
+
+#### Section 8: Not Included / Future Work
+
+1. Compile the "out of scope" items from shaping into this section
+2. Add any ideas that came up during planning but were deferred
+3. Present and confirm.
+
+After all sections are finalized, say: **"All sections planned. Moving to output generation..."** and proceed to Step 5.
+
+### Step 5: Generate Output
+
+Produce the final implementation plan document and a structured task list, then save them.
+
+1. **Generate the Implementation Plan** in the standard format:
+
+   ```markdown
+   # Implementation Plan: [Feature Name]
+
+   *When an engineer is assigned to a project but before you begin coding, you should fill in the implementation plan and get feedback from the engineering team. Once you have finished or you make any changes, tag Josh with the @ symbol so he can review. Also tag anyone else that needs to be notified, has conflicting work, etc.*
+
+   ## **Models**
+   [Content from plan step]
+
+   ## **APIs**
+   [Content from plan step]
+
+   ## **Notifications**
+   [Content from plan step]
+
+   ## **UI**
+   [Content from plan step]
+
+   ## Phases
+   [Content from plan step]
+
+   ## Feature Flags & Migrations
+   [Content from plan step]
+
+   ## Activity Log & User Updates
+   [Content from plan step]
+
+   ## **Not included/Future work**
+   [Content from plan step]
+
+   ## Acceptance Criteria
+   [If criteria exist from the PRD or shaping, include them here. Otherwise, leave a placeholder noting to run Step 6 (Acceptance Criteria) to generate them.]
+   ```
+
+2. **Generate the Task List** as a structured section at the bottom of the document:
+
+   ```markdown
+   ---
+
+   ## Task List (Bot Consumption)
+
+   *Structured task breakdown for automated implementation. Each task should be independently implementable and testable.*
+
+   ### Phase 1: [Phase Name]
+
+   - [ ] **Task 1.1**: [Short title]
+     - Description: [What to implement]
+     - Files: [Expected files to create/modify]
+     - Depends on: [Other task IDs, or "none"]
+     - Acceptance: [How to verify it's done]
+
+   - [ ] **Task 1.2**: [Short title]
+     ...
+
+   ### Phase 2: [Phase Name]
+   ...
+   ```
+
+   Tasks should be:
+   - Small enough to be a single PR or commit
+   - Ordered by dependency (models first, then APIs, then UI)
+   - Specific about which files to create/modify
+   - Clear about acceptance criteria
+
+3. **Ask the user for the feature name** to use in the filename (suggest one based on the PRD). The filename should be kebab-case.
+
+4. **Save the implementation plan:**
+   - Ensure `docs/implementationPlans/` directory exists (create if needed)
+   - Save to `docs/implementationPlans/[feature-name].md`
+   - Confirm the file was saved and show the path
+
+5. **Save the task plan:**
+   - Ensure `docs/tasks/` directory exists (create if needed)
+   - Save to `docs/tasks/[feature-name].md`
+   - Confirm the file was saved and show the path
+
+6. **Final summary:**
+
+   ```
+   ## Implementation Plan Complete
+
+   **Saved to**: docs/implementationPlans/[feature-name].md
+
+   ### Quick Stats
+   - Models: [count] new/modified
+   - API Endpoints: [count]
+   - Screens: [count]
+   - Phases: [count]
+   - Tasks: [count] total
+
+   ### Next Steps
+   1. Share with the engineering team for review
+   2. Tag @Josh and relevant stakeholders
+   3. Once approved, tasks can be loaded for implementation
+   ```
+
+7. Ask: "Want to make any final changes, or is this ready to share?"
+
+### Step 6: Acceptance Criteria
+
+Generate structured acceptance criteria for an implementation plan. The criteria should be specific enough for a human to manually test AND for a bot to translate into Playwright E2E tests.
+
+`$IP` (optional): path to an existing IP file. If not provided, look for the IP in the current conversation context or ask the user which IP to use.
+
+#### 1. Load the IP
+
+- If `$IP` is provided, read the file
+- Otherwise, check if an IP was generated in the current conversation
+- If neither, list available IPs from `docs/implementationPlans/` and ask which one to use
+
+#### 2. Check for existing acceptance criteria
+
+- If the PRD or IP already has an `## Acceptance Criteria` section, read it carefully
+- Also check each task in the Task List for `Acceptance:` lines
+- These are your starting point — you'll expand and formalize them, not replace them
+
+#### 3. Analyze the IP to identify testable behaviors
+
+Walk through each section of the IP and identify user-facing behaviors:
+
+- **Models & APIs**: What responses should the API return? What validation errors should occur?
+- **UI**: What should the user see? What happens when they interact with elements?
+- **Notifications**: What triggers them? What content appears?
+- **Permissions**: What should different roles see/not see?
+- **Error states**: What happens when things fail?
+- **Edge cases**: Empty states, boundary values, concurrent actions
+
+#### 4. Write acceptance criteria
+
+Write criteria in a dual-format that works for both humans and bots:
+
+```markdown
+## Acceptance Criteria
+
+### Feature: [Feature area name]
+
+#### AC-1: [Short descriptive title]
+**Priority:** P0 | P1 | P2
+**Screen:** [screen name, e.g., "Login Screen"]
+**Preconditions:**
+- [Any setup needed before testing, e.g., "User is logged in", "At least 3 items exist"]
+
+**Steps:**
+1. [Navigate to / open / tap specific element]
+2. [Perform action — be specific about what to type, tap, select]
+3. [Observe result]
+
+**Expected results:**
+- [ ] [Specific, observable outcome — what the user sees]
+- [ ] [Another expected outcome]
+
+**testIDs needed:** `screen-element-qualifier`, `screen-another-element`
+
+---
+```
+
+Format rules:
+
+- **Steps must reference specific UI elements** using the `{screen}-{element}-{qualifier}` testID naming convention
+- **Expected results must be visually verifiable** — things a human can see AND a bot can assert (`toBeVisible`, `toHaveText`, `toHaveCount`, etc.)
+- **Include the `testIDs needed` line** listing every testID the test will need. This serves as a checklist for the developer to add testIDs to components before tests can run.
+- **Priority levels:**
+  - **P0**: Core happy path — feature is broken without this
+  - **P1**: Important flows — error handling, validation, key edge cases
+  - **P2**: Nice-to-have — polish, edge cases, minor interactions
+- **Group by feature area** (e.g., "User Authentication", "Item Management", "Notifications")
+
+#### 5. Cover these categories
+
+Ensure you have at least one criterion for each:
+
+- **Happy path**: The main flow works end to end
+- **Validation**: Required fields, format checks, boundary values
+- **Error handling**: Network errors, server errors, invalid states
+- **Empty states**: What shows when there's no data?
+- **Permissions** (if applicable): Different roles see different things
+- **Navigation**: Moving between screens works correctly
+- **Data persistence**: Changes are saved and visible after refresh
+
+#### 6. Add the section to the IP
+
+Insert the `## Acceptance Criteria` section into the IP file, after the main plan sections but before the `## Task List` section.
+
+#### 7. Summary
+
+Present a summary:
+
+```
+## Acceptance Criteria Generated
+
+**Added to**: [IP file path]
+
+### Coverage
+- P0 (critical): [count] criteria
+- P1 (important): [count] criteria
+- P2 (nice-to-have): [count] criteria
+- Total testIDs needed: [count]
+
+### Next Steps
+1. Review criteria with the team
+2. Ensure all listed testIDs are added to components
+3. Run Step 7 (E2E Tests) to generate Playwright tests from these criteria
+```
+
+Ask: "Want to adjust any criteria or add coverage for something I missed?"
+
+### Step 7: E2E Tests (optional)
+
+Generate Playwright end-to-end tests from an IP's acceptance criteria. Uses the project's Playwright skill and testing conventions.
+
+`$IP` (optional): path to an IP file with acceptance criteria. If not provided, look for the IP in the current conversation context or ask the user which IP to use.
+
+#### 1. Load the IP and acceptance criteria
+
+- If `$IP` is provided, read the file
+- Otherwise, check if an IP was loaded in the current conversation
+- If neither, list available IPs from `docs/implementationPlans/` and ask which one to use
+- The IP **must** have an `## Acceptance Criteria` section. If it doesn't, tell the user to run Step 6 (Acceptance Criteria) first.
+
+#### 2. Research the codebase
+
+Before writing tests, understand the existing test setup:
+
+- Check if `playwright.config.ts` exists — if not, note that it needs to be created
+- Check if `e2e/` directory exists and what tests are already there
+- Check for `e2e/helpers/` and `e2e/fixtures/` for reusable utilities
+- Check for `e2e/auth.setup.ts` to understand auth patterns
+- Look at existing test files to match the style and patterns in use
+- Check if the testIDs listed in acceptance criteria already exist in the component code
+
+#### 3. Plan the test files
+
+Map acceptance criteria to test files:
+
+- **One test file per feature area** (matching the `### Feature:` groups in acceptance criteria)
+- File naming: `e2e/{feature-name}.spec.ts` (kebab-case)
+- Group related ACs into `test.describe()` blocks
+
+Present the plan to the user:
+
+```
+## E2E Test Plan
+
+### Files to create:
+- `e2e/feature-name.spec.ts` — [count] tests from [AC numbers]
+- `e2e/another-feature.spec.ts` — [count] tests from [AC numbers]
+
+### Missing testIDs (must be added to components first):
+- `screen-element-name` — [component file if known]
+- ...
+
+### Missing infrastructure:
+- [ ] playwright.config.ts (will create)
+- [ ] e2e/helpers/auth.ts (will create)
+- ...
+```
+
+Ask: "Should I generate these test files? Any changes to the plan?"
+
+#### 4. Generate test files
+
+For each test file, follow these rules strictly:
+
+**Structure:**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Feature: [Feature Name]', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to starting screen
+    // Wait for screen to be visible
+  });
+
+  // One test per acceptance criterion
+  test('[AC title — as user behavior]', async ({ page }) => {
+    // Steps from the AC, translated to Playwright actions
+    // Expected results as assertions
+  });
+});
+```
+
+**Translation rules (AC → Playwright):**
+
+| AC Step | Playwright Code |
+|---------|----------------|
+| Navigate to [screen] | `await page.goto('/path'); await page.getByTestId('screen-name').waitFor({ state: 'visible' });` |
+| Tap / click [element] | `await page.getByTestId('testid').click();` |
+| Type [text] into [field] | `await page.getByTestId('testid').fill('text');` |
+| Toggle [switch] | `await page.getByTestId('testid').click();` |
+| See [text/element] | `await expect(page.getByTestId('testid')).toBeVisible();` |
+| See text [content] | `await expect(page.getByTestId('testid')).toHaveText(/content/i);` |
+| Don't see [element] | `await expect(page.getByTestId('testid')).not.toBeVisible();` |
+| See [N] items in list | `await expect(page.getByTestId('list').getByTestId(/^item-/)).toHaveCount(N);` |
+| Wait for loading | `await page.getByTestId('loading-indicator').waitFor({ state: 'hidden' });` |
+| Page URL contains [path] | `await expect(page).toHaveURL(/path/);` |
+
+**Mandatory rules:**
+- Use `getByTestId()` as primary selector — never class names or deep selectors
+- Never use `waitForTimeout()` — always wait for element state
+- Wait for screen visibility after every navigation
+- Wait for `networkidle` after data-fetching actions when appropriate
+- Add `// AC-N: [title]` comment above each test for traceability
+- Mark tests that need auth setup with the appropriate Playwright project dependency
+- Use `test.skip()` with a reason for any AC that can't be automated yet (e.g., requires native device features)
+
+#### 5. Report missing testIDs
+
+After generating tests, produce a checklist of testIDs that need to be added to components:
+
+```markdown
+## testIDs to Add
+
+These testIDs are referenced in the generated tests but may not exist in the app yet.
+Add them before running the tests.
+
+### [Screen Name]
+- [ ] `screen-element-name` on `<ComponentType>` — [purpose]
+- [ ] `screen-another-element` on `<ComponentType>` — [purpose]
+```
+
+If you can identify the component files where testIDs should be added, include the file paths.
+
+#### 6. E2E Summary
+
+```
+## E2E Tests Generated
+
+### Files created:
+- `e2e/feature-name.spec.ts` — [count] tests
+- ...
+
+### Coverage:
+- P0 criteria covered: [count]/[total]
+- P1 criteria covered: [count]/[total]
+- P2 criteria covered: [count]/[total]
+- Skipped (not automatable): [count] — [reasons]
+
+### Before running tests:
+1. Add missing testIDs to components (see checklist above)
+2. Ensure `playwright.config.ts` is configured
+3. Start the dev server
+4. Run: `bunx playwright test`
+
+### After tests pass:
+Run `/verify` to verify the full implementation
+```
+
+### Step 8: Review (optional, dual-model)
+
+Review an implementation plan using both Claude (sub-agent) and OpenAI Codex in parallel. Each reviewer independently identifies issues, gaps, and questions. Results are combined, deduplicated, and presented as a structured question list for the user. After the user answers, the IP is updated.
+
+Argument: IP number, filename, or path to the plan file. If empty, infer from conversation context. Parse as `$ARGUMENTS`.
+
+#### Phase 1: Locate the Plan
+
+1. If argument provided, find the matching IP file:
+   - Check `docs/implementationPlans/` for matching file (by IP number, slug, or full path)
+   - If a path was given directly, use that
+2. If no argument, infer from conversation context (most recently discussed IP)
+3. If ambiguous, ask the user
+4. Read the full plan file
+5. If a corresponding task file exists in `docs/tasks/`, read that too
+
+#### Phase 2: Gather Codebase Context
+
+Collect context both reviewers will need:
+
+1. **CLAUDE.md** -- project conventions, tech stack, constraints
+2. **Relevant source files** -- scan the plan's "Files to Create/Modify" or "Files:" fields in tasks, read 3-5 of the most critical existing files
+3. **Data models** -- if the plan references models, find and read their current definitions
+4. **Recent changes** -- `git log --oneline -10` for recent momentum
+
+Keep context focused. Prioritize the plan itself and the most relevant code.
+
+#### Phase 3: Run Both Reviews in Parallel
+
+Launch both reviewers at the same time using parallel tool calls. Do NOT wait for one before starting the other.
+
+##### 3a: Claude Sub-Agent
+
+Use the **Agent tool** with `subagent_type: "general-purpose"`:
+
+Prompt the sub-agent with all gathered context and these instructions:
+
+> You are a senior engineer reviewing an implementation plan. Your goal is to surface issues, gaps, risks, and questions that should be answered before implementation begins.
+>
+> ## The Plan
+>
+> {full plan content}
+>
+> ## Task Breakdown
+>
+> {task list content, if available}
+>
+> ## Codebase Context
+>
+> {CLAUDE.md excerpt -- tech stack, conventions}
+>
+> {relevant source file excerpts}
+>
+> ## Your Review
+>
+> Analyze this plan and produce two outputs:
+>
+> ### Issues & Gaps
+>
+> For each issue found, provide:
+> - **Severity**: CRITICAL / HIGH / MEDIUM / LOW
+> - **Category**: one of: Missing Requirements, Unstated Assumptions, Technical Risks, Security & Data Integrity, Task Breakdown Gaps, Architecture Concerns, Scope Concerns
+> - **Description**: What's wrong or missing -- be specific, cite the plan section
+> - **Suggestion**: How to address it
+>
+> ### Questions for the Author
+>
+> Generate questions that, if answered, would materially improve the plan. Focus on:
+> - Ambiguous requirements that could be interpreted multiple ways
+> - Unstated preferences (e.g., "should this be real-time or batch?")
+> - Tradeoffs where the plan picked one side without discussing alternatives
+> - Missing context that would change the approach
+> - Scale/performance expectations that aren't specified
+> - Integration points with unclear contracts
+> - Rollback/migration strategies that aren't defined
+>
+> For each question:
+> - **Question**: The question itself
+> - **Why it matters**: What changes depending on the answer
+> - **Default assumption**: What the plan currently assumes (if anything)
+>
+> Do NOT ask questions that can be answered by reading the codebase -- use Glob, Grep, and Read to verify before asking. Only ask questions that require human judgment or domain knowledge.
+
+##### 3b: Codex CLI
+
+Build a prompt file at `$TMPDIR/ip-review-prompt.md` with the plan, tasks, and codebase context, then run:
+
+```bash
+codex --model o3 --quiet --approval-mode full-auto "$TMPDIR/ip-review-prompt.md"
+```
+
+The prompt file should contain:
+
+```markdown
+# Implementation Plan Review: {plan title}
+
+You are a senior engineer reviewing an implementation plan. Find issues, gaps, and generate questions for the plan author.
+
+## The Plan
+
+{full plan content}
+
+## Task Breakdown
+
+{task list content, if available}
+
+## Codebase Context
+
+{CLAUDE.md excerpt}
+
+{relevant source file excerpts}
+
+## Your Review
+
+### Part 1: Issues & Gaps
+
+For each issue, provide:
+- **Severity**: CRITICAL / HIGH / MEDIUM / LOW
+- **Category**: Missing Requirements, Unstated Assumptions, Technical Risks, Security & Data Integrity, Task Breakdown Gaps, Architecture Concerns, or Scope Concerns
+- **Description**: Be specific -- cite the plan section and explain exactly what's wrong or missing
+- **Suggestion**: How to fix it
+
+### Part 2: Questions for the Author
+
+Generate questions that require human judgment or domain knowledge to answer. For each:
+- **Question**: The question
+- **Why it matters**: What would change depending on the answer
+- **Default assumption**: What the plan currently assumes
+
+Focus on: ambiguous requirements, unstated tradeoffs, missing scale/performance expectations, unclear integration contracts, and migration/rollback gaps.
+
+Do NOT ask questions answerable from the codebase. Focus on decisions that need human input.
+```
+
+**Model selection:** Use `o3` for strong reasoning. If unavailable, fall back to `o4-mini`.
+
+If `codex` is not installed or fails, report the error and continue with Claude-only results.
+
+Capture the full output.
+
+#### Phase 4: Combine & Deduplicate
+
+After both reviews return:
+
+##### Issues
+
+1. Parse all issues from both reviewers
+2. Deduplicate: if both flagged the same issue (same plan section, similar concern), merge and keep the more detailed description
+3. Tag each with its source:
+   - `[Claude]` -- only Claude found it
+   - `[Codex]` -- only Codex found it
+   - `[Both]` -- both flagged it (higher confidence)
+4. Sort by severity: CRITICAL > HIGH > MEDIUM > LOW
+
+##### Questions
+
+1. Parse all questions from both reviewers
+2. Deduplicate: merge questions asking essentially the same thing
+3. Tag with source (`[Claude]`, `[Codex]`, `[Both]`)
+4. Group by theme (e.g., "Scope", "Architecture", "Data", "Performance", "Migration")
+5. Within each group, sort by impact (questions where the answer would most change the plan come first)
+
+##### Verify Critical Claims
+
+For CRITICAL and HIGH issues, do a quick Glob/Grep/Read to confirm the issue is real. Note which are verified vs unverified.
+
+#### Phase 5: Present Results
+
+Present the combined review:
+
+```
+## IP Review: {plan title}
+
+**Reviewers:** Claude (sub-agent) + OpenAI Codex ({model used})
+**Plan:** {IP file path}
+
+---
+
+### Issues Found
+
+#### Critical
+1. [Both] **{category}** -- {description}
+   → {suggestion}
+
+#### High
+2. [Claude] **{category}** -- {description}
+   → {suggestion}
+
+#### Medium / Low
+3. [Codex] **{category}** -- {description}
+   → {suggestion}
+
+---
+
+### Questions for You
+
+**Scope & Requirements**
+1. [Both] {question}
+   _Why it matters:_ {impact}
+   _Current assumption:_ {what plan assumes}
+
+**Architecture & Design**
+2. [Claude] {question}
+   _Why it matters:_ {impact}
+   _Current assumption:_ {what plan assumes}
+
+**Performance & Scale**
+3. [Codex] {question}
+   _Why it matters:_ {impact}
+
+{...more grouped questions...}
+```
+
+#### Phase 6: Collect Answers
+
+Use **AskUserQuestion** to collect the user's answers. Present the questions in a numbered list and ask the user to answer them. Options:
+
+- Answer all at once (numbered responses)
+- Answer one at a time interactively
+- Skip questions they don't want to address yet (mark as "deferred")
+
+For skipped questions, note the current assumption the plan makes and flag it as an unresolved decision.
+
+#### Phase 7: Update the Plan
+
+After collecting answers:
+
+1. **Read the current IP file** fresh (in case it changed)
+2. **For each answered question**, determine what section(s) of the plan need updating
+3. **For each confirmed issue**, draft the fix
+4. **Draft all changes** and present them to the user as a before/after diff for each section
+5. Ask: "Apply these updates to the plan?"
+6. If yes, edit the IP file with all changes
+7. If a task file exists, update it too if any tasks are affected
+8. Add an "## Review Log" entry at the bottom of the IP file:
+
+```markdown
+## Review Log
+
+### {today's date} -- Dual-Model Review
+- **Reviewers:** Claude + Codex ({model})
+- **Issues found:** {N} ({breakdown by severity})
+- **Questions asked:** {N} ({answered}/{deferred})
+- **Plan updated:** Yes/No
+- **Unresolved:** {list any deferred questions or unverified issues}
+```
+
+#### Cleanup
+
+```bash
+rm -f "$TMPDIR/ip-review-prompt.md"
+```
+
+#### Notes on Review
+
+- The value is **dual perspective** -- Claude and Codex have different biases and catch different things
+- Questions tagged `[Both]` deserve the most attention -- two independent models flagged the same gap
+- Don't pre-filter findings. Present honestly even if they contradict earlier Claude work on the plan
+- This step fits between Step 5 (Generate) and implementation -- use it as a quality gate
+- Can also be run mid-implementation to reassess the plan as understanding deepens
+
+### Step 9: Attack & Adjust
+
+Adversarially red-team the plan and then update it inline based on what comes back. This is the last thing `/ip` does before handing off to implementation.
+
+1. **Locate the plan** — use the file just saved in Step 5 (`docs/implementationPlans/[feature-name].md`). Read it, plus the task file in `docs/tasks/` if present.
+
+2. **Gather focused context** — collect what an external reviewer will need:
+   - `CLAUDE.md` (tech stack, conventions, constraints)
+   - 3–5 of the most critical existing files referenced in the plan's "Files to Create/Modify"
+   - Current definitions of any models the plan touches
+   - `git log --oneline -10` for recent momentum
+
+3. **Build the attack prompt** at `$TMPDIR/ip-attack-prompt.md`:
+
+   ```markdown
+   # Adversarial Review: {plan title}
+
+   You are a senior staff engineer conducting a hostile review of this implementation plan. Find every flaw, gap, risk, and unstated assumption. Be uncharitable — assume nothing works until proven otherwise.
+
+   ## The Plan
+   {full plan content}
+
+   ## Task Breakdown
+   {task list content, if available}
+
+   ## Codebase Context
+   {CLAUDE.md excerpt + relevant source file excerpts}
+
+   ## Your Review
+
+   For each finding, cite the section of the plan and explain exactly what's wrong or missing. Cover:
+
+   1. **Missing Requirements** — what the PRD implies but the plan ignores; uncovered user flows and error states.
+   2. **Unstated Assumptions** — what the plan assumes about codebase/infra/data/scale that isn't verified.
+   3. **Technical Risks** — parts harder than the plan suggests; highest rewrite probability.
+   4. **Security & Data Integrity** — injection, auth gaps, input validation, race conditions.
+   5. **Task Breakdown Gaps** — tasks not actually independent/testable; wrong dependencies; missing setup/migration/testing/docs tasks.
+   6. **Architecture Concerns** — fit with existing patterns; tech debt; simpler approaches overlooked.
+   7. **Verdict** — SHIP IT / REVISE / RETHINK.
+
+   Classify each finding: CRITICAL / HIGH / MEDIUM / LOW.
+   ```
+
+4. **Run the attacker — OpenAI first, Opus fallback:**
+
+   Try OpenAI Codex CLI:
+   ```bash
+   codex --model o3-pro --quiet --approval-mode full-auto "$TMPDIR/ip-attack-prompt.md"
+   ```
+   If `o3-pro` is unavailable or rate-limited, try `o3`, then `o4-mini`.
+
+   If the `codex` CLI is missing or every model fails, fall back to an Opus subagent: spawn a `general-purpose` Agent with `model: "opus"` and pass it the same prompt file contents, telling it to act as the hostile reviewer. Report clearly which path was taken.
+
+5. **Process the findings:**
+   - Deduplicate overlapping issues.
+   - For each CRITICAL/HIGH finding, verify with Glob/Grep/Read before treating it as real — reviewers hallucinate.
+   - Drop anything the plan actually already addresses.
+
+6. **Report to the user** in this shape:
+
+   ```
+   ## Adversarial Review: {plan title}
+
+   **Reviewer:** {OpenAI model used, or "Opus fallback"}
+   **Verdict:** {SHIP IT / REVISE / RETHINK}
+
+   ### Critical / High / Medium / Low
+   {findings grouped by severity, each with a one-line plan-section reference}
+
+   ### Verified vs Unverified
+   - Verified: {confirmed against the codebase}
+   - Unverified: {couldn't confirm — may be false positives}
+   ```
+
+7. **Adjust the plan** — don't stop at reporting. For every verified CRITICAL/HIGH finding, edit the IP file in place: tighten assumptions, add missing tasks, patch acceptance criteria, rewrite risky phases. For MEDIUM/LOW, ask the user which to fold in. Show the diff of your plan edits and ask "Anything else to adjust, or is this ready for implementation?"
+
+If the user provides a `$STEP` argument, skip to that step (assumes prior steps have been completed and context is available in conversation).
+
+## Lifecycle Operations
+
+These operations manage IPs through their lifecycle after creation. Each is self-contained and can be invoked directly by name.
+
+### Lifecycle: Init
+
+Set up the directory structure and tracking index for implementation plans in the current project.
+
+Argument: optional project description or notes (`$ARGUMENTS`).
+
+#### Before Starting
+
+1. Identify the **project root** -- this is the current working directory
+2. Check if IP tracking already exists by looking for `docs/implementationPlans/PLAN_INDEX.md`
+   - If it exists, report what's already set up and ask what to regenerate
+   - If it doesn't exist, proceed with full setup
+
+#### Init Step 1: Infer Project Context
+
+1. Read `CLAUDE.md` if it exists -- note the project name, key conventions, commit style
+2. Check `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, or similar for project name
+3. Look at recent git log for commit message style
+4. Note the primary language and any existing docs structure
+5. Check if `docs/implementationPlans/` already exists with plan files -- if so, scan them for the highest IP number to seed the index
+
+#### Init Step 2: Create Directory Structure
+
+```bash
+mkdir -p docs/implementationPlans/archive
+mkdir -p docs/tasks
+```
+
+#### Init Step 3: Create PLAN_INDEX.md
+
+Create `docs/implementationPlans/PLAN_INDEX.md`:
+
+```markdown
+# Implementation Plan Index
+
+Tracked implementation plans for {project_name}.
+
+See `CLAUDE.md` for IP lifecycle stages and management guidelines.
+
+## Active Plans
+
+| IP | Title | Status | Effort | Priority |
+|----|-------|--------|--------|----------|
+| - | - | - | - | No active plans yet |
+
+## Completed
+
+| IP | Title | Completed | Notes |
+|----|-------|-----------|-------|
+| - | - | - | No completed plans yet |
+
+## Deferred / Closed
+
+| IP | Title | Status | Notes |
+|----|-------|--------|-------|
+| - | - | - | No deferred plans yet |
+
+## Backlog
+
+Low-priority or blocked items. Promote to Active when ready to plan.
+
+| IP | Title | Notes |
+|----|-------|-------|
+| - | - | No backlog items yet |
+```
+
+If existing plan files were found in `docs/implementationPlans/`, populate the Active table with entries for each file, inferring IP numbers from filenames or assigning new ones.
+
+#### Init Step 4: Create IP_TEMPLATE.md
+
+Only create if `docs/implementationPlans/IP_TEMPLATE.md` does not already exist. If it exists, skip this step and report it was found.
+
+Create `docs/implementationPlans/IP_TEMPLATE.md`:
+
+```markdown
+# Implementation Plan: Title
+
+**Status:** Open
+**Priority:** Low | Medium | High
+**Effort:** Small batch (1-2 days) | Big batch (1-2 weeks) | Epic (2+ weeks)
+**IP:** IP-XXX
+
+*When an engineer is assigned to a project but before you begin coding, you should fill in the implementation plan and get feedback from the engineering team.*
+
+## Models
+
+New or modified data models, schemas, relationships.
+
+## APIs
+
+Endpoints, permissions, special queries, bulk operations.
+
+## Notifications
+
+Push, email, in-app alerts -- who, when, what.
+
+## UI
+
+New screens/components, navigation flow, key interactions, states.
+
+## Phases
+
+How to break the work into phases/PRs.
+
+## Feature Flags & Migrations
+
+Feature flags, data migrations, rollout strategy.
+
+## Activity Log & User Updates
+
+What actions get logged, what surfaces as user updates.
+
+## Not Included / Future Work
+
+Explicitly out of scope.
+
+---
+
+## Task List
+
+*Structured task breakdown. Each task should be independently implementable and testable.*
+
+### Phase 1: [Phase Name]
+
+- [ ] **Task 1.1**: [Short title]
+  - Description: [What to implement]
+  - Files: [Expected files to create/modify]
+  - Depends on: [Other task IDs, or "none"]
+  - Acceptance: [How to verify it's done]
+```
+
+#### Init Step 5: Update Project CLAUDE.md
+
+Read the project's `CLAUDE.md`. If it doesn't exist, create it with a minimal header.
+
+**Check if an IP section already exists** by searching for `## Implementation Plan` or `## IP Management`. If found, skip and report.
+
+Otherwise, **append** the following section:
+
+```markdown
+
+---
+
+## Implementation Plan (IP) Management
+
+Implementation plans are tracked in `docs/implementationPlans/`. Each IP has a dedicated file and is indexed in `PLAN_INDEX.md`.
+
+### IP Lifecycle
+
+| Stage | Description |
+|-------|-------------|
+| **Planned** | Identified but not yet designed |
+| **Design** | Actively designing (PRD ingested, shaping) |
+| **Open** | Shaped and ready for implementation |
+| **In Progress** | Currently being implemented |
+| **Pending Verification** | Code complete, awaiting verification |
+| **Complete** | Verified working, ready to archive |
+| **Deferred** | Postponed (low priority or blocked) |
+| **Closed** | Won't implement (superseded or not needed) |
+
+### Conventions
+
+- **IP files**: `docs/implementationPlans/{Title-Case-Name}.md` (e.g. `Zoom-Integration-Mvp.md`)
+- **Template**: `docs/implementationPlans/IP_TEMPLATE.md`
+- **Task files**: `docs/tasks/{feature-name}.md` (created by Step 5: Generate)
+- **Commit format**: `IP-XXX: Brief description`
+- **Numbering**: Next number = highest across all index sections + 1
+- **Source of truth**: IP file status > index (if discrepancy, file wins)
+- **Archive**: Completed IPs move to `docs/implementationPlans/archive/`
+
+### Inline Annotations (`%%`)
+
+Lines starting with `%%` in any file are **inline annotations from the user**. When you encounter them:
+- Treat each `%%` annotation as a direct instruction
+- Address **every** `%%` annotation in the file; do not skip any
+- After acting on an annotation, remove the `%%` line from the file
+- If an annotation is ambiguous, ask for clarification before acting
+```
+
+#### Init Step 6: Init Summary
+
+Report what was created:
+
+```
+## IP Tracking Initialized
+
+### Files Created
+- `docs/implementationPlans/PLAN_INDEX.md` -- Plan index
+- `docs/implementationPlans/IP_TEMPLATE.md` -- IP file template (if not already present)
+- `docs/implementationPlans/archive/` -- Archive directory
+- `docs/tasks/` -- Task files directory
+- `CLAUDE.md` -- Updated with IP conventions
+
+### Next Steps
+1. Run /ip to create your first implementation plan from a PRD
+2. Run the Lifecycle: Status operation to check the current state
+```
+
+### Lifecycle: Explore
+
+General-purpose exploration of any project using the IP system. Uses parallel subagents to quickly build context.
+
+#### Step 1: Launch Parallel Subagents
+
+Launch these THREE subagents IN PARALLEL (single message with multiple Task tool calls):
+
+##### Agent 1: Project Overview
+
+Explore the project root to understand what this project is and how it works:
+
+1. **Read key docs** -- `CLAUDE.md`, `README.md`, any top-level docs
+2. **Directory structure** -- Glob for top-level files and key subdirectories
+3. **Tech stack** -- Identify languages, frameworks, build tools from config files (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `Makefile`, etc.)
+4. **Gotchas** -- Note any warnings, constraints, or non-obvious conventions from CLAUDE.md
+
+Return: project name, purpose, tech stack, directory layout, key gotchas.
+
+##### Agent 2: IP History
+
+Explore the implementation plan system to understand what's been built and what's planned:
+
+1. **Read index** -- `docs/implementationPlans/PLAN_INDEX.md`
+2. **Active IPs** -- Read each active IP file (non-Complete status)
+3. **Archived IPs** -- List files in `docs/implementationPlans/archive/` to understand completed work
+4. **Task files** -- List and scan `docs/tasks/` for active task lists
+5. **Recent IP commits** -- Search git log for commits matching `IP-` pattern (last 20)
+
+Return: active IPs table, count of archived IPs, active tasks summary, recent IP commit summary.
+
+##### Agent 3: Recent Activity
+
+Explore recent development activity to understand current momentum:
+
+1. **Recent commits** -- Last 15 commits with messages
+2. **Modified files** -- Files changed in the last 5 commits
+3. **Branch context** -- Current branch name and how far ahead of main
+4. **Uncommitted work** -- Check git status for staged/unstaged changes
+
+Return: recent commit summary, files in flux, branch status, open work.
+
+#### Step 2: Synthesize Results
+
+Combine all agent outputs into a single briefing:
+
+##### Project Overview
+- Name, purpose, tech stack (from Agent 1)
+- Key gotchas or constraints
+
+##### IP Status
+- Active plans table (from Agent 2)
+- Active tasks and progress
+- Archived count and notable completions
+
+##### Recent Activity
+- What's been happening (from Agent 3)
+- Current branch and open work
+
+##### Quick Reference
+
+| Item | Value |
+|------|-------|
+| **Project** | {name} |
+| **Branch** | {current branch} |
+| **Active IPs** | {count} |
+| **Active Tasks** | {count remaining} |
+| **Recent focus** | {summary of last few commits} |
+
+Use the current working directory as the project root.
+
+### Lifecycle: Deep Analysis
+
+Parallel exploration of a hard problem from multiple angles, inspired by test-time compute scaling. Use when stuck, when the problem is complex enough to benefit from diverse perspectives, or when you need "big brains" on something.
+
+Argument: problem description or context (`$ARGUMENTS`).
+
+#### Phase 1: Understand the Problem
+
+1. **Parse the argument** -- what is the user stuck on? What are they trying to achieve?
+2. **Gather context** -- read conversation history for what's already been tried or discussed
+3. **Check for active IP** -- if there's a relevant implementation plan, read it for design context
+4. **Scan the codebase** -- do a quick targeted search to understand the relevant code area (key files, architecture, constraints). Keep this brief -- the agents will do the deep exploration.
+
+#### Phase 2: Design the Exploration
+
+Based on the problem, design **4 exploration angles**. These are NOT redundant -- each agent gets a **distinct lens** on the problem.
+
+**Before launching, check orthogonality:** Would two of these angles likely explore the same code paths and reach similar conclusions? If so, reframe one to ensure genuine diversity.
+
+**How to choose angles -- infer from the problem type:**
+
+For **performance optimization**:
+- Algorithmic: Can the approach itself be fundamentally different?
+- Structural: Can the data layout, schema, or architecture reduce work?
+- Incremental: Can we avoid redoing work (caching, materialization, deltas)?
+- Environmental: Are we fighting the platform? (query patterns, Python GIL, network topology)
+
+For **architecture/design decisions**:
+- Simplicity: What's the minimal viable approach?
+- Scalability: What happens at 10x/100x current load?
+- Precedent: How do similar systems/libraries solve this?
+- Contrarian: What if the obvious approach is wrong? What's the unconventional path?
+
+For **debugging / "why is this broken"**:
+- Symptoms: Trace the failure path precisely -- what's the chain of events?
+- Environment: What changed? Versions, configs, data, dependencies?
+- Assumptions: What are we assuming that might not be true?
+- Similar: Has this pattern of failure been seen elsewhere in the codebase or in public?
+
+For **anything else** -- choose angles that maximize diversity of insight. Ask: "If these 4 experts were in a room, what different specialties would give me the most useful debate?"
+
+**For each angle, decide:**
+- What codebase areas the agent should explore (specific files, directories, patterns)
+- What question the agent should answer
+- How deep vs. broad the agent should go
+- What existing context (if any) to seed the agent with -- only what's necessary, avoid anchoring
+
+#### Phase 3: Launch Parallel Exploration
+
+**Briefly tell the user** what angles you're exploring (2-3 words each) -- then launch immediately. Don't wait for approval. Speed matters when stuck.
+
+Launch **4 Explore agents IN PARALLEL** (single message with 4 Task tool calls). Use `model: "opus"` explicitly on each agent to ensure heavyweight reasoning. Each agent gets:
+
+```
+You are exploring a specific angle of a hard problem. Your analysis is input to a multi-agent synthesis -- be precise, flag uncertainties, and show your evidence.
+
+## Problem
+{problem description}
+
+## Your Angle
+{specific lens -- what you're looking for, what question you're answering}
+
+## Where to Look (Starting Points)
+{specific files, directories, or search patterns to start with}
+
+These are entry points, not the complete scope. Follow evidence wherever it leads -- if the trail points to related code outside this list, explore it.
+
+## Key Constraint
+You have read-only tools (Glob, Grep, Read). Use them liberally. If you can't verify something exists, don't claim it. Better to say "I couldn't locate a config file for X" than to guess at its name or path.
+
+## Instructions
+- Use Glob, Grep, and Read to thoroughly explore the relevant code
+- Think deeply about your specific angle -- don't try to solve the whole problem
+- Look for evidence, patterns, constraints, and opportunities related to your angle
+- Note anything surprising or that contradicts assumptions
+- Be concrete -- reference specific files, functions, line numbers, data flows
+- If you find something important outside your angle, note it briefly but stay focused
+- Before you finalize: is there evidence that contradicts your recommendation? If yes, address it directly rather than ignore it
+
+## Output
+Return a focused analysis (aim for 600-1000 words):
+
+1. **Key findings** -- specific observations with evidence. For each finding, cite the file/line or code pattern that shows it's true. Avoid vague claims like "this is slow" -- show why.
+
+2. **Implications** -- what this means for the problem. For each implication, explain the logical link: if this finding is true, then we should try X because [reason].
+
+3. **Recommendation** -- your angle's proposed direction:
+   - **Proposed approach:** [specific, actionable idea]
+   - **Why this angle suggests it:** [link findings -> recommendation]
+   - **Tradeoffs:** [what you'd give up]
+   - **Key assumptions:** [what has to be true for this to work]
+   - **Biggest uncertainty:** [what would most change your mind]
+```
+
+#### Phase 4: Verify Key Claims
+
+Before synthesizing, two verification passes:
+
+##### Pass 1: Contradiction Detection
+
+Scan all 4 agent reports for **opposing claims**. Examples:
+- Agent A says "this runs synchronously" while Agent B says "this is async"
+- Agent A says "no index on this column" while Agent C assumes an index exists
+- Two agents recommend opposite directions
+
+Flag contradictions prominently. **Prioritize verifying contradicted claims first** -- these are where the highest-value corrections live.
+
+##### Pass 2: Factual Verification
+
+**Cross-check the most important factual claims** from the agents. Agents can hallucinate file paths, function signatures, config options, or behavioral assumptions.
+
+**What to verify:**
+- **File paths and function names** -- do the files/functions agents referenced actually exist? Spot-check with Glob/Grep.
+- **Behavioral claims** -- "this function does X" or "this config controls Y" -- Read the actual code for the 2-3 most critical claims that the recommendation will hinge on.
+- **Performance/complexity claims** -- if an agent says "this is O(n^2)" or "this query scans the full table," verify against the actual code or query plan.
+- **Assumption checks** -- if agents assumed something about the system (e.g., "this runs synchronously," "this table has an index on X"), verify the ones that matter most.
+
+**How to verify:**
+- Focus on the **top 3-5 claims that would change the recommendation if wrong**. Don't verify everything -- verify what matters.
+- Use Glob, Grep, and Read directly (no subagents -- this should be fast).
+- If a claim is wrong, note the correction. If it's right, move on.
+
+**Output:** Note any corrections or confirmations. Flag anything that was wrong -- this changes the synthesis.
+
+#### Phase 5: Synthesize
+
+After verification, synthesize the agents' findings (with corrections applied) into a single analysis. This is the critical step -- don't just concatenate.
+
+**Synthesis structure:**
+
+##### 1. Agreements
+Where do multiple angles converge? High-confidence insights.
+
+##### 2. Tensions
+Where do angles disagree or present tradeoffs? These are the real design decisions.
+
+##### 3. Surprises
+What did agents find that wasn't expected? Novel insights that change the framing.
+
+##### 4. Corrections
+Any agent claims that were wrong or misleading, and what the truth is. Be transparent -- this builds trust in the analysis.
+
+##### 5. Recommendation
+Your synthesized recommendation. Be opinionated -- rank the options, state which direction you'd go and why. Tag each element with confidence (High/Medium/Low) and a one-line justification. Include:
+- **Proposed approach** -- the synthesized best path forward
+- **Key tradeoffs** -- what you're giving up
+- **Risks** -- what could go wrong
+- **Key assumptions** -- what the recommendation depends on being true
+- **First step** -- the concrete next action
+
+##### 6. Assumption Check
+After drafting the recommendation, note what assumptions it hinges on. Verify those specific assumptions with a quick Glob/Grep/Read check. If any fail, flag them and reassess.
+
+##### 7. If applicable: IP Update
+If there's an active IP related to this problem, propose specific updates to the plan's relevant sections based on the analysis. Don't update the file -- present the proposed changes for the user to approve.
+
+#### Notes on Deep Analysis
+
+- **Agent count**: Always 4. Four distinct angles. No exceptions.
+- **Agent type**: Always use `subagent_type: "Explore"` with `model: "opus"` -- read-only research agents on the heaviest model.
+- **Thoroughness**: Tell agents to be "very thorough" in their Task descriptions.
+- **No anchoring**: Don't give agents each other's angles. They should explore independently.
+- **Speed over perfection**: The user is stuck. A good-enough synthesis in 2 minutes beats a perfect one in 10. Don't over-polish the output.
+
+### Lifecycle: Status
+
+Generate an up-to-date summary of active implementation plans.
+
+#### Fast Path vs Full Grooming
+
+**Decide which path to take based on conversation context:**
+
+##### Fast Path (just print the table)
+Use this when you are **confident the index is up to date** -- for example:
+- You've been working on IPs in this session (closing, creating, updating)
+- You just ran a full grooming pass recently
+- The user just asked you to "print the status"
+
+Simply read `docs/implementationPlans/PLAN_INDEX.md` and each active IP file, then output the table.
+
+##### Full Grooming (first invocation or uncertain state)
+Use this when you have **no context about the current state**:
+- Start of a new conversation
+- You haven't touched any IPs yet
+- The user explicitly asks for a grooming check
+
+Perform these housekeeping checks:
+
+###### 1. Status Sync Check
+- Read each active IP file and compare its `**Status:**` line to the index
+- If discrepancy, update the index to match the file (file is source of truth)
+- Report any discrepancies found and fixed
+
+###### 2. Archive Check
+- Look for IP files in `docs/implementationPlans/` (not in `archive/`) with status: Complete, Deferred, or Closed
+- For each such IP not yet archived:
+  - Move to `docs/implementationPlans/archive/`
+  - Ensure it's in the appropriate section of the index
+- Report any files archived
+
+###### 3. Orphan Check
+- Check if any IPs in the index don't have corresponding files
+- Check if any IP files exist that aren't in the index (exclude IP_TEMPLATE.md and PLAN_INDEX.md)
+- Report any orphans found
+
+###### 4. Task Progress Check
+- For each active IP, check if a corresponding task file exists in `docs/tasks/`
+- Count completed vs total tasks (checked vs unchecked checkboxes)
+- Include task progress in the output table
+
+#### Status Output
+
+Format the output as a markdown table:
+
+    ## Active Implementation Plans
+
+    | IP | Title | Status | Effort | Tasks | Description |
+    |----|-------|--------|--------|-------|-------------|
+    | IP-XXX | Title here | Status | Effort | 3/10 | Brief description |
+
+    **Total:** X active plans (Y design, Z open, W in progress)
+
+If full grooming was performed and changes were made, prepend a grooming report.
+
+Notes:
+- Keep descriptions concise (< 60 chars if possible)
+- Include a count summary at the bottom
+- Task column shows completed/total if task file exists, "-" otherwise
+
+### Lifecycle: Close
+
+Close an IP by marking it complete (or closed/deferred), archiving the file, and updating the index.
+
+Argument should contain:
+- **IP number or name** (required-ish): e.g. `1`, `IP-001`, or the plan filename slug
+- **Disposition** (optional): `complete` (default), `closed`, or `deferred`
+- **Notes** (optional): any additional context
+
+Examples:
+- close 1 -- mark IP-001 as Complete
+- close user-permissions deferred blocked on auth refactor -- mark by name, Deferred
+- close 3 closed superseded by IP-005 -- mark IP-003 as Closed
+- close (no args) -- infer from conversation context
+
+Parse the argument: `$ARGUMENTS`
+
+#### Inferring the IP
+
+If no IP number/name provided, infer from conversation context:
+- Look at which IP was most recently discussed or worked on
+- If exactly one IP is obvious, use it and state which one
+- If ambiguous, ask the user
+
+#### Close Steps
+
+##### 1. Find and read the IP file
+
+- Search `docs/implementationPlans/` for matching file (by IP number, Title-Case filename, or slug)
+- Read to get title, current status
+- If already archived or not found, report and stop
+
+##### 2. Update the IP file
+
+- Set `**Status:**` to `Complete`, `Closed`, or `Deferred`
+- For Complete: add `**Completed:** {today YYYY-MM-DD}` after Status
+- For Closed/Deferred: add `**Closed:** {today}` if not present
+
+##### 3. Update PLAN_INDEX.md
+
+- Read `docs/implementationPlans/PLAN_INDEX.md`
+- Remove IP's row from **Active Plans** table
+- Add to appropriate section:
+  - **Complete** -> add to top of `## Completed` table with date and notes
+  - **Closed/Deferred** -> add to top of `## Deferred / Closed` table with status and notes
+
+##### 4. Archive the files
+
+- Move IP file to `docs/implementationPlans/archive/`
+- If a corresponding task file exists in `docs/tasks/`, move it to `docs/implementationPlans/archive/` as well (or leave in place if tasks are still referenced)
+
+##### 5. Commit
+
+Commit all changes in a single atomic commit:
+- Check `git status` for uncommitted changes related to the IP implementation
+- Stage implementation files, archived IP, deleted original path, `PLAN_INDEX.md`
+- Commit with message: `IP-{number}: {title}`
+
+##### 6. Close Summary
+
+Report:
+- IP number and title
+- Disposition (Complete / Closed / Deferred)
+- Status updated in IP file
+- Moved from Active to the appropriate section in index
+- Archived to `docs/implementationPlans/archive/`
+- Committed: {short hash}
+
+## Submitting the IP
+
+Once the plan is finalized, use `/submit` to commit the IP files, push the branch, and create a PR on the target project's GitHub repo. The worktree is already on a dedicated branch, so `/submit` works directly.
+
+## Arguments
+
+$PROJECT: Project alias or `owner/repo` (required — if omitted, user is prompted to select from the registry)
+$STEP: Optional step to skip to (ingest, research, shape, plan, generate, acceptance, e2e, review, attack). Note: Step 0 (project setup) always runs regardless of $STEP.
+$PRD: Optional path to a PRD markdown file (skips the paste prompt in ingest step)

--- a/.rulesync/skills/mongoose-schema-safety/SKILL.md
+++ b/.rulesync/skills/mongoose-schema-safety/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: mongoose-schema-safety
+description: >-
+  Invoke when making any Mongoose schema change: adding/removing/renaming
+  fields, creating a new model, adding indexes, or writing a backfill migration.
+  Provides the five-type pattern, risk matrix, type file checklist, and rollout
+  safety steps for terreno backends.
+---
+# Mongoose Schema Safety — Terreno
+
+## Where Schemas and Types Live
+
+| Package | Schemas | Types |
+|---------|---------|-------|
+| `@terreno/api` (built-in models like `User`, `ConsentForm`) | `api/src/models/*.ts` | `api/src/types/*.ts` (or co-located in the model file via `mongoose.Schema<Doc, Model, Methods>` generics) |
+| `example-backend` (`User`, `Todo`, `Configuration`) | `example-backend/src/models/*.ts` | `example-backend/src/types/models/*.ts` (`userTypes.ts`, `todoTypes.ts`, …) |
+| `@terreno/ai` (`AIRequest`, `GptHistory`) | `ai/src/models/*.ts` | `ai/src/types/index.ts` |
+
+Every field in every schema **must** have a `description` (see the API rule `01-model-field-descriptions.md`). Descriptions flow through to the OpenAPI spec via `mongoose-to-swagger`.
+
+## The Five-Type Pattern
+
+Every model has manually-maintained TypeScript types. **Types are NOT auto-generated** — every schema change must include a matching type update in the same commit/PR.
+
+```typescript
+import type {DefaultDoc, DefaultModel, DefaultStatics} from "@terreno/api";
+
+// 1. Instance methods (on the document)
+export type YourModelMethods = {
+  customMethod: (this: YourModelDocument, param: string) => Promise<void>;
+};
+
+// 2. Static methods (on the model class) — extend DefaultStatics for findExactlyOne / findOneOrNone
+export type YourModelStatics = DefaultStatics<YourModelDocument> & {
+  customStatic: (this: YourModelModel, param: string) => Promise<YourModelDocument>;
+};
+
+// 3. Model type combining document + statics
+export type YourModelModel = DefaultModel<YourModelDocument> & YourModelStatics;
+
+// 4. Schema type
+export type YourModelSchema = mongoose.Schema<YourModelDocument, YourModelModel, YourModelMethods>;
+
+// 5. Document type (the shape of a single record)
+export type YourModelDocument = DefaultDoc & YourModelMethods & {
+  fieldName: string;
+  optionalField?: number;
+  enumField: "value1" | "value2";
+};
+```
+
+Follow existing type files in `example-backend/src/types/models/` and `ai/src/types/index.ts` for naming and structure.
+
+## Statics & Methods — Direct Assignment
+
+Define statics and methods by direct assignment on the schema — not via `.method()` / `.static()` / `.add()`:
+
+```typescript
+schema.methods = {
+  getDisplayName(this: YourModelDocument): string { return this.name; },
+};
+schema.statics = {
+  async findByEmail(this: YourModelModel, email: string) { return this.findOne({email}); },
+};
+```
+
+## Critical Mongoose Rules
+
+- **Never use `Model.findOne`** — use `Model.findExactlyOne` (throws on 0 or many) or `Model.findOneOrNone` (throws on many). These come from the `findExactlyOne` / `findOneOrNone` plugins in `@terreno/api`.
+- Apply the standard plugins (`createdUpdatedPlugin`, `isDeletedPlugin`, `findOneOrNone`, `findExactlyOne`) on every new model. Most existing models go through `addDefaultPlugins`.
+- `checkModelsStrict()` runs at non-prod startup (`server.ts`) and validates schema consistency — keep it passing.
+
+## Schema Change Risk Matrix
+
+| Change Type | Risk Level | Required Mitigation |
+|-------------|-----------|---------------------|
+| Add optional field | Low | Safe to ship directly (still requires `description`) |
+| Add required field | High | Must provide a default value, OR write a backfill migration script first |
+| Remove field | Medium | Soft-remove first (mark optional, stop writing); hard-remove in next PR after deploys settle |
+| Rename field | High | Three-step: add new → backfill → remove old (separate PRs) |
+| Change field type | Critical | Treat as rename: new field + migration + remove old |
+| Add index | Medium | Safe in code, but build can slow writes on large collections — coordinate with ops |
+| Remove index | Low | Safe to ship directly |
+| Add unique index | High | Dedup migration must run first; otherwise the index build fails on existing duplicates |
+
+## Migration Scripts
+
+Migration / backfill scripts live in `example-backend/src/scripts/` (e.g. `syncConsents.ts`, `seedConsents.ts`). They use the `ScriptRunner` type and `BackgroundTask` model from `@terreno/api` (`api/src/scriptRunner.ts`):
+
+```typescript
+import type {ScriptContext, ScriptResult, ScriptRunner} from "@terreno/api";
+
+export const run: ScriptRunner = async (wetRun, ctx) => {
+  const results: string[] = [];
+  // ... do work ...
+  if (wetRun) {
+    // commit changes
+  }
+  return {success: true, results};
+};
+```
+
+Always run with `wetRun = false` first to verify the dry-run output. Use `ctx.checkCancellation()`, `ctx.addLog()`, and `ctx.updateProgress()` for long-running tasks.
+
+## Cross-Package Ripple
+
+A schema change in one place often ripples:
+
+- **API surface affected?** Regenerate the SDK with `cd example-frontend && bun run sdk` (or invoke the `generate-sdk` skill). The OpenAPI spec is derived from the schema, so the frontend hooks will go stale otherwise.
+- **`modelRouter` config?** If you added/removed a field, update `queryFields`, `populatePaths`, and `responseHandler` for any router that touches the model.
+- **Admin panel?** If the model is registered in `AdminApp`, update `listFields` so the table reflects the new shape.
+- **Populated refs?** If another model references this one via `ObjectId` + `ref`, and the referenced document shape changed, the consumer's populated type may need updating.
+
+## Post-Change Checklist
+
+- [ ] All new fields have a `description` (flows to OpenAPI)
+- [ ] Type file updated in the same commit/PR — field names, optionality, enum values, array types, refs, statics/methods all match the schema
+- [ ] For a new model: all five types (`Document`, `Methods`, `Statics`, `Model`, `Schema`) created
+- [ ] Statics/methods assigned directly on schema (`schema.statics = {...}`, `schema.methods = {...}`) — not `.static()` / `.method()`
+- [ ] Other model type files checked — any model that populates this one updated if its shape changed
+- [ ] Migration script written (and dry-run verified with `wetRun = false`) for any backfill
+- [ ] `modelRouter` config updated (`queryFields`, `populatePaths`, `responseHandler`) if needed
+- [ ] `AdminApp` `listFields` updated if the model is in the admin panel
+- [ ] `bun run sdk` run from `example-frontend/` if the API response shape changed
+- [ ] Test covers old-format document behavior (missing new field) if the change rolls out before a backfill
+- [ ] Unique index: dedup migration written and run before the index is added
+- [ ] `checkModelsStrict()` still passes (it runs on non-prod startup)
+- [ ] No `Model.findOne` introduced — use `findExactlyOne` / `findOneOrNone`
+
+## Common Pitfalls
+
+- Adding a required field without a default — first deploy fails for documents that pre-date the field
+- Skipping the type file update — TS happily compiles older callers but new ones break at runtime
+- Adding a `unique` index without dedup — index build fails on collections with existing duplicates
+- Renaming a field in one PR — frontend gets old field, backend writes new field, neither side is happy
+- Forgetting to regenerate the SDK after a shape change — frontend types drift from reality
+- Using `.method()` / `.static()` API — terreno's convention is direct assignment, and mixing styles makes types hard to maintain

--- a/.rulesync/skills/respond-to-review/SKILL.md
+++ b/.rulesync/skills/respond-to-review/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: respond-to-review
+description: Review PR comments, plan fixes, and implement — auto-submitting when no clarifications are needed
+disable-model-invocation: true
+---
+
+# PR Review Response Workflow
+
+Review comments on PR #$ARGUMENTS and plan fixes. If the plan has open questions for the user, pause for confirmation; otherwise implement, commit, and run `/submit` automatically without prompting.
+
+## Step 1: Setup Working Directory
+
+1. Check if we're already in a git worktree:
+   ```bash
+   git rev-parse --show-toplevel
+   git worktree list
+   ```
+
+2. **If already in a worktree**, use the current directory — skip to Step 2.
+
+3. **If NOT in a worktree**, set one up:
+
+   a. Get the repo name:
+      ```bash
+      basename $(git rev-parse --show-toplevel)
+      ```
+
+   b. Fetch PR details and branch name:
+      ```bash
+      gh pr view $ARGUMENTS --json headRefName,number,title,url,author
+      ```
+
+   c. Fetch the PR branch:
+      ```bash
+      git fetch origin pull/$ARGUMENTS/head
+      ```
+
+   d. Create worktree at `~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS`:
+      ```bash
+      git worktree add ~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS FETCH_HEAD
+      ```
+
+   e. Change to the worktree directory:
+      ```bash
+      cd ~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS
+      ```
+
+   f. Set up tracking for the PR branch:
+      ```bash
+      git checkout -B <branch-name> FETCH_HEAD
+      git branch --set-upstream-to=origin/<branch-name>
+      ```
+
+**Important**: All subsequent work happens in the working directory (worktree or current).
+
+## Step 2: Find the Reviews
+
+1. Get review threads with resolution status using GraphQL. **Important**: capture the thread `id` for each unresolved thread so you can resolve them later.
+   ```bash
+   gh api graphql -f query='
+     query($owner: String!, $repo: String!, $pr: Int!) {
+       repository(owner: $owner, name: $repo) {
+         pullRequest(number: $pr) {
+           reviewThreads(first: 100) {
+             nodes {
+               id
+               isResolved
+               comments(first: 50) {
+                 nodes {
+                   author { login }
+                   body
+                   path
+                   line
+                   createdAt
+                 }
+               }
+             }
+           }
+           reviews(first: 50) {
+             nodes {
+               author { login }
+               state
+               body
+             }
+           }
+         }
+       }
+     }' -F owner=':owner' -F repo=':repo' -F pr=$ARGUMENTS
+   ```
+
+2. **Ignore resolved threads entirely** — only process threads where `isResolved` is `false`
+
+3. Filter to comments from other users (not the PR author)
+
+4. Identify which remaining comments are:
+   - Blocking (CHANGES_REQUESTED) vs suggestions
+   - Inline code comments vs general comments
+
+## Step 3: Decide What To Do & Propose a Plan
+
+Decide the right action for each unresolved comment (fix, skip, ask), then present a structured plan organized by priority:
+
+```
+## PR #$ARGUMENTS Review Comments Plan
+
+### 🔴 Must Fix (Blocking)
+1. [file:line] @reviewer: "comment text"
+   → Proposed fix: <description>
+
+### ⚠️ Should Address (Suggestions)
+2. [file:line] @reviewer: "comment text"
+   → Proposed fix: <description>
+
+### 💬 Questions/Clarifications Needed
+- Comment X: Need your input on approach
+- Comment Y: Conflicts with existing pattern, which to use?
+
+### 📝 Will Skip (N/A or out of scope)
+- Comment Z: Not applicable or out of scope
+
+### 💬 Suggested Replies to Human Commenters
+For any comments that warrant a reply (e.g., to clarify a decision or thank a reviewer):
+- **Print the suggested reply text** so the user can see it
+- **Never post replies** via `gh pr comment`, `gh api`, or any other method — leave posting to the user
+```
+
+## Step 4: Confirmation (only if there are open questions)
+
+**If the plan has any items under 💬 Questions/Clarifications Needed:**
+Ask: **"Need your input on the questions above. Anything else to change before I implement?"**
+- Wait for explicit approval before making any changes
+- Incorporate any feedback
+- Re-present plan if significant changes requested
+
+**If there are no open questions:** skip confirmation entirely. Proceed directly to Step 5 — implement, commit, run `/submit`, and resolve threads without further prompts. Do not ask the user for plan approval in this case.
+
+## Step 5: Make the Fix
+
+After approval:
+
+1. Implement fixes one at a time, in priority order
+2. After each fix, briefly confirm what was changed
+
+## Step 6: Show the diff
+
+Show the complete diff so the user can scan what was implemented:
+```bash
+git diff
+git diff --stat
+```
+
+Do **not** commit here. `/submit` (next step) handles pre-commit checks, staging, commit, push, and PR updates — running pre-commit *before* the commit, which is the correct order. Committing here would invert that order and leave broken code committed locally if pre-commit fails.
+
+## Step 7: Run /submit
+
+Invoke the `/submit` skill to handle pre-commit checks, commit, push, and PR updates. This will also launch the CI check-watcher in the background. Pass a `$DESCRIPTION` summarizing what review comments were addressed so the commit message reflects the work.
+
+## Step 8: Resolve Addressed Threads
+
+After `/submit` completes, resolve each review thread that was addressed in the implementation. Use the thread `id` captured in Step 2.
+
+For each thread that was fixed or addressed (from the "Must Fix" and "Should Address" categories in the plan):
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }' -f threadId="<thread_id>"
+```
+
+Do NOT resolve threads that were:
+- Skipped (marked as N/A or out of scope)
+- Questions/clarifications that were not answered by code changes
+- Threads where the user decided not to take action
+
+Report which threads were resolved and which were left open.
+
+---
+
+## Error Handling
+
+- If worktree already exists, ask if user wants to reset it or use existing
+- If PR not found, show error and available PRs: `gh pr list`
+- If no comments found, inform user and ask if they want to proceed anyway
+- If merge conflicts occur during implementation, pause and ask for guidance
+
+## Cleanup Reminder
+
+If a new worktree was created, remind user:
+```
+To remove this worktree later:
+  git worktree remove ~/.claude-worktrees/<repo>/pr-$ARGUMENTS
+
+Or to keep working on it, you can open a new Claude session in:
+  cd ~/.claude-worktrees/<repo>/pr-$ARGUMENTS
+```

--- a/.rulesync/skills/submit/SKILL.md
+++ b/.rulesync/skills/submit/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: submit
+description: Lightweight pre-commit + commit + push + create/update PR, then spawn check-watcher in the background. Use /fullsend for the full pipeline with code review.
+model: sonnet
+---
+
+# Submit: Quick Commit & PR
+
+Lightweight path to run pre-commit checks, commit, push, and monitor CI. After pushing, this skill launches `/check-watcher` as a background sub-agent so CI is watched without blocking. Use `/fullsend` for the full pipeline that also includes code review.
+
+## Step 1: Assess Changes
+
+```bash
+git status && git diff --stat
+```
+
+```bash
+gh pr view --json number -q .number 2>/dev/null || echo "no-pr"
+```
+
+## Step 1.5: Pre-Commit Checks
+
+Delegate lint, type check, and related tests to the `pre-commit` subagent before committing.
+
+Use the `Agent` tool:
+- `subagent_type`: `pre-commit`
+- `description`: `Run pre-commit checks`
+- `prompt`: instruct it to run lint, compile, and related tests for the current project, fix any issues, and report back. Mention this is being run as part of `/submit` for an upcoming commit.
+
+Wait for the subagent to return its Pre-Commit Report. If it surfaces unfixable failures, STOP and report them — do not commit or push.
+
+If invoked from `/fullsend` (which already ran pre-commit), skip this step.
+
+## Step 2: Commit
+
+Stage and commit:
+- Review the diff to write an accurate message
+- Keep first line under 72 characters
+- No conventional commit prefixes
+- No AI attribution
+
+## Step 3: Push
+
+```bash
+git push origin HEAD
+```
+
+## Step 4: Create or Update PR
+
+### If no PR exists
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+[What changed and why — 2-4 sentences]
+
+## Human Testing Steps
+- [ ] [Step-by-step verification instructions]
+
+## Changes
+- [Bullet list of specific changes]
+
+## Automated Tests
+- [Tests that ran and passed, or "None"]
+EOF
+)" --draft
+```
+
+### If a PR already exists
+
+Read the current title and body, then compare against the full set of commits on the branch:
+
+```bash
+gh pr view --json title,body,baseRefName
+git log $(gh pr view --json baseRefName -q .baseRefName)..HEAD --oneline
+git diff $(gh pr view --json baseRefName -q .baseRefName)...HEAD --stat
+```
+
+Decide whether the description still reflects what's on the branch — pay attention to commits added since the PR was opened:
+- **Summary** still matches the actual goal of the changes
+- **Changes** list covers the new commits, not just the original ones
+- **Human Testing Steps** still cover what reviewers need to verify
+- **Automated Tests** section reflects current test state
+
+If the description is stale or incomplete, update it. Preserve sections the user has clearly edited by hand — only rewrite what's actually out of date, and merge new bullets into existing lists rather than replacing them wholesale:
+
+```bash
+gh pr edit --title "<title>" --body "$(cat <<'EOF'
+<updated body>
+EOF
+)"
+```
+
+If the description is already accurate, skip the edit and note that it's up to date.
+
+## Step 5: Print PR Link
+
+```bash
+gh pr view --json title,url -q '"**\(.title)** — \(.url)"'
+```
+
+## Step 6: Launch Check Watcher Sub-Agent
+
+Spawn `/check-watcher` as a **background sub-agent** so CI monitoring runs autonomously without blocking the parent conversation. Use the `Agent` tool with `run_in_background: true`.
+
+- `subagent_type`: `general-purpose`
+- `description`: `Watch CI for current PR`
+- `run_in_background`: `true`
+- `prompt`: instruct the sub-agent to invoke the `/check-watcher` skill for the current PR, fix any failures, and report back when checks are green or max attempts are hit. Include the PR number/URL from Step 5 so the sub-agent has context.
+
+Do **not** wait on the sub-agent — return control immediately after spawning. The user will be notified when it completes.
+
+By the time you reach this step, a PR is guaranteed to exist — either it pre-existed (from Step 1) or Step 4 just created it. Always spawn check-watcher.
+
+## Arguments
+
+$DESCRIPTION: Optional description to guide the commit message and PR

--- a/.windsurf/skills/ai-prompt-governance/SKILL.md
+++ b/.windsurf/skills/ai-prompt-governance/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: ai-prompt-governance
+description: >-
+  Invoke when adding, modifying, or reviewing any prompt used by `@terreno/ai`
+  (AIService methods, system prompts, helpers). Provides prompt-as-constant
+  rules, temperature preset guidance, logging requirements, and a testing
+  checklist.
+---
+# AI Prompt Governance — `@terreno/ai`
+
+`@terreno/ai` is a backend-only, provider-agnostic AI layer built on the Vercel AI SDK. Consuming apps inject a `LanguageModel` (Google, Anthropic, OpenAI, etc.) and call `AIService` methods. All requests are logged through the `AIRequest` model.
+
+See `ai/src/service/aiService.ts` and `ai/src/service/prompts.ts` for the canonical implementation.
+
+## Prompt Writing Rules
+
+1. **Always a named constant** — Define prompts in `ai/src/service/prompts.ts` (or the consuming app's equivalent constants file). Never inline prompt strings in route handlers, services, or `AIService` method bodies.
+2. **Self-contained** — A prompt should read coherently on its own. If you must inject runtime context, document why in a comment above the constant.
+3. **Typed return** — If the prompt asks for structured JSON, define a matching TypeScript interface in `ai/src/types/index.ts` and parse against it on every response.
+4. **Don't bake user-identifiable data into the prompt template itself** — inject it at call time as runtime parameters, never as defaults in the constant.
+
+## Temperature Preset Guidance
+
+Use the presets exported from `@terreno/ai`:
+
+| Preset | Value | When to use |
+|--------|-------|-------------|
+| `DETERMINISTIC` | 0 | Structured extraction, classification, deterministic transforms |
+| `LOW` | 0.3 | Summarization, translation, faithful rewording |
+| `BALANCED` | 0.7 | General Q&A, balanced creativity |
+| `DEFAULT` | 1.0 | Chat, open-ended responses |
+| `HIGH` | 1.5 | Brainstorming, creative variation |
+| `MAXIMUM` | 2.0 | Maximum variability — rarely the right choice |
+
+Pick the lowest temperature that still produces good results. Don't override the default unless you can name a reason in the call site.
+
+## Logging
+
+Every `AIService` method already logs to the `AIRequest` model via the internal `logRequest()` call. Do not bypass `AIService` and call the Vercel SDK directly from routes — you lose request logging, error capture, and the `requestType` taxonomy.
+
+Current `AIRequest.requestType` values: `"general" | "remix" | "summarization" | "translation"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
+
+Logging failures must never break the main flow — the existing pattern catches and logs internally. Preserve that behavior.
+
+## Testing a Prompt Change
+
+`@terreno/ai` tests inject a mock `LanguageModel` with `doGenerate` / `doStream` methods. See the mock pattern in `ai/src/aiApp.test.ts`. Never hit a live provider in unit tests.
+
+1. Add or update a unit test that mocks `doGenerate` / `doStream` and asserts the prompt your code sends matches expectations.
+2. Run against at least 3 inputs:
+   - A normal/expected case
+   - An edge case (empty input, very long input, missing optional fields)
+   - An adversarial case that could break structured JSON output
+3. For structured JSON: assert the response parses against the typed return interface.
+4. If the prompt affects streaming behavior, mock `doStream` and assert the emitted chunks.
+
+For a one-off manual smoke against a real provider, temporarily add `logger.debug("prompt test", {prompt, response})` in the `AIService` method, run locally, then remove the log before committing.
+
+## Prompt Change Checklist
+
+- [ ] Prompt is a named constant in `prompts.ts` (or app equivalent) — not inlined
+- [ ] Prompt still produces valid, parseable structured JSON if applicable (tested with 3+ inputs)
+- [ ] Temperature preset is appropriate (lowest viable for the task)
+- [ ] Call goes through `AIService` (so `AIRequest` logging fires) — no direct Vercel SDK calls from routes
+- [ ] If `requestType` taxonomy changed, the type union and admin explorer filters were updated
+- [ ] No user-identifiable data baked into the prompt template (only injected at call time)
+- [ ] Unit test added/updated with a mock model
+- [ ] Commit message explains the behavioral change (the prompt is the behavior)
+
+## Adding a New AI Feature
+
+1. Define prompt(s) as named constants in `ai/src/service/prompts.ts`.
+2. If structured JSON output, define the TypeScript interface for the return shape in `ai/src/types/index.ts`.
+3. Add a method to `AIService` (or a new service class) that calls `generateText` / `generateTextStream` and goes through the existing logging path.
+4. If exposing via HTTP, add a route in `ai/src/routes/` following the patterns in `gpt.ts` / `gptHistories.ts`. Use `createOpenApiBuilder` for OpenAPI docs.
+5. Add an integration test with a mock model that verifies:
+   - The prompt sent to the model matches the constant
+   - The structured JSON return parses against the typed interface
+   - `AIRequest.logRequest` is called with the correct `requestType`
+
+## Common Pitfalls
+
+- Calling the Vercel SDK directly from a route — bypasses logging and request typing
+- Inlining a prompt string in a route handler — makes future changes invisible and untestable
+- Using the wrong `requestType` value (or `"general"` as a catch-all) — degrades the admin explorer
+- Setting `temperature` numerically instead of via a preset — drifts away from the documented presets
+- Forgetting to type the JSON return — runtime parse failures show up later as confusing errors

--- a/.windsurf/skills/backend-test-env/SKILL.md
+++ b/.windsurf/skills/backend-test-env/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: backend-test-env
+description: >-
+  Invoke when writing tests that mutate `process.env` in `@terreno/api`,
+  `@terreno/ai`, or `example-backend` — feature flags, auth secrets, integration
+  toggles. Covers the preload contract, `setupEnvironment()`, and safe mutation
+  patterns.
+---
+# Backend Test — `process.env` Contract
+
+Bun's test runner preloads a per-package setup file (configured in each package's `bunfig.toml` under `[test].preload`):
+
+| Package | Preload file |
+|---------|--------------|
+| `@terreno/api` | `api/src/tests/bunSetup.ts` |
+| `@terreno/ai` | `ai/src/tests/bunSetup.ts` |
+| `example-backend` | `example-backend/src/tests/setup.ts` |
+
+The `@terreno/api` preload uses a global `beforeEach` to (1) reset the canonical auth secrets, (2) call `setupEnvironment()` (exported from `expressServer.ts`) for the wider baseline, and (3) re-silence the winston loggers. The next test always starts from the canonical baseline — you normally **do not** need to re-call `setupEnvironment()` in a file-level `beforeEach`.
+
+## Default — Rely on the Preload
+
+- Do not assume a toggle left by another file. Treat the preload's `beforeEach` as the source of truth for the canonical baseline.
+- Set only the keys this test needs in its own `beforeEach` or test body.
+- Don't reach in and call `setupEnvironment()` again unless you're explicitly testing env-driven behavior that the preload didn't cover.
+
+## When a Test Mutates `process.env`
+
+1. **Add the key to the preload's reset list** if it should always start from a fixed test value. Otherwise it leaks into the next test in the same worker.
+2. **Set only what this case needs** in the test body — avoid redundant manual restore if the preload already resets that key in `beforeEach`.
+3. **For keys that should be absent (unset)**, use **`Reflect.deleteProperty(process.env, "KEY")`**. Avoid `process.env.KEY = ""` to mean "unset" — on some platforms empty string and unset behave differently and can make tests flaky.
+4. **Avoid whole-env snapshots** (`const OLD_ENV = process.env; ...; process.env = OLD_ENV;`). This pattern exists in some older test files (`auth.test.ts`) — don't propagate it. It captures pre-`beforeEach` state and breaks ordering guarantees if the preload's `beforeEach` runs in between. Use targeted mutations + the preload's reset instead.
+
+## Adding a New Required Env Var
+
+If you introduce a new `process.env.FOO` that backend code reads at startup:
+
+1. Add `FOO` to `setupEnvironment()` in `api/src/expressServer.ts` so every package picks it up via the preload's `setupEnvironment()` call.
+2. If `example-backend` has its own startup needs for it, also add to `example-backend/src/tests/setup.ts`'s `beforeAll`.
+3. If a test needs to mutate it, follow the rules above — don't snapshot the whole env.
+
+## Auth-Related Keys
+
+`api/src/tests/bunSetup.ts` resets four auth keys in `beforeEach`: `TOKEN_SECRET`, `TOKEN_ISSUER`, `SESSION_SECRET`, `REFRESH_TOKEN_SECRET`. If your test changes any of these, you do not need to restore — the next `beforeEach` already does. If your test relies on them being **absent** for a code path, use `Reflect.deleteProperty` within the test, knowing the next `beforeEach` will restore.
+
+`auth.test.ts` is the established home for env-driven auth assertions; mirror its newer patterns (per-test `beforeEach` setting only what changes) rather than its older whole-env-snapshot blocks.
+
+## Log Capture & Sentry
+
+The preload silences winston and `console.*` and captures into an in-memory buffer (cleared in `beforeEach`/`afterEach`). It also mocks `@sentry/bun`. Don't re-mock Sentry inside individual tests — the preload's mock is shared and reset across tests.
+
+## Checklist
+
+- [ ] New env var added to `setupEnvironment()` and (if needed) `example-backend/src/tests/setup.ts`
+- [ ] Test mutations are targeted — no whole-env snapshots
+- [ ] "Unset" expressed as `Reflect.deleteProperty(process.env, "KEY")`, not `= ""`
+- [ ] No manual restore that duplicates the preload's `beforeEach` reset
+- [ ] No re-mock of `@sentry/bun` — the preload's mock is already in place
+- [ ] If you added an env-driven branch in code, a test covers both the set and the unset case

--- a/.windsurf/skills/check-watcher/SKILL.md
+++ b/.windsurf/skills/check-watcher/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: check-watcher
+description: Monitor GitHub Actions checks and automatically fix failures
+---
+# Check Watcher
+
+Monitor GitHub Actions checks and auto-fix failures. Designed to be called standalone or from other skills.
+
+## Instructions
+
+1. Get the PR number:
+   ```bash
+   gh pr view --json number -q .number
+   ```
+   If no PR exists, inform the user and exit.
+
+2. Wait for CI to finish using `--watch` (no manual polling):
+   ```bash
+   gh pr checks --watch --fail-fast
+   ```
+   - All passing → go to step 6
+   - Failed → continue to step 3
+
+3. Get failure details:
+   ```bash
+   gh run view <run-id> --log-failed
+   ```
+
+4. Determine if flaky or real:
+   - Compare failed files/tests against `gh pr diff` — is the failure in code you changed?
+   - Check for flaky signals: timeouts, race conditions, ECONNRESET, intermittent assertions
+   - If flaky (not in your code + flaky signals), rerun once: `gh run rerun <run-id> --failed`
+   - Run `gh pr checks --watch --fail-fast` again. If still failing, file an issue and move on:
+     ```bash
+     gh issue create --title "Flaky test: <test name>" --body "<error details and job link>"
+     ```
+
+5. If failure IS related to PR changes:
+   - Fix the code
+   - Run lint and compile locally to validate
+   - Commit and push (no AI attribution, no conventional prefixes)
+   - Return to step 2
+
+6. When all checks pass, check for bot review comments:
+   ```bash
+   gh api repos/:owner/:repo/pulls/<pr_number>/comments --jq '.[] | select(.user.type == "Bot") | "\(.path):\(.line) @\(.user.login): \(.body)"'
+   ```
+   Report any actionable bot comments found. Do NOT auto-fix — just report them.
+
+7. Print the PR link:
+   ```bash
+   gh pr view --json title,url -q '"**\(.title)** — \(.url)"'
+   ```
+
+Cap fix attempts at $MAX_ATTEMPTS (default: 5).
+
+## Arguments
+
+$MAX_ATTEMPTS: Optional max fix attempts before stopping (default: 5)

--- a/.windsurf/skills/commit/SKILL.md
+++ b/.windsurf/skills/commit/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: commit
+description: >-
+  Create a commit for the current staged/unstaged changes with a clear, accurate
+  message
+---
+# Commit Changes
+
+Create a commit for the current staged/unstaged changes.
+
+## Instructions
+
+1. Check git status and diff to understand what changed:
+   ```
+   git status
+   git diff
+   git diff --cached
+   ```
+
+
+2. Stage changes appropriately and create a commit:
+   - Review the actual changes to write an accurate commit message
+
+   **Message Format:**
+   - The first line must be under 72 characters
+   - Add a body if more context is needed
+   - Exclude conventional commit prefixes (feat:, fix:, chore:, etc.)
+
+   **Content Restrictions:**
+   - Exclude any mention of AI, Claude, or any AI assistant
+   - Exclude making the commit coauthored by any AI
+   - Exclude adding "Co-Authored-By" trailers
+
+   *If constraints conflict, prioritize Message Format for clarity and readability.*
+
+3. Never push unless explicitly asked.
+
+## Arguments
+
+$DESCRIPTION: Optional description to guide the commit message

--- a/.windsurf/skills/create-pr/SKILL.md
+++ b/.windsurf/skills/create-pr/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: create-pr
+description: Create a draft pull request for the current branch
+---
+# Create Pull Request
+
+Create a pull request for the current branch.
+
+## Instructions
+
+1. First ensure changes are committed and pushed:
+   ```
+   git status
+   git log origin/master..HEAD --oneline
+   ```
+
+2. If there are uncommitted changes, commit them first (run `/commit` command).
+
+3. Push the branch if not already pushed:
+   ```
+   git push origin HEAD
+   ```
+
+4. Create the pull request:
+   ```
+   gh pr create --title "<title>" --body "<body>" --draft
+   ```
+
+   Guidelines for the PR:
+   - Title: Clear, concise summary of the changes
+   - Do not use prefix commit format (feat:, fix:, chore:, etc.)
+   - Do not mention AI, Claude, or any AI assistant in the title or body
+   - Do not add "Generated with Claude" or similar footers
+   - Always create as draft
+
+   **PR Body Structure:**
+
+   ```markdown
+   ## Summary
+
+   [What changed and why — 2-4 sentences]
+
+   ## Human Testing Steps
+
+   - [ ] [Step-by-step instructions a reviewer can follow to verify the change works]
+   - [ ] [Cover happy path and at least one edge case]
+
+   ## Changes
+
+   - [Bullet list of specific changes]
+
+   ## Automated Tests
+
+   - [Tests that ran and passed, or "No automated tests"]
+   ```
+
+5. Return the PR URL to the user.
+
+## Arguments
+
+$DESCRIPTION: Optional description for the PR title and body

--- a/.windsurf/skills/fix-conflicts/SKILL.md
+++ b/.windsurf/skills/fix-conflicts/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: fix-conflicts
+description: >-
+  Pull latest from master, resolve merge conflicts, validate with lint/compile
+  checks, and monitor CI
+---
+# Fix Conflicts
+
+Pull latest from master, resolve merge conflicts, validate with lint/compile checks, and monitor CI.
+
+## Instructions
+
+1. Ensure the working tree is clean before starting:
+   ```
+   git status
+   ```
+   - If there are uncommitted changes, ask the user whether to stash them or abort
+
+2. Fetch and merge the latest master into the current branch:
+   ```
+   git fetch origin master
+   git merge origin/master
+   ```
+   - If the fetch or merge fails, check network connectivity and repository access permissions. Notify the user if the issue persists.
+
+3. Check for merge conflicts:
+   ```
+   git diff --name-only --diff-filter=U
+   ```
+   - If there are no conflicts, skip to step 5
+
+4. For each conflicted file:
+    - Read the file and understand both sides of the conflict
+    - Resolve the conflict by combining changes in a way that retains the functionality and purpose of both sets of changes, ensuring no critical information is lost.
+    - If the conflict cannot be resolved automatically, notify the user and provide a summary of the conflicting changes.
+    - After resolving all conflicts in a file, stage it:
+       ```
+       git add <file>
+       ```
+    - After all conflicts are resolved, complete the merge:
+       ```
+       git commit --no-edit
+       ```
+
+## Running Checks
+
+5. Run lint and compile checks at the project root:
+    ```
+    git rev-parse --show-toplevel
+    ```
+    - Run linting:
+       ```
+       cd <project-root> && bun run lint
+       ```
+       - If linting fails, fix the issues and re-run until passing
+    - Run type compilation/checking:
+       ```
+       cd <project-root> && bun run compile
+       ```
+       - If compilation fails, fix the type errors and re-run until passing
+    - If linting or compilation fails repeatedly and cannot be resolved, notify the user with the error details and suggest seeking assistance.
+
+## Handling Fixes and Commits
+
+6. If any fixes were needed in step 5, stage and commit them:
+   - Review the changes made
+   - Create a commit with a clear message describing what was fixed
+   - In step 6, do not use prefix commit format (feat:, fix:, chore:, etc.) for the commit message.
+   - Do not mention AI, Claude, or any AI assistant
+
+7. Push the changes:
+   ```
+   git push origin HEAD
+   ```
+
+8. Run check-watcher by invoking `/check-watcher`:
+   - This monitors GitHub Actions checks
+   - If checks fail, it will automatically read failures, fix them, and push again
+   - Continue until all checks pass
+
+## Arguments
+
+None

--- a/.windsurf/skills/implement/SKILL.md
+++ b/.windsurf/skills/implement/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: implement
+description: >-
+  Test-driven implementation execution skill for applying implementation plans
+  directly in code
+---
+# Implementation Execution Skill
+
+Use this skill when an Implementation Plan (IP) or implementation requirements are provided.
+
+
+The goal of this skill is to execute the implementation directly in code using test-driven development.
+
+If the implementation plan is incomplete or contains contradictions, highlight the conflicts and request clarification before proceeding.
+
+Do not stop after analysis or task generation unless blocked by material ambiguity.
+
+## Primary Behavior
+
+When an IP is provided:
+
+1. Read the full IP carefully.
+2. Determine implementation scope.
+3. Identify the smallest meaningful automated test coverage that should fail for the requested behavior.
+4. Write or update the failing tests before implementation code.
+5. Run the targeted tests and confirm they fail for the expected product reason, not because of syntax, setup, or unrelated failures.
+6. Implement the requested changes directly.
+7. Run the previously failing tests until they pass.
+8. Run relevant validation or broader test commands when available.
+9. Summarize completed work, assumptions, and remaining risks.
+
+Exclude generating a separate implementation plan unless explicitly requested.
+
+## Scope Detection
+
+Determine whether the implementation is:
+
+- backend only
+- frontend only
+- full stack
+- phased implementation
+- rollout-gated
+- migration-dependent
+
+
+// --- Assumption Rules ---
+Use best-effort assumptions when the assumption does not affect compliance, data integrity, or user experience.
+
+If the correct scope is unclear and could materially change implementation, ask concise clarifying questions before coding.
+
+## Clarifying Question Rules
+
+Only ask questions if missing information would materially affect:
+
+- architecture
+- data model behavior
+- API contracts
+- permissions/access control
+- user/admin visibility
+- rollout sequencing
+- migration/backfill behavior
+- destructive operations
+- compliance-sensitive behavior
+- whether implementation should be backend only, frontend only, phased, or full stack
+
+// --- Clarifying Question Exclusions ---
+Exclude asking questions for implementation details that do not affect functionality, performance, or compliance, and can reasonably be inferred.
+
+
+## Execution Expectations
+
+Implement the requested behavior directly in the codebase.
+
+### Test-Driven Development Flow
+
+Default to red/green/refactor:
+
+- red: write the focused failing test or regression test first
+- green: implement only enough production code to satisfy the requested behavior
+- refactor: clean up the implementation while preserving passing tests
+
+If no meaningful automated test can be written for the change, document why before implementation and use the strongest available manual or static validation instead.
+
+### Implementation Steps
+- update or add focused failing tests
+- update schemas/models
+- update services/controllers/routes
+- update validation
+- update frontend UI
+- update state management/API hooks
+- update OpenAPI/types
+- update permissions/visibility logic
+- update feature flags
+- update fixtures/mocks
+- rerun the focused tests that failed first
+- run broader validation when appropriate
+- preserve existing behavior unless the IP explicitly changes it
+
+## Phased Implementations
+
+If the IP implies phased implementation:
+
+- determine whether backend and frontend should be separated
+- determine whether rollout gating is required
+- determine whether app-version compatibility matters
+
+If phase requirements are unclear and could affect implementation safety, ask before coding.
+
+Otherwise proceed with best-effort assumptions.
+
+## Testing Requirements
+
+Add or update relevant tests before production implementation whenever applicable.
+
+Possible test types include:
+
+- backend unit tests
+- backend integration tests
+- API tests
+- frontend component tests
+- frontend flow tests
+- regression tests
+
+Run the most targeted available tests first and capture the initial failure before writing production code. After implementation, rerun the same focused tests to confirm the red-to-green transition.
+
+If full test execution is not practical, run the closest focused validation possible and document what was not run.
+
+## File Modification Rules
+
+Prefer modifying existing patterns consistently with the codebase.
+
+Avoid introducing new architectural patterns unless required.
+
+Do not invent exact file paths unless strongly implied by the repository structure.
+
+Prefer consistency over novelty.
+
+## Safety Rules
+
+Do not make destructive or irreversible changes without clear instruction.
+
+Do not silently change existing product behavior outside the requested scope.
+
+If implementation could create compliance, privacy, permission, or rollout risk, explicitly call it out in the final response.
+
+## Final Response Requirements
+
+At completion, summarize:
+
+- implementation scope
+- major code changes
+- assumptions made
+- tests updated/run
+- remaining risks or follow-up work
+
+Keep the summary concise and implementation-focused.

--- a/.windsurf/skills/improve-rulesync/SKILL.md
+++ b/.windsurf/skills/improve-rulesync/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: improve-rulesync
+description: >-
+  Invoke at the end of a session to evaluate whether any skills or rules were
+  misleading, incorrect, or missing — and fix or create them. Trigger with
+  /improve-rulesync.
+---
+# Improve Rulesync
+
+### Trigger
+Invoke explicitly at the end of a session with `/improve-rulesync`.
+
+### Behavior
+Review the current conversation session and evaluate the skills and rules in `.rulesync/`. Identify any that:
+- Gave misleading or incorrect guidance that caused errors or rework
+- Were missing and would have prevented incorrect behavior
+- Need to be updated to reflect decisions or patterns established in this session
+
+Then make the changes directly.
+
+### Step 1 — Session Review
+Scan the session for:
+- Moments where a skill or rule was followed but produced a wrong or suboptimal result
+- User corrections or decisions about AI model behavior (these indicate a gap or error in the rules)
+- New patterns, decisions, or constraints established that should be codified
+
+### Step 2 — Rules Audit
+Check `.rulesync/` for relevant existing rules and skills. Evaluate:
+- Are trigger conditions accurate?
+- Is the guidance still correct given what happened this session?
+- Are there gaps that caused confusion?
+
+### Step 3 — Make Changes
+For each issue found:
+- **Incorrect/misleading**: Edit the existing file to fix it
+- **Missing**: Create a new skill or rule file in `.rulesync/skills/` or `.rulesync/rules/`
+- **Outdated**: Update or remove the stale content
+
+Always edit `.rulesync/` as the source of truth.
+
+### Step 4 — Sync
+After all changes, run `bun run rules` to sync to all AI tool directories.
+
+### Step 5 — Summary
+Output a brief summary of what was changed and why. Format:
+- **Fixed**: [file] — [what was wrong and what was corrected]
+- **Created**: [file] — [what gap it fills]
+- **No changes needed**: [reason]

--- a/.windsurf/skills/ip/SKILL.md
+++ b/.windsurf/skills/ip/SKILL.md
@@ -1,0 +1,1559 @@
+---
+name: ip
+description: >-
+  Implementation Plan (/ip) — build an implementation plan from a PRD through an
+  interactive, multi-step process
+---
+# Implementation Plan (/ip)
+
+Build an implementation plan from a PRD through an interactive, multi-step process. Produces both a human-readable implementation plan and a structured task list for bot consumption.
+
+## Overview
+
+This skill walks through the Shape Up-inspired process of turning a raw PRD into a concrete implementation plan. Each step is a self-contained section in this file — you can re-run individual steps if needed by jumping to the matching section.
+
+**Every IP targets a specific project.** The project must be specified via the `$PROJECT` argument or selected interactively.
+
+## Project Registry
+
+| Alias(es) | GitHub Repo | Local Dir |
+|-----------|-------------|-----------|
+| `ter`, `terreno` | `flourishhealth/terreno` | `~/src/terreno` |
+
+Local Dir is derived from the repo name (the part after `/`). All repos clone into `~/src/`.
+
+If a project isn't in the registry, attempt to resolve it via `gh repo view <input>`. If found, use it. If not, ask the user for the full `owner/repo`.
+
+## Planning Workflow
+
+Run the following steps in order. Each step builds on the previous one.
+
+### Step 0: Project Setup (always runs first)
+
+This step is **mandatory** and runs before everything else, even when `$STEP` is provided.
+
+#### 0a. GitHub Auth Check
+
+```bash
+gh auth status
+```
+
+If not authenticated, tell the user:
+> You need to authenticate with GitHub. Run this in your terminal:
+> `! gh auth login --web`
+> Follow the prompts to open the browser link and enter the code.
+
+Then **stop** — do not proceed until the user confirms auth is complete.
+
+#### 0b. Resolve Project
+
+If `$PROJECT` was provided, match it against the registry aliases (case-insensitive). If no `$PROJECT`, show the registry table and ask the user to pick one.
+
+#### 0c. Clone if Needed
+
+Check if the local directory exists:
+```bash
+ls -d ~/src/{repo-name} 2>/dev/null
+```
+
+If it doesn't exist, clone it:
+```bash
+gh repo clone {owner/repo} ~/src/{repo-name}
+```
+
+#### 0d. Fetch Latest & Enter Worktree
+
+Navigate to the repo and ensure we have the latest code:
+```bash
+cd ~/src/{repo-name} && git fetch origin && git checkout master && git pull origin master
+```
+
+(If the default branch is `main` instead of `master`, detect it with `git remote show origin | grep 'HEAD branch'` and use that.)
+
+Then create a worktree for this IP using the `EnterWorktree` tool:
+- **name**: `ip-{feature-slug}` (derive from the PRD title once known, or use a temporary name like `ip-draft` and note that it can be renamed)
+
+Since the PRD title isn't known yet at this point, use `ip-draft` as the worktree name. After Step 1 (Ingest), if the worktree name doesn't match the feature, note the mismatch but continue — the branch can be renamed later.
+
+#### 0e. Confirm Ready
+
+Print a summary:
+```
+Project: {repo-name} ({owner/repo})
+Branch: {worktree-branch}
+Working dir: {worktree-path}
+Latest master: {short SHA + date of HEAD}
+```
+
+Proceed to Step 1.
+
+### Step 1: Ingest PRD
+
+Collect the PRD (Product Requirements Document) that will drive the implementation plan.
+
+1. `$PRD` is **required**. If it was not provided, stop immediately and tell the user: **"Error: /ip requires a PRD as the first argument (either a file path or the inline PRD text). Please re-run as `/ip <path-or-text>`."** Do not prompt for it interactively.
+
+2. Determine what the user provided:
+   - If it looks like a file path (e.g., ends in `.md`, `.txt`, contains `/` or `\`, or matches an existing file), read that file and use its contents as the PRD.
+   - Otherwise, treat the input as the PRD text itself.
+
+3. The PRD should contain at minimum a **Problem** section and ideally a **Business Case** section. If either is missing, note what's missing but proceed anyway.
+
+4. Display a brief summary of what you understood from the PRD:
+   - The core problem (1-2 sentences)
+   - The business impact (1-2 sentences)
+   - Key stakeholders or affected teams
+   - Any constraints or requirements called out
+
+5. Ask: "Does this summary capture the intent? Anything to add or correct?" and let the user adjust before moving on.
+
+6. Once confirmed, say: **"PRD ingested. Moving to research phase..."** and proceed to Step 2.
+
+### Step 2: Research Context
+
+Investigate the codebase and gather context for the PRD topic. Do this inline — do not invoke `/research` via the Skill tool. Follow this procedure:
+
+1. **Scope** — restate the topic in one sentence and tell the user what you plan to investigate. Ask if they want anything specific covered.
+2. **Codebase deep dive** — read relevant source files in depth (models, routes, screens, components, configs, tests). Search for existing patterns, conventions, and dependencies. Check `docs/`, `README.md`, `CLAUDE.md`, and any feature documentation. Note file paths, function names, and line numbers as you go.
+3. **External research** — search the web for any APIs, libraries, or best practices that aren't already in the codebase.
+4. **Present findings** — output a complete research document in chat with: Summary, Context, Findings (with file paths and snippets), Options Considered (table with pros/cons/effort), Recommendation (be opinionated), Open Questions, References.
+5. **Iterate** — ask "Anything you want me to dig deeper on, adjust, or investigate further?" If the user gives feedback, investigate and re-output the **full** updated document.
+6. **Save** — once the user is satisfied, write the final version to `research.md` in the project root and continue to Step 3.
+
+Be specific (file paths, line numbers, code snippets) and opinionated (recommend an approach, don't just list options).
+
+### Step 3: Shape & Question
+
+This is the core shaping step inspired by the Shape Up methodology. The goal is to narrow the solution from a raw idea to a well-defined approach with clear boundaries.
+
+#### Phase 1: Models & APIs (get alignment first)
+
+This is the most important part. Models and APIs define the shape of the feature — everything else follows from them.
+
+1. **Draft the data model** based on the PRD and research:
+   - Mongoose schemas with types, required fields, enums, defaults
+   - Relationships to existing models (refs)
+   - Indexes if relevant
+   - Plugins (soft delete, timestamps, etc.) based on existing patterns
+
+2. **Draft the API surface**:
+   - List each endpoint (method, path, description)
+   - Note if it's a standard CRUD modelRouter or custom
+   - Specify permissions for each endpoint
+   - Call out any special query parameters, filters, or bulk operations
+
+3. **Present both together** and ask the user: "Are these models and APIs the right approach?" Use AskUserQuestion.
+
+4. **Iterate** until the user confirms the models and APIs are right. This is the foundation — don't move on until it's solid.
+
+#### Phase 2: Everything Else (flows from models/APIs)
+
+Once models and APIs are confirmed, draft the remaining concerns in a single pass. These should follow naturally from the model/API decisions:
+
+- **Notifications**: Push, email, in-app — who gets notified, when, what content. If none needed, say so.
+- **Activity Log**: What actions get logged, which surface as User Updates, which user groups see them. If none, say so.
+- **Permissions & Access**: Role-based differences beyond what's already covered in API permissions.
+- **UI**: New screens/components, navigation flow, key interactions and states, reusable vs new components.
+- **Feature Flags & Migration**: Whether a flag is needed, any data migrations, rollout strategy.
+- **Phases**: How to break the work into PRs (Phase 1: models + APIs, Phase 2: core UI, Phase 3: polish). If small enough, say "single phase."
+- **Not Included / Future Work**: Compile out-of-scope items and deferred ideas.
+
+Present all of this as a single shaped solution summary:
+
+```
+## Shaped Solution
+
+### Core Concept
+[1-2 sentence description of the approach]
+
+### Models
+[schemas from Phase 1]
+
+### APIs
+[endpoints from Phase 1]
+
+### Notifications
+[notification plan or "none needed"]
+
+### Activity Log
+[logging plan or "none needed"]
+
+### UI
+[screens, flows, interactions]
+
+### Phases
+[implementation phases]
+
+### Not Included
+[explicitly excluded items]
+
+### Risks & Mitigations
+- [risk]: [mitigation approach]
+```
+
+Surface any **risks and rabbit holes** inline:
+- Technical risks: things that might be harder than they look
+- Scope risks: features that could balloon if not bounded
+- For each risk, suggest a mitigation or simpler fallback
+
+Ask: "Does this shaped solution look right? Any decisions you want to revisit?"
+
+Once confirmed, say: **"Solution shaped. Moving to plan sections..."** and proceed to Step 4.
+
+### Step 4: Plan Sections (optional deep pass)
+
+Optional interactive walk-through of each plan section, useful when Step 3 left details fuzzy. For each section: present a draft, ask the user if it looks right, let them refine, then move on.
+
+#### Section 1: Models
+
+1. Draft Mongoose schemas based on the shaped solution. Include:
+   - Full schema code blocks with types, required fields, enums, defaults
+   - Relationships to existing models (refs)
+   - Indexes if relevant
+   - Plugins (soft delete, timestamps, etc.) based on existing patterns found in research
+
+2. Present the schemas and ask:
+   - "Do these models look right?"
+   - "Any fields missing or that should be changed?"
+   - "Should any of these fields be optional vs required?"
+
+#### Section 2: APIs
+
+1. Draft the API surface:
+   - List each endpoint (method, path, description)
+   - Note if it's a standard CRUD modelRouter or custom
+   - Specify permissions for each endpoint
+   - Call out any special query parameters, filters, or bulk operations
+   - Note any webhook or external API integrations
+
+2. Present and ask: "Any endpoints missing? Do the permissions look right?"
+
+#### Section 3: Notifications
+
+1. Based on the shaped solution, list:
+   - Push notifications (who, when, what content)
+   - Email/text notifications
+   - In-app notifications or alerts
+   - If none needed, explicitly state "No notifications required for this feature"
+
+2. Present and confirm with user.
+
+#### Section 4: UI
+
+1. Draft the UI plan:
+   - List new screens/components
+   - Describe navigation flow (how users get there)
+   - Describe key interactions and states
+   - Note any reusable components that already exist vs need to be created
+   - Suggest fat-marker sketches if the UI is complex (describe what should be sketched)
+
+2. Present and ask: "Does this UI approach make sense? Any screens or interactions missing?"
+
+#### Section 5: Phases
+
+1. Propose how to break the work into phases/PRs:
+   - Phase 1: Usually models + basic APIs
+   - Phase 2: Core UI and integrations
+   - Phase 3: Polish, notifications, edge cases
+   - If the feature is small enough, note "Single phase - no need to break up"
+
+2. For each phase, list what's included and what the deliverable looks like.
+
+3. Present and ask: "Does this phasing make sense? Want to adjust?"
+
+#### Section 6: Feature Flags & Migrations
+
+1. Based on the shaped solution, recommend:
+   - Whether a feature flag is needed (and what it controls)
+   - Any data migrations required
+   - Rollout strategy
+
+2. Present and confirm.
+
+#### Section 7: Activity Log & User Updates
+
+1. List:
+   - What actions get logged to the activity log
+   - Which of those surface as User Updates
+   - Which user groups see the updates
+
+2. If no activity logging is needed, say so explicitly.
+
+#### Section 8: Not Included / Future Work
+
+1. Compile the "out of scope" items from shaping into this section
+2. Add any ideas that came up during planning but were deferred
+3. Present and confirm.
+
+After all sections are finalized, say: **"All sections planned. Moving to output generation..."** and proceed to Step 5.
+
+### Step 5: Generate Output
+
+Produce the final implementation plan document and a structured task list, then save them.
+
+1. **Generate the Implementation Plan** in the standard format:
+
+   ```markdown
+   # Implementation Plan: [Feature Name]
+
+   *When an engineer is assigned to a project but before you begin coding, you should fill in the implementation plan and get feedback from the engineering team. Once you have finished or you make any changes, tag Josh with the @ symbol so he can review. Also tag anyone else that needs to be notified, has conflicting work, etc.*
+
+   ## **Models**
+   [Content from plan step]
+
+   ## **APIs**
+   [Content from plan step]
+
+   ## **Notifications**
+   [Content from plan step]
+
+   ## **UI**
+   [Content from plan step]
+
+   ## Phases
+   [Content from plan step]
+
+   ## Feature Flags & Migrations
+   [Content from plan step]
+
+   ## Activity Log & User Updates
+   [Content from plan step]
+
+   ## **Not included/Future work**
+   [Content from plan step]
+
+   ## Acceptance Criteria
+   [If criteria exist from the PRD or shaping, include them here. Otherwise, leave a placeholder noting to run Step 6 (Acceptance Criteria) to generate them.]
+   ```
+
+2. **Generate the Task List** as a structured section at the bottom of the document:
+
+   ```markdown
+   ---
+
+   ## Task List (Bot Consumption)
+
+   *Structured task breakdown for automated implementation. Each task should be independently implementable and testable.*
+
+   ### Phase 1: [Phase Name]
+
+   - [ ] **Task 1.1**: [Short title]
+     - Description: [What to implement]
+     - Files: [Expected files to create/modify]
+     - Depends on: [Other task IDs, or "none"]
+     - Acceptance: [How to verify it's done]
+
+   - [ ] **Task 1.2**: [Short title]
+     ...
+
+   ### Phase 2: [Phase Name]
+   ...
+   ```
+
+   Tasks should be:
+   - Small enough to be a single PR or commit
+   - Ordered by dependency (models first, then APIs, then UI)
+   - Specific about which files to create/modify
+   - Clear about acceptance criteria
+
+3. **Ask the user for the feature name** to use in the filename (suggest one based on the PRD). The filename should be kebab-case.
+
+4. **Save the implementation plan:**
+   - Ensure `docs/implementationPlans/` directory exists (create if needed)
+   - Save to `docs/implementationPlans/[feature-name].md`
+   - Confirm the file was saved and show the path
+
+5. **Save the task plan:**
+   - Ensure `docs/tasks/` directory exists (create if needed)
+   - Save to `docs/tasks/[feature-name].md`
+   - Confirm the file was saved and show the path
+
+6. **Final summary:**
+
+   ```
+   ## Implementation Plan Complete
+
+   **Saved to**: docs/implementationPlans/[feature-name].md
+
+   ### Quick Stats
+   - Models: [count] new/modified
+   - API Endpoints: [count]
+   - Screens: [count]
+   - Phases: [count]
+   - Tasks: [count] total
+
+   ### Next Steps
+   1. Share with the engineering team for review
+   2. Tag @Josh and relevant stakeholders
+   3. Once approved, tasks can be loaded for implementation
+   ```
+
+7. Ask: "Want to make any final changes, or is this ready to share?"
+
+### Step 6: Acceptance Criteria
+
+Generate structured acceptance criteria for an implementation plan. The criteria should be specific enough for a human to manually test AND for a bot to translate into Playwright E2E tests.
+
+`$IP` (optional): path to an existing IP file. If not provided, look for the IP in the current conversation context or ask the user which IP to use.
+
+#### 1. Load the IP
+
+- If `$IP` is provided, read the file
+- Otherwise, check if an IP was generated in the current conversation
+- If neither, list available IPs from `docs/implementationPlans/` and ask which one to use
+
+#### 2. Check for existing acceptance criteria
+
+- If the PRD or IP already has an `## Acceptance Criteria` section, read it carefully
+- Also check each task in the Task List for `Acceptance:` lines
+- These are your starting point — you'll expand and formalize them, not replace them
+
+#### 3. Analyze the IP to identify testable behaviors
+
+Walk through each section of the IP and identify user-facing behaviors:
+
+- **Models & APIs**: What responses should the API return? What validation errors should occur?
+- **UI**: What should the user see? What happens when they interact with elements?
+- **Notifications**: What triggers them? What content appears?
+- **Permissions**: What should different roles see/not see?
+- **Error states**: What happens when things fail?
+- **Edge cases**: Empty states, boundary values, concurrent actions
+
+#### 4. Write acceptance criteria
+
+Write criteria in a dual-format that works for both humans and bots:
+
+```markdown
+## Acceptance Criteria
+
+### Feature: [Feature area name]
+
+#### AC-1: [Short descriptive title]
+**Priority:** P0 | P1 | P2
+**Screen:** [screen name, e.g., "Login Screen"]
+**Preconditions:**
+- [Any setup needed before testing, e.g., "User is logged in", "At least 3 items exist"]
+
+**Steps:**
+1. [Navigate to / open / tap specific element]
+2. [Perform action — be specific about what to type, tap, select]
+3. [Observe result]
+
+**Expected results:**
+- [ ] [Specific, observable outcome — what the user sees]
+- [ ] [Another expected outcome]
+
+**testIDs needed:** `screen-element-qualifier`, `screen-another-element`
+
+---
+```
+
+Format rules:
+
+- **Steps must reference specific UI elements** using the `{screen}-{element}-{qualifier}` testID naming convention
+- **Expected results must be visually verifiable** — things a human can see AND a bot can assert (`toBeVisible`, `toHaveText`, `toHaveCount`, etc.)
+- **Include the `testIDs needed` line** listing every testID the test will need. This serves as a checklist for the developer to add testIDs to components before tests can run.
+- **Priority levels:**
+  - **P0**: Core happy path — feature is broken without this
+  - **P1**: Important flows — error handling, validation, key edge cases
+  - **P2**: Nice-to-have — polish, edge cases, minor interactions
+- **Group by feature area** (e.g., "User Authentication", "Item Management", "Notifications")
+
+#### 5. Cover these categories
+
+Ensure you have at least one criterion for each:
+
+- **Happy path**: The main flow works end to end
+- **Validation**: Required fields, format checks, boundary values
+- **Error handling**: Network errors, server errors, invalid states
+- **Empty states**: What shows when there's no data?
+- **Permissions** (if applicable): Different roles see different things
+- **Navigation**: Moving between screens works correctly
+- **Data persistence**: Changes are saved and visible after refresh
+
+#### 6. Add the section to the IP
+
+Insert the `## Acceptance Criteria` section into the IP file, after the main plan sections but before the `## Task List` section.
+
+#### 7. Summary
+
+Present a summary:
+
+```
+## Acceptance Criteria Generated
+
+**Added to**: [IP file path]
+
+### Coverage
+- P0 (critical): [count] criteria
+- P1 (important): [count] criteria
+- P2 (nice-to-have): [count] criteria
+- Total testIDs needed: [count]
+
+### Next Steps
+1. Review criteria with the team
+2. Ensure all listed testIDs are added to components
+3. Run Step 7 (E2E Tests) to generate Playwright tests from these criteria
+```
+
+Ask: "Want to adjust any criteria or add coverage for something I missed?"
+
+### Step 7: E2E Tests (optional)
+
+Generate Playwright end-to-end tests from an IP's acceptance criteria. Uses the project's Playwright skill and testing conventions.
+
+`$IP` (optional): path to an IP file with acceptance criteria. If not provided, look for the IP in the current conversation context or ask the user which IP to use.
+
+#### 1. Load the IP and acceptance criteria
+
+- If `$IP` is provided, read the file
+- Otherwise, check if an IP was loaded in the current conversation
+- If neither, list available IPs from `docs/implementationPlans/` and ask which one to use
+- The IP **must** have an `## Acceptance Criteria` section. If it doesn't, tell the user to run Step 6 (Acceptance Criteria) first.
+
+#### 2. Research the codebase
+
+Before writing tests, understand the existing test setup:
+
+- Check if `playwright.config.ts` exists — if not, note that it needs to be created
+- Check if `e2e/` directory exists and what tests are already there
+- Check for `e2e/helpers/` and `e2e/fixtures/` for reusable utilities
+- Check for `e2e/auth.setup.ts` to understand auth patterns
+- Look at existing test files to match the style and patterns in use
+- Check if the testIDs listed in acceptance criteria already exist in the component code
+
+#### 3. Plan the test files
+
+Map acceptance criteria to test files:
+
+- **One test file per feature area** (matching the `### Feature:` groups in acceptance criteria)
+- File naming: `e2e/{feature-name}.spec.ts` (kebab-case)
+- Group related ACs into `test.describe()` blocks
+
+Present the plan to the user:
+
+```
+## E2E Test Plan
+
+### Files to create:
+- `e2e/feature-name.spec.ts` — [count] tests from [AC numbers]
+- `e2e/another-feature.spec.ts` — [count] tests from [AC numbers]
+
+### Missing testIDs (must be added to components first):
+- `screen-element-name` — [component file if known]
+- ...
+
+### Missing infrastructure:
+- [ ] playwright.config.ts (will create)
+- [ ] e2e/helpers/auth.ts (will create)
+- ...
+```
+
+Ask: "Should I generate these test files? Any changes to the plan?"
+
+#### 4. Generate test files
+
+For each test file, follow these rules strictly:
+
+**Structure:**
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Feature: [Feature Name]', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to starting screen
+    // Wait for screen to be visible
+  });
+
+  // One test per acceptance criterion
+  test('[AC title — as user behavior]', async ({ page }) => {
+    // Steps from the AC, translated to Playwright actions
+    // Expected results as assertions
+  });
+});
+```
+
+**Translation rules (AC → Playwright):**
+
+| AC Step | Playwright Code |
+|---------|----------------|
+| Navigate to [screen] | `await page.goto('/path'); await page.getByTestId('screen-name').waitFor({ state: 'visible' });` |
+| Tap / click [element] | `await page.getByTestId('testid').click();` |
+| Type [text] into [field] | `await page.getByTestId('testid').fill('text');` |
+| Toggle [switch] | `await page.getByTestId('testid').click();` |
+| See [text/element] | `await expect(page.getByTestId('testid')).toBeVisible();` |
+| See text [content] | `await expect(page.getByTestId('testid')).toHaveText(/content/i);` |
+| Don't see [element] | `await expect(page.getByTestId('testid')).not.toBeVisible();` |
+| See [N] items in list | `await expect(page.getByTestId('list').getByTestId(/^item-/)).toHaveCount(N);` |
+| Wait for loading | `await page.getByTestId('loading-indicator').waitFor({ state: 'hidden' });` |
+| Page URL contains [path] | `await expect(page).toHaveURL(/path/);` |
+
+**Mandatory rules:**
+- Use `getByTestId()` as primary selector — never class names or deep selectors
+- Never use `waitForTimeout()` — always wait for element state
+- Wait for screen visibility after every navigation
+- Wait for `networkidle` after data-fetching actions when appropriate
+- Add `// AC-N: [title]` comment above each test for traceability
+- Mark tests that need auth setup with the appropriate Playwright project dependency
+- Use `test.skip()` with a reason for any AC that can't be automated yet (e.g., requires native device features)
+
+#### 5. Report missing testIDs
+
+After generating tests, produce a checklist of testIDs that need to be added to components:
+
+```markdown
+## testIDs to Add
+
+These testIDs are referenced in the generated tests but may not exist in the app yet.
+Add them before running the tests.
+
+### [Screen Name]
+- [ ] `screen-element-name` on `<ComponentType>` — [purpose]
+- [ ] `screen-another-element` on `<ComponentType>` — [purpose]
+```
+
+If you can identify the component files where testIDs should be added, include the file paths.
+
+#### 6. E2E Summary
+
+```
+## E2E Tests Generated
+
+### Files created:
+- `e2e/feature-name.spec.ts` — [count] tests
+- ...
+
+### Coverage:
+- P0 criteria covered: [count]/[total]
+- P1 criteria covered: [count]/[total]
+- P2 criteria covered: [count]/[total]
+- Skipped (not automatable): [count] — [reasons]
+
+### Before running tests:
+1. Add missing testIDs to components (see checklist above)
+2. Ensure `playwright.config.ts` is configured
+3. Start the dev server
+4. Run: `bunx playwright test`
+
+### After tests pass:
+Run `/verify` to verify the full implementation
+```
+
+### Step 8: Review (optional, dual-model)
+
+Review an implementation plan using both Claude (sub-agent) and OpenAI Codex in parallel. Each reviewer independently identifies issues, gaps, and questions. Results are combined, deduplicated, and presented as a structured question list for the user. After the user answers, the IP is updated.
+
+Argument: IP number, filename, or path to the plan file. If empty, infer from conversation context. Parse as `$ARGUMENTS`.
+
+#### Phase 1: Locate the Plan
+
+1. If argument provided, find the matching IP file:
+   - Check `docs/implementationPlans/` for matching file (by IP number, slug, or full path)
+   - If a path was given directly, use that
+2. If no argument, infer from conversation context (most recently discussed IP)
+3. If ambiguous, ask the user
+4. Read the full plan file
+5. If a corresponding task file exists in `docs/tasks/`, read that too
+
+#### Phase 2: Gather Codebase Context
+
+Collect context both reviewers will need:
+
+1. **CLAUDE.md** -- project conventions, tech stack, constraints
+2. **Relevant source files** -- scan the plan's "Files to Create/Modify" or "Files:" fields in tasks, read 3-5 of the most critical existing files
+3. **Data models** -- if the plan references models, find and read their current definitions
+4. **Recent changes** -- `git log --oneline -10` for recent momentum
+
+Keep context focused. Prioritize the plan itself and the most relevant code.
+
+#### Phase 3: Run Both Reviews in Parallel
+
+Launch both reviewers at the same time using parallel tool calls. Do NOT wait for one before starting the other.
+
+##### 3a: Claude Sub-Agent
+
+Use the **Agent tool** with `subagent_type: "general-purpose"`:
+
+Prompt the sub-agent with all gathered context and these instructions:
+
+> You are a senior engineer reviewing an implementation plan. Your goal is to surface issues, gaps, risks, and questions that should be answered before implementation begins.
+>
+> ## The Plan
+>
+> {full plan content}
+>
+> ## Task Breakdown
+>
+> {task list content, if available}
+>
+> ## Codebase Context
+>
+> {CLAUDE.md excerpt -- tech stack, conventions}
+>
+> {relevant source file excerpts}
+>
+> ## Your Review
+>
+> Analyze this plan and produce two outputs:
+>
+> ### Issues & Gaps
+>
+> For each issue found, provide:
+> - **Severity**: CRITICAL / HIGH / MEDIUM / LOW
+> - **Category**: one of: Missing Requirements, Unstated Assumptions, Technical Risks, Security & Data Integrity, Task Breakdown Gaps, Architecture Concerns, Scope Concerns
+> - **Description**: What's wrong or missing -- be specific, cite the plan section
+> - **Suggestion**: How to address it
+>
+> ### Questions for the Author
+>
+> Generate questions that, if answered, would materially improve the plan. Focus on:
+> - Ambiguous requirements that could be interpreted multiple ways
+> - Unstated preferences (e.g., "should this be real-time or batch?")
+> - Tradeoffs where the plan picked one side without discussing alternatives
+> - Missing context that would change the approach
+> - Scale/performance expectations that aren't specified
+> - Integration points with unclear contracts
+> - Rollback/migration strategies that aren't defined
+>
+> For each question:
+> - **Question**: The question itself
+> - **Why it matters**: What changes depending on the answer
+> - **Default assumption**: What the plan currently assumes (if anything)
+>
+> Do NOT ask questions that can be answered by reading the codebase -- use Glob, Grep, and Read to verify before asking. Only ask questions that require human judgment or domain knowledge.
+
+##### 3b: Codex CLI
+
+Build a prompt file at `$TMPDIR/ip-review-prompt.md` with the plan, tasks, and codebase context, then run:
+
+```bash
+codex --model o3 --quiet --approval-mode full-auto "$TMPDIR/ip-review-prompt.md"
+```
+
+The prompt file should contain:
+
+```markdown
+# Implementation Plan Review: {plan title}
+
+You are a senior engineer reviewing an implementation plan. Find issues, gaps, and generate questions for the plan author.
+
+## The Plan
+
+{full plan content}
+
+## Task Breakdown
+
+{task list content, if available}
+
+## Codebase Context
+
+{CLAUDE.md excerpt}
+
+{relevant source file excerpts}
+
+## Your Review
+
+### Part 1: Issues & Gaps
+
+For each issue, provide:
+- **Severity**: CRITICAL / HIGH / MEDIUM / LOW
+- **Category**: Missing Requirements, Unstated Assumptions, Technical Risks, Security & Data Integrity, Task Breakdown Gaps, Architecture Concerns, or Scope Concerns
+- **Description**: Be specific -- cite the plan section and explain exactly what's wrong or missing
+- **Suggestion**: How to fix it
+
+### Part 2: Questions for the Author
+
+Generate questions that require human judgment or domain knowledge to answer. For each:
+- **Question**: The question
+- **Why it matters**: What would change depending on the answer
+- **Default assumption**: What the plan currently assumes
+
+Focus on: ambiguous requirements, unstated tradeoffs, missing scale/performance expectations, unclear integration contracts, and migration/rollback gaps.
+
+Do NOT ask questions answerable from the codebase. Focus on decisions that need human input.
+```
+
+**Model selection:** Use `o3` for strong reasoning. If unavailable, fall back to `o4-mini`.
+
+If `codex` is not installed or fails, report the error and continue with Claude-only results.
+
+Capture the full output.
+
+#### Phase 4: Combine & Deduplicate
+
+After both reviews return:
+
+##### Issues
+
+1. Parse all issues from both reviewers
+2. Deduplicate: if both flagged the same issue (same plan section, similar concern), merge and keep the more detailed description
+3. Tag each with its source:
+   - `[Claude]` -- only Claude found it
+   - `[Codex]` -- only Codex found it
+   - `[Both]` -- both flagged it (higher confidence)
+4. Sort by severity: CRITICAL > HIGH > MEDIUM > LOW
+
+##### Questions
+
+1. Parse all questions from both reviewers
+2. Deduplicate: merge questions asking essentially the same thing
+3. Tag with source (`[Claude]`, `[Codex]`, `[Both]`)
+4. Group by theme (e.g., "Scope", "Architecture", "Data", "Performance", "Migration")
+5. Within each group, sort by impact (questions where the answer would most change the plan come first)
+
+##### Verify Critical Claims
+
+For CRITICAL and HIGH issues, do a quick Glob/Grep/Read to confirm the issue is real. Note which are verified vs unverified.
+
+#### Phase 5: Present Results
+
+Present the combined review:
+
+```
+## IP Review: {plan title}
+
+**Reviewers:** Claude (sub-agent) + OpenAI Codex ({model used})
+**Plan:** {IP file path}
+
+---
+
+### Issues Found
+
+#### Critical
+1. [Both] **{category}** -- {description}
+   → {suggestion}
+
+#### High
+2. [Claude] **{category}** -- {description}
+   → {suggestion}
+
+#### Medium / Low
+3. [Codex] **{category}** -- {description}
+   → {suggestion}
+
+---
+
+### Questions for You
+
+**Scope & Requirements**
+1. [Both] {question}
+   _Why it matters:_ {impact}
+   _Current assumption:_ {what plan assumes}
+
+**Architecture & Design**
+2. [Claude] {question}
+   _Why it matters:_ {impact}
+   _Current assumption:_ {what plan assumes}
+
+**Performance & Scale**
+3. [Codex] {question}
+   _Why it matters:_ {impact}
+
+{...more grouped questions...}
+```
+
+#### Phase 6: Collect Answers
+
+Use **AskUserQuestion** to collect the user's answers. Present the questions in a numbered list and ask the user to answer them. Options:
+
+- Answer all at once (numbered responses)
+- Answer one at a time interactively
+- Skip questions they don't want to address yet (mark as "deferred")
+
+For skipped questions, note the current assumption the plan makes and flag it as an unresolved decision.
+
+#### Phase 7: Update the Plan
+
+After collecting answers:
+
+1. **Read the current IP file** fresh (in case it changed)
+2. **For each answered question**, determine what section(s) of the plan need updating
+3. **For each confirmed issue**, draft the fix
+4. **Draft all changes** and present them to the user as a before/after diff for each section
+5. Ask: "Apply these updates to the plan?"
+6. If yes, edit the IP file with all changes
+7. If a task file exists, update it too if any tasks are affected
+8. Add an "## Review Log" entry at the bottom of the IP file:
+
+```markdown
+## Review Log
+
+### {today's date} -- Dual-Model Review
+- **Reviewers:** Claude + Codex ({model})
+- **Issues found:** {N} ({breakdown by severity})
+- **Questions asked:** {N} ({answered}/{deferred})
+- **Plan updated:** Yes/No
+- **Unresolved:** {list any deferred questions or unverified issues}
+```
+
+#### Cleanup
+
+```bash
+rm -f "$TMPDIR/ip-review-prompt.md"
+```
+
+#### Notes on Review
+
+- The value is **dual perspective** -- Claude and Codex have different biases and catch different things
+- Questions tagged `[Both]` deserve the most attention -- two independent models flagged the same gap
+- Don't pre-filter findings. Present honestly even if they contradict earlier Claude work on the plan
+- This step fits between Step 5 (Generate) and implementation -- use it as a quality gate
+- Can also be run mid-implementation to reassess the plan as understanding deepens
+
+### Step 9: Attack & Adjust
+
+Adversarially red-team the plan and then update it inline based on what comes back. This is the last thing `/ip` does before handing off to implementation.
+
+1. **Locate the plan** — use the file just saved in Step 5 (`docs/implementationPlans/[feature-name].md`). Read it, plus the task file in `docs/tasks/` if present.
+
+2. **Gather focused context** — collect what an external reviewer will need:
+   - `CLAUDE.md` (tech stack, conventions, constraints)
+   - 3–5 of the most critical existing files referenced in the plan's "Files to Create/Modify"
+   - Current definitions of any models the plan touches
+   - `git log --oneline -10` for recent momentum
+
+3. **Build the attack prompt** at `$TMPDIR/ip-attack-prompt.md`:
+
+   ```markdown
+   # Adversarial Review: {plan title}
+
+   You are a senior staff engineer conducting a hostile review of this implementation plan. Find every flaw, gap, risk, and unstated assumption. Be uncharitable — assume nothing works until proven otherwise.
+
+   ## The Plan
+   {full plan content}
+
+   ## Task Breakdown
+   {task list content, if available}
+
+   ## Codebase Context
+   {CLAUDE.md excerpt + relevant source file excerpts}
+
+   ## Your Review
+
+   For each finding, cite the section of the plan and explain exactly what's wrong or missing. Cover:
+
+   1. **Missing Requirements** — what the PRD implies but the plan ignores; uncovered user flows and error states.
+   2. **Unstated Assumptions** — what the plan assumes about codebase/infra/data/scale that isn't verified.
+   3. **Technical Risks** — parts harder than the plan suggests; highest rewrite probability.
+   4. **Security & Data Integrity** — injection, auth gaps, input validation, race conditions.
+   5. **Task Breakdown Gaps** — tasks not actually independent/testable; wrong dependencies; missing setup/migration/testing/docs tasks.
+   6. **Architecture Concerns** — fit with existing patterns; tech debt; simpler approaches overlooked.
+   7. **Verdict** — SHIP IT / REVISE / RETHINK.
+
+   Classify each finding: CRITICAL / HIGH / MEDIUM / LOW.
+   ```
+
+4. **Run the attacker — OpenAI first, Opus fallback:**
+
+   Try OpenAI Codex CLI:
+   ```bash
+   codex --model o3-pro --quiet --approval-mode full-auto "$TMPDIR/ip-attack-prompt.md"
+   ```
+   If `o3-pro` is unavailable or rate-limited, try `o3`, then `o4-mini`.
+
+   If the `codex` CLI is missing or every model fails, fall back to an Opus subagent: spawn a `general-purpose` Agent with `model: "opus"` and pass it the same prompt file contents, telling it to act as the hostile reviewer. Report clearly which path was taken.
+
+5. **Process the findings:**
+   - Deduplicate overlapping issues.
+   - For each CRITICAL/HIGH finding, verify with Glob/Grep/Read before treating it as real — reviewers hallucinate.
+   - Drop anything the plan actually already addresses.
+
+6. **Report to the user** in this shape:
+
+   ```
+   ## Adversarial Review: {plan title}
+
+   **Reviewer:** {OpenAI model used, or "Opus fallback"}
+   **Verdict:** {SHIP IT / REVISE / RETHINK}
+
+   ### Critical / High / Medium / Low
+   {findings grouped by severity, each with a one-line plan-section reference}
+
+   ### Verified vs Unverified
+   - Verified: {confirmed against the codebase}
+   - Unverified: {couldn't confirm — may be false positives}
+   ```
+
+7. **Adjust the plan** — don't stop at reporting. For every verified CRITICAL/HIGH finding, edit the IP file in place: tighten assumptions, add missing tasks, patch acceptance criteria, rewrite risky phases. For MEDIUM/LOW, ask the user which to fold in. Show the diff of your plan edits and ask "Anything else to adjust, or is this ready for implementation?"
+
+If the user provides a `$STEP` argument, skip to that step (assumes prior steps have been completed and context is available in conversation).
+
+## Lifecycle Operations
+
+These operations manage IPs through their lifecycle after creation. Each is self-contained and can be invoked directly by name.
+
+### Lifecycle: Init
+
+Set up the directory structure and tracking index for implementation plans in the current project.
+
+Argument: optional project description or notes (`$ARGUMENTS`).
+
+#### Before Starting
+
+1. Identify the **project root** -- this is the current working directory
+2. Check if IP tracking already exists by looking for `docs/implementationPlans/PLAN_INDEX.md`
+   - If it exists, report what's already set up and ask what to regenerate
+   - If it doesn't exist, proceed with full setup
+
+#### Init Step 1: Infer Project Context
+
+1. Read `CLAUDE.md` if it exists -- note the project name, key conventions, commit style
+2. Check `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, or similar for project name
+3. Look at recent git log for commit message style
+4. Note the primary language and any existing docs structure
+5. Check if `docs/implementationPlans/` already exists with plan files -- if so, scan them for the highest IP number to seed the index
+
+#### Init Step 2: Create Directory Structure
+
+```bash
+mkdir -p docs/implementationPlans/archive
+mkdir -p docs/tasks
+```
+
+#### Init Step 3: Create PLAN_INDEX.md
+
+Create `docs/implementationPlans/PLAN_INDEX.md`:
+
+```markdown
+# Implementation Plan Index
+
+Tracked implementation plans for {project_name}.
+
+See `CLAUDE.md` for IP lifecycle stages and management guidelines.
+
+## Active Plans
+
+| IP | Title | Status | Effort | Priority |
+|----|-------|--------|--------|----------|
+| - | - | - | - | No active plans yet |
+
+## Completed
+
+| IP | Title | Completed | Notes |
+|----|-------|-----------|-------|
+| - | - | - | No completed plans yet |
+
+## Deferred / Closed
+
+| IP | Title | Status | Notes |
+|----|-------|--------|-------|
+| - | - | - | No deferred plans yet |
+
+## Backlog
+
+Low-priority or blocked items. Promote to Active when ready to plan.
+
+| IP | Title | Notes |
+|----|-------|-------|
+| - | - | No backlog items yet |
+```
+
+If existing plan files were found in `docs/implementationPlans/`, populate the Active table with entries for each file, inferring IP numbers from filenames or assigning new ones.
+
+#### Init Step 4: Create IP_TEMPLATE.md
+
+Only create if `docs/implementationPlans/IP_TEMPLATE.md` does not already exist. If it exists, skip this step and report it was found.
+
+Create `docs/implementationPlans/IP_TEMPLATE.md`:
+
+```markdown
+# Implementation Plan: Title
+
+**Status:** Open
+**Priority:** Low | Medium | High
+**Effort:** Small batch (1-2 days) | Big batch (1-2 weeks) | Epic (2+ weeks)
+**IP:** IP-XXX
+
+*When an engineer is assigned to a project but before you begin coding, you should fill in the implementation plan and get feedback from the engineering team.*
+
+## Models
+
+New or modified data models, schemas, relationships.
+
+## APIs
+
+Endpoints, permissions, special queries, bulk operations.
+
+## Notifications
+
+Push, email, in-app alerts -- who, when, what.
+
+## UI
+
+New screens/components, navigation flow, key interactions, states.
+
+## Phases
+
+How to break the work into phases/PRs.
+
+## Feature Flags & Migrations
+
+Feature flags, data migrations, rollout strategy.
+
+## Activity Log & User Updates
+
+What actions get logged, what surfaces as user updates.
+
+## Not Included / Future Work
+
+Explicitly out of scope.
+
+---
+
+## Task List
+
+*Structured task breakdown. Each task should be independently implementable and testable.*
+
+### Phase 1: [Phase Name]
+
+- [ ] **Task 1.1**: [Short title]
+  - Description: [What to implement]
+  - Files: [Expected files to create/modify]
+  - Depends on: [Other task IDs, or "none"]
+  - Acceptance: [How to verify it's done]
+```
+
+#### Init Step 5: Update Project CLAUDE.md
+
+Read the project's `CLAUDE.md`. If it doesn't exist, create it with a minimal header.
+
+**Check if an IP section already exists** by searching for `## Implementation Plan` or `## IP Management`. If found, skip and report.
+
+Otherwise, **append** the following section:
+
+```markdown
+
+---
+
+## Implementation Plan (IP) Management
+
+Implementation plans are tracked in `docs/implementationPlans/`. Each IP has a dedicated file and is indexed in `PLAN_INDEX.md`.
+
+### IP Lifecycle
+
+| Stage | Description |
+|-------|-------------|
+| **Planned** | Identified but not yet designed |
+| **Design** | Actively designing (PRD ingested, shaping) |
+| **Open** | Shaped and ready for implementation |
+| **In Progress** | Currently being implemented |
+| **Pending Verification** | Code complete, awaiting verification |
+| **Complete** | Verified working, ready to archive |
+| **Deferred** | Postponed (low priority or blocked) |
+| **Closed** | Won't implement (superseded or not needed) |
+
+### Conventions
+
+- **IP files**: `docs/implementationPlans/{Title-Case-Name}.md` (e.g. `Zoom-Integration-Mvp.md`)
+- **Template**: `docs/implementationPlans/IP_TEMPLATE.md`
+- **Task files**: `docs/tasks/{feature-name}.md` (created by Step 5: Generate)
+- **Commit format**: `IP-XXX: Brief description`
+- **Numbering**: Next number = highest across all index sections + 1
+- **Source of truth**: IP file status > index (if discrepancy, file wins)
+- **Archive**: Completed IPs move to `docs/implementationPlans/archive/`
+
+### Inline Annotations (`%%`)
+
+Lines starting with `%%` in any file are **inline annotations from the user**. When you encounter them:
+- Treat each `%%` annotation as a direct instruction
+- Address **every** `%%` annotation in the file; do not skip any
+- After acting on an annotation, remove the `%%` line from the file
+- If an annotation is ambiguous, ask for clarification before acting
+```
+
+#### Init Step 6: Init Summary
+
+Report what was created:
+
+```
+## IP Tracking Initialized
+
+### Files Created
+- `docs/implementationPlans/PLAN_INDEX.md` -- Plan index
+- `docs/implementationPlans/IP_TEMPLATE.md` -- IP file template (if not already present)
+- `docs/implementationPlans/archive/` -- Archive directory
+- `docs/tasks/` -- Task files directory
+- `CLAUDE.md` -- Updated with IP conventions
+
+### Next Steps
+1. Run /ip to create your first implementation plan from a PRD
+2. Run the Lifecycle: Status operation to check the current state
+```
+
+### Lifecycle: Explore
+
+General-purpose exploration of any project using the IP system. Uses parallel subagents to quickly build context.
+
+#### Step 1: Launch Parallel Subagents
+
+Launch these THREE subagents IN PARALLEL (single message with multiple Task tool calls):
+
+##### Agent 1: Project Overview
+
+Explore the project root to understand what this project is and how it works:
+
+1. **Read key docs** -- `CLAUDE.md`, `README.md`, any top-level docs
+2. **Directory structure** -- Glob for top-level files and key subdirectories
+3. **Tech stack** -- Identify languages, frameworks, build tools from config files (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `Makefile`, etc.)
+4. **Gotchas** -- Note any warnings, constraints, or non-obvious conventions from CLAUDE.md
+
+Return: project name, purpose, tech stack, directory layout, key gotchas.
+
+##### Agent 2: IP History
+
+Explore the implementation plan system to understand what's been built and what's planned:
+
+1. **Read index** -- `docs/implementationPlans/PLAN_INDEX.md`
+2. **Active IPs** -- Read each active IP file (non-Complete status)
+3. **Archived IPs** -- List files in `docs/implementationPlans/archive/` to understand completed work
+4. **Task files** -- List and scan `docs/tasks/` for active task lists
+5. **Recent IP commits** -- Search git log for commits matching `IP-` pattern (last 20)
+
+Return: active IPs table, count of archived IPs, active tasks summary, recent IP commit summary.
+
+##### Agent 3: Recent Activity
+
+Explore recent development activity to understand current momentum:
+
+1. **Recent commits** -- Last 15 commits with messages
+2. **Modified files** -- Files changed in the last 5 commits
+3. **Branch context** -- Current branch name and how far ahead of main
+4. **Uncommitted work** -- Check git status for staged/unstaged changes
+
+Return: recent commit summary, files in flux, branch status, open work.
+
+#### Step 2: Synthesize Results
+
+Combine all agent outputs into a single briefing:
+
+##### Project Overview
+- Name, purpose, tech stack (from Agent 1)
+- Key gotchas or constraints
+
+##### IP Status
+- Active plans table (from Agent 2)
+- Active tasks and progress
+- Archived count and notable completions
+
+##### Recent Activity
+- What's been happening (from Agent 3)
+- Current branch and open work
+
+##### Quick Reference
+
+| Item | Value |
+|------|-------|
+| **Project** | {name} |
+| **Branch** | {current branch} |
+| **Active IPs** | {count} |
+| **Active Tasks** | {count remaining} |
+| **Recent focus** | {summary of last few commits} |
+
+Use the current working directory as the project root.
+
+### Lifecycle: Deep Analysis
+
+Parallel exploration of a hard problem from multiple angles, inspired by test-time compute scaling. Use when stuck, when the problem is complex enough to benefit from diverse perspectives, or when you need "big brains" on something.
+
+Argument: problem description or context (`$ARGUMENTS`).
+
+#### Phase 1: Understand the Problem
+
+1. **Parse the argument** -- what is the user stuck on? What are they trying to achieve?
+2. **Gather context** -- read conversation history for what's already been tried or discussed
+3. **Check for active IP** -- if there's a relevant implementation plan, read it for design context
+4. **Scan the codebase** -- do a quick targeted search to understand the relevant code area (key files, architecture, constraints). Keep this brief -- the agents will do the deep exploration.
+
+#### Phase 2: Design the Exploration
+
+Based on the problem, design **4 exploration angles**. These are NOT redundant -- each agent gets a **distinct lens** on the problem.
+
+**Before launching, check orthogonality:** Would two of these angles likely explore the same code paths and reach similar conclusions? If so, reframe one to ensure genuine diversity.
+
+**How to choose angles -- infer from the problem type:**
+
+For **performance optimization**:
+- Algorithmic: Can the approach itself be fundamentally different?
+- Structural: Can the data layout, schema, or architecture reduce work?
+- Incremental: Can we avoid redoing work (caching, materialization, deltas)?
+- Environmental: Are we fighting the platform? (query patterns, Python GIL, network topology)
+
+For **architecture/design decisions**:
+- Simplicity: What's the minimal viable approach?
+- Scalability: What happens at 10x/100x current load?
+- Precedent: How do similar systems/libraries solve this?
+- Contrarian: What if the obvious approach is wrong? What's the unconventional path?
+
+For **debugging / "why is this broken"**:
+- Symptoms: Trace the failure path precisely -- what's the chain of events?
+- Environment: What changed? Versions, configs, data, dependencies?
+- Assumptions: What are we assuming that might not be true?
+- Similar: Has this pattern of failure been seen elsewhere in the codebase or in public?
+
+For **anything else** -- choose angles that maximize diversity of insight. Ask: "If these 4 experts were in a room, what different specialties would give me the most useful debate?"
+
+**For each angle, decide:**
+- What codebase areas the agent should explore (specific files, directories, patterns)
+- What question the agent should answer
+- How deep vs. broad the agent should go
+- What existing context (if any) to seed the agent with -- only what's necessary, avoid anchoring
+
+#### Phase 3: Launch Parallel Exploration
+
+**Briefly tell the user** what angles you're exploring (2-3 words each) -- then launch immediately. Don't wait for approval. Speed matters when stuck.
+
+Launch **4 Explore agents IN PARALLEL** (single message with 4 Task tool calls). Use `model: "opus"` explicitly on each agent to ensure heavyweight reasoning. Each agent gets:
+
+```
+You are exploring a specific angle of a hard problem. Your analysis is input to a multi-agent synthesis -- be precise, flag uncertainties, and show your evidence.
+
+## Problem
+{problem description}
+
+## Your Angle
+{specific lens -- what you're looking for, what question you're answering}
+
+## Where to Look (Starting Points)
+{specific files, directories, or search patterns to start with}
+
+These are entry points, not the complete scope. Follow evidence wherever it leads -- if the trail points to related code outside this list, explore it.
+
+## Key Constraint
+You have read-only tools (Glob, Grep, Read). Use them liberally. If you can't verify something exists, don't claim it. Better to say "I couldn't locate a config file for X" than to guess at its name or path.
+
+## Instructions
+- Use Glob, Grep, and Read to thoroughly explore the relevant code
+- Think deeply about your specific angle -- don't try to solve the whole problem
+- Look for evidence, patterns, constraints, and opportunities related to your angle
+- Note anything surprising or that contradicts assumptions
+- Be concrete -- reference specific files, functions, line numbers, data flows
+- If you find something important outside your angle, note it briefly but stay focused
+- Before you finalize: is there evidence that contradicts your recommendation? If yes, address it directly rather than ignore it
+
+## Output
+Return a focused analysis (aim for 600-1000 words):
+
+1. **Key findings** -- specific observations with evidence. For each finding, cite the file/line or code pattern that shows it's true. Avoid vague claims like "this is slow" -- show why.
+
+2. **Implications** -- what this means for the problem. For each implication, explain the logical link: if this finding is true, then we should try X because [reason].
+
+3. **Recommendation** -- your angle's proposed direction:
+   - **Proposed approach:** [specific, actionable idea]
+   - **Why this angle suggests it:** [link findings -> recommendation]
+   - **Tradeoffs:** [what you'd give up]
+   - **Key assumptions:** [what has to be true for this to work]
+   - **Biggest uncertainty:** [what would most change your mind]
+```
+
+#### Phase 4: Verify Key Claims
+
+Before synthesizing, two verification passes:
+
+##### Pass 1: Contradiction Detection
+
+Scan all 4 agent reports for **opposing claims**. Examples:
+- Agent A says "this runs synchronously" while Agent B says "this is async"
+- Agent A says "no index on this column" while Agent C assumes an index exists
+- Two agents recommend opposite directions
+
+Flag contradictions prominently. **Prioritize verifying contradicted claims first** -- these are where the highest-value corrections live.
+
+##### Pass 2: Factual Verification
+
+**Cross-check the most important factual claims** from the agents. Agents can hallucinate file paths, function signatures, config options, or behavioral assumptions.
+
+**What to verify:**
+- **File paths and function names** -- do the files/functions agents referenced actually exist? Spot-check with Glob/Grep.
+- **Behavioral claims** -- "this function does X" or "this config controls Y" -- Read the actual code for the 2-3 most critical claims that the recommendation will hinge on.
+- **Performance/complexity claims** -- if an agent says "this is O(n^2)" or "this query scans the full table," verify against the actual code or query plan.
+- **Assumption checks** -- if agents assumed something about the system (e.g., "this runs synchronously," "this table has an index on X"), verify the ones that matter most.
+
+**How to verify:**
+- Focus on the **top 3-5 claims that would change the recommendation if wrong**. Don't verify everything -- verify what matters.
+- Use Glob, Grep, and Read directly (no subagents -- this should be fast).
+- If a claim is wrong, note the correction. If it's right, move on.
+
+**Output:** Note any corrections or confirmations. Flag anything that was wrong -- this changes the synthesis.
+
+#### Phase 5: Synthesize
+
+After verification, synthesize the agents' findings (with corrections applied) into a single analysis. This is the critical step -- don't just concatenate.
+
+**Synthesis structure:**
+
+##### 1. Agreements
+Where do multiple angles converge? High-confidence insights.
+
+##### 2. Tensions
+Where do angles disagree or present tradeoffs? These are the real design decisions.
+
+##### 3. Surprises
+What did agents find that wasn't expected? Novel insights that change the framing.
+
+##### 4. Corrections
+Any agent claims that were wrong or misleading, and what the truth is. Be transparent -- this builds trust in the analysis.
+
+##### 5. Recommendation
+Your synthesized recommendation. Be opinionated -- rank the options, state which direction you'd go and why. Tag each element with confidence (High/Medium/Low) and a one-line justification. Include:
+- **Proposed approach** -- the synthesized best path forward
+- **Key tradeoffs** -- what you're giving up
+- **Risks** -- what could go wrong
+- **Key assumptions** -- what the recommendation depends on being true
+- **First step** -- the concrete next action
+
+##### 6. Assumption Check
+After drafting the recommendation, note what assumptions it hinges on. Verify those specific assumptions with a quick Glob/Grep/Read check. If any fail, flag them and reassess.
+
+##### 7. If applicable: IP Update
+If there's an active IP related to this problem, propose specific updates to the plan's relevant sections based on the analysis. Don't update the file -- present the proposed changes for the user to approve.
+
+#### Notes on Deep Analysis
+
+- **Agent count**: Always 4. Four distinct angles. No exceptions.
+- **Agent type**: Always use `subagent_type: "Explore"` with `model: "opus"` -- read-only research agents on the heaviest model.
+- **Thoroughness**: Tell agents to be "very thorough" in their Task descriptions.
+- **No anchoring**: Don't give agents each other's angles. They should explore independently.
+- **Speed over perfection**: The user is stuck. A good-enough synthesis in 2 minutes beats a perfect one in 10. Don't over-polish the output.
+
+### Lifecycle: Status
+
+Generate an up-to-date summary of active implementation plans.
+
+#### Fast Path vs Full Grooming
+
+**Decide which path to take based on conversation context:**
+
+##### Fast Path (just print the table)
+Use this when you are **confident the index is up to date** -- for example:
+- You've been working on IPs in this session (closing, creating, updating)
+- You just ran a full grooming pass recently
+- The user just asked you to "print the status"
+
+Simply read `docs/implementationPlans/PLAN_INDEX.md` and each active IP file, then output the table.
+
+##### Full Grooming (first invocation or uncertain state)
+Use this when you have **no context about the current state**:
+- Start of a new conversation
+- You haven't touched any IPs yet
+- The user explicitly asks for a grooming check
+
+Perform these housekeeping checks:
+
+###### 1. Status Sync Check
+- Read each active IP file and compare its `**Status:**` line to the index
+- If discrepancy, update the index to match the file (file is source of truth)
+- Report any discrepancies found and fixed
+
+###### 2. Archive Check
+- Look for IP files in `docs/implementationPlans/` (not in `archive/`) with status: Complete, Deferred, or Closed
+- For each such IP not yet archived:
+  - Move to `docs/implementationPlans/archive/`
+  - Ensure it's in the appropriate section of the index
+- Report any files archived
+
+###### 3. Orphan Check
+- Check if any IPs in the index don't have corresponding files
+- Check if any IP files exist that aren't in the index (exclude IP_TEMPLATE.md and PLAN_INDEX.md)
+- Report any orphans found
+
+###### 4. Task Progress Check
+- For each active IP, check if a corresponding task file exists in `docs/tasks/`
+- Count completed vs total tasks (checked vs unchecked checkboxes)
+- Include task progress in the output table
+
+#### Status Output
+
+Format the output as a markdown table:
+
+    ## Active Implementation Plans
+
+    | IP | Title | Status | Effort | Tasks | Description |
+    |----|-------|--------|--------|-------|-------------|
+    | IP-XXX | Title here | Status | Effort | 3/10 | Brief description |
+
+    **Total:** X active plans (Y design, Z open, W in progress)
+
+If full grooming was performed and changes were made, prepend a grooming report.
+
+Notes:
+- Keep descriptions concise (< 60 chars if possible)
+- Include a count summary at the bottom
+- Task column shows completed/total if task file exists, "-" otherwise
+
+### Lifecycle: Close
+
+Close an IP by marking it complete (or closed/deferred), archiving the file, and updating the index.
+
+Argument should contain:
+- **IP number or name** (required-ish): e.g. `1`, `IP-001`, or the plan filename slug
+- **Disposition** (optional): `complete` (default), `closed`, or `deferred`
+- **Notes** (optional): any additional context
+
+Examples:
+- close 1 -- mark IP-001 as Complete
+- close user-permissions deferred blocked on auth refactor -- mark by name, Deferred
+- close 3 closed superseded by IP-005 -- mark IP-003 as Closed
+- close (no args) -- infer from conversation context
+
+Parse the argument: `$ARGUMENTS`
+
+#### Inferring the IP
+
+If no IP number/name provided, infer from conversation context:
+- Look at which IP was most recently discussed or worked on
+- If exactly one IP is obvious, use it and state which one
+- If ambiguous, ask the user
+
+#### Close Steps
+
+##### 1. Find and read the IP file
+
+- Search `docs/implementationPlans/` for matching file (by IP number, Title-Case filename, or slug)
+- Read to get title, current status
+- If already archived or not found, report and stop
+
+##### 2. Update the IP file
+
+- Set `**Status:**` to `Complete`, `Closed`, or `Deferred`
+- For Complete: add `**Completed:** {today YYYY-MM-DD}` after Status
+- For Closed/Deferred: add `**Closed:** {today}` if not present
+
+##### 3. Update PLAN_INDEX.md
+
+- Read `docs/implementationPlans/PLAN_INDEX.md`
+- Remove IP's row from **Active Plans** table
+- Add to appropriate section:
+  - **Complete** -> add to top of `## Completed` table with date and notes
+  - **Closed/Deferred** -> add to top of `## Deferred / Closed` table with status and notes
+
+##### 4. Archive the files
+
+- Move IP file to `docs/implementationPlans/archive/`
+- If a corresponding task file exists in `docs/tasks/`, move it to `docs/implementationPlans/archive/` as well (or leave in place if tasks are still referenced)
+
+##### 5. Commit
+
+Commit all changes in a single atomic commit:
+- Check `git status` for uncommitted changes related to the IP implementation
+- Stage implementation files, archived IP, deleted original path, `PLAN_INDEX.md`
+- Commit with message: `IP-{number}: {title}`
+
+##### 6. Close Summary
+
+Report:
+- IP number and title
+- Disposition (Complete / Closed / Deferred)
+- Status updated in IP file
+- Moved from Active to the appropriate section in index
+- Archived to `docs/implementationPlans/archive/`
+- Committed: {short hash}
+
+## Submitting the IP
+
+Once the plan is finalized, use `/submit` to commit the IP files, push the branch, and create a PR on the target project's GitHub repo. The worktree is already on a dedicated branch, so `/submit` works directly.
+
+## Arguments
+
+$PROJECT: Project alias or `owner/repo` (required — if omitted, user is prompted to select from the registry)
+$STEP: Optional step to skip to (ingest, research, shape, plan, generate, acceptance, e2e, review, attack). Note: Step 0 (project setup) always runs regardless of $STEP.
+$PRD: Optional path to a PRD markdown file (skips the paste prompt in ingest step)

--- a/.windsurf/skills/mongoose-schema-safety/SKILL.md
+++ b/.windsurf/skills/mongoose-schema-safety/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: mongoose-schema-safety
+description: >-
+  Invoke when making any Mongoose schema change: adding/removing/renaming
+  fields, creating a new model, adding indexes, or writing a backfill migration.
+  Provides the five-type pattern, risk matrix, type file checklist, and rollout
+  safety steps for terreno backends.
+---
+# Mongoose Schema Safety — Terreno
+
+## Where Schemas and Types Live
+
+| Package | Schemas | Types |
+|---------|---------|-------|
+| `@terreno/api` (built-in models like `User`, `ConsentForm`) | `api/src/models/*.ts` | `api/src/types/*.ts` (or co-located in the model file via `mongoose.Schema<Doc, Model, Methods>` generics) |
+| `example-backend` (`User`, `Todo`, `Configuration`) | `example-backend/src/models/*.ts` | `example-backend/src/types/models/*.ts` (`userTypes.ts`, `todoTypes.ts`, …) |
+| `@terreno/ai` (`AIRequest`, `GptHistory`) | `ai/src/models/*.ts` | `ai/src/types/index.ts` |
+
+Every field in every schema **must** have a `description` (see the API rule `01-model-field-descriptions.md`). Descriptions flow through to the OpenAPI spec via `mongoose-to-swagger`.
+
+## The Five-Type Pattern
+
+Every model has manually-maintained TypeScript types. **Types are NOT auto-generated** — every schema change must include a matching type update in the same commit/PR.
+
+```typescript
+import type {DefaultDoc, DefaultModel, DefaultStatics} from "@terreno/api";
+
+// 1. Instance methods (on the document)
+export type YourModelMethods = {
+  customMethod: (this: YourModelDocument, param: string) => Promise<void>;
+};
+
+// 2. Static methods (on the model class) — extend DefaultStatics for findExactlyOne / findOneOrNone
+export type YourModelStatics = DefaultStatics<YourModelDocument> & {
+  customStatic: (this: YourModelModel, param: string) => Promise<YourModelDocument>;
+};
+
+// 3. Model type combining document + statics
+export type YourModelModel = DefaultModel<YourModelDocument> & YourModelStatics;
+
+// 4. Schema type
+export type YourModelSchema = mongoose.Schema<YourModelDocument, YourModelModel, YourModelMethods>;
+
+// 5. Document type (the shape of a single record)
+export type YourModelDocument = DefaultDoc & YourModelMethods & {
+  fieldName: string;
+  optionalField?: number;
+  enumField: "value1" | "value2";
+};
+```
+
+Follow existing type files in `example-backend/src/types/models/` and `ai/src/types/index.ts` for naming and structure.
+
+## Statics & Methods — Direct Assignment
+
+Define statics and methods by direct assignment on the schema — not via `.method()` / `.static()` / `.add()`:
+
+```typescript
+schema.methods = {
+  getDisplayName(this: YourModelDocument): string { return this.name; },
+};
+schema.statics = {
+  async findByEmail(this: YourModelModel, email: string) { return this.findOne({email}); },
+};
+```
+
+## Critical Mongoose Rules
+
+- **Never use `Model.findOne`** — use `Model.findExactlyOne` (throws on 0 or many) or `Model.findOneOrNone` (throws on many). These come from the `findExactlyOne` / `findOneOrNone` plugins in `@terreno/api`.
+- Apply the standard plugins (`createdUpdatedPlugin`, `isDeletedPlugin`, `findOneOrNone`, `findExactlyOne`) on every new model. Most existing models go through `addDefaultPlugins`.
+- `checkModelsStrict()` runs at non-prod startup (`server.ts`) and validates schema consistency — keep it passing.
+
+## Schema Change Risk Matrix
+
+| Change Type | Risk Level | Required Mitigation |
+|-------------|-----------|---------------------|
+| Add optional field | Low | Safe to ship directly (still requires `description`) |
+| Add required field | High | Must provide a default value, OR write a backfill migration script first |
+| Remove field | Medium | Soft-remove first (mark optional, stop writing); hard-remove in next PR after deploys settle |
+| Rename field | High | Three-step: add new → backfill → remove old (separate PRs) |
+| Change field type | Critical | Treat as rename: new field + migration + remove old |
+| Add index | Medium | Safe in code, but build can slow writes on large collections — coordinate with ops |
+| Remove index | Low | Safe to ship directly |
+| Add unique index | High | Dedup migration must run first; otherwise the index build fails on existing duplicates |
+
+## Migration Scripts
+
+Migration / backfill scripts live in `example-backend/src/scripts/` (e.g. `syncConsents.ts`, `seedConsents.ts`). They use the `ScriptRunner` type and `BackgroundTask` model from `@terreno/api` (`api/src/scriptRunner.ts`):
+
+```typescript
+import type {ScriptContext, ScriptResult, ScriptRunner} from "@terreno/api";
+
+export const run: ScriptRunner = async (wetRun, ctx) => {
+  const results: string[] = [];
+  // ... do work ...
+  if (wetRun) {
+    // commit changes
+  }
+  return {success: true, results};
+};
+```
+
+Always run with `wetRun = false` first to verify the dry-run output. Use `ctx.checkCancellation()`, `ctx.addLog()`, and `ctx.updateProgress()` for long-running tasks.
+
+## Cross-Package Ripple
+
+A schema change in one place often ripples:
+
+- **API surface affected?** Regenerate the SDK with `cd example-frontend && bun run sdk` (or invoke the `generate-sdk` skill). The OpenAPI spec is derived from the schema, so the frontend hooks will go stale otherwise.
+- **`modelRouter` config?** If you added/removed a field, update `queryFields`, `populatePaths`, and `responseHandler` for any router that touches the model.
+- **Admin panel?** If the model is registered in `AdminApp`, update `listFields` so the table reflects the new shape.
+- **Populated refs?** If another model references this one via `ObjectId` + `ref`, and the referenced document shape changed, the consumer's populated type may need updating.
+
+## Post-Change Checklist
+
+- [ ] All new fields have a `description` (flows to OpenAPI)
+- [ ] Type file updated in the same commit/PR — field names, optionality, enum values, array types, refs, statics/methods all match the schema
+- [ ] For a new model: all five types (`Document`, `Methods`, `Statics`, `Model`, `Schema`) created
+- [ ] Statics/methods assigned directly on schema (`schema.statics = {...}`, `schema.methods = {...}`) — not `.static()` / `.method()`
+- [ ] Other model type files checked — any model that populates this one updated if its shape changed
+- [ ] Migration script written (and dry-run verified with `wetRun = false`) for any backfill
+- [ ] `modelRouter` config updated (`queryFields`, `populatePaths`, `responseHandler`) if needed
+- [ ] `AdminApp` `listFields` updated if the model is in the admin panel
+- [ ] `bun run sdk` run from `example-frontend/` if the API response shape changed
+- [ ] Test covers old-format document behavior (missing new field) if the change rolls out before a backfill
+- [ ] Unique index: dedup migration written and run before the index is added
+- [ ] `checkModelsStrict()` still passes (it runs on non-prod startup)
+- [ ] No `Model.findOne` introduced — use `findExactlyOne` / `findOneOrNone`
+
+## Common Pitfalls
+
+- Adding a required field without a default — first deploy fails for documents that pre-date the field
+- Skipping the type file update — TS happily compiles older callers but new ones break at runtime
+- Adding a `unique` index without dedup — index build fails on collections with existing duplicates
+- Renaming a field in one PR — frontend gets old field, backend writes new field, neither side is happy
+- Forgetting to regenerate the SDK after a shape change — frontend types drift from reality
+- Using `.method()` / `.static()` API — terreno's convention is direct assignment, and mixing styles makes types hard to maintain

--- a/.windsurf/skills/respond-to-review/SKILL.md
+++ b/.windsurf/skills/respond-to-review/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: respond-to-review
+description: >-
+  Review PR comments, plan fixes, and implement — auto-submitting when no
+  clarifications are needed
+---
+# PR Review Response Workflow
+
+Review comments on PR #$ARGUMENTS and plan fixes. If the plan has open questions for the user, pause for confirmation; otherwise implement, commit, and run `/submit` automatically without prompting.
+
+## Step 1: Setup Working Directory
+
+1. Check if we're already in a git worktree:
+   ```bash
+   git rev-parse --show-toplevel
+   git worktree list
+   ```
+
+2. **If already in a worktree**, use the current directory — skip to Step 2.
+
+3. **If NOT in a worktree**, set one up:
+
+   a. Get the repo name:
+      ```bash
+      basename $(git rev-parse --show-toplevel)
+      ```
+
+   b. Fetch PR details and branch name:
+      ```bash
+      gh pr view $ARGUMENTS --json headRefName,number,title,url,author
+      ```
+
+   c. Fetch the PR branch:
+      ```bash
+      git fetch origin pull/$ARGUMENTS/head
+      ```
+
+   d. Create worktree at `~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS`:
+      ```bash
+      git worktree add ~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS FETCH_HEAD
+      ```
+
+   e. Change to the worktree directory:
+      ```bash
+      cd ~/.claude-worktrees/<repo-name>/pr-$ARGUMENTS
+      ```
+
+   f. Set up tracking for the PR branch:
+      ```bash
+      git checkout -B <branch-name> FETCH_HEAD
+      git branch --set-upstream-to=origin/<branch-name>
+      ```
+
+**Important**: All subsequent work happens in the working directory (worktree or current).
+
+## Step 2: Find the Reviews
+
+1. Get review threads with resolution status using GraphQL. **Important**: capture the thread `id` for each unresolved thread so you can resolve them later.
+   ```bash
+   gh api graphql -f query='
+     query($owner: String!, $repo: String!, $pr: Int!) {
+       repository(owner: $owner, name: $repo) {
+         pullRequest(number: $pr) {
+           reviewThreads(first: 100) {
+             nodes {
+               id
+               isResolved
+               comments(first: 50) {
+                 nodes {
+                   author { login }
+                   body
+                   path
+                   line
+                   createdAt
+                 }
+               }
+             }
+           }
+           reviews(first: 50) {
+             nodes {
+               author { login }
+               state
+               body
+             }
+           }
+         }
+       }
+     }' -F owner=':owner' -F repo=':repo' -F pr=$ARGUMENTS
+   ```
+
+2. **Ignore resolved threads entirely** — only process threads where `isResolved` is `false`
+
+3. Filter to comments from other users (not the PR author)
+
+4. Identify which remaining comments are:
+   - Blocking (CHANGES_REQUESTED) vs suggestions
+   - Inline code comments vs general comments
+
+## Step 3: Decide What To Do & Propose a Plan
+
+Decide the right action for each unresolved comment (fix, skip, ask), then present a structured plan organized by priority:
+
+```
+## PR #$ARGUMENTS Review Comments Plan
+
+### 🔴 Must Fix (Blocking)
+1. [file:line] @reviewer: "comment text"
+   → Proposed fix: <description>
+
+### ⚠️ Should Address (Suggestions)
+2. [file:line] @reviewer: "comment text"
+   → Proposed fix: <description>
+
+### 💬 Questions/Clarifications Needed
+- Comment X: Need your input on approach
+- Comment Y: Conflicts with existing pattern, which to use?
+
+### 📝 Will Skip (N/A or out of scope)
+- Comment Z: Not applicable or out of scope
+
+### 💬 Suggested Replies to Human Commenters
+For any comments that warrant a reply (e.g., to clarify a decision or thank a reviewer):
+- **Print the suggested reply text** so the user can see it
+- **Never post replies** via `gh pr comment`, `gh api`, or any other method — leave posting to the user
+```
+
+## Step 4: Confirmation (only if there are open questions)
+
+**If the plan has any items under 💬 Questions/Clarifications Needed:**
+Ask: **"Need your input on the questions above. Anything else to change before I implement?"**
+- Wait for explicit approval before making any changes
+- Incorporate any feedback
+- Re-present plan if significant changes requested
+
+**If there are no open questions:** skip confirmation entirely. Proceed directly to Step 5 — implement, commit, run `/submit`, and resolve threads without further prompts. Do not ask the user for plan approval in this case.
+
+## Step 5: Make the Fix
+
+After approval:
+
+1. Implement fixes one at a time, in priority order
+2. After each fix, briefly confirm what was changed
+
+## Step 6: Show the diff
+
+Show the complete diff so the user can scan what was implemented:
+```bash
+git diff
+git diff --stat
+```
+
+Do **not** commit here. `/submit` (next step) handles pre-commit checks, staging, commit, push, and PR updates — running pre-commit *before* the commit, which is the correct order. Committing here would invert that order and leave broken code committed locally if pre-commit fails.
+
+## Step 7: Run /submit
+
+Invoke the `/submit` skill to handle pre-commit checks, commit, push, and PR updates. This will also launch the CI check-watcher in the background. Pass a `$DESCRIPTION` summarizing what review comments were addressed so the commit message reflects the work.
+
+## Step 8: Resolve Addressed Threads
+
+After `/submit` completes, resolve each review thread that was addressed in the implementation. Use the thread `id` captured in Step 2.
+
+For each thread that was fixed or addressed (from the "Must Fix" and "Should Address" categories in the plan):
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { isResolved }
+    }
+  }' -f threadId="<thread_id>"
+```
+
+Do NOT resolve threads that were:
+- Skipped (marked as N/A or out of scope)
+- Questions/clarifications that were not answered by code changes
+- Threads where the user decided not to take action
+
+Report which threads were resolved and which were left open.
+
+---
+
+## Error Handling
+
+- If worktree already exists, ask if user wants to reset it or use existing
+- If PR not found, show error and available PRs: `gh pr list`
+- If no comments found, inform user and ask if they want to proceed anyway
+- If merge conflicts occur during implementation, pause and ask for guidance
+
+## Cleanup Reminder
+
+If a new worktree was created, remind user:
+```
+To remove this worktree later:
+  git worktree remove ~/.claude-worktrees/<repo>/pr-$ARGUMENTS
+
+Or to keep working on it, you can open a new Claude session in:
+  cd ~/.claude-worktrees/<repo>/pr-$ARGUMENTS
+```

--- a/.windsurf/skills/submit/SKILL.md
+++ b/.windsurf/skills/submit/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: submit
+description: >-
+  Lightweight pre-commit + commit + push + create/update PR, then spawn
+  check-watcher in the background. Use /fullsend for the full pipeline with code
+  review.
+---
+# Submit: Quick Commit & PR
+
+Lightweight path to run pre-commit checks, commit, push, and monitor CI. After pushing, this skill launches `/check-watcher` as a background sub-agent so CI is watched without blocking. Use `/fullsend` for the full pipeline that also includes code review.
+
+## Step 1: Assess Changes
+
+```bash
+git status && git diff --stat
+```
+
+```bash
+gh pr view --json number -q .number 2>/dev/null || echo "no-pr"
+```
+
+## Step 1.5: Pre-Commit Checks
+
+Delegate lint, type check, and related tests to the `pre-commit` subagent before committing.
+
+Use the `Agent` tool:
+- `subagent_type`: `pre-commit`
+- `description`: `Run pre-commit checks`
+- `prompt`: instruct it to run lint, compile, and related tests for the current project, fix any issues, and report back. Mention this is being run as part of `/submit` for an upcoming commit.
+
+Wait for the subagent to return its Pre-Commit Report. If it surfaces unfixable failures, STOP and report them — do not commit or push.
+
+If invoked from `/fullsend` (which already ran pre-commit), skip this step.
+
+## Step 2: Commit
+
+Stage and commit:
+- Review the diff to write an accurate message
+- Keep first line under 72 characters
+- No conventional commit prefixes
+- No AI attribution
+
+## Step 3: Push
+
+```bash
+git push origin HEAD
+```
+
+## Step 4: Create or Update PR
+
+### If no PR exists
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+[What changed and why — 2-4 sentences]
+
+## Human Testing Steps
+- [ ] [Step-by-step verification instructions]
+
+## Changes
+- [Bullet list of specific changes]
+
+## Automated Tests
+- [Tests that ran and passed, or "None"]
+EOF
+)" --draft
+```
+
+### If a PR already exists
+
+Read the current title and body, then compare against the full set of commits on the branch:
+
+```bash
+gh pr view --json title,body,baseRefName
+git log $(gh pr view --json baseRefName -q .baseRefName)..HEAD --oneline
+git diff $(gh pr view --json baseRefName -q .baseRefName)...HEAD --stat
+```
+
+Decide whether the description still reflects what's on the branch — pay attention to commits added since the PR was opened:
+- **Summary** still matches the actual goal of the changes
+- **Changes** list covers the new commits, not just the original ones
+- **Human Testing Steps** still cover what reviewers need to verify
+- **Automated Tests** section reflects current test state
+
+If the description is stale or incomplete, update it. Preserve sections the user has clearly edited by hand — only rewrite what's actually out of date, and merge new bullets into existing lists rather than replacing them wholesale:
+
+```bash
+gh pr edit --title "<title>" --body "$(cat <<'EOF'
+<updated body>
+EOF
+)"
+```
+
+If the description is already accurate, skip the edit and note that it's up to date.
+
+## Step 5: Print PR Link
+
+```bash
+gh pr view --json title,url -q '"**\(.title)** — \(.url)"'
+```
+
+## Step 6: Launch Check Watcher Sub-Agent
+
+Spawn `/check-watcher` as a **background sub-agent** so CI monitoring runs autonomously without blocking the parent conversation. Use the `Agent` tool with `run_in_background: true`.
+
+- `subagent_type`: `general-purpose`
+- `description`: `Watch CI for current PR`
+- `run_in_background`: `true`
+- `prompt`: instruct the sub-agent to invoke the `/check-watcher` skill for the current PR, fix any failures, and report back when checks are green or max attempts are hit. Include the PR number/URL from Step 5 so the sub-agent has context.
+
+Do **not** wait on the sub-agent — return control immediately after spawning. The user will be notified when it completes.
+
+By the time you reach this step, a PR is guaranteed to exist — either it pre-existed (from Step 1) or Step 4 just created it. Always spawn check-watcher.
+
+## Arguments
+
+$DESCRIPTION: Optional description to guide the commit message and PR


### PR DESCRIPTION
## Summary

Brings terreno in line with the flourishhealth/flourish skill set so the workflow skills (commit, create-pr, submit, check-watcher, respond-to-review, fix-conflicts, implement, ip) are available here, and fixes an existing inconsistency where the four previously-adapted skills lived directly in `.claude/skills/` rather than being sourced from `.rulesync/skills/` like `generate-sdk`.

## Changes

- **Added 8 new skills** in `.rulesync/skills/`:
  - `check-watcher`, `commit`, `create-pr`, `respond-to-review`, `submit` — copied verbatim from flourish
  - `fix-conflicts` — adapted `bun lint`/`bun compile` to `bun run lint`/`bun run compile` to match terreno's scripts
  - `implement` — replaced clinical "patient/caregiver/staff visibility" with "user/admin visibility"
  - `ip` — trimmed the project registry to terreno only (dropped flourish/gitsight/zoom-notifier entries)
- **Moved 4 adapted skills** from `.claude/skills/` into `.rulesync/skills/` so rulesync owns them like `generate-sdk` already does: `ai-prompt-governance`, `backend-test-env`, `improve-rulesync`, `mongoose-schema-safety`
- **Skipped** `flourish-scheduling` — purely clinical domain, no relevance to terreno
- **Regenerated** outputs under `.claude/`, `.agents/`, `.cursor/`, `.github/`, and `.windsurf/` via `bun run rules` (idempotent on re-run)

## Human Testing Steps

- [ ] Open a Claude Code session in this repo and confirm the new skills appear in the available-skills list (`commit`, `create-pr`, `submit`, `check-watcher`, `respond-to-review`, `fix-conflicts`, `implement`, `ip`)
- [ ] Invoke `/ip` and verify the project registry lists only `terreno`
- [ ] Invoke `/fix-conflicts` and verify lint/compile steps reference `bun run lint` and `bun run compile`
- [ ] Run `bun run rules:check` after merging — should exit clean with no drift

## Automated Tests

None — changes are markdown skill files and rulesync-generated artifacts only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes adding/updating markdown skill definitions and regenerating their synced copies; no runtime application code is modified.
> 
> **Overview**
> Adds a set of workflow automation skills (e.g., `commit`, `create-pr`, `submit`, `check-watcher`, `respond-to-review`, `fix-conflicts`, `implement`, `ip`) to align this repo with the shared Flourish skillset.
> 
> Moves previously customized skills to be sourced from `.rulesync/` and regenerates the synced skill artifacts under `.agents/`, `.claude/`, and `.cursor/` so all tool directories share the same definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c526d79a3fce0e313723590b2615e96e9db6355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->