### PR TITLE
Add request and session log context

### DIFF
--- a/api/src/auth.test.ts
+++ b/api/src/auth.test.ts
@@ -13,6 +13,11 @@ import {type Food, FoodModel, getBaseServer, setupDb, UserModel} from "./tests";
 import {AdminOwnerTransformer} from "./transformers";
 import {timeout} from "./utils";
 
+const decodeTokenPayload = <T extends Record<string, unknown>>(token: string): T => {
+  const encodedPayload = token.split(".")[1];
+  return JSON.parse(Buffer.from(encodedPayload, "base64url").toString("utf8")) as T;
+};
+
 describe("auth tests", () => {
   let app: express.Application;
   let admin: any;
@@ -200,6 +205,38 @@ describe("auth tests", () => {
       .send({email: "ADMIN+other@example.com", password: "otherPassword"})
       .expect(200);
     expect(res.body.data.token).toBeDefined();
+  });
+
+  it("preserves JWT session id across refresh and request context", async () => {
+    const loginRes = await agent
+      .post("/auth/login")
+      .send({email: "admin@example.com", password: "securePassword"})
+      .expect(200);
+    const loginTokenPayload = decodeTokenPayload<{sid?: string}>(loginRes.body.data.token);
+    const loginRefreshPayload = decodeTokenPayload<{sid?: string}>(loginRes.body.data.refreshToken);
+
+    expect(loginTokenPayload.sid).toBeDefined();
+    expect(loginRefreshPayload.sid).toBe(loginTokenPayload.sid);
+    expect(loginRes.headers["x-session-id"]).toBe(loginTokenPayload.sid);
+
+    const refreshRes = await agent
+      .post("/auth/refresh_token")
+      .send({refreshToken: loginRes.body.data.refreshToken})
+      .expect(200);
+    const refreshedTokenPayload = decodeTokenPayload<{sid?: string}>(refreshRes.body.data.token);
+    const refreshedRefreshPayload = decodeTokenPayload<{sid?: string}>(
+      refreshRes.body.data.refreshToken
+    );
+
+    expect(refreshedTokenPayload.sid).toBe(loginTokenPayload.sid);
+    expect(refreshedRefreshPayload.sid).toBe(loginTokenPayload.sid);
+    expect(refreshRes.headers["x-session-id"]).toBe(loginTokenPayload.sid);
+
+    const foodRes = await agent
+      .get("/food")
+      .set("authorization", `Bearer ${refreshRes.body.data.token}`)
+      .expect(200);
+    expect(foodRes.headers["x-session-id"]).toBe(loginTokenPayload.sid);
   });
 
   it("completes token login e2e", async () => {

--- a/api/src/auth.test.ts
+++ b/api/src/auth.test.ts
@@ -9,6 +9,7 @@ import {modelRouter} from "./api";
 import {addAuthRoutes, addMeRoutes, generateTokens, setupAuth} from "./auth";
 import {setupServer} from "./expressServer";
 import {Permissions} from "./permissions";
+import {getCurrentRequestContext} from "./requestContext";
 import {type Food, FoodModel, getBaseServer, setupDb, UserModel} from "./tests";
 import {AdminOwnerTransformer} from "./transformers";
 import {timeout} from "./utils";
@@ -21,6 +22,13 @@ const decodeTokenPayload = <T extends Record<string, unknown>>(token: string): T
 describe("auth tests", () => {
   let app: express.Application;
   let admin: any;
+  let contextEvents: Array<{
+    currentSessionId?: string;
+    requestId?: string;
+    sessionId?: string;
+    stage: string;
+    userId?: string;
+  }>;
   let notAdmin: any;
   let agent: TestAgent;
 
@@ -29,6 +37,7 @@ describe("auth tests", () => {
     // lockout mechanism needs real time to progress
     setSystemTime();
     [admin, notAdmin] = await setupDb();
+    contextEvents = [];
 
     await Promise.all([
       FoodModel.create({
@@ -80,6 +89,65 @@ describe("auth tests", () => {
             ownerReadFields: ["name", "calories", "created", "ownerId"],
             ownerWriteFields: ["name", "calories", "created"],
           }),
+        })
+      );
+      router.use(
+        "/context-food",
+        modelRouter(FoodModel, {
+          permissions: {
+            create: [Permissions.IsAuthenticated],
+            delete: [],
+            list: [],
+            read: [],
+            update: [],
+          },
+          postCreate: async (_value, req) => {
+            contextEvents.push({
+              currentSessionId: getCurrentRequestContext()?.sessionId,
+              requestId: req.requestId,
+              sessionId: req.sessionId,
+              stage: "postCreate",
+              userId: req.user?.id,
+            });
+          },
+          preCreate: (body, req) => {
+            contextEvents.push({
+              currentSessionId: getCurrentRequestContext()?.sessionId,
+              requestId: req.requestId,
+              sessionId: req.sessionId,
+              stage: "preCreate",
+              userId: req.user?.id,
+            });
+
+            return {
+              ...(body as Partial<Food>),
+              categories: [],
+              eatenBy: [req.user?._id],
+              expiration: "2026-01-01",
+              lastEatenWith: {},
+              likesIds: [],
+              ownerId: req.user?._id,
+              source: {name: "context-test"},
+              tags: [],
+            } as unknown as Food;
+          },
+          responseHandler: async (value, method, req) => {
+            contextEvents.push({
+              currentSessionId: getCurrentRequestContext()?.sessionId,
+              requestId: req.requestId,
+              sessionId: req.sessionId,
+              stage: `responseHandler:${method}`,
+              userId: req.user?.id,
+            });
+
+            return {
+              id: String((value as {_id: unknown})._id),
+              requestId: req.requestId ?? null,
+              sessionContext: getCurrentRequestContext()?.sessionId ?? null,
+              sessionId: req.sessionId ?? null,
+              userId: req.user?.id ?? null,
+            };
+          },
         })
       );
     }
@@ -207,6 +275,56 @@ describe("auth tests", () => {
     expect(res.body.data.token).toBeDefined();
   });
 
+  it("passes request and session context through modelRouter hooks", async () => {
+    const loginRes = await agent
+      .post("/auth/login")
+      .send({email: "admin@example.com", password: "securePassword"})
+      .expect(200);
+    const loginTokenPayload = decodeTokenPayload<{sid?: string}>(loginRes.body.data.token);
+
+    const createRes = await agent
+      .post("/context-food")
+      .set("authorization", `Bearer ${loginRes.body.data.token}`)
+      .set("X-Request-ID", "model-router-request-1")
+      .send({calories: 10, name: "Context Apple"})
+      .expect(201);
+
+    expect(loginTokenPayload.sid).toBeDefined();
+    const sessionId = loginTokenPayload.sid;
+    if (!sessionId) {
+      throw new Error("Expected login token to include a session id");
+    }
+    expect(createRes.headers["x-request-id"]).toBe("model-router-request-1");
+    expect(createRes.headers["x-session-id"]).toBe(sessionId);
+    expect(createRes.body.data.requestId).toBe("model-router-request-1");
+    expect(createRes.body.data.sessionId).toBe(sessionId);
+    expect(createRes.body.data.sessionContext).toBe(sessionId);
+    expect(createRes.body.data.userId).toBe(String(admin._id));
+    expect(contextEvents).toEqual([
+      {
+        currentSessionId: sessionId,
+        requestId: "model-router-request-1",
+        sessionId,
+        stage: "preCreate",
+        userId: String(admin._id),
+      },
+      {
+        currentSessionId: sessionId,
+        requestId: "model-router-request-1",
+        sessionId,
+        stage: "postCreate",
+        userId: String(admin._id),
+      },
+      {
+        currentSessionId: sessionId,
+        requestId: "model-router-request-1",
+        sessionId,
+        stage: "responseHandler:create",
+        userId: String(admin._id),
+      },
+    ]);
+  });
+
   it("preserves JWT session id across refresh and request context", async () => {
     const loginRes = await agent
       .post("/auth/login")
@@ -216,8 +334,12 @@ describe("auth tests", () => {
     const loginRefreshPayload = decodeTokenPayload<{sid?: string}>(loginRes.body.data.refreshToken);
 
     expect(loginTokenPayload.sid).toBeDefined();
-    expect(loginRefreshPayload.sid).toBe(loginTokenPayload.sid);
-    expect(loginRes.headers["x-session-id"]).toBe(loginTokenPayload.sid);
+    const loginSessionId = loginTokenPayload.sid;
+    if (!loginSessionId) {
+      throw new Error("Expected login token to include a session id");
+    }
+    expect(loginRefreshPayload.sid).toBe(loginSessionId);
+    expect(loginRes.headers["x-session-id"]).toBe(loginSessionId);
 
     const refreshRes = await agent
       .post("/auth/refresh_token")
@@ -228,15 +350,15 @@ describe("auth tests", () => {
       refreshRes.body.data.refreshToken
     );
 
-    expect(refreshedTokenPayload.sid).toBe(loginTokenPayload.sid);
-    expect(refreshedRefreshPayload.sid).toBe(loginTokenPayload.sid);
-    expect(refreshRes.headers["x-session-id"]).toBe(loginTokenPayload.sid);
+    expect(refreshedTokenPayload.sid).toBe(loginSessionId);
+    expect(refreshedRefreshPayload.sid).toBe(loginSessionId);
+    expect(refreshRes.headers["x-session-id"]).toBe(loginSessionId);
 
     const foodRes = await agent
       .get("/food")
       .set("authorization", `Bearer ${refreshRes.body.data.token}`)
       .expect(200);
-    expect(foodRes.headers["x-session-id"]).toBe(loginTokenPayload.sid);
+    expect(foodRes.headers["x-session-id"]).toBe(loginSessionId);
   });
 
   it("completes token login e2e", async () => {

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -3,6 +3,7 @@ import jwt, {type JwtPayload} from "jsonwebtoken";
 import type {Model, ObjectId} from "mongoose";
 import ms, {type StringValue} from "ms";
 import passport from "passport";
+import {randomUUID} from "node:crypto";
 import {Strategy as AnonymousStrategy} from "passport-anonymous";
 import {
   type JwtFromRequestFunction,
@@ -14,6 +15,12 @@ import {Strategy as LocalStrategy} from "passport-local";
 import {APIError, apiErrorMiddleware, errorMessage} from "./errors";
 import type {AuthOptions} from "./expressServer";
 import {logger} from "./logger";
+import {
+  getSessionIdFromJwtPayload,
+  setRequestContext,
+  updateRequestContextFromRequest,
+  type JwtSessionPayload,
+} from "./requestContext";
 
 export interface User {
   _id: ObjectId | string;
@@ -41,6 +48,10 @@ export interface UserModel extends Model<User> {
   deserializeUser(): any;
   // biome-ignore lint/suspicious/noExplicitAny: passport-local-mongoose return types are untyped
   findByUsername(username: string, findOpts: any): any;
+}
+
+export interface GenerateTokensOptions {
+  sessionId?: string;
 }
 
 export function authenticateMiddleware(anonymous = false) {
@@ -109,7 +120,11 @@ export async function signupUser(
  * This ensures consistent and secure token issuance across different authentication flows.
  */
 // biome-ignore lint/suspicious/noExplicitAny: user object is variable (Mongoose Document, plain object, anonymous user) — strict typing here would require generics that break call sites
-export const generateTokens = async (user: any, authOptions?: AuthOptions) => {
+export const generateTokens = async (
+  user: any,
+  authOptions?: AuthOptions,
+  options: GenerateTokensOptions = {}
+) => {
   const tokenSecretOrKey = process.env.TOKEN_SECRET;
   if (!tokenSecretOrKey) {
     throw new Error("TOKEN_SECRET must be set in env.");
@@ -118,7 +133,8 @@ export const generateTokens = async (user: any, authOptions?: AuthOptions) => {
     logger.warn("No user found for token generation");
     return {refreshToken: null, token: null};
   }
-  let payload: Record<string, unknown> = {id: String(user._id)};
+  const sessionId = options.sessionId ?? randomUUID();
+  let payload: Record<string, unknown> = {id: String(user._id), sid: sessionId};
   if (authOptions?.generateJWTPayload) {
     payload = {...authOptions.generateJWTPayload(user), ...payload};
   }
@@ -166,7 +182,7 @@ export const generateTokens = async (user: any, authOptions?: AuthOptions) => {
   } else {
     logger.info("REFRESH_TOKEN_SECRET not set so refresh tokens will not be issued");
   }
-  return {refreshToken, token};
+  return {refreshToken, sessionId, token};
 };
 
 // TODO allow customization
@@ -289,9 +305,16 @@ export function setupAuth(app: express.Application, userModel: UserModel) {
       return res.status(401).json({details, message});
     }
     if (decoded?.id) {
+      const sessionId = getSessionIdFromJwtPayload(decoded as JwtSessionPayload);
+      req.authTokenPayload = decoded as JwtSessionPayload;
+      if (sessionId) {
+        req.sessionId = sessionId;
+        setRequestContext({sessionId});
+      }
       try {
         const user = await userModel.findById(decoded.id);
         req.user = user as unknown as express.Request["user"];
+        updateRequestContextFromRequest(req, res);
         if (req.user?.disabled) {
           logger.warn(`[jwt] User ${req.user.id} is disabled`);
           return res.status(401).json({status: 401, title: "User is disabled"});
@@ -334,6 +357,8 @@ export function addAuthRoutes(
           logger.info(`User logged in: ${user._id}, type: ${user.type || "N/A"}`);
         }
         const tokens = await generateTokens(user, authOptions);
+        setRequestContext({sessionId: tokens.sessionId, userId: String(user._id)});
+        res.setHeader("X-Session-ID", tokens.sessionId);
         return res.json({
           data: {refreshToken: tokens.refreshToken, token: tokens.token, userId: user?._id},
         });
@@ -365,7 +390,13 @@ export function addAuthRoutes(
     }
     if (decoded?.id) {
       const user = await userModel.findById(decoded.id);
-      const tokens = await generateTokens(user, authOptions);
+      const sessionId = getSessionIdFromJwtPayload(decoded as JwtSessionPayload);
+      const tokens = await generateTokens(user, authOptions, {sessionId});
+      setRequestContext({
+        sessionId: tokens.sessionId,
+        userId: user?._id ? String(user._id) : undefined,
+      });
+      res.setHeader("X-Session-ID", tokens.sessionId);
       logger.debug(`Refreshed token for ${user?.id}`);
       return res.json({data: {refreshToken: tokens.refreshToken, token: tokens.token}});
     }
@@ -380,6 +411,11 @@ export function addAuthRoutes(
       passport.authenticate("signup", {failWithError: true, session: false}),
       async (req: express.Request, res: express.Response) => {
         const tokens = await generateTokens(req.user, authOptions);
+        setRequestContext({
+          sessionId: tokens.sessionId,
+          userId: req.user?._id ? String(req.user._id) : undefined,
+        });
+        res.setHeader("X-Session-ID", tokens.sessionId);
         return res.json({
           data: {refreshToken: tokens.refreshToken, token: tokens.token, userId: req.user?._id},
         });

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -1,9 +1,9 @@
+import {randomUUID} from "node:crypto";
 import express from "express";
 import jwt, {type JwtPayload} from "jsonwebtoken";
 import type {Model, ObjectId} from "mongoose";
 import ms, {type StringValue} from "ms";
 import passport from "passport";
-import {randomUUID} from "node:crypto";
 import {Strategy as AnonymousStrategy} from "passport-anonymous";
 import {
   type JwtFromRequestFunction,
@@ -17,9 +17,9 @@ import type {AuthOptions} from "./expressServer";
 import {logger} from "./logger";
 import {
   getSessionIdFromJwtPayload,
+  type JwtSessionPayload,
   setRequestContext,
   updateRequestContextFromRequest,
-  type JwtSessionPayload,
 } from "./requestContext";
 
 export interface User {
@@ -119,9 +119,8 @@ export async function signupUser(
  * authentication providers) to reuse and customize the same token generation logic.
  * This ensures consistent and secure token issuance across different authentication flows.
  */
-// biome-ignore lint/suspicious/noExplicitAny: user object is variable (Mongoose Document, plain object, anonymous user) — strict typing here would require generics that break call sites
 export const generateTokens = async (
-  user: any,
+  user: unknown,
   authOptions?: AuthOptions,
   options: GenerateTokensOptions = {}
 ) => {
@@ -129,12 +128,13 @@ export const generateTokens = async (
   if (!tokenSecretOrKey) {
     throw new Error("TOKEN_SECRET must be set in env.");
   }
-  if (!user?._id) {
+  const tokenUser = user as {_id?: ObjectId | string} | null | undefined;
+  if (!tokenUser?._id) {
     logger.warn("No user found for token generation");
     return {refreshToken: null, token: null};
   }
   const sessionId = options.sessionId ?? randomUUID();
-  let payload: Record<string, unknown> = {id: String(user._id), sid: sessionId};
+  let payload: Record<string, unknown> = {id: String(tokenUser._id), sid: sessionId};
   if (authOptions?.generateJWTPayload) {
     payload = {...authOptions.generateJWTPayload(user), ...payload};
   }

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -357,8 +357,10 @@ export function addAuthRoutes(
           logger.info(`User logged in: ${user._id}, type: ${user.type || "N/A"}`);
         }
         const tokens = await generateTokens(user, authOptions);
-        setRequestContext({sessionId: tokens.sessionId, userId: String(user._id)});
-        res.setHeader("X-Session-ID", tokens.sessionId);
+        if (tokens.sessionId) {
+          setRequestContext({sessionId: tokens.sessionId, userId: String(user._id)});
+          res.setHeader("X-Session-ID", tokens.sessionId);
+        }
         return res.json({
           data: {refreshToken: tokens.refreshToken, token: tokens.token, userId: user?._id},
         });
@@ -392,11 +394,13 @@ export function addAuthRoutes(
       const user = await userModel.findById(decoded.id);
       const sessionId = getSessionIdFromJwtPayload(decoded as JwtSessionPayload);
       const tokens = await generateTokens(user, authOptions, {sessionId});
-      setRequestContext({
-        sessionId: tokens.sessionId,
-        userId: user?._id ? String(user._id) : undefined,
-      });
-      res.setHeader("X-Session-ID", tokens.sessionId);
+      if (tokens.sessionId) {
+        setRequestContext({
+          sessionId: tokens.sessionId,
+          userId: user?._id ? String(user._id) : undefined,
+        });
+        res.setHeader("X-Session-ID", tokens.sessionId);
+      }
       logger.debug(`Refreshed token for ${user?.id}`);
       return res.json({data: {refreshToken: tokens.refreshToken, token: tokens.token}});
     }
@@ -411,11 +415,13 @@ export function addAuthRoutes(
       passport.authenticate("signup", {failWithError: true, session: false}),
       async (req: express.Request, res: express.Response) => {
         const tokens = await generateTokens(req.user, authOptions);
-        setRequestContext({
-          sessionId: tokens.sessionId,
-          userId: req.user?._id ? String(req.user._id) : undefined,
-        });
-        res.setHeader("X-Session-ID", tokens.sessionId);
+        if (tokens.sessionId) {
+          setRequestContext({
+            sessionId: tokens.sessionId,
+            userId: req.user?._id ? String(req.user._id) : undefined,
+          });
+          res.setHeader("X-Session-ID", tokens.sessionId);
+        }
         return res.json({
           data: {refreshToken: tokens.refreshToken, token: tokens.token, userId: req.user?._id},
         });

--- a/api/src/betterAuthSetup.ts
+++ b/api/src/betterAuthSetup.ts
@@ -14,6 +14,7 @@ import type {UserModel} from "./auth";
 import type {BetterAuthConfig, BetterAuthSessionData, BetterAuthUser} from "./betterAuth";
 import {logger} from "./logger";
 import {findOneOrNoneFor} from "./plugins";
+import {updateRequestContextFromRequest} from "./requestContext";
 
 /**
  * The Better Auth instance type.
@@ -126,11 +127,13 @@ export const createBetterAuthSessionMiddleware = (
           if (appUser) {
             reqWithSession.user = appUser as unknown as Request["user"];
             reqWithSession.betterAuthSession = session as unknown as BetterAuthSessionData;
+            updateRequestContextFromRequest(req);
           } else {
             // User exists in Better Auth but not synced yet - create them
             const newUser = await syncBetterAuthUser(userModel, betterAuthUser);
             reqWithSession.user = newUser as unknown as Request["user"];
             reqWithSession.betterAuthSession = session as unknown as BetterAuthSessionData;
+            updateRequestContextFromRequest(req);
           }
         } else {
           // No user model - just attach the Better Auth user directly
@@ -143,6 +146,7 @@ export const createBetterAuthSessionMiddleware = (
             name: betterAuthUser.name,
           } as unknown as Request["user"];
           reqWithSession.betterAuthSession = session as unknown as BetterAuthSessionData;
+          updateRequestContextFromRequest(req);
         }
       }
 

--- a/api/src/express.d.ts
+++ b/api/src/express.d.ts
@@ -1,5 +1,12 @@
 declare namespace Express {
   export interface Request {
+    authTokenPayload?: {
+      sid?: string;
+      sessionId?: string;
+      [key: string]: unknown;
+    };
+    requestId?: string;
+    sessionId?: string;
     user?: {
       _id: string | ObjectId;
       id: string;

--- a/api/src/express.d.ts
+++ b/api/src/express.d.ts
@@ -5,6 +5,7 @@ declare namespace Express {
       sessionId?: string;
       [key: string]: unknown;
     };
+    jobId?: string;
     requestId?: string;
     sessionId?: string;
     user?: {

--- a/api/src/expressServer.test.ts
+++ b/api/src/expressServer.test.ts
@@ -1,7 +1,9 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: test mock typing
 import {afterEach, beforeEach, describe, expect, it, mock} from "bun:test";
+import {Writable} from "node:stream";
 import express from "express";
 import supertest from "supertest";
+import winston from "winston";
 
 import {
   createRouter,
@@ -12,6 +14,7 @@ import {
   setupServer,
   wrapScript,
 } from "./expressServer";
+import {logger, winstonLogger} from "./logger";
 import {UserModel} from "./tests";
 
 describe("expressServer", () => {
@@ -59,6 +62,52 @@ describe("expressServer", () => {
   });
 
   describe("logRequests", () => {
+    it("attaches request and session context to route logs", async () => {
+      const logs: string[] = [];
+      const logStream = new Writable({
+        write(chunk, _encoding, callback) {
+          logs.push(chunk.toString());
+          callback();
+        },
+      });
+      const transport = new winston.transports.Stream({
+        format: winston.format.json(),
+        stream: logStream,
+      });
+
+      const app = setupServer({
+        addRoutes: (router) => {
+          router.get("/context-test", (req, res) => {
+            logger.info("context route log");
+            return res.json({requestId: req.requestId, sessionId: req.sessionId});
+          });
+        },
+        logRequests: false,
+        skipListen: true,
+        userModel: UserModel as any,
+      });
+      winstonLogger.add(transport);
+
+      const res = await supertest(app)
+        .get("/context-test")
+        .set("X-Request-ID", "req-123")
+        .set("X-Session-ID", "session-123")
+        .expect(200);
+
+      expect(res.headers["x-request-id"]).toBe("req-123");
+      expect(res.headers["x-session-id"]).toBe("session-123");
+      expect(res.body).toEqual({requestId: "req-123", sessionId: "session-123"});
+
+      const parsedLog = logs
+        .map((entry) => JSON.parse(entry))
+        .find((entry) => entry.message === "context route log");
+      expect(parsedLog).toBeDefined();
+      expect(parsedLog.requestId).toBe("req-123");
+      expect(parsedLog.sessionId).toBe("session-123");
+
+      winstonLogger.remove(transport);
+    });
+
     it("logs request with admin user type", () => {
       const req = {
         body: {},

--- a/api/src/expressServer.ts
+++ b/api/src/expressServer.ts
@@ -311,6 +311,8 @@ export interface SetupServerOptions {
   userModel: UserMongooseModel;
   addRoutes: AddRoutes;
   loggingOptions?: LoggingOptions;
+  // Whether requests should be logged. Defaults to true.
+  logRequests?: boolean;
   authOptions?: AuthOptions;
   /**
    * GitHub OAuth configuration. When provided, enables GitHub authentication.
@@ -348,6 +350,8 @@ export const setupServer = (options: SetupServerOptions): express.Application =>
       authOptions: options.authOptions,
       corsOrigin: options.corsOrigin,
       githubAuth: options.githubAuth,
+      logRequests: options.logRequests,
+      loggingOptions: options.loggingOptions,
     });
   } catch (error: unknown) {
     const stack = error instanceof Error && error.stack ? error.stack : String(error);

--- a/api/src/expressServer.ts
+++ b/api/src/expressServer.ts
@@ -15,6 +15,11 @@ import {type LoggingOptions, logger, setupLogging} from "./logger";
 import {sendToSlack} from "./notifiers";
 import {openApiCompatMiddleware, patchAppUse} from "./openApiCompat";
 import {openApiEtagMiddleware} from "./openApiEtag";
+import {
+  getCurrentRequestContext,
+  requestContextMiddleware,
+  updateRequestContextFromRequest,
+} from "./requestContext";
 import openapi from "./vendor/wesleytodd-openapi/index";
 
 const SLOW_READ_MAX = 200;
@@ -198,6 +203,8 @@ const initializeRoutes = (
 
   app.set("query parser", (str: string) => qs.parse(str, {arrayLimit: options.arrayLimit ?? 200}));
 
+  app.use(requestContextMiddleware);
+
   app.use(
     cors({
       origin: options.corsOrigin ?? "*",
@@ -213,6 +220,10 @@ const initializeRoutes = (
   // Add login/signup/refresh_token before the JWT/auth middlewares
   addAuthRoutes(app, UserModel, options?.authOptions);
   setupAuth(app, UserModel);
+  app.use((req, res, next) => {
+    updateRequestContextFromRequest(req, res);
+    next();
+  });
 
   if (options.logRequests !== false) {
     app.use(logRequests);
@@ -226,8 +237,12 @@ const initializeRoutes = (
 
   // Add Sentry scopes for session, transaction, and userId if any are set
   app.use((req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    const context = getCurrentRequestContext();
     const transactionId = req.header("X-Transaction-ID");
-    const sessionId = req.header("X-Session-ID");
+    const sessionId = context?.sessionId ?? req.header("X-Session-ID");
+    if (context?.requestId) {
+      Sentry.getCurrentScope().setTag("request_id", context.requestId);
+    }
     if (transactionId) {
       Sentry.getCurrentScope().setTag("transaction_id", transactionId);
     }

--- a/api/src/expressServer.ts
+++ b/api/src/expressServer.ts
@@ -350,8 +350,8 @@ export const setupServer = (options: SetupServerOptions): express.Application =>
       authOptions: options.authOptions,
       corsOrigin: options.corsOrigin,
       githubAuth: options.githubAuth,
-      logRequests: options.logRequests,
       loggingOptions: options.loggingOptions,
+      logRequests: options.logRequests,
     });
   } catch (error: unknown) {
     const stack = error instanceof Error && error.stack ? error.stack : String(error);

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -22,6 +22,7 @@ export * from "./openApiValidator";
 export * from "./permissions";
 export * from "./plugins";
 export * from "./populate";
+export * from "./requestContext";
 export * from "./scriptRunner";
 export * from "./secretProviders";
 export * from "./syncConsents";

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import {inspect} from "node:util";
 import * as Sentry from "@sentry/bun";
 import winston from "winston";
+import {getCurrentLogContext} from "./requestContext";
 
 const isPrimitive = (val: unknown) => {
   return val === null || (typeof val !== "object" && typeof val !== "function");
@@ -14,6 +15,25 @@ const formatWithInspect = (val: unknown) => {
   return prefix + (shouldFormat ? inspect(val, {colors: true, depth: null}) : val);
 };
 
+const addRequestContextFormat = winston.format((info) => {
+  const context = getCurrentLogContext();
+  return {...context, ...info};
+});
+
+const formatContext = (info: winston.Logform.TransformableInfo): string => {
+  const contextParts = [
+    info.requestId ? `requestId=${info.requestId}` : undefined,
+    info.sessionId ? `sessionId=${info.sessionId}` : undefined,
+    info.userId ? `userId=${info.userId}` : undefined,
+    info.traceId ? `traceId=${info.traceId}` : undefined,
+  ].filter(Boolean);
+
+  if (contextParts.length === 0) {
+    return "";
+  }
+  return ` ${contextParts.join(" ")}`;
+};
+
 // Winston doesn't operate like console.log by default, e.g. `logger.error('error',
 // error)` only prints the message and no args. Add handling for all the args,
 // while also supporting splat logging.
@@ -23,10 +43,11 @@ const printf = (timestamp = false) => {
     const splatKey = Symbol.for("splat") as unknown as keyof winston.Logform.TransformableInfo;
     const splatArgs = (info[splatKey] || []) as unknown[];
     const rest = splatArgs.map((data) => formatWithInspect(data)).join(" ");
+    const context = formatContext(info);
     if (timestamp) {
-      return `${info.timestamp} - ${info.level}: ${msg} ${rest}`;
+      return `${info.timestamp} - ${info.level}: ${msg}${context} ${rest}`;
     }
-    return `${info.level}: ${msg} ${rest}`;
+    return `${info.level}: ${msg}${context} ${rest}`;
   };
 };
 
@@ -35,6 +56,7 @@ winston.add(
   new winston.transports.Console({
     debugStdout: true,
     format: winston.format.combine(
+      addRequestContextFormat(),
       winston.format.colorize(),
       winston.format.simple(),
       winston.format.printf(printf(false))
@@ -53,6 +75,7 @@ export const winstonLogger = winston.createLogger({
     new winston.transports.Console({
       debugStdout: true,
       format: winston.format.combine(
+        addRequestContextFormat(),
         winston.format.colorize(),
         winston.format.simple(),
         winston.format.printf(printf(false))
@@ -122,7 +145,7 @@ export interface LoggingOptions {
 export const setupLogging = (options?: LoggingOptions): void => {
   winstonLogger.clear();
   if (!options?.disableConsoleLogging) {
-    const formats: winston.Logform.Format[] = [winston.format.simple()];
+    const formats: winston.Logform.Format[] = [addRequestContextFormat(), winston.format.simple()];
     if (!options?.disableConsoleColors) {
       formats.push(winston.format.colorize());
     }
@@ -145,7 +168,7 @@ export const setupLogging = (options?: LoggingOptions): void => {
       colorize: false,
       compress: true,
       dirname: logDirectory,
-      format: winston.format.simple(),
+      format: winston.format.combine(addRequestContextFormat(), winston.format.simple()),
       // 30 days of retention
       maxFiles: 30,
       // 50MB max file size

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -23,6 +23,7 @@ const addRequestContextFormat = winston.format((info) => {
 const formatContext = (info: winston.Logform.TransformableInfo): string => {
   const contextParts = [
     info.requestId ? `requestId=${info.requestId}` : undefined,
+    info.jobId ? `jobId=${info.jobId}` : undefined,
     info.sessionId ? `sessionId=${info.sessionId}` : undefined,
     info.userId ? `userId=${info.userId}` : undefined,
     info.traceId ? `traceId=${info.traceId}` : undefined,

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -91,7 +91,11 @@ export const winstonLogger = winston.createLogger({
 // Helper function to send logs to Sentry if enabled
 const sendToSentry = (message: string, level: "debug" | "info" | "warn" | "error"): void => {
   if (process.env.USE_SENTRY_LOGGING === "true" && Sentry.logger) {
-    Sentry.logger[level](message);
+    const logWithContext = Sentry.logger[level] as (
+      message: string,
+      attributes?: Record<string, unknown>
+    ) => void;
+    logWithContext(message, getCurrentLogContext());
   }
 };
 

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -47,6 +47,7 @@ winston.add(
 
 // Setup a default console logger.
 export const winstonLogger = winston.createLogger({
+  format: addRequestContextFormat(),
   level: "debug",
   transports: [
     new winston.transports.Console({

--- a/api/src/requestContext.test.ts
+++ b/api/src/requestContext.test.ts
@@ -1,0 +1,150 @@
+import {afterEach, describe, expect, it} from "bun:test";
+import {Writable} from "node:stream";
+import express from "express";
+import supertest from "supertest";
+import winston from "winston";
+
+import {logger, setupLogging} from "./logger";
+import {
+  getCurrentLogContext,
+  getCurrentRequestContext,
+  getCurrentRequestContextAttributes,
+  getRequestContextFromAttributes,
+  requestContextMiddleware,
+  runWithRequestContext,
+  runWithRequestContextAttributes,
+} from "./requestContext";
+
+describe("request context job propagation", () => {
+  afterEach(() => {
+    setupLogging({disableFileLogging: true});
+  });
+
+  it("serializes the current context for downstream jobs", () => {
+    runWithRequestContext(
+      {
+        jobId: "job-1",
+        requestId: "request-1",
+        sessionId: "session-1",
+        spanId: "span-1",
+        traceId: "trace-1",
+        traceSampled: false,
+        userId: "user-1",
+      },
+      () => {
+        expect(getCurrentRequestContextAttributes()).toEqual({
+          "x-job-id": "job-1",
+          "x-request-id": "request-1",
+          "x-session-id": "session-1",
+          "x-span-id": "span-1",
+          "x-trace-id": "trace-1",
+          "x-trace-sampled": "false",
+          "x-user-id": "user-1",
+        });
+      }
+    );
+  });
+
+  it("allows downstream jobs to replace only the job id", () => {
+    runWithRequestContext(
+      {jobId: "job-parent", requestId: "request-1", sessionId: "session-1"},
+      () => {
+        expect(getCurrentRequestContextAttributes({jobId: "job-child"})).toEqual({
+          "x-job-id": "job-child",
+          "x-request-id": "request-1",
+          "x-session-id": "session-1",
+        });
+      }
+    );
+  });
+
+  it("restores worker context from message attributes", () => {
+    runWithRequestContextAttributes(
+      {
+        traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        "x-job-id": "job-worker-1",
+        "x-request-id": "request-1",
+        "x-session-id": "session-1",
+        "x-user-id": "user-1",
+      },
+      () => {
+        expect(getCurrentRequestContext()).toEqual({
+          jobId: "job-worker-1",
+          requestId: "request-1",
+          sessionId: "session-1",
+          spanId: "00f067aa0ba902b7",
+          traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+          traceSampled: true,
+          userId: "user-1",
+        });
+      }
+    );
+  });
+
+  it("uses trace id as request id when attributes do not include request id", () => {
+    const context = getRequestContextFromAttributes({
+      traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
+      "x-job-id": "job-worker-1",
+    });
+
+    expect(context).toEqual({
+      jobId: "job-worker-1",
+      requestId: "4bf92f3577b34da6a3ce929d0e0e4736",
+      sessionId: undefined,
+      spanId: "00f067aa0ba902b7",
+      traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+      traceSampled: false,
+      userId: undefined,
+    });
+  });
+
+  it("accepts job id from HTTP headers", async () => {
+    const app = express();
+    app.use(requestContextMiddleware);
+    app.get("/job", (req, res) => {
+      res.json({context: getCurrentLogContext(), jobId: req.jobId});
+    });
+
+    const res = await supertest(app)
+      .get("/job")
+      .set("X-Job-ID", "job-http-1")
+      .set("X-Request-ID", "request-http-1")
+      .expect(200);
+
+    expect(res.headers["x-job-id"]).toBe("job-http-1");
+    expect(res.body).toEqual({
+      context: {jobId: "job-http-1", requestId: "request-http-1"},
+      jobId: "job-http-1",
+    });
+  });
+
+  it("adds job id to logger context", () => {
+    let output = "";
+    const stream = new Writable({
+      write: (chunk, _encoding, callback): void => {
+        output += chunk.toString();
+        callback();
+      },
+    });
+
+    setupLogging({
+      disableConsoleLogging: true,
+      disableFileLogging: true,
+      transports: [
+        new winston.transports.Stream({
+          format: winston.format.printf((info) => {
+            return `${info.level}: ${info.message} requestId=${info.requestId} jobId=${info.jobId}`;
+          }),
+          stream,
+        }),
+      ],
+    });
+
+    runWithRequestContext({jobId: "job-log-1", requestId: "request-log-1"}, () => {
+      logger.info("worker handled job");
+    });
+
+    expect(output).toContain("requestId=request-log-1");
+    expect(output).toContain("jobId=job-log-1");
+  });
+});

--- a/api/src/requestContext.test.ts
+++ b/api/src/requestContext.test.ts
@@ -1,5 +1,6 @@
-import {afterEach, describe, expect, it} from "bun:test";
+import {afterEach, beforeEach, describe, expect, it, type Mock} from "bun:test";
 import {Writable} from "node:stream";
+import * as Sentry from "@sentry/bun";
 import express from "express";
 import supertest from "supertest";
 import winston from "winston";
@@ -13,9 +14,17 @@ import {
   requestContextMiddleware,
   runWithRequestContext,
   runWithRequestContextAttributes,
+  setRequestContext,
 } from "./requestContext";
 
 describe("request context job propagation", () => {
+  beforeEach(() => {
+    const scope = Sentry.getCurrentScope();
+    (scope.setContext as unknown as Mock<(...args: unknown[]) => void>).mockClear();
+    (scope.setTag as unknown as Mock<(...args: unknown[]) => void>).mockClear();
+    (scope.setUser as unknown as Mock<(...args: unknown[]) => void>).mockClear();
+  });
+
   afterEach(() => {
     setupLogging({disableFileLogging: true});
   });
@@ -59,6 +68,11 @@ describe("request context job propagation", () => {
   });
 
   it("restores worker context from message attributes", () => {
+    const scope = Sentry.getCurrentScope();
+    const setContextMock = scope.setContext as unknown as Mock<(...args: unknown[]) => void>;
+    const setTagMock = scope.setTag as unknown as Mock<(...args: unknown[]) => void>;
+    const setUserMock = scope.setUser as unknown as Mock<(...args: unknown[]) => void>;
+
     runWithRequestContextAttributes(
       {
         traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
@@ -79,6 +93,38 @@ describe("request context job propagation", () => {
         });
       }
     );
+
+    expect(setTagMock).toHaveBeenCalledWith("request_id", "request-1");
+    expect(setTagMock).toHaveBeenCalledWith("session_id", "session-1");
+    expect(setTagMock).toHaveBeenCalledWith("job_id", "job-worker-1");
+    expect(setTagMock).toHaveBeenCalledWith("user_id", "user-1");
+    expect(setTagMock).toHaveBeenCalledWith("trace_id", "4bf92f3577b34da6a3ce929d0e0e4736");
+    expect(setUserMock).toHaveBeenCalledWith({id: "user-1"});
+    expect(setContextMock).toHaveBeenCalledWith("request_context", {
+      jobId: "job-worker-1",
+      requestId: "request-1",
+      sessionId: "session-1",
+      spanId: "00f067aa0ba902b7",
+      traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+      traceSampled: true,
+      userId: "user-1",
+    });
+  });
+
+  it("sends context updates to Sentry for auth session changes", () => {
+    const scope = Sentry.getCurrentScope();
+    const setTagMock = scope.setTag as unknown as Mock<(...args: unknown[]) => void>;
+    const setUserMock = scope.setUser as unknown as Mock<(...args: unknown[]) => void>;
+
+    runWithRequestContext({requestId: "request-auth-1"}, () => {
+      setTagMock.mockClear();
+      setUserMock.mockClear();
+      setRequestContext({sessionId: "session-auth-1", userId: "user-auth-1"});
+    });
+
+    expect(setTagMock).toHaveBeenCalledWith("session_id", "session-auth-1");
+    expect(setTagMock).toHaveBeenCalledWith("user_id", "user-auth-1");
+    expect(setUserMock).toHaveBeenCalledWith({id: "user-auth-1"});
   });
 
   it("uses trace id as request id when attributes do not include request id", () => {

--- a/api/src/requestContext.ts
+++ b/api/src/requestContext.ts
@@ -1,0 +1,192 @@
+import {AsyncLocalStorage} from "node:async_hooks";
+import {randomUUID} from "node:crypto";
+import type express from "express";
+import type {JwtPayload} from "jsonwebtoken";
+
+const CLOUD_TRACE_CONTEXT_HEADER = "x-cloud-trace-context";
+const REQUEST_ID_HEADERS = ["x-request-id", "x-correlation-id", "x-transaction-id"];
+const SESSION_ID_HEADER = "x-session-id";
+const TRACE_PARENT_HEADER = "traceparent";
+
+export interface RequestContext {
+  requestId: string;
+  sessionId?: string;
+  spanId?: string;
+  traceId?: string;
+  traceSampled?: boolean;
+  userId?: string;
+}
+
+interface GoogleCloudTraceContext {
+  spanId?: string;
+  traceId?: string;
+  traceSampled?: boolean;
+}
+
+export interface JwtSessionPayload extends JwtPayload {
+  sid?: string;
+  sessionId?: string;
+}
+
+const requestContextStorage = new AsyncLocalStorage<RequestContext>();
+
+const getHeader = (req: express.Request, headerName: string): string | undefined => {
+  const value = req.header(headerName);
+  if (!Array.isArray(value)) {
+    return value;
+  }
+  return value[0];
+};
+
+const parseGoogleCloudTraceContext = (
+  headerValue?: string
+): GoogleCloudTraceContext | undefined => {
+  if (!headerValue) {
+    return undefined;
+  }
+
+  const [traceAndSpan, options] = headerValue.split(";");
+  const [traceId, spanId] = traceAndSpan.split("/");
+  if (!traceId) {
+    return undefined;
+  }
+
+  return {
+    spanId,
+    traceId,
+    traceSampled: options === "o=1",
+  };
+};
+
+const parseTraceParent = (headerValue?: string): GoogleCloudTraceContext | undefined => {
+  if (!headerValue) {
+    return undefined;
+  }
+
+  const [_version, traceId, spanId, flags] = headerValue.split("-");
+  if (!traceId) {
+    return undefined;
+  }
+
+  return {
+    spanId,
+    traceId,
+    traceSampled: flags === "01",
+  };
+};
+
+const getIncomingRequestId = (
+  req: express.Request,
+  traceContext?: GoogleCloudTraceContext
+): string => {
+  for (const headerName of REQUEST_ID_HEADERS) {
+    const headerValue = getHeader(req, headerName);
+    if (headerValue) {
+      return headerValue;
+    }
+  }
+
+  if (traceContext?.traceId) {
+    return traceContext.traceId;
+  }
+
+  return randomUUID();
+};
+
+export const getSessionIdFromJwtPayload = (
+  payload?: JwtSessionPayload | null
+): string | undefined => {
+  if (!payload) {
+    return undefined;
+  }
+  if (payload.sid) {
+    return payload.sid;
+  }
+  return payload.sessionId;
+};
+
+export const getCurrentRequestContext = (): RequestContext | undefined => {
+  return requestContextStorage.getStore();
+};
+
+export const getCurrentLogContext = (): Partial<RequestContext> => {
+  const context = getCurrentRequestContext();
+  if (!context) {
+    return {};
+  }
+
+  return {
+    requestId: context.requestId,
+    sessionId: context.sessionId,
+    spanId: context.spanId,
+    traceId: context.traceId,
+    traceSampled: context.traceSampled,
+    userId: context.userId,
+  };
+};
+
+export const setRequestContext = (updates: Partial<RequestContext>): void => {
+  const context = getCurrentRequestContext();
+  if (!context) {
+    return;
+  }
+  Object.assign(context, updates);
+};
+
+export const updateRequestContextFromRequest = (
+  req: express.Request,
+  res?: express.Response
+): void => {
+  const reqWithContext = req as express.Request & {
+    authTokenPayload?: JwtSessionPayload;
+    betterAuthSession?: {session?: {id?: string}};
+    sessionId?: string;
+  };
+  const sessionId =
+    getSessionIdFromJwtPayload(reqWithContext.authTokenPayload) ??
+    reqWithContext.betterAuthSession?.session?.id ??
+    reqWithContext.sessionId ??
+    getHeader(req, SESSION_ID_HEADER);
+  const userId = req.user?.id ?? (req.user?._id ? String(req.user._id) : undefined);
+
+  setRequestContext({sessionId, userId});
+
+  if (sessionId) {
+    reqWithContext.sessionId = sessionId;
+    res?.setHeader("X-Session-ID", sessionId);
+  }
+};
+
+export const requestContextMiddleware = (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+): void => {
+  const cloudTraceContext = parseGoogleCloudTraceContext(
+    getHeader(req, CLOUD_TRACE_CONTEXT_HEADER)
+  );
+  const traceParentContext = parseTraceParent(getHeader(req, TRACE_PARENT_HEADER));
+  const traceContext = cloudTraceContext ?? traceParentContext;
+  const requestId = getIncomingRequestId(req, traceContext);
+  const sessionId = getHeader(req, SESSION_ID_HEADER);
+
+  const context: RequestContext = {
+    requestId,
+    sessionId,
+    spanId: traceContext?.spanId,
+    traceId: traceContext?.traceId,
+    traceSampled: traceContext?.traceSampled,
+  };
+
+  req.requestId = requestId;
+  if (sessionId) {
+    req.sessionId = sessionId;
+  }
+  res.setHeader("X-Request-ID", requestId);
+
+  requestContextStorage.run(context, () => {
+    updateRequestContextFromRequest(req, res);
+    next();
+  });
+};
+

--- a/api/src/requestContext.ts
+++ b/api/src/requestContext.ts
@@ -4,11 +4,17 @@ import type express from "express";
 import type {JwtPayload} from "jsonwebtoken";
 
 const CLOUD_TRACE_CONTEXT_HEADER = "x-cloud-trace-context";
+const JOB_ID_HEADER = "x-job-id";
 const REQUEST_ID_HEADERS = ["x-request-id", "x-correlation-id", "x-transaction-id"];
 const SESSION_ID_HEADER = "x-session-id";
+const SPAN_ID_HEADER = "x-span-id";
+const TRACE_ID_HEADER = "x-trace-id";
 const TRACE_PARENT_HEADER = "traceparent";
+const TRACE_SAMPLED_HEADER = "x-trace-sampled";
+const USER_ID_HEADER = "x-user-id";
 
 export interface RequestContext {
+  jobId?: string;
   requestId: string;
   sessionId?: string;
   spanId?: string;
@@ -16,6 +22,19 @@ export interface RequestContext {
   traceSampled?: boolean;
   userId?: string;
 }
+
+export type RequestContextAttributes = Record<string, string>;
+
+export const REQUEST_CONTEXT_ATTRIBUTE_NAMES = {
+  jobId: JOB_ID_HEADER,
+  requestId: "x-request-id",
+  sessionId: SESSION_ID_HEADER,
+  spanId: SPAN_ID_HEADER,
+  traceId: TRACE_ID_HEADER,
+  traceParent: TRACE_PARENT_HEADER,
+  traceSampled: TRACE_SAMPLED_HEADER,
+  userId: USER_ID_HEADER,
+} as const;
 
 interface GoogleCloudTraceContext {
   spanId?: string;
@@ -75,6 +94,19 @@ const parseTraceParent = (headerValue?: string): GoogleCloudTraceContext | undef
   };
 };
 
+const parseTraceSampled = (value?: string | boolean): boolean | undefined => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (value === "true" || value === "1") {
+    return true;
+  }
+  if (value === "false" || value === "0") {
+    return false;
+  }
+  return undefined;
+};
+
 const getIncomingRequestId = (
   req: express.Request,
   traceContext?: GoogleCloudTraceContext
@@ -105,6 +137,29 @@ export const getSessionIdFromJwtPayload = (
   return payload.sessionId;
 };
 
+export const getRequestContextFromAttributes = (
+  attributes: Record<string, string | undefined> = {}
+): RequestContext => {
+  const cloudTraceContext = parseGoogleCloudTraceContext(attributes[CLOUD_TRACE_CONTEXT_HEADER]);
+  const traceParentContext = parseTraceParent(attributes[TRACE_PARENT_HEADER]);
+  const traceContext = cloudTraceContext ?? traceParentContext;
+
+  return {
+    jobId: attributes[JOB_ID_HEADER],
+    requestId:
+      attributes[REQUEST_CONTEXT_ATTRIBUTE_NAMES.requestId] ??
+      attributes["x-correlation-id"] ??
+      attributes["x-transaction-id"] ??
+      traceContext?.traceId ??
+      randomUUID(),
+    sessionId: attributes[SESSION_ID_HEADER],
+    spanId: attributes[SPAN_ID_HEADER] ?? traceContext?.spanId,
+    traceId: attributes[TRACE_ID_HEADER] ?? traceContext?.traceId,
+    traceSampled: parseTraceSampled(attributes[TRACE_SAMPLED_HEADER]) ?? traceContext?.traceSampled,
+    userId: attributes[USER_ID_HEADER],
+  };
+};
+
 export const getCurrentRequestContext = (): RequestContext | undefined => {
   return requestContextStorage.getStore();
 };
@@ -116,6 +171,7 @@ export const getCurrentLogContext = (): Partial<RequestContext> => {
   }
 
   return {
+    jobId: context.jobId,
     requestId: context.requestId,
     sessionId: context.sessionId,
     spanId: context.spanId,
@@ -133,6 +189,52 @@ export const setRequestContext = (updates: Partial<RequestContext>): void => {
   Object.assign(context, updates);
 };
 
+const setAttribute = (
+  attributes: RequestContextAttributes,
+  name: string,
+  value?: string | boolean
+): void => {
+  if (typeof value === "undefined") {
+    return;
+  }
+  attributes[name] = String(value);
+};
+
+export const getCurrentRequestContextAttributes = (
+  overrides: Partial<RequestContext> = {}
+): RequestContextAttributes => {
+  const context = {...getCurrentLogContext(), ...overrides};
+  const attributes: RequestContextAttributes = {};
+  setAttribute(attributes, REQUEST_CONTEXT_ATTRIBUTE_NAMES.requestId, context.requestId);
+  setAttribute(attributes, REQUEST_CONTEXT_ATTRIBUTE_NAMES.sessionId, context.sessionId);
+  setAttribute(attributes, REQUEST_CONTEXT_ATTRIBUTE_NAMES.jobId, context.jobId);
+  setAttribute(attributes, REQUEST_CONTEXT_ATTRIBUTE_NAMES.userId, context.userId);
+  setAttribute(attributes, REQUEST_CONTEXT_ATTRIBUTE_NAMES.traceId, context.traceId);
+  setAttribute(attributes, REQUEST_CONTEXT_ATTRIBUTE_NAMES.spanId, context.spanId);
+  setAttribute(attributes, REQUEST_CONTEXT_ATTRIBUTE_NAMES.traceSampled, context.traceSampled);
+  return attributes;
+};
+
+export const runWithRequestContext = <T>(
+  context: Partial<RequestContext>,
+  callback: () => T
+): T => {
+  return requestContextStorage.run(
+    {
+      ...context,
+      requestId: context.requestId ?? randomUUID(),
+    },
+    callback
+  );
+};
+
+export const runWithRequestContextAttributes = <T>(
+  attributes: Record<string, string | undefined> = {},
+  callback: () => T
+): T => {
+  return runWithRequestContext(getRequestContextFromAttributes(attributes), callback);
+};
+
 export const updateRequestContextFromRequest = (
   req: express.Request,
   res?: express.Response
@@ -140,9 +242,11 @@ export const updateRequestContextFromRequest = (
   const reqWithContext = req as express.Request & {
     authTokenPayload?: JwtSessionPayload;
     betterAuthSession?: {session?: {id?: string}};
+    jobId?: string;
     requestId?: string;
     sessionId?: string;
   };
+  const jobId = reqWithContext.jobId ?? getHeader(req, JOB_ID_HEADER);
   const sessionId =
     getSessionIdFromJwtPayload(reqWithContext.authTokenPayload) ??
     reqWithContext.betterAuthSession?.session?.id ??
@@ -151,7 +255,12 @@ export const updateRequestContextFromRequest = (
   const user = req.user as {_id?: unknown; id?: string} | undefined;
   const userId = user?.id ?? (user?._id ? String(user._id) : undefined);
 
-  setRequestContext({sessionId, userId});
+  setRequestContext({jobId, sessionId, userId});
+
+  if (jobId) {
+    reqWithContext.jobId = jobId;
+    res?.setHeader("X-Job-ID", jobId);
+  }
 
   if (sessionId) {
     reqWithContext.sessionId = sessionId;
@@ -170,9 +279,11 @@ export const requestContextMiddleware = (
   const traceParentContext = parseTraceParent(getHeader(req, TRACE_PARENT_HEADER));
   const traceContext = cloudTraceContext ?? traceParentContext;
   const requestId = getIncomingRequestId(req, traceContext);
+  const jobId = getHeader(req, JOB_ID_HEADER);
   const sessionId = getHeader(req, SESSION_ID_HEADER);
 
   const context: RequestContext = {
+    jobId,
     requestId,
     sessionId,
     spanId: traceContext?.spanId,
@@ -180,7 +291,14 @@ export const requestContextMiddleware = (
     traceSampled: traceContext?.traceSampled,
   };
 
-  const reqWithContext = req as express.Request & {requestId?: string; sessionId?: string};
+  const reqWithContext = req as express.Request & {
+    jobId?: string;
+    requestId?: string;
+    sessionId?: string;
+  };
+  if (jobId) {
+    reqWithContext.jobId = jobId;
+  }
   reqWithContext.requestId = requestId;
   if (sessionId) {
     reqWithContext.sessionId = sessionId;

--- a/api/src/requestContext.ts
+++ b/api/src/requestContext.ts
@@ -1,5 +1,6 @@
 import {AsyncLocalStorage} from "node:async_hooks";
 import {randomUUID} from "node:crypto";
+import * as Sentry from "@sentry/bun";
 import type express from "express";
 import type {JwtPayload} from "jsonwebtoken";
 
@@ -181,12 +182,65 @@ export const getCurrentLogContext = (): Partial<RequestContext> => {
   };
 };
 
+const setSentryTag = (
+  scope: ReturnType<typeof Sentry.getCurrentScope>,
+  name: string,
+  value?: string | boolean
+): void => {
+  if (typeof value === "undefined") {
+    return;
+  }
+  scope.setTag(name, String(value));
+};
+
+const setSentryContextValue = (
+  context: Record<string, string | boolean>,
+  name: string,
+  value?: string | boolean
+): void => {
+  if (typeof value === "undefined") {
+    return;
+  }
+  context[name] = value;
+};
+
+export const applyRequestContextToSentry = (
+  context: Partial<RequestContext> = getCurrentLogContext()
+): void => {
+  const scope = Sentry.getCurrentScope();
+  setSentryTag(scope, "request_id", context.requestId);
+  setSentryTag(scope, "session_id", context.sessionId);
+  setSentryTag(scope, "job_id", context.jobId);
+  setSentryTag(scope, "user_id", context.userId);
+  setSentryTag(scope, "trace_id", context.traceId);
+  setSentryTag(scope, "span_id", context.spanId);
+  setSentryTag(scope, "trace_sampled", context.traceSampled);
+
+  if (context.userId) {
+    scope.setUser({id: context.userId});
+  }
+
+  const sentryContext: Record<string, string | boolean> = {};
+  setSentryContextValue(sentryContext, "requestId", context.requestId);
+  setSentryContextValue(sentryContext, "sessionId", context.sessionId);
+  setSentryContextValue(sentryContext, "jobId", context.jobId);
+  setSentryContextValue(sentryContext, "userId", context.userId);
+  setSentryContextValue(sentryContext, "traceId", context.traceId);
+  setSentryContextValue(sentryContext, "spanId", context.spanId);
+  setSentryContextValue(sentryContext, "traceSampled", context.traceSampled);
+
+  if (Object.keys(sentryContext).length > 0) {
+    scope.setContext("request_context", sentryContext);
+  }
+};
+
 export const setRequestContext = (updates: Partial<RequestContext>): void => {
   const context = getCurrentRequestContext();
   if (!context) {
     return;
   }
   Object.assign(context, updates);
+  applyRequestContextToSentry(context);
 };
 
 const setAttribute = (
@@ -219,13 +273,15 @@ export const runWithRequestContext = <T>(
   context: Partial<RequestContext>,
   callback: () => T
 ): T => {
-  return requestContextStorage.run(
-    {
-      ...context,
-      requestId: context.requestId ?? randomUUID(),
-    },
-    callback
-  );
+  const nextContext = {
+    ...context,
+    requestId: context.requestId ?? randomUUID(),
+  };
+
+  return requestContextStorage.run(nextContext, () => {
+    applyRequestContextToSentry(nextContext);
+    return callback();
+  });
 };
 
 export const runWithRequestContextAttributes = <T>(

--- a/api/src/requestContext.ts
+++ b/api/src/requestContext.ts
@@ -189,4 +189,3 @@ export const requestContextMiddleware = (
     next();
   });
 };
-

--- a/api/src/requestContext.ts
+++ b/api/src/requestContext.ts
@@ -140,6 +140,7 @@ export const updateRequestContextFromRequest = (
   const reqWithContext = req as express.Request & {
     authTokenPayload?: JwtSessionPayload;
     betterAuthSession?: {session?: {id?: string}};
+    requestId?: string;
     sessionId?: string;
   };
   const sessionId =
@@ -147,7 +148,8 @@ export const updateRequestContextFromRequest = (
     reqWithContext.betterAuthSession?.session?.id ??
     reqWithContext.sessionId ??
     getHeader(req, SESSION_ID_HEADER);
-  const userId = req.user?.id ?? (req.user?._id ? String(req.user._id) : undefined);
+  const user = req.user as {_id?: unknown; id?: string} | undefined;
+  const userId = user?.id ?? (user?._id ? String(user._id) : undefined);
 
   setRequestContext({sessionId, userId});
 
@@ -178,9 +180,10 @@ export const requestContextMiddleware = (
     traceSampled: traceContext?.traceSampled,
   };
 
-  req.requestId = requestId;
+  const reqWithContext = req as express.Request & {requestId?: string; sessionId?: string};
+  reqWithContext.requestId = requestId;
   if (sessionId) {
-    req.sessionId = sessionId;
+    reqWithContext.sessionId = sessionId;
   }
   res.setHeader("X-Request-ID", requestId);
 

--- a/api/src/terrenoApp.ts
+++ b/api/src/terrenoApp.ts
@@ -11,6 +11,11 @@ import {addGitHubAuthRoutes, type GitHubAuthOptions, setupGitHubAuth} from "./gi
 import {type LoggingOptions, logger, setupLogging} from "./logger";
 import {openApiCompatMiddleware, patchAppUse} from "./openApiCompat";
 import {openApiEtagMiddleware} from "./openApiEtag";
+import {
+  getCurrentRequestContext,
+  requestContextMiddleware,
+  updateRequestContextFromRequest,
+} from "./requestContext";
 import type {TerrenoPlugin} from "./terrenoPlugin";
 import openapi from "./vendor/wesleytodd-openapi/index";
 
@@ -240,6 +245,8 @@ export class TerrenoApp {
       qs.parse(str, {arrayLimit: options.arrayLimit ?? 200})
     );
 
+    app.use(requestContextMiddleware);
+
     app.use(cors({credentials: true, origin: options.corsOrigin ?? "*"}));
 
     // Apply custom middleware before JSON parsing
@@ -258,6 +265,10 @@ export class TerrenoApp {
     // Auth routes (login/signup/refresh_token) before JWT middleware
     addAuthRoutes(app, options.userModel, options.authOptions);
     setupAuth(app, options.userModel);
+    app.use((req, res, next) => {
+      updateRequestContextFromRequest(req, res);
+      next();
+    });
 
     if (options.logRequests !== false) {
       app.use(logRequests);
@@ -271,8 +282,12 @@ export class TerrenoApp {
 
     // Sentry scopes
     app.use((req: express.Request, _res: express.Response, next: express.NextFunction) => {
+      const context = getCurrentRequestContext();
       const transactionId = req.header("X-Transaction-ID");
-      const sessionId = req.header("X-Session-ID");
+      const sessionId = context?.sessionId ?? req.header("X-Session-ID");
+      if (context?.requestId) {
+        Sentry.getCurrentScope().setTag("request_id", context.requestId);
+      }
       if (transactionId) {
         Sentry.getCurrentScope().setTag("transaction_id", transactionId);
       }


### PR DESCRIPTION
Trying out a system to give us request ids (a single request and the downstream effects) and session ids (all the things a user has done in a session, so we can see the multiple requests more easily). Also tie Sentry to errors so we can trace more easily. 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add request-scoped correlation metadata for request IDs, session IDs, user IDs, and trace fields.
- Preserve JWT session IDs across token refreshes.
- Attach correlation metadata to Winston logs for structured transports such as Google Cloud Logging.
- Add tests covering logger metadata, JWT session preservation, and modelRouter hook/response propagation.
- Fix CI lint formatting and cross-package TypeScript issues.

### Testing
- `bun run lint`
- `bun run compile`
- `bun run admin-backend:compile`
- `bun test --preload ./src/tests/bunSetup.ts src/auth.test.ts src/expressServer.test.ts`
- `bun run test:ci`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ae0ba73-2093-4bf5-b85c-196651dd76d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ae0ba73-2093-4bf5-b85c-196651dd76d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

