### PR TITLE
Update rulesync check workflow

### DIFF
--- a/.agents/skills/ai-prompt-governance/SKILL.md
+++ b/.agents/skills/ai-prompt-governance/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: ai-prompt-governance
+description: >-
+  Invoke when adding, modifying, or reviewing any prompt used by `@terreno/ai`
+  (AIService methods, system prompts, helpers). Provides prompt-as-constant
+  rules, temperature preset guidance, logging requirements, and a testing
+  checklist.
+---
+# AI Prompt Governance — `@terreno/ai`
+
+`@terreno/ai` is a backend-only, provider-agnostic AI layer built on the Vercel AI SDK. Consuming apps inject a `LanguageModel` (Google, Anthropic, OpenAI, etc.) and call `AIService` methods. All requests are logged through the `AIRequest` model.
+
+See `ai/src/service/aiService.ts` and `ai/src/service/prompts.ts` for the canonical implementation.
+
+## Prompt Writing Rules
+
+1. **Always a named constant** — Define prompts in `ai/src/service/prompts.ts` (or the consuming app's equivalent constants file). Never inline prompt strings in route handlers, services, or `AIService` method bodies.
+2. **Self-contained** — A prompt should read coherently on its own. If you must inject runtime context, document why in a comment above the constant.
+3. **Typed return** — If the prompt asks for structured JSON, define a matching TypeScript interface in `ai/src/types/index.ts` and parse against it on every response.
+4. **Don't bake user-identifiable data into the prompt template itself** — inject it at call time as runtime parameters, never as defaults in the constant.
+
+## Temperature Preset Guidance
+
+Use the presets exported from `@terreno/ai`:
+
+| Preset | Value | When to use |
+|--------|-------|-------------|
+| `DETERMINISTIC` | 0 | Structured extraction, classification, deterministic transforms |
+| `LOW` | 0.3 | Summarization, translation, faithful rewording |
+| `BALANCED` | 0.7 | General Q&A, balanced creativity |
+| `DEFAULT` | 1.0 | Chat, open-ended responses |
+| `HIGH` | 1.5 | Brainstorming, creative variation |
+| `MAXIMUM` | 2.0 | Maximum variability — rarely the right choice |
+
+Pick the lowest temperature that still produces good results. Don't override the default unless you can name a reason in the call site.
+
+## Logging
+
+Every `AIService` method already logs to the `AIRequest` model via the internal `logRequest()` call. Do not bypass `AIService` and call the Vercel SDK directly from routes — you lose request logging, error capture, and the `requestType` taxonomy.
+
+Current `AIRequest.requestType` values: `"general" | "remix" | "summarization" | "translation"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
+
+Logging failures must never break the main flow — the existing pattern catches and logs internally. Preserve that behavior.
+
+## Testing a Prompt Change
+
+`@terreno/ai` tests inject a mock `LanguageModel` with `doGenerate` / `doStream` methods. See the mock pattern in `ai/src/aiApp.test.ts`. Never hit a live provider in unit tests.
+
+1. Add or update a unit test that mocks `doGenerate` / `doStream` and asserts the prompt your code sends matches expectations.
+2. Run against at least 3 inputs:
+   - A normal/expected case
+   - An edge case (empty input, very long input, missing optional fields)
+   - An adversarial case that could break structured JSON output
+3. For structured JSON: assert the response parses against the typed return interface.
+4. If the prompt affects streaming behavior, mock `doStream` and assert the emitted chunks.
+
+For a one-off manual smoke against a real provider, temporarily add `logger.debug("prompt test", {prompt, response})` in the `AIService` method, run locally, then remove the log before committing.
+
+## Prompt Change Checklist
+
+- [ ] Prompt is a named constant in `prompts.ts` (or app equivalent) — not inlined
+- [ ] Prompt still produces valid, parseable structured JSON if applicable (tested with 3+ inputs)
+- [ ] Temperature preset is appropriate (lowest viable for the task)
+- [ ] Call goes through `AIService` (so `AIRequest` logging fires) — no direct Vercel SDK calls from routes
+- [ ] If `requestType` taxonomy changed, the type union and admin explorer filters were updated
+- [ ] No user-identifiable data baked into the prompt template (only injected at call time)
+- [ ] Unit test added/updated with a mock model
+- [ ] Commit message explains the behavioral change (the prompt is the behavior)
+
+## Adding a New AI Feature
+
+1. Define prompt(s) as named constants in `ai/src/service/prompts.ts`.
+2. If structured JSON output, define the TypeScript interface for the return shape in `ai/src/types/index.ts`.
+3. Add a method to `AIService` (or a new service class) that calls `generateText` / `generateTextStream` and goes through the existing logging path.
+4. If exposing via HTTP, add a route in `ai/src/routes/` following the patterns in `gpt.ts` / `gptHistories.ts`. Use `createOpenApiBuilder` for OpenAPI docs.
+5. Add an integration test with a mock model that verifies:
+   - The prompt sent to the model matches the constant
+   - The structured JSON return parses against the typed interface
+   - `AIRequest.logRequest` is called with the correct `requestType`
+
+## Common Pitfalls
+
+- Calling the Vercel SDK directly from a route — bypasses logging and request typing
+- Inlining a prompt string in a route handler — makes future changes invisible and untestable
+- Using the wrong `requestType` value (or `"general"` as a catch-all) — degrades the admin explorer
+- Setting `temperature` numerically instead of via a preset — drifts away from the documented presets
+- Forgetting to type the JSON return — runtime parse failures show up later as confusing errors

--- a/.agents/skills/backend-test-env/SKILL.md
+++ b/.agents/skills/backend-test-env/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: backend-test-env
+description: >-
+  Invoke when writing tests that mutate `process.env` in `@terreno/api`,
+  `@terreno/ai`, or `example-backend` — feature flags, auth secrets, integration
+  toggles. Covers the preload contract, `setupEnvironment()`, and safe mutation
+  patterns.
+---
+# Backend Test — `process.env` Contract
+
+Bun's test runner preloads a per-package setup file (configured in each package's `bunfig.toml` under `[test].preload`):
+
+| Package | Preload file |
+|---------|--------------|
+| `@terreno/api` | `api/src/tests/bunSetup.ts` |
+| `@terreno/ai` | `ai/src/tests/bunSetup.ts` |
+| `example-backend` | `example-backend/src/tests/setup.ts` |
+
+The `@terreno/api` preload uses a global `beforeEach` to (1) reset the canonical auth secrets, (2) call `setupEnvironment()` (exported from `expressServer.ts`) for the wider baseline, and (3) re-silence the winston loggers. The next test always starts from the canonical baseline — you normally **do not** need to re-call `setupEnvironment()` in a file-level `beforeEach`.
+
+## Default — Rely on the Preload
+
+- Do not assume a toggle left by another file. Treat the preload's `beforeEach` as the source of truth for the canonical baseline.
+- Set only the keys this test needs in its own `beforeEach` or test body.
+- Don't reach in and call `setupEnvironment()` again unless you're explicitly testing env-driven behavior that the preload didn't cover.
+
+## When a Test Mutates `process.env`
+
+1. **Add the key to the preload's reset list** if it should always start from a fixed test value. Otherwise it leaks into the next test in the same worker.
+2. **Set only what this case needs** in the test body — avoid redundant manual restore if the preload already resets that key in `beforeEach`.
+3. **For keys that should be absent (unset)**, use **`Reflect.deleteProperty(process.env, "KEY")`**. Avoid `process.env.KEY = ""` to mean "unset" — on some platforms empty string and unset behave differently and can make tests flaky.
+4. **Avoid whole-env snapshots** (`const OLD_ENV = process.env; ...; process.env = OLD_ENV;`). This pattern exists in some older test files (`auth.test.ts`) — don't propagate it. It captures pre-`beforeEach` state and breaks ordering guarantees if the preload's `beforeEach` runs in between. Use targeted mutations + the preload's reset instead.
+
+## Adding a New Required Env Var
+
+If you introduce a new `process.env.FOO` that backend code reads at startup:
+
+1. Add `FOO` to `setupEnvironment()` in `api/src/expressServer.ts` so every package picks it up via the preload's `setupEnvironment()` call.
+2. If `example-backend` has its own startup needs for it, also add to `example-backend/src/tests/setup.ts`'s `beforeAll`.
+3. If a test needs to mutate it, follow the rules above — don't snapshot the whole env.
+
+## Auth-Related Keys
+
+`api/src/tests/bunSetup.ts` resets four auth keys in `beforeEach`: `TOKEN_SECRET`, `TOKEN_ISSUER`, `SESSION_SECRET`, `REFRESH_TOKEN_SECRET`. If your test changes any of these, you do not need to restore — the next `beforeEach` already does. If your test relies on them being **absent** for a code path, use `Reflect.deleteProperty` within the test, knowing the next `beforeEach` will restore.
+
+`auth.test.ts` is the established home for env-driven auth assertions; mirror its newer patterns (per-test `beforeEach` setting only what changes) rather than its older whole-env-snapshot blocks.
+
+## Log Capture & Sentry
+
+The preload silences winston and `console.*` and captures into an in-memory buffer (cleared in `beforeEach`/`afterEach`). It also mocks `@sentry/bun`. Don't re-mock Sentry inside individual tests — the preload's mock is shared and reset across tests.
+
+## Checklist
+
+- [ ] New env var added to `setupEnvironment()` and (if needed) `example-backend/src/tests/setup.ts`
+- [ ] Test mutations are targeted — no whole-env snapshots
+- [ ] "Unset" expressed as `Reflect.deleteProperty(process.env, "KEY")`, not `= ""`
+- [ ] No manual restore that duplicates the preload's `beforeEach` reset
+- [ ] No re-mock of `@sentry/bun` — the preload's mock is already in place
+- [ ] If you added an env-driven branch in code, a test covers both the set and the unset case

--- a/.agents/skills/improve-rulesync/SKILL.md
+++ b/.agents/skills/improve-rulesync/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: improve-rulesync
+description: >-
+  Invoke at the end of a session to evaluate whether any skills or rules were
+  misleading, incorrect, or missing — and fix or create them. Trigger with
+  /improve-rulesync.
+---
+# Improve Rulesync
+
+### Trigger
+Invoke explicitly at the end of a session with `/improve-rulesync`.
+
+### Behavior
+Review the current conversation session and evaluate the skills and rules in `.rulesync/`. Identify any that:
+- Gave misleading or incorrect guidance that caused errors or rework
+- Were missing and would have prevented incorrect behavior
+- Need to be updated to reflect decisions or patterns established in this session
+
+Then make the changes directly.
+
+### Step 1 — Session Review
+Scan the session for:
+- Moments where a skill or rule was followed but produced a wrong or suboptimal result
+- User corrections or decisions about AI model behavior (these indicate a gap or error in the rules)
+- New patterns, decisions, or constraints established that should be codified
+
+### Step 2 — Rules Audit
+Check `.rulesync/` for relevant existing rules and skills. Evaluate:
+- Are trigger conditions accurate?
+- Is the guidance still correct given what happened this session?
+- Are there gaps that caused confusion?
+
+### Step 3 — Make Changes
+For each issue found:
+- **Incorrect/misleading**: Edit the existing file to fix it
+- **Missing**: Create a new skill or rule file in `.rulesync/skills/` or `.rulesync/rules/`
+- **Outdated**: Update or remove the stale content
+
+Always edit `.rulesync/` as the source of truth.
+
+### Step 4 — Sync
+After all changes, run `bun run rules` to sync to all AI tool directories.
+
+### Step 5 — Summary
+Output a brief summary of what was changed and why. Format:
+- **Fixed**: [file] — [what was wrong and what was corrected]
+- **Created**: [file] — [what gap it fills]
+- **No changes needed**: [reason]

--- a/.agents/skills/mongoose-schema-safety/SKILL.md
+++ b/.agents/skills/mongoose-schema-safety/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: mongoose-schema-safety
+description: >-
+  Invoke when making any Mongoose schema change: adding/removing/renaming
+  fields, creating a new model, adding indexes, or writing a backfill migration.
+  Provides the five-type pattern, risk matrix, type file checklist, and rollout
+  safety steps for terreno backends.
+---
+# Mongoose Schema Safety — Terreno
+
+## Where Schemas and Types Live
+
+| Package | Schemas | Types |
+|---------|---------|-------|
+| `@terreno/api` (built-in models like `User`, `ConsentForm`) | `api/src/models/*.ts` | `api/src/types/*.ts` (or co-located in the model file via `mongoose.Schema<Doc, Model, Methods>` generics) |
+| `example-backend` (`User`, `Todo`, `Configuration`) | `example-backend/src/models/*.ts` | `example-backend/src/types/models/*.ts` (`userTypes.ts`, `todoTypes.ts`, …) |
+| `@terreno/ai` (`AIRequest`, `GptHistory`) | `ai/src/models/*.ts` | `ai/src/types/index.ts` |
+
+Every field in every schema **must** have a `description` (see the API rule `01-model-field-descriptions.md`). Descriptions flow through to the OpenAPI spec via `mongoose-to-swagger`.
+
+## The Five-Type Pattern
+
+Every model has manually-maintained TypeScript types. **Types are NOT auto-generated** — every schema change must include a matching type update in the same commit/PR.
+
+```typescript
+import type {DefaultDoc, DefaultModel, DefaultStatics} from "@terreno/api";
+
+// 1. Instance methods (on the document)
+export type YourModelMethods = {
+  customMethod: (this: YourModelDocument, param: string) => Promise<void>;
+};
+
+// 2. Static methods (on the model class) — extend DefaultStatics for findExactlyOne / findOneOrNone
+export type YourModelStatics = DefaultStatics<YourModelDocument> & {
+  customStatic: (this: YourModelModel, param: string) => Promise<YourModelDocument>;
+};
+
+// 3. Model type combining document + statics
+export type YourModelModel = DefaultModel<YourModelDocument> & YourModelStatics;
+
+// 4. Schema type
+export type YourModelSchema = mongoose.Schema<YourModelDocument, YourModelModel, YourModelMethods>;
+
+// 5. Document type (the shape of a single record)
+export type YourModelDocument = DefaultDoc & YourModelMethods & {
+  fieldName: string;
+  optionalField?: number;
+  enumField: "value1" | "value2";
+};
+```
+
+Follow existing type files in `example-backend/src/types/models/` and `ai/src/types/index.ts` for naming and structure.
+
+## Statics & Methods — Direct Assignment
+
+Define statics and methods by direct assignment on the schema — not via `.method()` / `.static()` / `.add()`:
+
+```typescript
+schema.methods = {
+  getDisplayName(this: YourModelDocument): string { return this.name; },
+};
+schema.statics = {
+  async findByEmail(this: YourModelModel, email: string) { return this.findOne({email}); },
+};
+```
+
+## Critical Mongoose Rules
+
+- **Never use `Model.findOne`** — use `Model.findExactlyOne` (throws on 0 or many) or `Model.findOneOrNone` (throws on many). These come from the `findExactlyOne` / `findOneOrNone` plugins in `@terreno/api`.
+- Apply the standard plugins (`createdUpdatedPlugin`, `isDeletedPlugin`, `findOneOrNone`, `findExactlyOne`) on every new model. Most existing models go through `addDefaultPlugins`.
+- `checkModelsStrict()` runs at non-prod startup (`server.ts`) and validates schema consistency — keep it passing.
+
+## Schema Change Risk Matrix
+
+| Change Type | Risk Level | Required Mitigation |
+|-------------|-----------|---------------------|
+| Add optional field | Low | Safe to ship directly (still requires `description`) |
+| Add required field | High | Must provide a default value, OR write a backfill migration script first |
+| Remove field | Medium | Soft-remove first (mark optional, stop writing); hard-remove in next PR after deploys settle |
+| Rename field | High | Three-step: add new → backfill → remove old (separate PRs) |
+| Change field type | Critical | Treat as rename: new field + migration + remove old |
+| Add index | Medium | Safe in code, but build can slow writes on large collections — coordinate with ops |
+| Remove index | Low | Safe to ship directly |
+| Add unique index | High | Dedup migration must run first; otherwise the index build fails on existing duplicates |
+
+## Migration Scripts
+
+Migration / backfill scripts live in `example-backend/src/scripts/` (e.g. `syncConsents.ts`, `seedConsents.ts`). They use the `ScriptRunner` type and `BackgroundTask` model from `@terreno/api` (`api/src/scriptRunner.ts`):
+
+```typescript
+import type {ScriptContext, ScriptResult, ScriptRunner} from "@terreno/api";
+
+export const run: ScriptRunner = async (wetRun, ctx) => {
+  const results: string[] = [];
+  // ... do work ...
+  if (wetRun) {
+    // commit changes
+  }
+  return {success: true, results};
+};
+```
+
+Always run with `wetRun = false` first to verify the dry-run output. Use `ctx.checkCancellation()`, `ctx.addLog()`, and `ctx.updateProgress()` for long-running tasks.
+
+## Cross-Package Ripple
+
+A schema change in one place often ripples:
+
+- **API surface affected?** Regenerate the SDK with `cd example-frontend && bun run sdk` (or invoke the `generate-sdk` skill). The OpenAPI spec is derived from the schema, so the frontend hooks will go stale otherwise.
+- **`modelRouter` config?** If you added/removed a field, update `queryFields`, `populatePaths`, and `responseHandler` for any router that touches the model.
+- **Admin panel?** If the model is registered in `AdminApp`, update `listFields` so the table reflects the new shape.
+- **Populated refs?** If another model references this one via `ObjectId` + `ref`, and the referenced document shape changed, the consumer's populated type may need updating.
+
+## Post-Change Checklist
+
+- [ ] All new fields have a `description` (flows to OpenAPI)
+- [ ] Type file updated in the same commit/PR — field names, optionality, enum values, array types, refs, statics/methods all match the schema
+- [ ] For a new model: all five types (`Document`, `Methods`, `Statics`, `Model`, `Schema`) created
+- [ ] Statics/methods assigned directly on schema (`schema.statics = {...}`, `schema.methods = {...}`) — not `.static()` / `.method()`
+- [ ] Other model type files checked — any model that populates this one updated if its shape changed
+- [ ] Migration script written (and dry-run verified with `wetRun = false`) for any backfill
+- [ ] `modelRouter` config updated (`queryFields`, `populatePaths`, `responseHandler`) if needed
+- [ ] `AdminApp` `listFields` updated if the model is in the admin panel
+- [ ] `bun run sdk` run from `example-frontend/` if the API response shape changed
+- [ ] Test covers old-format document behavior (missing new field) if the change rolls out before a backfill
+- [ ] Unique index: dedup migration written and run before the index is added
+- [ ] `checkModelsStrict()` still passes (it runs on non-prod startup)
+- [ ] No `Model.findOne` introduced — use `findExactlyOne` / `findOneOrNone`
+
+## Common Pitfalls
+
+- Adding a required field without a default — first deploy fails for documents that pre-date the field
+- Skipping the type file update — TS happily compiles older callers but new ones break at runtime
+- Adding a `unique` index without dedup — index build fails on collections with existing duplicates
+- Renaming a field in one PR — frontend gets old field, backend writes new field, neither side is happy
+- Forgetting to regenerate the SDK after a shape change — frontend types drift from reality
+- Using `.method()` / `.static()` API — terreno's convention is direct assignment, and mixing styles makes types hard to maintain

--- a/.cursor/skills/ai-prompt-governance/SKILL.md
+++ b/.cursor/skills/ai-prompt-governance/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: ai-prompt-governance
+description: Invoke when adding, modifying, or reviewing any prompt used by `@terreno/ai` (AIService methods, system prompts, helpers). Provides prompt-as-constant rules, temperature preset guidance, logging requirements, and a testing checklist.
+---
+# AI Prompt Governance — `@terreno/ai`
+
+`@terreno/ai` is a backend-only, provider-agnostic AI layer built on the Vercel AI SDK. Consuming apps inject a `LanguageModel` (Google, Anthropic, OpenAI, etc.) and call `AIService` methods. All requests are logged through the `AIRequest` model.
+
+See `ai/src/service/aiService.ts` and `ai/src/service/prompts.ts` for the canonical implementation.
+
+## Prompt Writing Rules
+
+1. **Always a named constant** — Define prompts in `ai/src/service/prompts.ts` (or the consuming app's equivalent constants file). Never inline prompt strings in route handlers, services, or `AIService` method bodies.
+2. **Self-contained** — A prompt should read coherently on its own. If you must inject runtime context, document why in a comment above the constant.
+3. **Typed return** — If the prompt asks for structured JSON, define a matching TypeScript interface in `ai/src/types/index.ts` and parse against it on every response.
+4. **Don't bake user-identifiable data into the prompt template itself** — inject it at call time as runtime parameters, never as defaults in the constant.
+
+## Temperature Preset Guidance
+
+Use the presets exported from `@terreno/ai`:
+
+| Preset | Value | When to use |
+|--------|-------|-------------|
+| `DETERMINISTIC` | 0 | Structured extraction, classification, deterministic transforms |
+| `LOW` | 0.3 | Summarization, translation, faithful rewording |
+| `BALANCED` | 0.7 | General Q&A, balanced creativity |
+| `DEFAULT` | 1.0 | Chat, open-ended responses |
+| `HIGH` | 1.5 | Brainstorming, creative variation |
+| `MAXIMUM` | 2.0 | Maximum variability — rarely the right choice |
+
+Pick the lowest temperature that still produces good results. Don't override the default unless you can name a reason in the call site.
+
+## Logging
+
+Every `AIService` method already logs to the `AIRequest` model via the internal `logRequest()` call. Do not bypass `AIService` and call the Vercel SDK directly from routes — you lose request logging, error capture, and the `requestType` taxonomy.
+
+Current `AIRequest.requestType` values: `"general" | "remix" | "summarization" | "translation"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
+
+Logging failures must never break the main flow — the existing pattern catches and logs internally. Preserve that behavior.
+
+## Testing a Prompt Change
+
+`@terreno/ai` tests inject a mock `LanguageModel` with `doGenerate` / `doStream` methods. See the mock pattern in `ai/src/aiApp.test.ts`. Never hit a live provider in unit tests.
+
+1. Add or update a unit test that mocks `doGenerate` / `doStream` and asserts the prompt your code sends matches expectations.
+2. Run against at least 3 inputs:
+   - A normal/expected case
+   - An edge case (empty input, very long input, missing optional fields)
+   - An adversarial case that could break structured JSON output
+3. For structured JSON: assert the response parses against the typed return interface.
+4. If the prompt affects streaming behavior, mock `doStream` and assert the emitted chunks.
+
+For a one-off manual smoke against a real provider, temporarily add `logger.debug("prompt test", {prompt, response})` in the `AIService` method, run locally, then remove the log before committing.
+
+## Prompt Change Checklist
+
+- [ ] Prompt is a named constant in `prompts.ts` (or app equivalent) — not inlined
+- [ ] Prompt still produces valid, parseable structured JSON if applicable (tested with 3+ inputs)
+- [ ] Temperature preset is appropriate (lowest viable for the task)
+- [ ] Call goes through `AIService` (so `AIRequest` logging fires) — no direct Vercel SDK calls from routes
+- [ ] If `requestType` taxonomy changed, the type union and admin explorer filters were updated
+- [ ] No user-identifiable data baked into the prompt template (only injected at call time)
+- [ ] Unit test added/updated with a mock model
+- [ ] Commit message explains the behavioral change (the prompt is the behavior)
+
+## Adding a New AI Feature
+
+1. Define prompt(s) as named constants in `ai/src/service/prompts.ts`.
+2. If structured JSON output, define the TypeScript interface for the return shape in `ai/src/types/index.ts`.
+3. Add a method to `AIService` (or a new service class) that calls `generateText` / `generateTextStream` and goes through the existing logging path.
+4. If exposing via HTTP, add a route in `ai/src/routes/` following the patterns in `gpt.ts` / `gptHistories.ts`. Use `createOpenApiBuilder` for OpenAPI docs.
+5. Add an integration test with a mock model that verifies:
+   - The prompt sent to the model matches the constant
+   - The structured JSON return parses against the typed interface
+   - `AIRequest.logRequest` is called with the correct `requestType`
+
+## Common Pitfalls
+
+- Calling the Vercel SDK directly from a route — bypasses logging and request typing
+- Inlining a prompt string in a route handler — makes future changes invisible and untestable
+- Using the wrong `requestType` value (or `"general"` as a catch-all) — degrades the admin explorer
+- Setting `temperature` numerically instead of via a preset — drifts away from the documented presets
+- Forgetting to type the JSON return — runtime parse failures show up later as confusing errors

--- a/.cursor/skills/backend-test-env/SKILL.md
+++ b/.cursor/skills/backend-test-env/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: backend-test-env
+description: Invoke when writing tests that mutate `process.env` in `@terreno/api`, `@terreno/ai`, or `example-backend` — feature flags, auth secrets, integration toggles. Covers the preload contract, `setupEnvironment()`, and safe mutation patterns.
+---
+# Backend Test — `process.env` Contract
+
+Bun's test runner preloads a per-package setup file (configured in each package's `bunfig.toml` under `[test].preload`):
+
+| Package | Preload file |
+|---------|--------------|
+| `@terreno/api` | `api/src/tests/bunSetup.ts` |
+| `@terreno/ai` | `ai/src/tests/bunSetup.ts` |
+| `example-backend` | `example-backend/src/tests/setup.ts` |
+
+The `@terreno/api` preload uses a global `beforeEach` to (1) reset the canonical auth secrets, (2) call `setupEnvironment()` (exported from `expressServer.ts`) for the wider baseline, and (3) re-silence the winston loggers. The next test always starts from the canonical baseline — you normally **do not** need to re-call `setupEnvironment()` in a file-level `beforeEach`.
+
+## Default — Rely on the Preload
+
+- Do not assume a toggle left by another file. Treat the preload's `beforeEach` as the source of truth for the canonical baseline.
+- Set only the keys this test needs in its own `beforeEach` or test body.
+- Don't reach in and call `setupEnvironment()` again unless you're explicitly testing env-driven behavior that the preload didn't cover.
+
+## When a Test Mutates `process.env`
+
+1. **Add the key to the preload's reset list** if it should always start from a fixed test value. Otherwise it leaks into the next test in the same worker.
+2. **Set only what this case needs** in the test body — avoid redundant manual restore if the preload already resets that key in `beforeEach`.
+3. **For keys that should be absent (unset)**, use **`Reflect.deleteProperty(process.env, "KEY")`**. Avoid `process.env.KEY = ""` to mean "unset" — on some platforms empty string and unset behave differently and can make tests flaky.
+4. **Avoid whole-env snapshots** (`const OLD_ENV = process.env; ...; process.env = OLD_ENV;`). This pattern exists in some older test files (`auth.test.ts`) — don't propagate it. It captures pre-`beforeEach` state and breaks ordering guarantees if the preload's `beforeEach` runs in between. Use targeted mutations + the preload's reset instead.
+
+## Adding a New Required Env Var
+
+If you introduce a new `process.env.FOO` that backend code reads at startup:
+
+1. Add `FOO` to `setupEnvironment()` in `api/src/expressServer.ts` so every package picks it up via the preload's `setupEnvironment()` call.
+2. If `example-backend` has its own startup needs for it, also add to `example-backend/src/tests/setup.ts`'s `beforeAll`.
+3. If a test needs to mutate it, follow the rules above — don't snapshot the whole env.
+
+## Auth-Related Keys
+
+`api/src/tests/bunSetup.ts` resets four auth keys in `beforeEach`: `TOKEN_SECRET`, `TOKEN_ISSUER`, `SESSION_SECRET`, `REFRESH_TOKEN_SECRET`. If your test changes any of these, you do not need to restore — the next `beforeEach` already does. If your test relies on them being **absent** for a code path, use `Reflect.deleteProperty` within the test, knowing the next `beforeEach` will restore.
+
+`auth.test.ts` is the established home for env-driven auth assertions; mirror its newer patterns (per-test `beforeEach` setting only what changes) rather than its older whole-env-snapshot blocks.
+
+## Log Capture & Sentry
+
+The preload silences winston and `console.*` and captures into an in-memory buffer (cleared in `beforeEach`/`afterEach`). It also mocks `@sentry/bun`. Don't re-mock Sentry inside individual tests — the preload's mock is shared and reset across tests.
+
+## Checklist
+
+- [ ] New env var added to `setupEnvironment()` and (if needed) `example-backend/src/tests/setup.ts`
+- [ ] Test mutations are targeted — no whole-env snapshots
+- [ ] "Unset" expressed as `Reflect.deleteProperty(process.env, "KEY")`, not `= ""`
+- [ ] No manual restore that duplicates the preload's `beforeEach` reset
+- [ ] No re-mock of `@sentry/bun` — the preload's mock is already in place
+- [ ] If you added an env-driven branch in code, a test covers both the set and the unset case

--- a/.cursor/skills/improve-rulesync/SKILL.md
+++ b/.cursor/skills/improve-rulesync/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: improve-rulesync
+description: Invoke at the end of a session to evaluate whether any skills or rules were misleading, incorrect, or missing — and fix or create them. Trigger with /improve-rulesync.
+---
+# Improve Rulesync
+
+### Trigger
+Invoke explicitly at the end of a session with `/improve-rulesync`.
+
+### Behavior
+Review the current conversation session and evaluate the skills and rules in `.rulesync/`. Identify any that:
+- Gave misleading or incorrect guidance that caused errors or rework
+- Were missing and would have prevented incorrect behavior
+- Need to be updated to reflect decisions or patterns established in this session
+
+Then make the changes directly.
+
+### Step 1 — Session Review
+Scan the session for:
+- Moments where a skill or rule was followed but produced a wrong or suboptimal result
+- User corrections or decisions about AI model behavior (these indicate a gap or error in the rules)
+- New patterns, decisions, or constraints established that should be codified
+
+### Step 2 — Rules Audit
+Check `.rulesync/` for relevant existing rules and skills. Evaluate:
+- Are trigger conditions accurate?
+- Is the guidance still correct given what happened this session?
+- Are there gaps that caused confusion?
+
+### Step 3 — Make Changes
+For each issue found:
+- **Incorrect/misleading**: Edit the existing file to fix it
+- **Missing**: Create a new skill or rule file in `.rulesync/skills/` or `.rulesync/rules/`
+- **Outdated**: Update or remove the stale content
+
+Always edit `.rulesync/` as the source of truth.
+
+### Step 4 — Sync
+After all changes, run `bun run rules` to sync to all AI tool directories.
+
+### Step 5 — Summary
+Output a brief summary of what was changed and why. Format:
+- **Fixed**: [file] — [what was wrong and what was corrected]
+- **Created**: [file] — [what gap it fills]
+- **No changes needed**: [reason]

--- a/.cursor/skills/mongoose-schema-safety/SKILL.md
+++ b/.cursor/skills/mongoose-schema-safety/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: mongoose-schema-safety
+description: 'Invoke when making any Mongoose schema change: adding/removing/renaming fields, creating a new model, adding indexes, or writing a backfill migration. Provides the five-type pattern, risk matrix, type file checklist, and rollout safety steps for terreno backends.'
+---
+# Mongoose Schema Safety — Terreno
+
+## Where Schemas and Types Live
+
+| Package | Schemas | Types |
+|---------|---------|-------|
+| `@terreno/api` (built-in models like `User`, `ConsentForm`) | `api/src/models/*.ts` | `api/src/types/*.ts` (or co-located in the model file via `mongoose.Schema<Doc, Model, Methods>` generics) |
+| `example-backend` (`User`, `Todo`, `Configuration`) | `example-backend/src/models/*.ts` | `example-backend/src/types/models/*.ts` (`userTypes.ts`, `todoTypes.ts`, …) |
+| `@terreno/ai` (`AIRequest`, `GptHistory`) | `ai/src/models/*.ts` | `ai/src/types/index.ts` |
+
+Every field in every schema **must** have a `description` (see the API rule `01-model-field-descriptions.md`). Descriptions flow through to the OpenAPI spec via `mongoose-to-swagger`.
+
+## The Five-Type Pattern
+
+Every model has manually-maintained TypeScript types. **Types are NOT auto-generated** — every schema change must include a matching type update in the same commit/PR.
+
+```typescript
+import type {DefaultDoc, DefaultModel, DefaultStatics} from "@terreno/api";
+
+// 1. Instance methods (on the document)
+export type YourModelMethods = {
+  customMethod: (this: YourModelDocument, param: string) => Promise<void>;
+};
+
+// 2. Static methods (on the model class) — extend DefaultStatics for findExactlyOne / findOneOrNone
+export type YourModelStatics = DefaultStatics<YourModelDocument> & {
+  customStatic: (this: YourModelModel, param: string) => Promise<YourModelDocument>;
+};
+
+// 3. Model type combining document + statics
+export type YourModelModel = DefaultModel<YourModelDocument> & YourModelStatics;
+
+// 4. Schema type
+export type YourModelSchema = mongoose.Schema<YourModelDocument, YourModelModel, YourModelMethods>;
+
+// 5. Document type (the shape of a single record)
+export type YourModelDocument = DefaultDoc & YourModelMethods & {
+  fieldName: string;
+  optionalField?: number;
+  enumField: "value1" | "value2";
+};
+```
+
+Follow existing type files in `example-backend/src/types/models/` and `ai/src/types/index.ts` for naming and structure.
+
+## Statics & Methods — Direct Assignment
+
+Define statics and methods by direct assignment on the schema — not via `.method()` / `.static()` / `.add()`:
+
+```typescript
+schema.methods = {
+  getDisplayName(this: YourModelDocument): string { return this.name; },
+};
+schema.statics = {
+  async findByEmail(this: YourModelModel, email: string) { return this.findOne({email}); },
+};
+```
+
+## Critical Mongoose Rules
+
+- **Never use `Model.findOne`** — use `Model.findExactlyOne` (throws on 0 or many) or `Model.findOneOrNone` (throws on many). These come from the `findExactlyOne` / `findOneOrNone` plugins in `@terreno/api`.
+- Apply the standard plugins (`createdUpdatedPlugin`, `isDeletedPlugin`, `findOneOrNone`, `findExactlyOne`) on every new model. Most existing models go through `addDefaultPlugins`.
+- `checkModelsStrict()` runs at non-prod startup (`server.ts`) and validates schema consistency — keep it passing.
+
+## Schema Change Risk Matrix
+
+| Change Type | Risk Level | Required Mitigation |
+|-------------|-----------|---------------------|
+| Add optional field | Low | Safe to ship directly (still requires `description`) |
+| Add required field | High | Must provide a default value, OR write a backfill migration script first |
+| Remove field | Medium | Soft-remove first (mark optional, stop writing); hard-remove in next PR after deploys settle |
+| Rename field | High | Three-step: add new → backfill → remove old (separate PRs) |
+| Change field type | Critical | Treat as rename: new field + migration + remove old |
+| Add index | Medium | Safe in code, but build can slow writes on large collections — coordinate with ops |
+| Remove index | Low | Safe to ship directly |
+| Add unique index | High | Dedup migration must run first; otherwise the index build fails on existing duplicates |
+
+## Migration Scripts
+
+Migration / backfill scripts live in `example-backend/src/scripts/` (e.g. `syncConsents.ts`, `seedConsents.ts`). They use the `ScriptRunner` type and `BackgroundTask` model from `@terreno/api` (`api/src/scriptRunner.ts`):
+
+```typescript
+import type {ScriptContext, ScriptResult, ScriptRunner} from "@terreno/api";
+
+export const run: ScriptRunner = async (wetRun, ctx) => {
+  const results: string[] = [];
+  // ... do work ...
+  if (wetRun) {
+    // commit changes
+  }
+  return {success: true, results};
+};
+```
+
+Always run with `wetRun = false` first to verify the dry-run output. Use `ctx.checkCancellation()`, `ctx.addLog()`, and `ctx.updateProgress()` for long-running tasks.
+
+## Cross-Package Ripple
+
+A schema change in one place often ripples:
+
+- **API surface affected?** Regenerate the SDK with `cd example-frontend && bun run sdk` (or invoke the `generate-sdk` skill). The OpenAPI spec is derived from the schema, so the frontend hooks will go stale otherwise.
+- **`modelRouter` config?** If you added/removed a field, update `queryFields`, `populatePaths`, and `responseHandler` for any router that touches the model.
+- **Admin panel?** If the model is registered in `AdminApp`, update `listFields` so the table reflects the new shape.
+- **Populated refs?** If another model references this one via `ObjectId` + `ref`, and the referenced document shape changed, the consumer's populated type may need updating.
+
+## Post-Change Checklist
+
+- [ ] All new fields have a `description` (flows to OpenAPI)
+- [ ] Type file updated in the same commit/PR — field names, optionality, enum values, array types, refs, statics/methods all match the schema
+- [ ] For a new model: all five types (`Document`, `Methods`, `Statics`, `Model`, `Schema`) created
+- [ ] Statics/methods assigned directly on schema (`schema.statics = {...}`, `schema.methods = {...}`) — not `.static()` / `.method()`
+- [ ] Other model type files checked — any model that populates this one updated if its shape changed
+- [ ] Migration script written (and dry-run verified with `wetRun = false`) for any backfill
+- [ ] `modelRouter` config updated (`queryFields`, `populatePaths`, `responseHandler`) if needed
+- [ ] `AdminApp` `listFields` updated if the model is in the admin panel
+- [ ] `bun run sdk` run from `example-frontend/` if the API response shape changed
+- [ ] Test covers old-format document behavior (missing new field) if the change rolls out before a backfill
+- [ ] Unique index: dedup migration written and run before the index is added
+- [ ] `checkModelsStrict()` still passes (it runs on non-prod startup)
+- [ ] No `Model.findOne` introduced — use `findExactlyOne` / `findOneOrNone`
+
+## Common Pitfalls
+
+- Adding a required field without a default — first deploy fails for documents that pre-date the field
+- Skipping the type file update — TS happily compiles older callers but new ones break at runtime
+- Adding a `unique` index without dedup — index build fails on collections with existing duplicates
+- Renaming a field in one PR — frontend gets old field, backend writes new field, neither side is happy
+- Forgetting to regenerate the SDK after a shape change — frontend types drift from reality
+- Using `.method()` / `.static()` API — terreno's convention is direct assignment, and mixing styles makes types hard to maintain

--- a/.github/skills/ai-prompt-governance/SKILL.md
+++ b/.github/skills/ai-prompt-governance/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: ai-prompt-governance
+description: >-
+  Invoke when adding, modifying, or reviewing any prompt used by `@terreno/ai`
+  (AIService methods, system prompts, helpers). Provides prompt-as-constant
+  rules, temperature preset guidance, logging requirements, and a testing
+  checklist.
+---
+# AI Prompt Governance — `@terreno/ai`
+
+`@terreno/ai` is a backend-only, provider-agnostic AI layer built on the Vercel AI SDK. Consuming apps inject a `LanguageModel` (Google, Anthropic, OpenAI, etc.) and call `AIService` methods. All requests are logged through the `AIRequest` model.
+
+See `ai/src/service/aiService.ts` and `ai/src/service/prompts.ts` for the canonical implementation.
+
+## Prompt Writing Rules
+
+1. **Always a named constant** — Define prompts in `ai/src/service/prompts.ts` (or the consuming app's equivalent constants file). Never inline prompt strings in route handlers, services, or `AIService` method bodies.
+2. **Self-contained** — A prompt should read coherently on its own. If you must inject runtime context, document why in a comment above the constant.
+3. **Typed return** — If the prompt asks for structured JSON, define a matching TypeScript interface in `ai/src/types/index.ts` and parse against it on every response.
+4. **Don't bake user-identifiable data into the prompt template itself** — inject it at call time as runtime parameters, never as defaults in the constant.
+
+## Temperature Preset Guidance
+
+Use the presets exported from `@terreno/ai`:
+
+| Preset | Value | When to use |
+|--------|-------|-------------|
+| `DETERMINISTIC` | 0 | Structured extraction, classification, deterministic transforms |
+| `LOW` | 0.3 | Summarization, translation, faithful rewording |
+| `BALANCED` | 0.7 | General Q&A, balanced creativity |
+| `DEFAULT` | 1.0 | Chat, open-ended responses |
+| `HIGH` | 1.5 | Brainstorming, creative variation |
+| `MAXIMUM` | 2.0 | Maximum variability — rarely the right choice |
+
+Pick the lowest temperature that still produces good results. Don't override the default unless you can name a reason in the call site.
+
+## Logging
+
+Every `AIService` method already logs to the `AIRequest` model via the internal `logRequest()` call. Do not bypass `AIService` and call the Vercel SDK directly from routes — you lose request logging, error capture, and the `requestType` taxonomy.
+
+Current `AIRequest.requestType` values: `"general" | "remix" | "summarization" | "translation"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
+
+Logging failures must never break the main flow — the existing pattern catches and logs internally. Preserve that behavior.
+
+## Testing a Prompt Change
+
+`@terreno/ai` tests inject a mock `LanguageModel` with `doGenerate` / `doStream` methods. See the mock pattern in `ai/src/aiApp.test.ts`. Never hit a live provider in unit tests.
+
+1. Add or update a unit test that mocks `doGenerate` / `doStream` and asserts the prompt your code sends matches expectations.
+2. Run against at least 3 inputs:
+   - A normal/expected case
+   - An edge case (empty input, very long input, missing optional fields)
+   - An adversarial case that could break structured JSON output
+3. For structured JSON: assert the response parses against the typed return interface.
+4. If the prompt affects streaming behavior, mock `doStream` and assert the emitted chunks.
+
+For a one-off manual smoke against a real provider, temporarily add `logger.debug("prompt test", {prompt, response})` in the `AIService` method, run locally, then remove the log before committing.
+
+## Prompt Change Checklist
+
+- [ ] Prompt is a named constant in `prompts.ts` (or app equivalent) — not inlined
+- [ ] Prompt still produces valid, parseable structured JSON if applicable (tested with 3+ inputs)
+- [ ] Temperature preset is appropriate (lowest viable for the task)
+- [ ] Call goes through `AIService` (so `AIRequest` logging fires) — no direct Vercel SDK calls from routes
+- [ ] If `requestType` taxonomy changed, the type union and admin explorer filters were updated
+- [ ] No user-identifiable data baked into the prompt template (only injected at call time)
+- [ ] Unit test added/updated with a mock model
+- [ ] Commit message explains the behavioral change (the prompt is the behavior)
+
+## Adding a New AI Feature
+
+1. Define prompt(s) as named constants in `ai/src/service/prompts.ts`.
+2. If structured JSON output, define the TypeScript interface for the return shape in `ai/src/types/index.ts`.
+3. Add a method to `AIService` (or a new service class) that calls `generateText` / `generateTextStream` and goes through the existing logging path.
+4. If exposing via HTTP, add a route in `ai/src/routes/` following the patterns in `gpt.ts` / `gptHistories.ts`. Use `createOpenApiBuilder` for OpenAPI docs.
+5. Add an integration test with a mock model that verifies:
+   - The prompt sent to the model matches the constant
+   - The structured JSON return parses against the typed interface
+   - `AIRequest.logRequest` is called with the correct `requestType`
+
+## Common Pitfalls
+
+- Calling the Vercel SDK directly from a route — bypasses logging and request typing
+- Inlining a prompt string in a route handler — makes future changes invisible and untestable
+- Using the wrong `requestType` value (or `"general"` as a catch-all) — degrades the admin explorer
+- Setting `temperature` numerically instead of via a preset — drifts away from the documented presets
+- Forgetting to type the JSON return — runtime parse failures show up later as confusing errors

--- a/.github/skills/backend-test-env/SKILL.md
+++ b/.github/skills/backend-test-env/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: backend-test-env
+description: >-
+  Invoke when writing tests that mutate `process.env` in `@terreno/api`,
+  `@terreno/ai`, or `example-backend` — feature flags, auth secrets, integration
+  toggles. Covers the preload contract, `setupEnvironment()`, and safe mutation
+  patterns.
+---
+# Backend Test — `process.env` Contract
+
+Bun's test runner preloads a per-package setup file (configured in each package's `bunfig.toml` under `[test].preload`):
+
+| Package | Preload file |
+|---------|--------------|
+| `@terreno/api` | `api/src/tests/bunSetup.ts` |
+| `@terreno/ai` | `ai/src/tests/bunSetup.ts` |
+| `example-backend` | `example-backend/src/tests/setup.ts` |
+
+The `@terreno/api` preload uses a global `beforeEach` to (1) reset the canonical auth secrets, (2) call `setupEnvironment()` (exported from `expressServer.ts`) for the wider baseline, and (3) re-silence the winston loggers. The next test always starts from the canonical baseline — you normally **do not** need to re-call `setupEnvironment()` in a file-level `beforeEach`.
+
+## Default — Rely on the Preload
+
+- Do not assume a toggle left by another file. Treat the preload's `beforeEach` as the source of truth for the canonical baseline.
+- Set only the keys this test needs in its own `beforeEach` or test body.
+- Don't reach in and call `setupEnvironment()` again unless you're explicitly testing env-driven behavior that the preload didn't cover.
+
+## When a Test Mutates `process.env`
+
+1. **Add the key to the preload's reset list** if it should always start from a fixed test value. Otherwise it leaks into the next test in the same worker.
+2. **Set only what this case needs** in the test body — avoid redundant manual restore if the preload already resets that key in `beforeEach`.
+3. **For keys that should be absent (unset)**, use **`Reflect.deleteProperty(process.env, "KEY")`**. Avoid `process.env.KEY = ""` to mean "unset" — on some platforms empty string and unset behave differently and can make tests flaky.
+4. **Avoid whole-env snapshots** (`const OLD_ENV = process.env; ...; process.env = OLD_ENV;`). This pattern exists in some older test files (`auth.test.ts`) — don't propagate it. It captures pre-`beforeEach` state and breaks ordering guarantees if the preload's `beforeEach` runs in between. Use targeted mutations + the preload's reset instead.
+
+## Adding a New Required Env Var
+
+If you introduce a new `process.env.FOO` that backend code reads at startup:
+
+1. Add `FOO` to `setupEnvironment()` in `api/src/expressServer.ts` so every package picks it up via the preload's `setupEnvironment()` call.
+2. If `example-backend` has its own startup needs for it, also add to `example-backend/src/tests/setup.ts`'s `beforeAll`.
+3. If a test needs to mutate it, follow the rules above — don't snapshot the whole env.
+
+## Auth-Related Keys
+
+`api/src/tests/bunSetup.ts` resets four auth keys in `beforeEach`: `TOKEN_SECRET`, `TOKEN_ISSUER`, `SESSION_SECRET`, `REFRESH_TOKEN_SECRET`. If your test changes any of these, you do not need to restore — the next `beforeEach` already does. If your test relies on them being **absent** for a code path, use `Reflect.deleteProperty` within the test, knowing the next `beforeEach` will restore.
+
+`auth.test.ts` is the established home for env-driven auth assertions; mirror its newer patterns (per-test `beforeEach` setting only what changes) rather than its older whole-env-snapshot blocks.
+
+## Log Capture & Sentry
+
+The preload silences winston and `console.*` and captures into an in-memory buffer (cleared in `beforeEach`/`afterEach`). It also mocks `@sentry/bun`. Don't re-mock Sentry inside individual tests — the preload's mock is shared and reset across tests.
+
+## Checklist
+
+- [ ] New env var added to `setupEnvironment()` and (if needed) `example-backend/src/tests/setup.ts`
+- [ ] Test mutations are targeted — no whole-env snapshots
+- [ ] "Unset" expressed as `Reflect.deleteProperty(process.env, "KEY")`, not `= ""`
+- [ ] No manual restore that duplicates the preload's `beforeEach` reset
+- [ ] No re-mock of `@sentry/bun` — the preload's mock is already in place
+- [ ] If you added an env-driven branch in code, a test covers both the set and the unset case

--- a/.github/skills/improve-rulesync/SKILL.md
+++ b/.github/skills/improve-rulesync/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: improve-rulesync
+description: >-
+  Invoke at the end of a session to evaluate whether any skills or rules were
+  misleading, incorrect, or missing — and fix or create them. Trigger with
+  /improve-rulesync.
+---
+# Improve Rulesync
+
+### Trigger
+Invoke explicitly at the end of a session with `/improve-rulesync`.
+
+### Behavior
+Review the current conversation session and evaluate the skills and rules in `.rulesync/`. Identify any that:
+- Gave misleading or incorrect guidance that caused errors or rework
+- Were missing and would have prevented incorrect behavior
+- Need to be updated to reflect decisions or patterns established in this session
+
+Then make the changes directly.
+
+### Step 1 — Session Review
+Scan the session for:
+- Moments where a skill or rule was followed but produced a wrong or suboptimal result
+- User corrections or decisions about AI model behavior (these indicate a gap or error in the rules)
+- New patterns, decisions, or constraints established that should be codified
+
+### Step 2 — Rules Audit
+Check `.rulesync/` for relevant existing rules and skills. Evaluate:
+- Are trigger conditions accurate?
+- Is the guidance still correct given what happened this session?
+- Are there gaps that caused confusion?
+
+### Step 3 — Make Changes
+For each issue found:
+- **Incorrect/misleading**: Edit the existing file to fix it
+- **Missing**: Create a new skill or rule file in `.rulesync/skills/` or `.rulesync/rules/`
+- **Outdated**: Update or remove the stale content
+
+Always edit `.rulesync/` as the source of truth.
+
+### Step 4 — Sync
+After all changes, run `bun run rules` to sync to all AI tool directories.
+
+### Step 5 — Summary
+Output a brief summary of what was changed and why. Format:
+- **Fixed**: [file] — [what was wrong and what was corrected]
+- **Created**: [file] — [what gap it fills]
+- **No changes needed**: [reason]

--- a/.github/skills/mongoose-schema-safety/SKILL.md
+++ b/.github/skills/mongoose-schema-safety/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: mongoose-schema-safety
+description: >-
+  Invoke when making any Mongoose schema change: adding/removing/renaming
+  fields, creating a new model, adding indexes, or writing a backfill migration.
+  Provides the five-type pattern, risk matrix, type file checklist, and rollout
+  safety steps for terreno backends.
+---
+# Mongoose Schema Safety — Terreno
+
+## Where Schemas and Types Live
+
+| Package | Schemas | Types |
+|---------|---------|-------|
+| `@terreno/api` (built-in models like `User`, `ConsentForm`) | `api/src/models/*.ts` | `api/src/types/*.ts` (or co-located in the model file via `mongoose.Schema<Doc, Model, Methods>` generics) |
+| `example-backend` (`User`, `Todo`, `Configuration`) | `example-backend/src/models/*.ts` | `example-backend/src/types/models/*.ts` (`userTypes.ts`, `todoTypes.ts`, …) |
+| `@terreno/ai` (`AIRequest`, `GptHistory`) | `ai/src/models/*.ts` | `ai/src/types/index.ts` |
+
+Every field in every schema **must** have a `description` (see the API rule `01-model-field-descriptions.md`). Descriptions flow through to the OpenAPI spec via `mongoose-to-swagger`.
+
+## The Five-Type Pattern
+
+Every model has manually-maintained TypeScript types. **Types are NOT auto-generated** — every schema change must include a matching type update in the same commit/PR.
+
+```typescript
+import type {DefaultDoc, DefaultModel, DefaultStatics} from "@terreno/api";
+
+// 1. Instance methods (on the document)
+export type YourModelMethods = {
+  customMethod: (this: YourModelDocument, param: string) => Promise<void>;
+};
+
+// 2. Static methods (on the model class) — extend DefaultStatics for findExactlyOne / findOneOrNone
+export type YourModelStatics = DefaultStatics<YourModelDocument> & {
+  customStatic: (this: YourModelModel, param: string) => Promise<YourModelDocument>;
+};
+
+// 3. Model type combining document + statics
+export type YourModelModel = DefaultModel<YourModelDocument> & YourModelStatics;
+
+// 4. Schema type
+export type YourModelSchema = mongoose.Schema<YourModelDocument, YourModelModel, YourModelMethods>;
+
+// 5. Document type (the shape of a single record)
+export type YourModelDocument = DefaultDoc & YourModelMethods & {
+  fieldName: string;
+  optionalField?: number;
+  enumField: "value1" | "value2";
+};
+```
+
+Follow existing type files in `example-backend/src/types/models/` and `ai/src/types/index.ts` for naming and structure.
+
+## Statics & Methods — Direct Assignment
+
+Define statics and methods by direct assignment on the schema — not via `.method()` / `.static()` / `.add()`:
+
+```typescript
+schema.methods = {
+  getDisplayName(this: YourModelDocument): string { return this.name; },
+};
+schema.statics = {
+  async findByEmail(this: YourModelModel, email: string) { return this.findOne({email}); },
+};
+```
+
+## Critical Mongoose Rules
+
+- **Never use `Model.findOne`** — use `Model.findExactlyOne` (throws on 0 or many) or `Model.findOneOrNone` (throws on many). These come from the `findExactlyOne` / `findOneOrNone` plugins in `@terreno/api`.
+- Apply the standard plugins (`createdUpdatedPlugin`, `isDeletedPlugin`, `findOneOrNone`, `findExactlyOne`) on every new model. Most existing models go through `addDefaultPlugins`.
+- `checkModelsStrict()` runs at non-prod startup (`server.ts`) and validates schema consistency — keep it passing.
+
+## Schema Change Risk Matrix
+
+| Change Type | Risk Level | Required Mitigation |
+|-------------|-----------|---------------------|
+| Add optional field | Low | Safe to ship directly (still requires `description`) |
+| Add required field | High | Must provide a default value, OR write a backfill migration script first |
+| Remove field | Medium | Soft-remove first (mark optional, stop writing); hard-remove in next PR after deploys settle |
+| Rename field | High | Three-step: add new → backfill → remove old (separate PRs) |
+| Change field type | Critical | Treat as rename: new field + migration + remove old |
+| Add index | Medium | Safe in code, but build can slow writes on large collections — coordinate with ops |
+| Remove index | Low | Safe to ship directly |
+| Add unique index | High | Dedup migration must run first; otherwise the index build fails on existing duplicates |
+
+## Migration Scripts
+
+Migration / backfill scripts live in `example-backend/src/scripts/` (e.g. `syncConsents.ts`, `seedConsents.ts`). They use the `ScriptRunner` type and `BackgroundTask` model from `@terreno/api` (`api/src/scriptRunner.ts`):
+
+```typescript
+import type {ScriptContext, ScriptResult, ScriptRunner} from "@terreno/api";
+
+export const run: ScriptRunner = async (wetRun, ctx) => {
+  const results: string[] = [];
+  // ... do work ...
+  if (wetRun) {
+    // commit changes
+  }
+  return {success: true, results};
+};
+```
+
+Always run with `wetRun = false` first to verify the dry-run output. Use `ctx.checkCancellation()`, `ctx.addLog()`, and `ctx.updateProgress()` for long-running tasks.
+
+## Cross-Package Ripple
+
+A schema change in one place often ripples:
+
+- **API surface affected?** Regenerate the SDK with `cd example-frontend && bun run sdk` (or invoke the `generate-sdk` skill). The OpenAPI spec is derived from the schema, so the frontend hooks will go stale otherwise.
+- **`modelRouter` config?** If you added/removed a field, update `queryFields`, `populatePaths`, and `responseHandler` for any router that touches the model.
+- **Admin panel?** If the model is registered in `AdminApp`, update `listFields` so the table reflects the new shape.
+- **Populated refs?** If another model references this one via `ObjectId` + `ref`, and the referenced document shape changed, the consumer's populated type may need updating.
+
+## Post-Change Checklist
+
+- [ ] All new fields have a `description` (flows to OpenAPI)
+- [ ] Type file updated in the same commit/PR — field names, optionality, enum values, array types, refs, statics/methods all match the schema
+- [ ] For a new model: all five types (`Document`, `Methods`, `Statics`, `Model`, `Schema`) created
+- [ ] Statics/methods assigned directly on schema (`schema.statics = {...}`, `schema.methods = {...}`) — not `.static()` / `.method()`
+- [ ] Other model type files checked — any model that populates this one updated if its shape changed
+- [ ] Migration script written (and dry-run verified with `wetRun = false`) for any backfill
+- [ ] `modelRouter` config updated (`queryFields`, `populatePaths`, `responseHandler`) if needed
+- [ ] `AdminApp` `listFields` updated if the model is in the admin panel
+- [ ] `bun run sdk` run from `example-frontend/` if the API response shape changed
+- [ ] Test covers old-format document behavior (missing new field) if the change rolls out before a backfill
+- [ ] Unique index: dedup migration written and run before the index is added
+- [ ] `checkModelsStrict()` still passes (it runs on non-prod startup)
+- [ ] No `Model.findOne` introduced — use `findExactlyOne` / `findOneOrNone`
+
+## Common Pitfalls
+
+- Adding a required field without a default — first deploy fails for documents that pre-date the field
+- Skipping the type file update — TS happily compiles older callers but new ones break at runtime
+- Adding a `unique` index without dedup — index build fails on collections with existing duplicates
+- Renaming a field in one PR — frontend gets old field, backend writes new field, neither side is happy
+- Forgetting to regenerate the SDK after a shape change — frontend types drift from reality
+- Using `.method()` / `.static()` API — terreno's convention is direct assignment, and mixing styles makes types hard to maintain

--- a/.github/workflows/rulesync-check.yml
+++ b/.github/workflows/rulesync-check.yml
@@ -1,38 +1,20 @@
 name: Rulesync Check
 
 on:
-  push:
-    paths:
-      - ".rulesync/**"
-      - "rulesync.jsonc"
-      - ".github/workflows/rulesync-check.yml"
   pull_request:
-    paths:
-      - ".rulesync/**"
-      - "rulesync.jsonc"
-      - ".github/workflows/rulesync-check.yml"
 
 jobs:
-  check:
-    name: Check rules are up to date
+  rulesync-check:
+    name: Verify rules are in sync
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup Bun
+      - name: Install Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-
-      - name: Cache Bun dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('bun.lock', 'package.json') }}
-          restore-keys: |
-            bun-${{ runner.os }}-${{ github.ref }}-
-            bun-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -40,9 +22,11 @@ jobs:
       - name: Generate rules
         run: bun run rules
 
-      - name: Check for uncommitted changes
+      - name: Check for changes
         run: |
-          if ! git diff --exit-code; then
-            echo "::error::Generated rules are out of date. Run 'bun run rules' and commit the changes."
+          if [[ -n $(git status -s) ]]; then
+            echo "Error: Running bun run rules produced changes. Please run bun run rules locally and commit the changes."
+            git status
+            git diff
             exit 1
           fi

--- a/.rulesync/skills/ai-prompt-governance/SKILL.md
+++ b/.rulesync/skills/ai-prompt-governance/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: ai-prompt-governance
+description: >-
+  Invoke when adding, modifying, or reviewing any prompt used by `@terreno/ai`
+  (AIService methods, system prompts, helpers). Provides prompt-as-constant
+  rules, temperature preset guidance, logging requirements, and a testing
+  checklist.
+---
+# AI Prompt Governance — `@terreno/ai`
+
+`@terreno/ai` is a backend-only, provider-agnostic AI layer built on the Vercel AI SDK. Consuming apps inject a `LanguageModel` (Google, Anthropic, OpenAI, etc.) and call `AIService` methods. All requests are logged through the `AIRequest` model.
+
+See `ai/src/service/aiService.ts` and `ai/src/service/prompts.ts` for the canonical implementation.
+
+## Prompt Writing Rules
+
+1. **Always a named constant** — Define prompts in `ai/src/service/prompts.ts` (or the consuming app's equivalent constants file). Never inline prompt strings in route handlers, services, or `AIService` method bodies.
+2. **Self-contained** — A prompt should read coherently on its own. If you must inject runtime context, document why in a comment above the constant.
+3. **Typed return** — If the prompt asks for structured JSON, define a matching TypeScript interface in `ai/src/types/index.ts` and parse against it on every response.
+4. **Don't bake user-identifiable data into the prompt template itself** — inject it at call time as runtime parameters, never as defaults in the constant.
+
+## Temperature Preset Guidance
+
+Use the presets exported from `@terreno/ai`:
+
+| Preset | Value | When to use |
+|--------|-------|-------------|
+| `DETERMINISTIC` | 0 | Structured extraction, classification, deterministic transforms |
+| `LOW` | 0.3 | Summarization, translation, faithful rewording |
+| `BALANCED` | 0.7 | General Q&A, balanced creativity |
+| `DEFAULT` | 1.0 | Chat, open-ended responses |
+| `HIGH` | 1.5 | Brainstorming, creative variation |
+| `MAXIMUM` | 2.0 | Maximum variability — rarely the right choice |
+
+Pick the lowest temperature that still produces good results. Don't override the default unless you can name a reason in the call site.
+
+## Logging
+
+Every `AIService` method already logs to the `AIRequest` model via the internal `logRequest()` call. Do not bypass `AIService` and call the Vercel SDK directly from routes — you lose request logging, error capture, and the `requestType` taxonomy.
+
+Current `AIRequest.requestType` values: `"general" | "remix" | "summarization" | "translation"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
+
+Logging failures must never break the main flow — the existing pattern catches and logs internally. Preserve that behavior.
+
+## Testing a Prompt Change
+
+`@terreno/ai` tests inject a mock `LanguageModel` with `doGenerate` / `doStream` methods. See the mock pattern in `ai/src/aiApp.test.ts`. Never hit a live provider in unit tests.
+
+1. Add or update a unit test that mocks `doGenerate` / `doStream` and asserts the prompt your code sends matches expectations.
+2. Run against at least 3 inputs:
+   - A normal/expected case
+   - An edge case (empty input, very long input, missing optional fields)
+   - An adversarial case that could break structured JSON output
+3. For structured JSON: assert the response parses against the typed return interface.
+4. If the prompt affects streaming behavior, mock `doStream` and assert the emitted chunks.
+
+For a one-off manual smoke against a real provider, temporarily add `logger.debug("prompt test", {prompt, response})` in the `AIService` method, run locally, then remove the log before committing.
+
+## Prompt Change Checklist
+
+- [ ] Prompt is a named constant in `prompts.ts` (or app equivalent) — not inlined
+- [ ] Prompt still produces valid, parseable structured JSON if applicable (tested with 3+ inputs)
+- [ ] Temperature preset is appropriate (lowest viable for the task)
+- [ ] Call goes through `AIService` (so `AIRequest` logging fires) — no direct Vercel SDK calls from routes
+- [ ] If `requestType` taxonomy changed, the type union and admin explorer filters were updated
+- [ ] No user-identifiable data baked into the prompt template (only injected at call time)
+- [ ] Unit test added/updated with a mock model
+- [ ] Commit message explains the behavioral change (the prompt is the behavior)
+
+## Adding a New AI Feature
+
+1. Define prompt(s) as named constants in `ai/src/service/prompts.ts`.
+2. If structured JSON output, define the TypeScript interface for the return shape in `ai/src/types/index.ts`.
+3. Add a method to `AIService` (or a new service class) that calls `generateText` / `generateTextStream` and goes through the existing logging path.
+4. If exposing via HTTP, add a route in `ai/src/routes/` following the patterns in `gpt.ts` / `gptHistories.ts`. Use `createOpenApiBuilder` for OpenAPI docs.
+5. Add an integration test with a mock model that verifies:
+   - The prompt sent to the model matches the constant
+   - The structured JSON return parses against the typed interface
+   - `AIRequest.logRequest` is called with the correct `requestType`
+
+## Common Pitfalls
+
+- Calling the Vercel SDK directly from a route — bypasses logging and request typing
+- Inlining a prompt string in a route handler — makes future changes invisible and untestable
+- Using the wrong `requestType` value (or `"general"` as a catch-all) — degrades the admin explorer
+- Setting `temperature` numerically instead of via a preset — drifts away from the documented presets
+- Forgetting to type the JSON return — runtime parse failures show up later as confusing errors

--- a/.rulesync/skills/backend-test-env/SKILL.md
+++ b/.rulesync/skills/backend-test-env/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: backend-test-env
+description: >-
+  Invoke when writing tests that mutate `process.env` in `@terreno/api`,
+  `@terreno/ai`, or `example-backend` — feature flags, auth secrets, integration
+  toggles. Covers the preload contract, `setupEnvironment()`, and safe mutation
+  patterns.
+---
+# Backend Test — `process.env` Contract
+
+Bun's test runner preloads a per-package setup file (configured in each package's `bunfig.toml` under `[test].preload`):
+
+| Package | Preload file |
+|---------|--------------|
+| `@terreno/api` | `api/src/tests/bunSetup.ts` |
+| `@terreno/ai` | `ai/src/tests/bunSetup.ts` |
+| `example-backend` | `example-backend/src/tests/setup.ts` |
+
+The `@terreno/api` preload uses a global `beforeEach` to (1) reset the canonical auth secrets, (2) call `setupEnvironment()` (exported from `expressServer.ts`) for the wider baseline, and (3) re-silence the winston loggers. The next test always starts from the canonical baseline — you normally **do not** need to re-call `setupEnvironment()` in a file-level `beforeEach`.
+
+## Default — Rely on the Preload
+
+- Do not assume a toggle left by another file. Treat the preload's `beforeEach` as the source of truth for the canonical baseline.
+- Set only the keys this test needs in its own `beforeEach` or test body.
+- Don't reach in and call `setupEnvironment()` again unless you're explicitly testing env-driven behavior that the preload didn't cover.
+
+## When a Test Mutates `process.env`
+
+1. **Add the key to the preload's reset list** if it should always start from a fixed test value. Otherwise it leaks into the next test in the same worker.
+2. **Set only what this case needs** in the test body — avoid redundant manual restore if the preload already resets that key in `beforeEach`.
+3. **For keys that should be absent (unset)**, use **`Reflect.deleteProperty(process.env, "KEY")`**. Avoid `process.env.KEY = ""` to mean "unset" — on some platforms empty string and unset behave differently and can make tests flaky.
+4. **Avoid whole-env snapshots** (`const OLD_ENV = process.env; ...; process.env = OLD_ENV;`). This pattern exists in some older test files (`auth.test.ts`) — don't propagate it. It captures pre-`beforeEach` state and breaks ordering guarantees if the preload's `beforeEach` runs in between. Use targeted mutations + the preload's reset instead.
+
+## Adding a New Required Env Var
+
+If you introduce a new `process.env.FOO` that backend code reads at startup:
+
+1. Add `FOO` to `setupEnvironment()` in `api/src/expressServer.ts` so every package picks it up via the preload's `setupEnvironment()` call.
+2. If `example-backend` has its own startup needs for it, also add to `example-backend/src/tests/setup.ts`'s `beforeAll`.
+3. If a test needs to mutate it, follow the rules above — don't snapshot the whole env.
+
+## Auth-Related Keys
+
+`api/src/tests/bunSetup.ts` resets four auth keys in `beforeEach`: `TOKEN_SECRET`, `TOKEN_ISSUER`, `SESSION_SECRET`, `REFRESH_TOKEN_SECRET`. If your test changes any of these, you do not need to restore — the next `beforeEach` already does. If your test relies on them being **absent** for a code path, use `Reflect.deleteProperty` within the test, knowing the next `beforeEach` will restore.
+
+`auth.test.ts` is the established home for env-driven auth assertions; mirror its newer patterns (per-test `beforeEach` setting only what changes) rather than its older whole-env-snapshot blocks.
+
+## Log Capture & Sentry
+
+The preload silences winston and `console.*` and captures into an in-memory buffer (cleared in `beforeEach`/`afterEach`). It also mocks `@sentry/bun`. Don't re-mock Sentry inside individual tests — the preload's mock is shared and reset across tests.
+
+## Checklist
+
+- [ ] New env var added to `setupEnvironment()` and (if needed) `example-backend/src/tests/setup.ts`
+- [ ] Test mutations are targeted — no whole-env snapshots
+- [ ] "Unset" expressed as `Reflect.deleteProperty(process.env, "KEY")`, not `= ""`
+- [ ] No manual restore that duplicates the preload's `beforeEach` reset
+- [ ] No re-mock of `@sentry/bun` — the preload's mock is already in place
+- [ ] If you added an env-driven branch in code, a test covers both the set and the unset case

--- a/.rulesync/skills/improve-rulesync/SKILL.md
+++ b/.rulesync/skills/improve-rulesync/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: improve-rulesync
+description: >-
+  Invoke at the end of a session to evaluate whether any skills or rules were
+  misleading, incorrect, or missing — and fix or create them. Trigger with
+  /improve-rulesync.
+---
+# Improve Rulesync
+
+### Trigger
+Invoke explicitly at the end of a session with `/improve-rulesync`.
+
+### Behavior
+Review the current conversation session and evaluate the skills and rules in `.rulesync/`. Identify any that:
+- Gave misleading or incorrect guidance that caused errors or rework
+- Were missing and would have prevented incorrect behavior
+- Need to be updated to reflect decisions or patterns established in this session
+
+Then make the changes directly.
+
+### Step 1 — Session Review
+Scan the session for:
+- Moments where a skill or rule was followed but produced a wrong or suboptimal result
+- User corrections or decisions about AI model behavior (these indicate a gap or error in the rules)
+- New patterns, decisions, or constraints established that should be codified
+
+### Step 2 — Rules Audit
+Check `.rulesync/` for relevant existing rules and skills. Evaluate:
+- Are trigger conditions accurate?
+- Is the guidance still correct given what happened this session?
+- Are there gaps that caused confusion?
+
+### Step 3 — Make Changes
+For each issue found:
+- **Incorrect/misleading**: Edit the existing file to fix it
+- **Missing**: Create a new skill or rule file in `.rulesync/skills/` or `.rulesync/rules/`
+- **Outdated**: Update or remove the stale content
+
+Always edit `.rulesync/` as the source of truth.
+
+### Step 4 — Sync
+After all changes, run `bun run rules` to sync to all AI tool directories.
+
+### Step 5 — Summary
+Output a brief summary of what was changed and why. Format:
+- **Fixed**: [file] — [what was wrong and what was corrected]
+- **Created**: [file] — [what gap it fills]
+- **No changes needed**: [reason]

--- a/.rulesync/skills/mongoose-schema-safety/SKILL.md
+++ b/.rulesync/skills/mongoose-schema-safety/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: mongoose-schema-safety
+description: >-
+  Invoke when making any Mongoose schema change: adding/removing/renaming
+  fields, creating a new model, adding indexes, or writing a backfill migration.
+  Provides the five-type pattern, risk matrix, type file checklist, and rollout
+  safety steps for terreno backends.
+---
+# Mongoose Schema Safety — Terreno
+
+## Where Schemas and Types Live
+
+| Package | Schemas | Types |
+|---------|---------|-------|
+| `@terreno/api` (built-in models like `User`, `ConsentForm`) | `api/src/models/*.ts` | `api/src/types/*.ts` (or co-located in the model file via `mongoose.Schema<Doc, Model, Methods>` generics) |
+| `example-backend` (`User`, `Todo`, `Configuration`) | `example-backend/src/models/*.ts` | `example-backend/src/types/models/*.ts` (`userTypes.ts`, `todoTypes.ts`, …) |
+| `@terreno/ai` (`AIRequest`, `GptHistory`) | `ai/src/models/*.ts` | `ai/src/types/index.ts` |
+
+Every field in every schema **must** have a `description` (see the API rule `01-model-field-descriptions.md`). Descriptions flow through to the OpenAPI spec via `mongoose-to-swagger`.
+
+## The Five-Type Pattern
+
+Every model has manually-maintained TypeScript types. **Types are NOT auto-generated** — every schema change must include a matching type update in the same commit/PR.
+
+```typescript
+import type {DefaultDoc, DefaultModel, DefaultStatics} from "@terreno/api";
+
+// 1. Instance methods (on the document)
+export type YourModelMethods = {
+  customMethod: (this: YourModelDocument, param: string) => Promise<void>;
+};
+
+// 2. Static methods (on the model class) — extend DefaultStatics for findExactlyOne / findOneOrNone
+export type YourModelStatics = DefaultStatics<YourModelDocument> & {
+  customStatic: (this: YourModelModel, param: string) => Promise<YourModelDocument>;
+};
+
+// 3. Model type combining document + statics
+export type YourModelModel = DefaultModel<YourModelDocument> & YourModelStatics;
+
+// 4. Schema type
+export type YourModelSchema = mongoose.Schema<YourModelDocument, YourModelModel, YourModelMethods>;
+
+// 5. Document type (the shape of a single record)
+export type YourModelDocument = DefaultDoc & YourModelMethods & {
+  fieldName: string;
+  optionalField?: number;
+  enumField: "value1" | "value2";
+};
+```
+
+Follow existing type files in `example-backend/src/types/models/` and `ai/src/types/index.ts` for naming and structure.
+
+## Statics & Methods — Direct Assignment
+
+Define statics and methods by direct assignment on the schema — not via `.method()` / `.static()` / `.add()`:
+
+```typescript
+schema.methods = {
+  getDisplayName(this: YourModelDocument): string { return this.name; },
+};
+schema.statics = {
+  async findByEmail(this: YourModelModel, email: string) { return this.findOne({email}); },
+};
+```
+
+## Critical Mongoose Rules
+
+- **Never use `Model.findOne`** — use `Model.findExactlyOne` (throws on 0 or many) or `Model.findOneOrNone` (throws on many). These come from the `findExactlyOne` / `findOneOrNone` plugins in `@terreno/api`.
+- Apply the standard plugins (`createdUpdatedPlugin`, `isDeletedPlugin`, `findOneOrNone`, `findExactlyOne`) on every new model. Most existing models go through `addDefaultPlugins`.
+- `checkModelsStrict()` runs at non-prod startup (`server.ts`) and validates schema consistency — keep it passing.
+
+## Schema Change Risk Matrix
+
+| Change Type | Risk Level | Required Mitigation |
+|-------------|-----------|---------------------|
+| Add optional field | Low | Safe to ship directly (still requires `description`) |
+| Add required field | High | Must provide a default value, OR write a backfill migration script first |
+| Remove field | Medium | Soft-remove first (mark optional, stop writing); hard-remove in next PR after deploys settle |
+| Rename field | High | Three-step: add new → backfill → remove old (separate PRs) |
+| Change field type | Critical | Treat as rename: new field + migration + remove old |
+| Add index | Medium | Safe in code, but build can slow writes on large collections — coordinate with ops |
+| Remove index | Low | Safe to ship directly |
+| Add unique index | High | Dedup migration must run first; otherwise the index build fails on existing duplicates |
+
+## Migration Scripts
+
+Migration / backfill scripts live in `example-backend/src/scripts/` (e.g. `syncConsents.ts`, `seedConsents.ts`). They use the `ScriptRunner` type and `BackgroundTask` model from `@terreno/api` (`api/src/scriptRunner.ts`):
+
+```typescript
+import type {ScriptContext, ScriptResult, ScriptRunner} from "@terreno/api";
+
+export const run: ScriptRunner = async (wetRun, ctx) => {
+  const results: string[] = [];
+  // ... do work ...
+  if (wetRun) {
+    // commit changes
+  }
+  return {success: true, results};
+};
+```
+
+Always run with `wetRun = false` first to verify the dry-run output. Use `ctx.checkCancellation()`, `ctx.addLog()`, and `ctx.updateProgress()` for long-running tasks.
+
+## Cross-Package Ripple
+
+A schema change in one place often ripples:
+
+- **API surface affected?** Regenerate the SDK with `cd example-frontend && bun run sdk` (or invoke the `generate-sdk` skill). The OpenAPI spec is derived from the schema, so the frontend hooks will go stale otherwise.
+- **`modelRouter` config?** If you added/removed a field, update `queryFields`, `populatePaths`, and `responseHandler` for any router that touches the model.
+- **Admin panel?** If the model is registered in `AdminApp`, update `listFields` so the table reflects the new shape.
+- **Populated refs?** If another model references this one via `ObjectId` + `ref`, and the referenced document shape changed, the consumer's populated type may need updating.
+
+## Post-Change Checklist
+
+- [ ] All new fields have a `description` (flows to OpenAPI)
+- [ ] Type file updated in the same commit/PR — field names, optionality, enum values, array types, refs, statics/methods all match the schema
+- [ ] For a new model: all five types (`Document`, `Methods`, `Statics`, `Model`, `Schema`) created
+- [ ] Statics/methods assigned directly on schema (`schema.statics = {...}`, `schema.methods = {...}`) — not `.static()` / `.method()`
+- [ ] Other model type files checked — any model that populates this one updated if its shape changed
+- [ ] Migration script written (and dry-run verified with `wetRun = false`) for any backfill
+- [ ] `modelRouter` config updated (`queryFields`, `populatePaths`, `responseHandler`) if needed
+- [ ] `AdminApp` `listFields` updated if the model is in the admin panel
+- [ ] `bun run sdk` run from `example-frontend/` if the API response shape changed
+- [ ] Test covers old-format document behavior (missing new field) if the change rolls out before a backfill
+- [ ] Unique index: dedup migration written and run before the index is added
+- [ ] `checkModelsStrict()` still passes (it runs on non-prod startup)
+- [ ] No `Model.findOne` introduced — use `findExactlyOne` / `findOneOrNone`
+
+## Common Pitfalls
+
+- Adding a required field without a default — first deploy fails for documents that pre-date the field
+- Skipping the type file update — TS happily compiles older callers but new ones break at runtime
+- Adding a `unique` index without dedup — index build fails on collections with existing duplicates
+- Renaming a field in one PR — frontend gets old field, backend writes new field, neither side is happy
+- Forgetting to regenerate the SDK after a shape change — frontend types drift from reality
+- Using `.method()` / `.static()` API — terreno's convention is direct assignment, and mixing styles makes types hard to maintain

--- a/.windsurf/skills/ai-prompt-governance/SKILL.md
+++ b/.windsurf/skills/ai-prompt-governance/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: ai-prompt-governance
+description: >-
+  Invoke when adding, modifying, or reviewing any prompt used by `@terreno/ai`
+  (AIService methods, system prompts, helpers). Provides prompt-as-constant
+  rules, temperature preset guidance, logging requirements, and a testing
+  checklist.
+---
+# AI Prompt Governance — `@terreno/ai`
+
+`@terreno/ai` is a backend-only, provider-agnostic AI layer built on the Vercel AI SDK. Consuming apps inject a `LanguageModel` (Google, Anthropic, OpenAI, etc.) and call `AIService` methods. All requests are logged through the `AIRequest` model.
+
+See `ai/src/service/aiService.ts` and `ai/src/service/prompts.ts` for the canonical implementation.
+
+## Prompt Writing Rules
+
+1. **Always a named constant** — Define prompts in `ai/src/service/prompts.ts` (or the consuming app's equivalent constants file). Never inline prompt strings in route handlers, services, or `AIService` method bodies.
+2. **Self-contained** — A prompt should read coherently on its own. If you must inject runtime context, document why in a comment above the constant.
+3. **Typed return** — If the prompt asks for structured JSON, define a matching TypeScript interface in `ai/src/types/index.ts` and parse against it on every response.
+4. **Don't bake user-identifiable data into the prompt template itself** — inject it at call time as runtime parameters, never as defaults in the constant.
+
+## Temperature Preset Guidance
+
+Use the presets exported from `@terreno/ai`:
+
+| Preset | Value | When to use |
+|--------|-------|-------------|
+| `DETERMINISTIC` | 0 | Structured extraction, classification, deterministic transforms |
+| `LOW` | 0.3 | Summarization, translation, faithful rewording |
+| `BALANCED` | 0.7 | General Q&A, balanced creativity |
+| `DEFAULT` | 1.0 | Chat, open-ended responses |
+| `HIGH` | 1.5 | Brainstorming, creative variation |
+| `MAXIMUM` | 2.0 | Maximum variability — rarely the right choice |
+
+Pick the lowest temperature that still produces good results. Don't override the default unless you can name a reason in the call site.
+
+## Logging
+
+Every `AIService` method already logs to the `AIRequest` model via the internal `logRequest()` call. Do not bypass `AIService` and call the Vercel SDK directly from routes — you lose request logging, error capture, and the `requestType` taxonomy.
+
+Current `AIRequest.requestType` values: `"general" | "remix" | "summarization" | "translation"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
+
+Logging failures must never break the main flow — the existing pattern catches and logs internally. Preserve that behavior.
+
+## Testing a Prompt Change
+
+`@terreno/ai` tests inject a mock `LanguageModel` with `doGenerate` / `doStream` methods. See the mock pattern in `ai/src/aiApp.test.ts`. Never hit a live provider in unit tests.
+
+1. Add or update a unit test that mocks `doGenerate` / `doStream` and asserts the prompt your code sends matches expectations.
+2. Run against at least 3 inputs:
+   - A normal/expected case
+   - An edge case (empty input, very long input, missing optional fields)
+   - An adversarial case that could break structured JSON output
+3. For structured JSON: assert the response parses against the typed return interface.
+4. If the prompt affects streaming behavior, mock `doStream` and assert the emitted chunks.
+
+For a one-off manual smoke against a real provider, temporarily add `logger.debug("prompt test", {prompt, response})` in the `AIService` method, run locally, then remove the log before committing.
+
+## Prompt Change Checklist
+
+- [ ] Prompt is a named constant in `prompts.ts` (or app equivalent) — not inlined
+- [ ] Prompt still produces valid, parseable structured JSON if applicable (tested with 3+ inputs)
+- [ ] Temperature preset is appropriate (lowest viable for the task)
+- [ ] Call goes through `AIService` (so `AIRequest` logging fires) — no direct Vercel SDK calls from routes
+- [ ] If `requestType` taxonomy changed, the type union and admin explorer filters were updated
+- [ ] No user-identifiable data baked into the prompt template (only injected at call time)
+- [ ] Unit test added/updated with a mock model
+- [ ] Commit message explains the behavioral change (the prompt is the behavior)
+
+## Adding a New AI Feature
+
+1. Define prompt(s) as named constants in `ai/src/service/prompts.ts`.
+2. If structured JSON output, define the TypeScript interface for the return shape in `ai/src/types/index.ts`.
+3. Add a method to `AIService` (or a new service class) that calls `generateText` / `generateTextStream` and goes through the existing logging path.
+4. If exposing via HTTP, add a route in `ai/src/routes/` following the patterns in `gpt.ts` / `gptHistories.ts`. Use `createOpenApiBuilder` for OpenAPI docs.
+5. Add an integration test with a mock model that verifies:
+   - The prompt sent to the model matches the constant
+   - The structured JSON return parses against the typed interface
+   - `AIRequest.logRequest` is called with the correct `requestType`
+
+## Common Pitfalls
+
+- Calling the Vercel SDK directly from a route — bypasses logging and request typing
+- Inlining a prompt string in a route handler — makes future changes invisible and untestable
+- Using the wrong `requestType` value (or `"general"` as a catch-all) — degrades the admin explorer
+- Setting `temperature` numerically instead of via a preset — drifts away from the documented presets
+- Forgetting to type the JSON return — runtime parse failures show up later as confusing errors

--- a/.windsurf/skills/backend-test-env/SKILL.md
+++ b/.windsurf/skills/backend-test-env/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: backend-test-env
+description: >-
+  Invoke when writing tests that mutate `process.env` in `@terreno/api`,
+  `@terreno/ai`, or `example-backend` — feature flags, auth secrets, integration
+  toggles. Covers the preload contract, `setupEnvironment()`, and safe mutation
+  patterns.
+---
+# Backend Test — `process.env` Contract
+
+Bun's test runner preloads a per-package setup file (configured in each package's `bunfig.toml` under `[test].preload`):
+
+| Package | Preload file |
+|---------|--------------|
+| `@terreno/api` | `api/src/tests/bunSetup.ts` |
+| `@terreno/ai` | `ai/src/tests/bunSetup.ts` |
+| `example-backend` | `example-backend/src/tests/setup.ts` |
+
+The `@terreno/api` preload uses a global `beforeEach` to (1) reset the canonical auth secrets, (2) call `setupEnvironment()` (exported from `expressServer.ts`) for the wider baseline, and (3) re-silence the winston loggers. The next test always starts from the canonical baseline — you normally **do not** need to re-call `setupEnvironment()` in a file-level `beforeEach`.
+
+## Default — Rely on the Preload
+
+- Do not assume a toggle left by another file. Treat the preload's `beforeEach` as the source of truth for the canonical baseline.
+- Set only the keys this test needs in its own `beforeEach` or test body.
+- Don't reach in and call `setupEnvironment()` again unless you're explicitly testing env-driven behavior that the preload didn't cover.
+
+## When a Test Mutates `process.env`
+
+1. **Add the key to the preload's reset list** if it should always start from a fixed test value. Otherwise it leaks into the next test in the same worker.
+2. **Set only what this case needs** in the test body — avoid redundant manual restore if the preload already resets that key in `beforeEach`.
+3. **For keys that should be absent (unset)**, use **`Reflect.deleteProperty(process.env, "KEY")`**. Avoid `process.env.KEY = ""` to mean "unset" — on some platforms empty string and unset behave differently and can make tests flaky.
+4. **Avoid whole-env snapshots** (`const OLD_ENV = process.env; ...; process.env = OLD_ENV;`). This pattern exists in some older test files (`auth.test.ts`) — don't propagate it. It captures pre-`beforeEach` state and breaks ordering guarantees if the preload's `beforeEach` runs in between. Use targeted mutations + the preload's reset instead.
+
+## Adding a New Required Env Var
+
+If you introduce a new `process.env.FOO` that backend code reads at startup:
+
+1. Add `FOO` to `setupEnvironment()` in `api/src/expressServer.ts` so every package picks it up via the preload's `setupEnvironment()` call.
+2. If `example-backend` has its own startup needs for it, also add to `example-backend/src/tests/setup.ts`'s `beforeAll`.
+3. If a test needs to mutate it, follow the rules above — don't snapshot the whole env.
+
+## Auth-Related Keys
+
+`api/src/tests/bunSetup.ts` resets four auth keys in `beforeEach`: `TOKEN_SECRET`, `TOKEN_ISSUER`, `SESSION_SECRET`, `REFRESH_TOKEN_SECRET`. If your test changes any of these, you do not need to restore — the next `beforeEach` already does. If your test relies on them being **absent** for a code path, use `Reflect.deleteProperty` within the test, knowing the next `beforeEach` will restore.
+
+`auth.test.ts` is the established home for env-driven auth assertions; mirror its newer patterns (per-test `beforeEach` setting only what changes) rather than its older whole-env-snapshot blocks.
+
+## Log Capture & Sentry
+
+The preload silences winston and `console.*` and captures into an in-memory buffer (cleared in `beforeEach`/`afterEach`). It also mocks `@sentry/bun`. Don't re-mock Sentry inside individual tests — the preload's mock is shared and reset across tests.
+
+## Checklist
+
+- [ ] New env var added to `setupEnvironment()` and (if needed) `example-backend/src/tests/setup.ts`
+- [ ] Test mutations are targeted — no whole-env snapshots
+- [ ] "Unset" expressed as `Reflect.deleteProperty(process.env, "KEY")`, not `= ""`
+- [ ] No manual restore that duplicates the preload's `beforeEach` reset
+- [ ] No re-mock of `@sentry/bun` — the preload's mock is already in place
+- [ ] If you added an env-driven branch in code, a test covers both the set and the unset case

--- a/.windsurf/skills/improve-rulesync/SKILL.md
+++ b/.windsurf/skills/improve-rulesync/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: improve-rulesync
+description: >-
+  Invoke at the end of a session to evaluate whether any skills or rules were
+  misleading, incorrect, or missing — and fix or create them. Trigger with
+  /improve-rulesync.
+---
+# Improve Rulesync
+
+### Trigger
+Invoke explicitly at the end of a session with `/improve-rulesync`.
+
+### Behavior
+Review the current conversation session and evaluate the skills and rules in `.rulesync/`. Identify any that:
+- Gave misleading or incorrect guidance that caused errors or rework
+- Were missing and would have prevented incorrect behavior
+- Need to be updated to reflect decisions or patterns established in this session
+
+Then make the changes directly.
+
+### Step 1 — Session Review
+Scan the session for:
+- Moments where a skill or rule was followed but produced a wrong or suboptimal result
+- User corrections or decisions about AI model behavior (these indicate a gap or error in the rules)
+- New patterns, decisions, or constraints established that should be codified
+
+### Step 2 — Rules Audit
+Check `.rulesync/` for relevant existing rules and skills. Evaluate:
+- Are trigger conditions accurate?
+- Is the guidance still correct given what happened this session?
+- Are there gaps that caused confusion?
+
+### Step 3 — Make Changes
+For each issue found:
+- **Incorrect/misleading**: Edit the existing file to fix it
+- **Missing**: Create a new skill or rule file in `.rulesync/skills/` or `.rulesync/rules/`
+- **Outdated**: Update or remove the stale content
+
+Always edit `.rulesync/` as the source of truth.
+
+### Step 4 — Sync
+After all changes, run `bun run rules` to sync to all AI tool directories.
+
+### Step 5 — Summary
+Output a brief summary of what was changed and why. Format:
+- **Fixed**: [file] — [what was wrong and what was corrected]
+- **Created**: [file] — [what gap it fills]
+- **No changes needed**: [reason]

--- a/.windsurf/skills/mongoose-schema-safety/SKILL.md
+++ b/.windsurf/skills/mongoose-schema-safety/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: mongoose-schema-safety
+description: >-
+  Invoke when making any Mongoose schema change: adding/removing/renaming
+  fields, creating a new model, adding indexes, or writing a backfill migration.
+  Provides the five-type pattern, risk matrix, type file checklist, and rollout
+  safety steps for terreno backends.
+---
+# Mongoose Schema Safety — Terreno
+
+## Where Schemas and Types Live
+
+| Package | Schemas | Types |
+|---------|---------|-------|
+| `@terreno/api` (built-in models like `User`, `ConsentForm`) | `api/src/models/*.ts` | `api/src/types/*.ts` (or co-located in the model file via `mongoose.Schema<Doc, Model, Methods>` generics) |
+| `example-backend` (`User`, `Todo`, `Configuration`) | `example-backend/src/models/*.ts` | `example-backend/src/types/models/*.ts` (`userTypes.ts`, `todoTypes.ts`, …) |
+| `@terreno/ai` (`AIRequest`, `GptHistory`) | `ai/src/models/*.ts` | `ai/src/types/index.ts` |
+
+Every field in every schema **must** have a `description` (see the API rule `01-model-field-descriptions.md`). Descriptions flow through to the OpenAPI spec via `mongoose-to-swagger`.
+
+## The Five-Type Pattern
+
+Every model has manually-maintained TypeScript types. **Types are NOT auto-generated** — every schema change must include a matching type update in the same commit/PR.
+
+```typescript
+import type {DefaultDoc, DefaultModel, DefaultStatics} from "@terreno/api";
+
+// 1. Instance methods (on the document)
+export type YourModelMethods = {
+  customMethod: (this: YourModelDocument, param: string) => Promise<void>;
+};
+
+// 2. Static methods (on the model class) — extend DefaultStatics for findExactlyOne / findOneOrNone
+export type YourModelStatics = DefaultStatics<YourModelDocument> & {
+  customStatic: (this: YourModelModel, param: string) => Promise<YourModelDocument>;
+};
+
+// 3. Model type combining document + statics
+export type YourModelModel = DefaultModel<YourModelDocument> & YourModelStatics;
+
+// 4. Schema type
+export type YourModelSchema = mongoose.Schema<YourModelDocument, YourModelModel, YourModelMethods>;
+
+// 5. Document type (the shape of a single record)
+export type YourModelDocument = DefaultDoc & YourModelMethods & {
+  fieldName: string;
+  optionalField?: number;
+  enumField: "value1" | "value2";
+};
+```
+
+Follow existing type files in `example-backend/src/types/models/` and `ai/src/types/index.ts` for naming and structure.
+
+## Statics & Methods — Direct Assignment
+
+Define statics and methods by direct assignment on the schema — not via `.method()` / `.static()` / `.add()`:
+
+```typescript
+schema.methods = {
+  getDisplayName(this: YourModelDocument): string { return this.name; },
+};
+schema.statics = {
+  async findByEmail(this: YourModelModel, email: string) { return this.findOne({email}); },
+};
+```
+
+## Critical Mongoose Rules
+
+- **Never use `Model.findOne`** — use `Model.findExactlyOne` (throws on 0 or many) or `Model.findOneOrNone` (throws on many). These come from the `findExactlyOne` / `findOneOrNone` plugins in `@terreno/api`.
+- Apply the standard plugins (`createdUpdatedPlugin`, `isDeletedPlugin`, `findOneOrNone`, `findExactlyOne`) on every new model. Most existing models go through `addDefaultPlugins`.
+- `checkModelsStrict()` runs at non-prod startup (`server.ts`) and validates schema consistency — keep it passing.
+
+## Schema Change Risk Matrix
+
+| Change Type | Risk Level | Required Mitigation |
+|-------------|-----------|---------------------|
+| Add optional field | Low | Safe to ship directly (still requires `description`) |
+| Add required field | High | Must provide a default value, OR write a backfill migration script first |
+| Remove field | Medium | Soft-remove first (mark optional, stop writing); hard-remove in next PR after deploys settle |
+| Rename field | High | Three-step: add new → backfill → remove old (separate PRs) |
+| Change field type | Critical | Treat as rename: new field + migration + remove old |
+| Add index | Medium | Safe in code, but build can slow writes on large collections — coordinate with ops |
+| Remove index | Low | Safe to ship directly |
+| Add unique index | High | Dedup migration must run first; otherwise the index build fails on existing duplicates |
+
+## Migration Scripts
+
+Migration / backfill scripts live in `example-backend/src/scripts/` (e.g. `syncConsents.ts`, `seedConsents.ts`). They use the `ScriptRunner` type and `BackgroundTask` model from `@terreno/api` (`api/src/scriptRunner.ts`):
+
+```typescript
+import type {ScriptContext, ScriptResult, ScriptRunner} from "@terreno/api";
+
+export const run: ScriptRunner = async (wetRun, ctx) => {
+  const results: string[] = [];
+  // ... do work ...
+  if (wetRun) {
+    // commit changes
+  }
+  return {success: true, results};
+};
+```
+
+Always run with `wetRun = false` first to verify the dry-run output. Use `ctx.checkCancellation()`, `ctx.addLog()`, and `ctx.updateProgress()` for long-running tasks.
+
+## Cross-Package Ripple
+
+A schema change in one place often ripples:
+
+- **API surface affected?** Regenerate the SDK with `cd example-frontend && bun run sdk` (or invoke the `generate-sdk` skill). The OpenAPI spec is derived from the schema, so the frontend hooks will go stale otherwise.
+- **`modelRouter` config?** If you added/removed a field, update `queryFields`, `populatePaths`, and `responseHandler` for any router that touches the model.
+- **Admin panel?** If the model is registered in `AdminApp`, update `listFields` so the table reflects the new shape.
+- **Populated refs?** If another model references this one via `ObjectId` + `ref`, and the referenced document shape changed, the consumer's populated type may need updating.
+
+## Post-Change Checklist
+
+- [ ] All new fields have a `description` (flows to OpenAPI)
+- [ ] Type file updated in the same commit/PR — field names, optionality, enum values, array types, refs, statics/methods all match the schema
+- [ ] For a new model: all five types (`Document`, `Methods`, `Statics`, `Model`, `Schema`) created
+- [ ] Statics/methods assigned directly on schema (`schema.statics = {...}`, `schema.methods = {...}`) — not `.static()` / `.method()`
+- [ ] Other model type files checked — any model that populates this one updated if its shape changed
+- [ ] Migration script written (and dry-run verified with `wetRun = false`) for any backfill
+- [ ] `modelRouter` config updated (`queryFields`, `populatePaths`, `responseHandler`) if needed
+- [ ] `AdminApp` `listFields` updated if the model is in the admin panel
+- [ ] `bun run sdk` run from `example-frontend/` if the API response shape changed
+- [ ] Test covers old-format document behavior (missing new field) if the change rolls out before a backfill
+- [ ] Unique index: dedup migration written and run before the index is added
+- [ ] `checkModelsStrict()` still passes (it runs on non-prod startup)
+- [ ] No `Model.findOne` introduced — use `findExactlyOne` / `findOneOrNone`
+
+## Common Pitfalls
+
+- Adding a required field without a default — first deploy fails for documents that pre-date the field
+- Skipping the type file update — TS happily compiles older callers but new ones break at runtime
+- Adding a `unique` index without dedup — index build fails on collections with existing duplicates
+- Renaming a field in one PR — frontend gets old field, backend writes new field, neither side is happy
+- Forgetting to regenerate the SDK after a shape change — frontend types drift from reality
+- Using `.method()` / `.static()` API — terreno's convention is direct assignment, and mixing styles makes types hard to maintain


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Update the rulesync check workflow to match the stricter Flourish PR-only check pattern.
- Generate rules in CI and fail when `git status -s` reports generated changes, including untracked files.
- Add missing `.rulesync/skills` source files and regenerated skill outputs so the new check passes from a clean tree.

### Testing
- `bun run rules && test -z "$(git status --short)"`
- `bun run rules:check`
- `bunx prettier --check .github/workflows/rulesync-check.yml`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f27cbc9-4c11-47d6-aaea-d3e7e5336ddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f27cbc9-4c11-47d6-aaea-d3e7e5336ddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

