### PR TITLE
Enforce realtime websocket subscription permissions

### DIFF
--- a/api/src/realtime/changeStreamWatcher.ts
+++ b/api/src/realtime/changeStreamWatcher.ts
@@ -25,6 +25,7 @@ import {checkPermissions} from "../permissions";
 import {matchesQuery} from "./queryMatcher";
 import {getQuerySubscriptionsForCollection} from "./queryStore";
 import {findRegistryEntryByCollection, type RealtimeRegistryEntry} from "./registry";
+import {getSocketUser, type SocketWithDecodedToken} from "./socketUser";
 import type {ChangeStreamConfig, RealtimeEvent} from "./types";
 
 let changeWatcher: ChangeStream | null = null;
@@ -75,22 +76,7 @@ export const mapOperationType = (
  */
 const getCollectionTag = (routePath: string): string => routePath.replace(/^\//, "");
 
-interface RealtimeSocketWithAuth extends Socket {
-  decodedToken?: {id?: string; admin?: boolean; isAnonymous?: boolean};
-}
-
-const getSocketUser = (socket: RealtimeSocketWithAuth): User | undefined => {
-  const userId = socket.decodedToken?.id;
-  if (!userId) {
-    return undefined;
-  }
-  return {
-    _id: userId,
-    admin: socket.decodedToken?.admin === true,
-    id: userId,
-    isAnonymous: socket.decodedToken?.isAnonymous,
-  };
-};
+interface RealtimeSocketWithAuth extends Socket, SocketWithDecodedToken {}
 
 const getSocketsInRoom = (io: Server, room: string): RealtimeSocketWithAuth[] => {
   const socketIds = io.sockets.adapter.rooms.get(room);
@@ -230,22 +216,30 @@ export const emitToAuthorizedRoom = async (
   const sockets = getSocketsInRoom(io, room);
   for (const socket of sockets) {
     const user = getSocketUser(socket);
-    // Hard deletes have no document context; use an empty object so object-scoped
-    // permission helpers fail closed instead of treating the check as preflight.
-    const permissionDocument = fullDocument ?? {};
-    const canRead = await canReadDocument(entry, user, permissionDocument);
-    if (!canRead) {
-      logDebug(`[realtime] Skipped ${room} for ${socket.id}: read permission denied`);
+    try {
+      // Hard deletes have no document context; use an empty object so object-scoped
+      // permission helpers fail closed instead of treating the check as preflight.
+      const permissionDocument = fullDocument ?? {};
+      const canRead = await canReadDocument(entry, user, permissionDocument);
+      if (!canRead) {
+        logDebug(`[realtime] Skipped ${room} for ${socket.id}: read permission denied`);
+        continue;
+      }
+
+      if (!fullDocument) {
+        socket.emit("sync", event);
+        continue;
+      }
+
+      const data = await serializeDoc(entry, fullDocument, event.method, user);
+      socket.emit("sync", {...event, data});
+    } catch (error) {
+      logger.error(
+        `[realtime] Failed to emit ${entry.modelName}/${event.method} to socket ${socket.id}: ${error}`
+      );
+      Sentry.captureException(error);
       continue;
     }
-
-    if (!fullDocument) {
-      socket.emit("sync", event);
-      continue;
-    }
-
-    const data = await serializeDoc(entry, fullDocument, event.method, user);
-    socket.emit("sync", {...event, data});
   }
 };
 

--- a/api/src/realtime/changeStreamWatcher.ts
+++ b/api/src/realtime/changeStreamWatcher.ts
@@ -76,7 +76,7 @@ export const mapOperationType = (
  */
 const getCollectionTag = (routePath: string): string => routePath.replace(/^\//, "");
 
-interface RealtimeSocketWithAuth extends Socket, SocketWithDecodedToken {}
+type RealtimeSocketWithAuth = Socket & SocketWithDecodedToken;
 
 const getSocketsInRoom = (io: Server, room: string): RealtimeSocketWithAuth[] => {
   const socketIds = io.sockets.adapter.rooms.get(room);

--- a/api/src/realtime/changeStreamWatcher.ts
+++ b/api/src/realtime/changeStreamWatcher.ts
@@ -3,7 +3,7 @@ import * as Sentry from "@sentry/bun";
 import type express from "express";
 import {DateTime} from "luxon";
 import mongoose from "mongoose";
-import type {Server} from "socket.io";
+import type {Server, Socket} from "socket.io";
 
 type ChangeStream = mongoose.mongo.ChangeStream;
 type ChangeStreamDocument = mongoose.mongo.ChangeStreamDocument;
@@ -19,7 +19,9 @@ type WatchedChange = Extract<
   {operationType: "insert" | "update" | "replace" | "delete"}
 >;
 
+import type {User} from "../auth";
 import {logger} from "../logger";
+import {checkPermissions} from "../permissions";
 import {matchesQuery} from "./queryMatcher";
 import {getQuerySubscriptionsForCollection} from "./queryStore";
 import {findRegistryEntryByCollection, type RealtimeRegistryEntry} from "./registry";
@@ -72,6 +74,48 @@ export const mapOperationType = (
  * E.g. "/todos" -> "todos"
  */
 const getCollectionTag = (routePath: string): string => routePath.replace(/^\//, "");
+
+interface RealtimeSocketWithAuth extends Socket {
+  decodedToken?: {id?: string; admin?: boolean; isAnonymous?: boolean};
+}
+
+const getSocketUser = (socket: RealtimeSocketWithAuth): User | undefined => {
+  const userId = socket.decodedToken?.id;
+  if (!userId) {
+    return undefined;
+  }
+  return {
+    _id: userId,
+    admin: socket.decodedToken?.admin === true,
+    id: userId,
+    isAnonymous: socket.decodedToken?.isAnonymous,
+  };
+};
+
+const getSocketsInRoom = (io: Server, room: string): RealtimeSocketWithAuth[] => {
+  const socketIds = io.sockets.adapter.rooms.get(room);
+  if (!socketIds) {
+    return [];
+  }
+
+  const sockets: RealtimeSocketWithAuth[] = [];
+  for (const socketId of socketIds) {
+    const socket = io.sockets.sockets.get(socketId);
+    if (socket) {
+      sockets.push(socket as RealtimeSocketWithAuth);
+    }
+  }
+  return sockets;
+};
+
+const canReadDocument = async (
+  entry: RealtimeRegistryEntry,
+  user?: User,
+  // biome-ignore lint/suspicious/noExplicitAny: document shape varies per consumer model
+  doc?: any
+): Promise<boolean> => {
+  return checkPermissions("read", entry.options.permissions.read, user, doc);
+};
 
 /**
  * Determine which Socket.io rooms to emit to based on the room strategy.
@@ -146,7 +190,8 @@ export const serializeDoc = async (
   entry: RealtimeRegistryEntry,
   // biome-ignore lint/suspicious/noExplicitAny: doc is a Mongoose document for an arbitrary consumer model
   doc: any,
-  method: "create" | "update" | "delete"
+  method: "create" | "update" | "delete",
+  user?: User
   // biome-ignore lint/suspicious/noExplicitAny: serializer return shape is consumer-defined
 ): Promise<any> => {
   if (entry.config.realtimeResponseHandler) {
@@ -167,10 +212,8 @@ export const serializeDoc = async (
       // The REST responseHandler signature expects a "list" | "create" | "read" | "update" method.
       // Map "delete" → "read" so handlers that branch on method receive a sane value.
       const restMethod = method === "delete" ? "read" : method;
-      // Synthesize the minimal request shape a sanitizing responseHandler is likely to read.
-      // We intentionally do not pass a user — handlers must not depend on per-recipient context
-      // for realtime serialization (events fan out to many rooms).
-      const syntheticReq = {params: {}, query: {}, user: undefined} as unknown as express.Request;
+      // Synthesize the minimal request shape responseHandlers commonly inspect.
+      const syntheticReq = {params: {}, query: {}, user} as unknown as express.Request;
       return ensureApiId(await responseHandler(doc, restMethod, syntheticReq, entry.options));
     } catch (error) {
       logger.error(
@@ -182,6 +225,34 @@ export const serializeDoc = async (
   }
 
   return ensureApiId(typeof doc.toJSON === "function" ? doc.toJSON() : doc);
+};
+
+export const emitToAuthorizedRoom = async (
+  io: Server,
+  room: string,
+  event: RealtimeEvent,
+  entry: RealtimeRegistryEntry,
+  // biome-ignore lint/suspicious/noExplicitAny: fullDocument shape varies per consumer model
+  fullDocument: any,
+  logDebug: (msg: string) => void
+): Promise<void> => {
+  const sockets = getSocketsInRoom(io, room);
+  for (const socket of sockets) {
+    const user = getSocketUser(socket);
+    const canRead = await canReadDocument(entry, user, fullDocument);
+    if (!canRead) {
+      logDebug(`[realtime] Skipped ${room} for ${socket.id}: read permission denied`);
+      continue;
+    }
+
+    if (!fullDocument) {
+      socket.emit("sync", event);
+      continue;
+    }
+
+    const data = await serializeDoc(entry, fullDocument, event.method, user);
+    socket.emit("sync", {...event, data});
+  }
 };
 
 /**
@@ -200,7 +271,7 @@ export const serializeDoc = async (
  *
  * Exported for testing.
  */
-export const emitToDocumentAndQueryRooms = (
+export const emitToDocumentAndQueryRooms = async (
   io: Server,
   collection: string,
   event: RealtimeEvent,
@@ -208,10 +279,14 @@ export const emitToDocumentAndQueryRooms = (
   fullDocument: any,
   logDebug: (msg: string) => void,
   entry?: RealtimeRegistryEntry
-): void => {
+): Promise<void> => {
   // Emit to document-specific room
   const docRoom = `document:${collection}:${event.id}`;
-  io.to(docRoom).emit("sync", event);
+  if (entry) {
+    await emitToAuthorizedRoom(io, docRoom, event, entry, fullDocument, logDebug);
+  } else {
+    io.to(docRoom).emit("sync", event);
+  }
   logDebug(`[realtime] Emitted ${event.method} to ${docRoom}`);
 
   const isOwnerStrategy = entry?.config.roomStrategy === "owner";
@@ -232,14 +307,22 @@ export const emitToDocumentAndQueryRooms = (
           );
           continue;
         }
-        io.to(queryRoom).emit("sync", event);
+        if (entry) {
+          await emitToAuthorizedRoom(io, queryRoom, event, entry, fullDocument, logDebug);
+        } else {
+          io.to(queryRoom).emit("sync", event);
+        }
         logDebug(`[realtime] Emitted hard delete to ${queryRoom}`);
         continue;
       }
 
       // Soft delete: only forward to query rooms whose filter the document satisfies.
       if (matchesQuery(fullDocument, query)) {
-        io.to(queryRoom).emit("sync", event);
+        if (entry) {
+          await emitToAuthorizedRoom(io, queryRoom, event, entry, fullDocument, logDebug);
+        } else {
+          io.to(queryRoom).emit("sync", event);
+        }
         logDebug(`[realtime] Emitted soft delete to ${queryRoom} (query matched)`);
       }
       continue;
@@ -253,12 +336,20 @@ export const emitToDocumentAndQueryRooms = (
 
     if (event.method === "create" && docMatches) {
       // New document matches the query — send create event
-      io.to(queryRoom).emit("sync", event);
+      if (entry) {
+        await emitToAuthorizedRoom(io, queryRoom, event, entry, fullDocument, logDebug);
+      } else {
+        io.to(queryRoom).emit("sync", event);
+      }
       logDebug(`[realtime] Emitted create to ${queryRoom} (query matched)`);
     } else if (event.method === "update") {
       if (docMatches) {
         // Document still matches (or newly matches) — send update event
-        io.to(queryRoom).emit("sync", event);
+        if (entry) {
+          await emitToAuthorizedRoom(io, queryRoom, event, entry, fullDocument, logDebug);
+        } else {
+          io.to(queryRoom).emit("sync", event);
+        }
         logDebug(`[realtime] Emitted update to ${queryRoom} (query matched)`);
       } else {
         // Document no longer matches the query — send delete event so client removes it
@@ -266,7 +357,11 @@ export const emitToDocumentAndQueryRooms = (
           ...event,
           method: "delete",
         };
-        io.to(queryRoom).emit("sync", removeEvent);
+        if (entry) {
+          await emitToAuthorizedRoom(io, queryRoom, removeEvent, entry, fullDocument, logDebug);
+        } else {
+          io.to(queryRoom).emit("sync", removeEvent);
+        }
         logDebug(`[realtime] Emitted delete to ${queryRoom} (query no longer matched)`);
       }
     }
@@ -413,17 +508,10 @@ export const startChangeStreamWatcher = (
           rooms = resolveRooms(entry, fullDocument, method);
         }
 
-        // Serialize the document. Shape varies per consumer model, so the variable is unknown.
-        let data: unknown;
-        if (!isHardDelete && fullDocument) {
-          data = await serializeDoc(entry, fullDocument, method);
-        }
-
         const collection = getCollectionTag(entry.routePath);
 
         const event: RealtimeEvent = {
           collection,
-          data,
           id: docId,
           method,
           model: entry.modelName,
@@ -435,11 +523,11 @@ export const startChangeStreamWatcher = (
 
         // Emit to strategy-based rooms (model/owner/broadcast)
         for (const room of rooms) {
-          io.to(room).emit("sync", event);
+          await emitToAuthorizedRoom(io, room, event, entry, fullDocument, logDebug);
         }
 
         // Emit to document-specific and query rooms
-        emitToDocumentAndQueryRooms(io, collection, event, fullDocument, logDebug, entry);
+        await emitToDocumentAndQueryRooms(io, collection, event, fullDocument, logDebug, entry);
 
         logDebug(
           `[realtime] Emitted ${method} for ${entry.modelName}/${docId} to rooms: ${rooms.join(", ")}`

--- a/api/src/realtime/changeStreamWatcher.ts
+++ b/api/src/realtime/changeStreamWatcher.ts
@@ -111,7 +111,6 @@ const getSocketsInRoom = (io: Server, room: string): RealtimeSocketWithAuth[] =>
 const canReadDocument = async (
   entry: RealtimeRegistryEntry,
   user?: User,
-  // biome-ignore lint/suspicious/noExplicitAny: document shape varies per consumer model
   doc?: any
 ): Promise<boolean> => {
   return checkPermissions("read", entry.options.permissions.read, user, doc);
@@ -121,12 +120,7 @@ const canReadDocument = async (
  * Determine which Socket.io rooms to emit to based on the room strategy.
  * Exported for testing.
  */
-export const resolveRooms = (
-  entry: RealtimeRegistryEntry,
-  // biome-ignore lint/suspicious/noExplicitAny: doc shape varies per consumer model; resolver is at the framework boundary
-  doc: any,
-  method: string
-): string[] => {
+export const resolveRooms = (entry: RealtimeRegistryEntry, doc: any, method: string): string[] => {
   const {roomStrategy} = entry.config;
   // Use the collection tag (e.g. "todos") for model rooms, matching what the frontend subscribes to
   const collectionTag = getCollectionTag(entry.routePath);
@@ -188,11 +182,9 @@ export const ensureApiId = (data: unknown): unknown => {
  */
 export const serializeDoc = async (
   entry: RealtimeRegistryEntry,
-  // biome-ignore lint/suspicious/noExplicitAny: doc is a Mongoose document for an arbitrary consumer model
   doc: any,
   method: "create" | "update" | "delete",
   user?: User
-  // biome-ignore lint/suspicious/noExplicitAny: serializer return shape is consumer-defined
 ): Promise<any> => {
   if (entry.config.realtimeResponseHandler) {
     try {
@@ -232,7 +224,6 @@ export const emitToAuthorizedRoom = async (
   room: string,
   event: RealtimeEvent,
   entry: RealtimeRegistryEntry,
-  // biome-ignore lint/suspicious/noExplicitAny: fullDocument shape varies per consumer model
   fullDocument: any,
   logDebug: (msg: string) => void
 ): Promise<void> => {
@@ -275,7 +266,6 @@ export const emitToDocumentAndQueryRooms = async (
   io: Server,
   collection: string,
   event: RealtimeEvent,
-  // biome-ignore lint/suspicious/noExplicitAny: fullDocument shape varies per consumer model
   fullDocument: any,
   logDebug: (msg: string) => void,
   entry?: RealtimeRegistryEntry

--- a/api/src/realtime/changeStreamWatcher.ts
+++ b/api/src/realtime/changeStreamWatcher.ts
@@ -230,7 +230,10 @@ export const emitToAuthorizedRoom = async (
   const sockets = getSocketsInRoom(io, room);
   for (const socket of sockets) {
     const user = getSocketUser(socket);
-    const canRead = await canReadDocument(entry, user, fullDocument);
+    // Hard deletes have no document context; use an empty object so object-scoped
+    // permission helpers fail closed instead of treating the check as preflight.
+    const permissionDocument = fullDocument ?? {};
+    const canRead = await canReadDocument(entry, user, permissionDocument);
     if (!canRead) {
       logDebug(`[realtime] Skipped ${room} for ${socket.id}: read permission denied`);
       continue;

--- a/api/src/realtime/realtime.test.ts
+++ b/api/src/realtime/realtime.test.ts
@@ -13,6 +13,7 @@ import {afterEach, beforeEach, describe, expect, it, mock} from "bun:test";
 import express from "express";
 
 import {
+  emitToAuthorizedRoom,
   emitToDocumentAndQueryRooms,
   mapOperationType,
   resolveRooms,
@@ -1322,19 +1323,55 @@ describe("resolveRooms", () => {
 });
 
 describe("emitToDocumentAndQueryRooms", () => {
+  const permissiveOptions = {
+    permissions: {
+      create: [() => true],
+      delete: [() => true],
+      list: [() => true],
+      read: [() => true],
+      update: [() => true],
+    },
+  };
+
   const makeIo = (): {
+    addSocketToRoom: (room: string, decodedToken?: {id?: string; admin?: boolean}) => void;
     emissions: Array<{room: string; event: string; payload: unknown}>;
     io: any;
   } => {
     const emissions: Array<{room: string; event: string; payload: unknown}> = [];
+    const roomSockets = new Map<string, Set<string>>();
+    const sockets = new Map<string, any>();
+    let nextSocketId = 1;
+    const addSocketToRoom = (
+      room: string,
+      decodedToken: {id?: string; admin?: boolean} = {admin: true, id: "admin"}
+    ): void => {
+      const socketId = `socket-${nextSocketId}`;
+      nextSocketId += 1;
+      if (!roomSockets.has(room)) {
+        roomSockets.set(room, new Set());
+      }
+      roomSockets.get(room)?.add(socketId);
+      sockets.set(socketId, {
+        decodedToken,
+        emit: (event: string, payload: unknown): void => {
+          emissions.push({event, payload, room});
+        },
+        id: socketId,
+      });
+    };
     const io = {
+      sockets: {
+        adapter: {rooms: roomSockets},
+        sockets,
+      },
       to: (room: string) => ({
         emit: (event: string, payload: unknown): void => {
           emissions.push({event, payload, room});
         },
       }),
     };
-    return {emissions, io};
+    return {addSocketToRoom, emissions, io};
   };
 
   beforeEach(() => {
@@ -1345,7 +1382,7 @@ describe("emitToDocumentAndQueryRooms", () => {
     clearQueryStore();
   });
 
-  it("emits to the document room", () => {
+  it("emits to the document room", async () => {
     const {emissions, io} = makeIo();
     const event: any = {
       collection: "todos",
@@ -1354,14 +1391,15 @@ describe("emitToDocumentAndQueryRooms", () => {
       model: "Todo",
       timestamp: 1,
     };
-    emitToDocumentAndQueryRooms(io, "todos", event, {}, () => {});
+    await emitToDocumentAndQueryRooms(io, "todos", event, {}, () => {});
     expect(emissions.some((e) => e.room === "document:todos:doc-1")).toBe(true);
   });
 
-  it("forwards hard deletes to every query room for non-owner strategies", () => {
+  it("forwards hard deletes to every query room for non-owner strategies", async () => {
     const queryId = computeQueryId("todos", {priority: 1});
     addQuerySubscription("socket-a", "todos", {priority: 1}, queryId);
-    const {emissions, io} = makeIo();
+    const {addSocketToRoom, emissions, io} = makeIo();
+    addSocketToRoom(`query:${queryId}`);
     const event: any = {
       collection: "todos",
       id: "doc-1",
@@ -1373,17 +1411,19 @@ describe("emitToDocumentAndQueryRooms", () => {
       collectionName: "todos",
       config: {methods: ["delete"], roomStrategy: "model"},
       modelName: "Todo",
-      options: {},
+      options: permissiveOptions,
       routePath: "/todos",
     };
-    emitToDocumentAndQueryRooms(io, "todos", event, undefined, () => {}, entry);
+    await emitToDocumentAndQueryRooms(io, "todos", event, undefined, () => {}, entry);
     expect(emissions.some((e) => e.room === `query:${queryId}` && e.event === "sync")).toBe(true);
   });
 
-  it("does NOT forward hard deletes to query rooms for owner-strategy collections", () => {
+  it("does NOT forward hard deletes to query rooms for owner-strategy collections", async () => {
     const queryId = computeQueryId("todos", {ownerId: "user-1"});
     addQuerySubscription("socket-a", "todos", {ownerId: "user-1"}, queryId);
-    const {emissions, io} = makeIo();
+    const {addSocketToRoom, emissions, io} = makeIo();
+    addSocketToRoom("document:todos:doc-1");
+    addSocketToRoom(`query:${queryId}`);
     const event: any = {
       collection: "todos",
       id: "doc-1",
@@ -1395,22 +1435,24 @@ describe("emitToDocumentAndQueryRooms", () => {
       collectionName: "todos",
       config: {methods: ["delete"], roomStrategy: "owner"},
       modelName: "Todo",
-      options: {},
+      options: permissiveOptions,
       routePath: "/todos",
     };
-    emitToDocumentAndQueryRooms(io, "todos", event, undefined, () => {}, entry);
+    await emitToDocumentAndQueryRooms(io, "todos", event, undefined, () => {}, entry);
     // Document room still receives the event, but query rooms must not — otherwise users
     // would see deletes for docs they don't own.
     expect(emissions.some((e) => e.room === `query:${queryId}`)).toBe(false);
     expect(emissions.some((e) => e.room === "document:todos:doc-1")).toBe(true);
   });
 
-  it("forwards soft deletes only to query rooms whose filter the document satisfies", () => {
+  it("forwards soft deletes only to query rooms whose filter the document satisfies", async () => {
     const matchingQueryId = computeQueryId("todos", {priority: 1});
     const nonMatchingQueryId = computeQueryId("todos", {priority: 9});
     addQuerySubscription("socket-a", "todos", {priority: 1}, matchingQueryId);
     addQuerySubscription("socket-b", "todos", {priority: 9}, nonMatchingQueryId);
-    const {emissions, io} = makeIo();
+    const {addSocketToRoom, emissions, io} = makeIo();
+    addSocketToRoom(`query:${matchingQueryId}`);
+    addSocketToRoom(`query:${nonMatchingQueryId}`);
     const event: any = {
       collection: "todos",
       data: {deleted: true, priority: 1},
@@ -1423,15 +1465,22 @@ describe("emitToDocumentAndQueryRooms", () => {
       collectionName: "todos",
       config: {methods: ["delete"], roomStrategy: "owner"},
       modelName: "Todo",
-      options: {},
+      options: permissiveOptions,
       routePath: "/todos",
     };
-    emitToDocumentAndQueryRooms(io, "todos", event, {deleted: true, priority: 1}, () => {}, entry);
+    await emitToDocumentAndQueryRooms(
+      io,
+      "todos",
+      event,
+      {deleted: true, priority: 1},
+      () => {},
+      entry
+    );
     expect(emissions.some((e) => e.room === `query:${matchingQueryId}`)).toBe(true);
     expect(emissions.some((e) => e.room === `query:${nonMatchingQueryId}`)).toBe(false);
   });
 
-  it("skips matching when fullDocument is missing on non-delete events", () => {
+  it("skips matching when fullDocument is missing on non-delete events", async () => {
     const queryId = computeQueryId("todos", {priority: 1});
     addQuerySubscription("socket-a", "todos", {priority: 1}, queryId);
     const {emissions, io} = makeIo();
@@ -1442,11 +1491,11 @@ describe("emitToDocumentAndQueryRooms", () => {
       model: "Todo",
       timestamp: 1,
     };
-    emitToDocumentAndQueryRooms(io, "todos", event, undefined, () => {});
+    await emitToDocumentAndQueryRooms(io, "todos", event, undefined, () => {});
     expect(emissions.some((e) => e.room === `query:${queryId}`)).toBe(false);
   });
 
-  it("emits create events to query rooms when the doc matches", () => {
+  it("emits create events to query rooms when the doc matches", async () => {
     const queryId = computeQueryId("todos", {priority: 1});
     addQuerySubscription("socket-a", "todos", {priority: 1}, queryId);
     const {emissions, io} = makeIo();
@@ -1457,13 +1506,13 @@ describe("emitToDocumentAndQueryRooms", () => {
       model: "Todo",
       timestamp: 1,
     };
-    emitToDocumentAndQueryRooms(io, "todos", event, {priority: 1}, () => {});
+    await emitToDocumentAndQueryRooms(io, "todos", event, {priority: 1}, () => {});
     const queryEmissions = emissions.filter((e) => e.room === `query:${queryId}`);
     expect(queryEmissions.length).toBe(1);
     expect(queryEmissions[0].payload).toMatchObject({method: "create"});
   });
 
-  it("does not emit create events to query rooms when the doc does not match", () => {
+  it("does not emit create events to query rooms when the doc does not match", async () => {
     const queryId = computeQueryId("todos", {priority: 1});
     addQuerySubscription("socket-a", "todos", {priority: 1}, queryId);
     const {emissions, io} = makeIo();
@@ -1474,11 +1523,11 @@ describe("emitToDocumentAndQueryRooms", () => {
       model: "Todo",
       timestamp: 1,
     };
-    emitToDocumentAndQueryRooms(io, "todos", event, {priority: 9}, () => {});
+    await emitToDocumentAndQueryRooms(io, "todos", event, {priority: 9}, () => {});
     expect(emissions.some((e) => e.room === `query:${queryId}`)).toBe(false);
   });
 
-  it("emits update as-is when the document still matches the query", () => {
+  it("emits update as-is when the document still matches the query", async () => {
     const queryId = computeQueryId("todos", {priority: 1});
     addQuerySubscription("socket-a", "todos", {priority: 1}, queryId);
     const {emissions, io} = makeIo();
@@ -1489,13 +1538,13 @@ describe("emitToDocumentAndQueryRooms", () => {
       model: "Todo",
       timestamp: 1,
     };
-    emitToDocumentAndQueryRooms(io, "todos", event, {priority: 1}, () => {});
+    await emitToDocumentAndQueryRooms(io, "todos", event, {priority: 1}, () => {});
     const queryEmissions = emissions.filter((e) => e.room === `query:${queryId}`);
     expect(queryEmissions.length).toBe(1);
     expect(queryEmissions[0].payload).toMatchObject({method: "update"});
   });
 
-  it("converts updates that no longer match into delete events for the query", () => {
+  it("converts updates that no longer match into delete events for the query", async () => {
     const queryId = computeQueryId("todos", {priority: 1});
     addQuerySubscription("socket-a", "todos", {priority: 1}, queryId);
     const {emissions, io} = makeIo();
@@ -1506,10 +1555,59 @@ describe("emitToDocumentAndQueryRooms", () => {
       model: "Todo",
       timestamp: 1,
     };
-    emitToDocumentAndQueryRooms(io, "todos", event, {priority: 9}, () => {});
+    await emitToDocumentAndQueryRooms(io, "todos", event, {priority: 9}, () => {});
     const queryEmissions = emissions.filter((e) => e.room === `query:${queryId}`);
     expect(queryEmissions.length).toBe(1);
     expect(queryEmissions[0].payload).toMatchObject({method: "delete"});
+  });
+
+  it("filters socket emissions by object read permission and responseHandler", async () => {
+    const {addSocketToRoom, emissions, io} = makeIo();
+    addSocketToRoom("model:todos", {id: "owner-1"});
+    addSocketToRoom("model:todos", {id: "other-user"});
+    const entry: any = {
+      collectionName: "todos",
+      config: {methods: ["update"], roomStrategy: "model"},
+      modelName: "Todo",
+      options: {
+        permissions: {
+          create: [() => true],
+          delete: [() => true],
+          list: [() => true],
+          read: [
+            (_method: string, user?: {admin?: boolean; id?: string}, obj?: {ownerId?: string}) =>
+              user?.admin === true || user?.id === obj?.ownerId,
+          ],
+          update: [() => true],
+        },
+        responseHandler: (doc: any, _method: string, req: any) => ({
+          id: doc._id,
+          title: doc.title,
+          visibleTo: req.user?.id,
+        }),
+      },
+      routePath: "/todos",
+    };
+
+    await emitToAuthorizedRoom(
+      io,
+      "model:todos",
+      {
+        collection: "todos",
+        id: "todo-1",
+        method: "update",
+        model: "Todo",
+        timestamp: 1,
+      },
+      entry,
+      {_id: "todo-1", ownerId: "owner-1", secret: "hidden", title: "Visible"},
+      () => {}
+    );
+
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].payload).toMatchObject({
+      data: {id: "todo-1", title: "Visible", visibleTo: "owner-1"},
+    });
   });
 });
 

--- a/api/src/realtime/realtime.test.ts
+++ b/api/src/realtime/realtime.test.ts
@@ -1609,6 +1609,46 @@ describe("emitToDocumentAndQueryRooms", () => {
       data: {id: "todo-1", title: "Visible", visibleTo: "owner-1"},
     });
   });
+
+  it("does not emit hard delete metadata when read permission requires an object owner", async () => {
+    const {addSocketToRoom, emissions, io} = makeIo();
+    addSocketToRoom("model:todos", {id: "other-user"});
+    const entry: any = {
+      collectionName: "todos",
+      config: {methods: ["delete"], roomStrategy: "model"},
+      modelName: "Todo",
+      options: {
+        permissions: {
+          create: [() => true],
+          delete: [() => true],
+          list: [() => true],
+          read: [
+            (_method: string, user?: {admin?: boolean; id?: string}, obj?: {ownerId?: string}) =>
+              user?.admin === true || user?.id === obj?.ownerId,
+          ],
+          update: [() => true],
+        },
+      },
+      routePath: "/todos",
+    };
+
+    await emitToAuthorizedRoom(
+      io,
+      "model:todos",
+      {
+        collection: "todos",
+        id: "todo-1",
+        method: "delete",
+        model: "Todo",
+        timestamp: 1,
+      },
+      entry,
+      undefined,
+      () => {}
+    );
+
+    expect(emissions).toEqual([]);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/api/src/realtime/realtime.test.ts
+++ b/api/src/realtime/realtime.test.ts
@@ -989,6 +989,37 @@ describe("installRealtimeSocketHandlers", () => {
       expect(subs[0].query).toEqual({status: "active", tenantId: "tenant-1"});
     });
 
+    it("denies query subscriptions when modelRouter queryFilter throws", async () => {
+      registerRealtime({
+        collectionName: "filtered",
+        config: {methods: ["create"], roomStrategy: "model"},
+        modelName: "Filtered",
+        options: {
+          permissions: {
+            create: [() => true],
+            delete: [() => true],
+            list: [() => true],
+            read: [() => true],
+            update: [() => true],
+          },
+          queryFilter: () => {
+            throw new Error("tenant lookup failed");
+          },
+        } as any,
+        routePath: "/filtered",
+      });
+      const socket = createMockSocket({id: "user1"});
+      installRealtimeSocketHandlers(socket);
+      await socket.trigger("subscribe:query", {
+        collection: "filtered",
+        query: {status: "active"},
+      });
+      const queryRooms = Array.from(socket.rooms).filter((r) => r.startsWith("query:"));
+      expect(queryRooms).toHaveLength(0);
+      expect(getQuerySubscriptionsForCollection("filtered")).toHaveLength(0);
+      expect(socket.emitted.some((e) => e.event === "query:subscribed")).toBe(false);
+    });
+
     it("ignores malformed query payloads", async () => {
       registerOwnerCollection();
       const socket = createMockSocket({id: "user1"});
@@ -1607,6 +1638,54 @@ describe("emitToDocumentAndQueryRooms", () => {
     expect(emissions).toHaveLength(1);
     expect(emissions[0].payload).toMatchObject({
       data: {id: "todo-1", title: "Visible", visibleTo: "owner-1"},
+    });
+  });
+
+  it("continues emitting to other sockets when per-socket serialization fails", async () => {
+    const {addSocketToRoom, emissions, io} = makeIo();
+    addSocketToRoom("model:todos", {id: "bad-user"});
+    addSocketToRoom("model:todos", {id: "good-user"});
+    const entry: any = {
+      collectionName: "todos",
+      config: {methods: ["update"], roomStrategy: "model"},
+      modelName: "Todo",
+      options: {
+        permissions: {
+          create: [() => true],
+          delete: [() => true],
+          list: [() => true],
+          read: [() => true],
+          update: [() => true],
+        },
+        responseHandler: (doc: any, _method: string, req: any) => {
+          if (req.user?.id === "bad-user") {
+            throw new Error("cannot serialize for bad user");
+          }
+
+          return {...doc, visibleTo: req.user?.id};
+        },
+      },
+      routePath: "/todos",
+    };
+
+    await emitToAuthorizedRoom(
+      io,
+      "model:todos",
+      {
+        collection: "todos",
+        id: "todo-1",
+        method: "update",
+        model: "Todo",
+        timestamp: 1,
+      },
+      entry,
+      {_id: "todo-1", title: "Visible"},
+      () => {}
+    );
+
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].payload).toMatchObject({
+      data: {id: "todo-1", title: "Visible", visibleTo: "good-user"},
     });
   });
 

--- a/api/src/realtime/realtime.test.ts
+++ b/api/src/realtime/realtime.test.ts
@@ -662,7 +662,15 @@ describe("installRealtimeSocketHandlers", () => {
       collectionName: "todos",
       config: {methods: ["create", "update", "delete"], roomStrategy: "owner"},
       modelName: "Todo",
-      options: {} as any,
+      options: {
+        permissions: {
+          create: [() => true],
+          delete: [() => true],
+          list: [() => true],
+          read: [() => true],
+          update: [() => true],
+        },
+      } as any,
       routePath: "/todos",
     });
   };
@@ -672,8 +680,34 @@ describe("installRealtimeSocketHandlers", () => {
       collectionName: "broadcasts",
       config: {methods: ["create", "update", "delete"], roomStrategy: "model"},
       modelName: "Broadcast",
-      options: {} as any,
+      options: {
+        permissions: {
+          create: [() => true],
+          delete: [() => true],
+          list: [() => true],
+          read: [() => true],
+          update: [() => true],
+        },
+      } as any,
       routePath: "/broadcasts",
+    });
+  };
+
+  const registerAdminOnlyCollection = (): void => {
+    registerRealtime({
+      collectionName: "secrets",
+      config: {methods: ["create", "update", "delete"], roomStrategy: "model"},
+      modelName: "Secret",
+      options: {
+        permissions: {
+          create: [(_method: string, user?: {admin?: boolean}) => user?.admin === true],
+          delete: [(_method: string, user?: {admin?: boolean}) => user?.admin === true],
+          list: [(_method: string, user?: {admin?: boolean}) => user?.admin === true],
+          read: [(_method: string, user?: {admin?: boolean}) => user?.admin === true],
+          update: [(_method: string, user?: {admin?: boolean}) => user?.admin === true],
+        },
+      } as any,
+      routePath: "/secrets",
     });
   };
 
@@ -737,6 +771,22 @@ describe("installRealtimeSocketHandlers", () => {
       expect(socket.rooms.has("model:broadcasts")).toBe(true);
     });
 
+    it("denies model-strategy collections when modelRouter list permission fails", async () => {
+      registerAdminOnlyCollection();
+      const socket = createMockSocket({admin: false, id: "user1"});
+      installRealtimeSocketHandlers(socket);
+      await socket.trigger("subscribe:model", "secrets");
+      expect(socket.rooms.has("model:secrets")).toBe(false);
+    });
+
+    it("allows model-strategy collections when modelRouter list permission passes", async () => {
+      registerAdminOnlyCollection();
+      const socket = createMockSocket({admin: true, id: "admin1"});
+      installRealtimeSocketHandlers(socket);
+      await socket.trigger("subscribe:model", "secrets");
+      expect(socket.rooms.has("model:secrets")).toBe(true);
+    });
+
     it("ignores empty or non-string model names", async () => {
       registerModelCollection();
       const socket = createMockSocket({id: "user1"});
@@ -755,7 +805,15 @@ describe("installRealtimeSocketHandlers", () => {
           collectionName: `coll${i}`,
           config: {methods: ["create"], roomStrategy: "model"},
           modelName: `Coll${i}`,
-          options: {} as any,
+          options: {
+            permissions: {
+              create: [() => true],
+              delete: [() => true],
+              list: [() => true],
+              read: [() => true],
+              update: [() => true],
+            },
+          } as any,
           routePath: `/coll${i}`,
         });
       }
@@ -800,6 +858,14 @@ describe("installRealtimeSocketHandlers", () => {
       installRealtimeSocketHandlers(socket);
       await socket.trigger("subscribe:document", {collection: "broadcasts", id: "doc1"});
       expect(socket.rooms.has("document:broadcasts:doc1")).toBe(true);
+    });
+
+    it("denies document subscriptions when modelRouter read permission fails", async () => {
+      registerAdminOnlyCollection();
+      const socket = createMockSocket({admin: false, id: "user1"});
+      installRealtimeSocketHandlers(socket);
+      await socket.trigger("subscribe:document", {collection: "secrets", id: "doc1"});
+      expect(socket.rooms.has("document:secrets:doc1")).toBe(false);
     });
 
     it("ignores malformed payloads", async () => {
@@ -881,6 +947,47 @@ describe("installRealtimeSocketHandlers", () => {
       expect(payload.queryId).toBe(computeQueryId("todos", {completed: false}));
     });
 
+    it("denies query subscriptions when modelRouter list permission fails", async () => {
+      registerAdminOnlyCollection();
+      const socket = createMockSocket({admin: false, id: "user1"});
+      installRealtimeSocketHandlers(socket);
+      await socket.trigger("subscribe:query", {
+        collection: "secrets",
+        query: {classification: "restricted"},
+      });
+      const queryRooms = Array.from(socket.rooms).filter((r) => r.startsWith("query:"));
+      expect(queryRooms).toHaveLength(0);
+      expect(getQuerySubscriptionsForCollection("secrets")).toHaveLength(0);
+    });
+
+    it("applies modelRouter queryFilter before storing a query subscription", async () => {
+      registerRealtime({
+        collectionName: "filtered",
+        config: {methods: ["create"], roomStrategy: "model"},
+        modelName: "Filtered",
+        options: {
+          permissions: {
+            create: [() => true],
+            delete: [() => true],
+            list: [() => true],
+            read: [() => true],
+            update: [() => true],
+          },
+          queryFilter: () => ({tenantId: "tenant-1"}),
+        } as any,
+        routePath: "/filtered",
+      });
+      const socket = createMockSocket({id: "user1"});
+      installRealtimeSocketHandlers(socket);
+      await socket.trigger("subscribe:query", {
+        collection: "filtered",
+        query: {status: "active"},
+      });
+      const subs = getQuerySubscriptionsForCollection("filtered");
+      expect(subs).toHaveLength(1);
+      expect(subs[0].query).toEqual({status: "active", tenantId: "tenant-1"});
+    });
+
     it("ignores malformed query payloads", async () => {
       registerOwnerCollection();
       const socket = createMockSocket({id: "user1"});
@@ -915,7 +1022,15 @@ describe("installRealtimeSocketHandlers", () => {
         collectionName: "other",
         config: {methods: ["create"], roomStrategy: "model"},
         modelName: "Other",
-        options: {} as any,
+        options: {
+          permissions: {
+            create: [() => true],
+            delete: [() => true],
+            list: [() => true],
+            read: [() => true],
+            update: [() => true],
+          },
+        } as any,
         routePath: "/other",
       });
       const socket = createMockSocket({id: "user1"});

--- a/api/src/realtime/realtimeApp.ts
+++ b/api/src/realtime/realtimeApp.ts
@@ -5,7 +5,9 @@ import {authorize} from "@thream/socketio-jwt";
 import type express from "express";
 import {Server, type Socket} from "socket.io";
 
+import type {User} from "../auth";
 import {logger} from "../logger";
+import {checkPermissions} from "../permissions";
 import type {TerrenoPlugin} from "../terrenoPlugin";
 import {startChangeStreamWatcher, stopChangeStreamWatcher} from "./changeStreamWatcher";
 import {
@@ -14,7 +16,7 @@ import {
   removeAllSocketQueries,
   removeQuerySubscription,
 } from "./queryStore";
-import {findRegistryEntryByRoutePath} from "./registry";
+import {findRegistryEntryByRoutePath, type RealtimeRegistryEntry} from "./registry";
 import type {DocumentSubscription, QuerySubscription, RealtimeAppOptions} from "./types";
 
 /**
@@ -54,13 +56,56 @@ export const redactCredentials = (url: string): string => {
  */
 export interface RealtimeSocketLike {
   id: string;
-  decodedToken?: {id?: string; admin?: boolean};
+  decodedToken?: {id?: string; admin?: boolean; isAnonymous?: boolean};
   join: (room: string) => Promise<void> | void;
   leave: (room: string) => Promise<void> | void;
   emit: (event: string, payload: unknown) => void;
   // biome-ignore lint/suspicious/noExplicitAny: Socket.io event handlers accept arbitrary argument shapes per event name
   on: (event: string, handler: (...args: any[]) => any) => void;
 }
+
+const getSocketUser = (socket: RealtimeSocketLike): User | undefined => {
+  const userId = socket.decodedToken?.id;
+  if (!userId) {
+    return undefined;
+  }
+  return {
+    _id: userId,
+    admin: socket.decodedToken?.admin === true,
+    id: userId,
+    isAnonymous: socket.decodedToken?.isAnonymous,
+  };
+};
+
+const canSubscribe = async (
+  entry: RealtimeRegistryEntry,
+  method: "list" | "read",
+  user?: User
+): Promise<boolean> => {
+  const permissions = entry.options.permissions[method];
+  return checkPermissions(method, permissions, user);
+};
+
+const getAuthorizedQuery = async (
+  entry: RealtimeRegistryEntry,
+  query: Record<string, any>,
+  user?: User
+): Promise<Record<string, any> | null> => {
+  if (!(await canSubscribe(entry, "list", user))) {
+    return null;
+  }
+
+  if (!entry.options.queryFilter) {
+    return query;
+  }
+
+  const filteredQuery = await entry.options.queryFilter(user, query);
+  if (filteredQuery === null) {
+    return null;
+  }
+
+  return {...query, ...filteredQuery};
+};
 
 /**
  * Install the realtime subscription handlers on a single socket. Extracted from the
@@ -80,6 +125,7 @@ export const installRealtimeSocketHandlers = (
   const logInfo = options.logInfo ?? ((): void => {});
   const userId = socket.decodedToken?.id;
   const isAdmin = socket.decodedToken?.admin === true;
+  const user = getSocketUser(socket);
 
   const counts = {document: 0, model: 0, query: 0};
 
@@ -126,6 +172,13 @@ export const installRealtimeSocketHandlers = (
       return;
     }
 
+    if (!(await canSubscribe(entry, "list", user))) {
+      logInfo(
+        `[realtime] User ${userId} denied model subscription for ${modelName}: list permission denied`
+      );
+      return;
+    }
+
     counts.model += 1;
     await socket.join(`model:${modelName}`);
     logInfo(`[realtime] User ${userId} subscribed to model:${modelName}`);
@@ -158,6 +211,14 @@ export const installRealtimeSocketHandlers = (
       logInfo(
         `[realtime] User ${userId} denied document subscription: ` +
           `collection "${payload.collection}" not registered`
+      );
+      return;
+    }
+
+    if (!(await canSubscribe(entry, "read", user))) {
+      logInfo(
+        `[realtime] User ${userId} denied document subscription for ` +
+          `${payload.collection}/${payload.id}: read permission denied`
       );
       return;
     }
@@ -209,7 +270,15 @@ export const installRealtimeSocketHandlers = (
       return;
     }
 
-    let query = {...payload.query};
+    let query = await getAuthorizedQuery(entry, {...payload.query}, user);
+    if (!query) {
+      logInfo(
+        `[realtime] User ${userId} denied query subscription for ${payload.collection}: ` +
+          "list permission or query filter denied"
+      );
+      return;
+    }
+
     if (entry.config.roomStrategy === "owner" && !isAdmin) {
       if (!userId) {
         return;
@@ -222,7 +291,11 @@ export const installRealtimeSocketHandlers = (
     addQuerySubscription(socket.id, payload.collection, query, queryId);
     counts.query += 1;
     await socket.join(`query:${queryId}`);
-    socket.emit("query:subscribed", {collection: payload.collection, queryId});
+    socket.emit("query:subscribed", {
+      clientQueryId: payload.queryId,
+      collection: payload.collection,
+      queryId,
+    });
     logInfo(`[realtime] User ${userId} subscribed to query:${queryId} on ${payload.collection}`);
   });
 

--- a/api/src/realtime/realtimeApp.ts
+++ b/api/src/realtime/realtimeApp.ts
@@ -17,6 +17,7 @@ import {
   removeQuerySubscription,
 } from "./queryStore";
 import {findRegistryEntryByRoutePath, type RealtimeRegistryEntry} from "./registry";
+import {getSocketUser, type SocketWithDecodedToken} from "./socketUser";
 import type {DocumentSubscription, QuerySubscription, RealtimeAppOptions} from "./types";
 
 /**
@@ -54,28 +55,14 @@ export const redactCredentials = (url: string): string => {
  * Minimal shape this module requires from a Socket.io socket. Lets tests pass a
  * mock without standing up a real server.
  */
-export interface RealtimeSocketLike {
+export interface RealtimeSocketLike extends SocketWithDecodedToken {
   id: string;
-  decodedToken?: {id?: string; admin?: boolean; isAnonymous?: boolean};
   join: (room: string) => Promise<void> | void;
   leave: (room: string) => Promise<void> | void;
   emit: (event: string, payload: unknown) => void;
   // biome-ignore lint/suspicious/noExplicitAny: Socket.io event handlers accept arbitrary argument shapes per event name
   on: (event: string, handler: (...args: any[]) => any) => void;
 }
-
-const getSocketUser = (socket: RealtimeSocketLike): User | undefined => {
-  const userId = socket.decodedToken?.id;
-  if (!userId) {
-    return undefined;
-  }
-  return {
-    _id: userId,
-    admin: socket.decodedToken?.admin === true,
-    id: userId,
-    isAnonymous: socket.decodedToken?.isAnonymous,
-  };
-};
 
 const canSubscribe = async (
   entry: RealtimeRegistryEntry,
@@ -99,7 +86,17 @@ const getAuthorizedQuery = async (
     return query;
   }
 
-  const filteredQuery = await entry.options.queryFilter(user, query);
+  let filteredQuery: Record<string, any> | null;
+  try {
+    filteredQuery = await entry.options.queryFilter(user, query);
+  } catch (error) {
+    logger.error(
+      `[realtime] queryFilter threw for ${entry.modelName}/list: ${error}. Denying query subscription.`
+    );
+    Sentry.captureException(error);
+    return null;
+  }
+
   if (filteredQuery === null) {
     return null;
   }

--- a/api/src/realtime/socketUser.ts
+++ b/api/src/realtime/socketUser.ts
@@ -1,0 +1,25 @@
+import type {User} from "../auth";
+
+export interface DecodedRealtimeToken {
+  admin?: boolean;
+  id?: string;
+  isAnonymous?: boolean;
+}
+
+export interface SocketWithDecodedToken {
+  decodedToken?: DecodedRealtimeToken;
+}
+
+export const getSocketUser = (socket: SocketWithDecodedToken): User | undefined => {
+  const userId = socket.decodedToken?.id;
+  if (!userId) {
+    return undefined;
+  }
+
+  return {
+    _id: userId,
+    admin: socket.decodedToken?.admin === true,
+    id: userId,
+    isAnonymous: socket.decodedToken?.isAnonymous,
+  };
+};

--- a/rtk/src/realtime.test.ts
+++ b/rtk/src/realtime.test.ts
@@ -1,5 +1,5 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: realtime RTK tests mock Socket.io and RTK Query runtime shapes
-import {afterEach, describe, expect, it, mock} from "bun:test";
+import {afterEach, describe, expect, it} from "bun:test";
 
 const {realtimeList, setRealtimeSocket} = await import("./realtime");
 

--- a/rtk/src/realtime.test.ts
+++ b/rtk/src/realtime.test.ts
@@ -1,11 +1,6 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: realtime RTK tests mock Socket.io and RTK Query runtime shapes
 import {afterEach, describe, expect, it, mock} from "bun:test";
 
-mock.module("./constants", () => ({
-  isWebsocketsDebugEnabled: () => false,
-  logSocket: () => undefined,
-}));
-
 const {realtimeList, setRealtimeSocket} = await import("./realtime");
 
 interface MockSocket {

--- a/rtk/src/realtime.test.ts
+++ b/rtk/src/realtime.test.ts
@@ -1,0 +1,84 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: realtime RTK tests mock Socket.io and RTK Query runtime shapes
+import {afterEach, describe, expect, it, mock} from "bun:test";
+
+mock.module("./constants", () => ({
+  isWebsocketsDebugEnabled: () => false,
+  logSocket: () => undefined,
+}));
+
+const {realtimeList, setRealtimeSocket} = await import("./realtime");
+
+interface MockSocket {
+  emitted: Array<{event: string; payload: any}>;
+  emit: (event: string, payload: any) => void;
+  off: (event: string, handler: (payload: any) => void) => void;
+  on: (event: string, handler: (payload: any) => void) => void;
+}
+
+const createDeferred = (): {promise: Promise<void>; resolve: () => void} => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return {promise, resolve};
+};
+
+const createMockSocket = (canonicalQueryId: string): MockSocket => {
+  const listeners = new Map<string, Set<(payload: any) => void>>();
+  const socket: MockSocket = {
+    emit: (event, payload) => {
+      socket.emitted.push({event, payload});
+      if (event !== "subscribe:query") {
+        return;
+      }
+      queueMicrotask(() => {
+        const handlers = listeners.get("query:subscribed") ?? new Set();
+        for (const handler of handlers) {
+          handler({collection: payload.collection, queryId: canonicalQueryId});
+        }
+      });
+    },
+    emitted: [],
+    off: (event, handler) => {
+      listeners.get(event)?.delete(handler);
+    },
+    on: (event, handler) => {
+      if (!listeners.has(event)) {
+        listeners.set(event, new Set());
+      }
+      listeners.get(event)?.add(handler);
+    },
+  };
+  return socket;
+};
+
+describe("realtimeList", () => {
+  afterEach(() => {
+    setRealtimeSocket(null);
+  });
+
+  it("unsubscribes from the server-canonical queryId", async () => {
+    const cacheEntryRemoved = createDeferred();
+    const socket = createMockSocket('todos:{"completed":false,"ownerId":"user1"}');
+    setRealtimeSocket(socket as any);
+
+    const task = realtimeList("todos")(
+      {completed: false, limit: 20},
+      {
+        cacheDataLoaded: Promise.resolve(),
+        cacheEntryRemoved: cacheEntryRemoved.promise,
+        updateCachedData: () => undefined,
+      }
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    cacheEntryRemoved.resolve();
+    await task;
+
+    const unsubscribed = socket.emitted.find((item) => item.event === "unsubscribe:query");
+    expect(unsubscribed?.payload).toEqual({
+      queryId: 'todos:{"completed":false,"ownerId":"user1"}',
+    });
+  });
+});

--- a/rtk/src/realtime.test.ts
+++ b/rtk/src/realtime.test.ts
@@ -1,13 +1,14 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: realtime RTK tests mock Socket.io and RTK Query runtime shapes
 import {afterEach, describe, expect, it} from "bun:test";
 
-const {realtimeList, setRealtimeSocket} = await import("./realtime");
+const {realtimeDocument, realtimeList, setRealtimeSocket} = await import("./realtime");
 
 interface MockSocket {
   emitted: Array<{event: string; payload: any}>;
   emit: (event: string, payload: any) => void;
   off: (event: string, handler: (payload: any) => void) => void;
   on: (event: string, handler: (payload: any) => void) => void;
+  trigger: (event: string, payload: any) => void;
 }
 
 const createDeferred = (): {promise: Promise<void>; resolve: () => void} => {
@@ -18,12 +19,12 @@ const createDeferred = (): {promise: Promise<void>; resolve: () => void} => {
   return {promise, resolve};
 };
 
-const createMockSocket = (canonicalQueryId: string): MockSocket => {
+const createMockSocket = (canonicalQueryId?: string): MockSocket => {
   const listeners = new Map<string, Set<(payload: any) => void>>();
   const socket: MockSocket = {
     emit: (event, payload) => {
       socket.emitted.push({event, payload});
-      if (event !== "subscribe:query") {
+      if (event !== "subscribe:query" || !canonicalQueryId) {
         return;
       }
       queueMicrotask(() => {
@@ -43,9 +44,115 @@ const createMockSocket = (canonicalQueryId: string): MockSocket => {
       }
       listeners.get(event)?.add(handler);
     },
+    trigger: (event, payload) => {
+      const handlers = listeners.get(event) ?? new Set();
+      for (const handler of handlers) {
+        handler(payload);
+      }
+    },
   };
   return socket;
 };
+
+const createCacheApi = (
+  draft: any
+): {
+  cacheDataLoaded: Promise<void>;
+  cacheEntryRemoved: Promise<void>;
+  remove: () => void;
+  updateCachedData: (callback: (draft: any) => void) => void;
+} => {
+  const cacheEntryRemoved = createDeferred();
+  return {
+    cacheDataLoaded: Promise.resolve(),
+    cacheEntryRemoved: cacheEntryRemoved.promise,
+    remove: cacheEntryRemoved.resolve,
+    updateCachedData: (callback): void => {
+      callback(draft);
+    },
+  };
+};
+
+const flushPromises = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe("realtimeDocument", () => {
+  afterEach(() => {
+    setRealtimeSocket(null);
+  });
+
+  it("waits for a socket, patches matching update payloads, and unsubscribes", async () => {
+    const draft: any = {id: "doc-1", title: "Old"};
+    const api = createCacheApi(draft);
+    const task = realtimeDocument("todos")("doc-1", api);
+
+    await Promise.resolve();
+    const socket = createMockSocket();
+    setRealtimeSocket(socket as any);
+    await flushPromises();
+
+    socket.trigger("sync", {
+      collection: "other",
+      data: {_id: "doc-1", title: "Ignored"},
+      id: "doc-1",
+      method: "update",
+      model: "Todo",
+      timestamp: 1,
+    });
+    socket.trigger("sync", {
+      collection: "todos",
+      data: {_id: "doc-2", title: "Ignored"},
+      id: "doc-2",
+      method: "update",
+      model: "Todo",
+      timestamp: 1,
+    });
+    socket.trigger("sync", {
+      collection: "todos",
+      data: {_id: "doc-1", title: "New"},
+      id: "doc-1",
+      method: "update",
+      model: "Todo",
+      timestamp: 1,
+    });
+    socket.trigger("sync", {
+      collection: "todos",
+      id: "doc-1",
+      method: "delete",
+      model: "Todo",
+      timestamp: 1,
+    });
+
+    expect(draft).toEqual({_id: "doc-1", id: "doc-1", title: "New"});
+    api.remove();
+    await task;
+
+    expect(socket.emitted).toContainEqual({
+      event: "subscribe:document",
+      payload: {collection: "todos", id: "doc-1"},
+    });
+    expect(socket.emitted).toContainEqual({
+      event: "unsubscribe:document",
+      payload: {collection: "todos", id: "doc-1"},
+    });
+  });
+
+  it("returns before subscribing when id or cache load is unavailable", async () => {
+    const socket = createMockSocket();
+    setRealtimeSocket(socket as any);
+
+    await realtimeDocument("todos")({}, createCacheApi({}));
+    await realtimeDocument("todos")("doc-1", {
+      cacheDataLoaded: Promise.reject(new Error("missing")),
+      cacheEntryRemoved: Promise.resolve(),
+      updateCachedData: () => undefined,
+    });
+
+    expect(socket.emitted).toEqual([]);
+  });
+});
 
 describe("realtimeList", () => {
   afterEach(() => {
@@ -75,5 +182,135 @@ describe("realtimeList", () => {
     expect(unsubscribed?.payload).toEqual({
       queryId: 'todos:{"completed":false,"ownerId":"user1"}',
     });
+  });
+
+  it("handles model-room create, update, stale update, insert-on-update, and delete events", async () => {
+    const socket = createMockSocket();
+    setRealtimeSocket(socket as any);
+    const draft = {
+      data: [{id: "todo-1", title: "Existing", updated: "2026-01-02T00:00:00.000Z"}],
+      total: 1,
+    };
+    const api = createCacheApi(draft);
+    const task = realtimeList("todos")({limit: 20}, api);
+
+    await flushPromises();
+
+    socket.trigger("sync", {
+      collection: "other",
+      data: {_id: "ignored"},
+      id: "ignored",
+      method: "create",
+      model: "Todo",
+      timestamp: 1,
+    });
+    socket.trigger("sync", {
+      collection: "todos",
+      data: {_id: "todo-2", title: "Created"},
+      id: "todo-2",
+      method: "create",
+      model: "Todo",
+      timestamp: 1,
+    });
+    socket.trigger("sync", {
+      collection: "todos",
+      data: {id: "todo-1", title: "Stale", updated: "2026-01-01T00:00:00.000Z"},
+      id: "todo-1",
+      method: "update",
+      model: "Todo",
+      timestamp: 1,
+    });
+    socket.trigger("sync", {
+      collection: "todos",
+      data: {id: "todo-1", title: "Updated", updated: "2026-01-03T00:00:00.000Z"},
+      id: "todo-1",
+      method: "update",
+      model: "Todo",
+      timestamp: 1,
+    });
+    socket.trigger("sync", {
+      collection: "todos",
+      data: {id: "todo-3", title: "New match"},
+      id: "todo-3",
+      method: "update",
+      model: "Todo",
+      timestamp: 1,
+    });
+    socket.trigger("sync", {
+      collection: "todos",
+      id: "todo-2",
+      method: "delete",
+      model: "Todo",
+      timestamp: 1,
+    });
+
+    expect(draft.data.map((item: any) => item.id)).toEqual(["todo-3", "todo-1"]);
+    expect(draft.data[1].title).toBe("Updated");
+    expect(draft.total).toBe(2);
+
+    api.remove();
+    await task;
+    expect(socket.emitted).toContainEqual({event: "subscribe:model", payload: "todos"});
+    expect(socket.emitted).toContainEqual({event: "unsubscribe:model", payload: "todos"});
+  });
+
+  it("correlates query subscription acknowledgements before using canonical queryId", async () => {
+    const socket = createMockSocket();
+    setRealtimeSocket(socket as any);
+    const api = createCacheApi({data: [], total: 0});
+    const task = realtimeList("todos")({completed: false}, api);
+
+    await flushPromises();
+
+    socket.trigger("query:subscribed", {
+      collection: "other",
+      queryId: "wrong-collection",
+    });
+    socket.trigger("query:subscribed", {
+      clientQueryId: 'todos:{"completed":true}',
+      collection: "todos",
+      queryId: "wrong-client",
+    });
+    socket.trigger("query:subscribed", {
+      clientQueryId: 'todos:{"completed":false}',
+      collection: "todos",
+      queryId: 'todos:{"completed":false,"ownerId":"owner-1"}',
+    });
+
+    api.remove();
+    await task;
+
+    expect(socket.emitted).toContainEqual({
+      event: "unsubscribe:query",
+      payload: {queryId: 'todos:{"completed":false,"ownerId":"owner-1"}'},
+    });
+  });
+
+  it("returns before subscribing when cache load fails or socket never arrives", async () => {
+    const socket = createMockSocket();
+    setRealtimeSocket(socket as any);
+    await realtimeList("todos")(
+      {},
+      {
+        cacheDataLoaded: Promise.reject(new Error("missing")),
+        cacheEntryRemoved: Promise.resolve(),
+        updateCachedData: () => undefined,
+      }
+    );
+    expect(socket.emitted).toEqual([]);
+
+    setRealtimeSocket(null);
+    const removed = createDeferred();
+    const task = realtimeList("todos")(
+      {},
+      {
+        cacheDataLoaded: Promise.resolve(),
+        cacheEntryRemoved: removed.promise,
+        updateCachedData: () => undefined,
+      }
+    );
+    await Promise.resolve();
+    removed.resolve();
+    await task;
   });
 });

--- a/rtk/src/realtime.ts
+++ b/rtk/src/realtime.ts
@@ -219,6 +219,12 @@ interface RealtimeListOptions {
   getQuery?: (arg: any) => Record<string, any> | undefined;
 }
 
+interface QuerySubscribedPayload {
+  clientQueryId?: string;
+  collection: string;
+  queryId: string;
+}
+
 /**
  * Factory that returns an `onCacheEntryAdded` callback for real-time
  * updates on a **list of documents**, optionally filtered by query.
@@ -265,9 +271,21 @@ export const realtimeList = (collection: string, options?: RealtimeListOptions) 
 
     const query = getQuery(arg);
     let queryId: string | undefined;
+    let canonicalQueryId: string | undefined;
+    let handleQuerySubscribed: ((payload: QuerySubscribedPayload) => void) | undefined;
 
     if (query) {
       queryId = hashQuery(collection, query);
+      handleQuerySubscribed = (payload: QuerySubscribedPayload): void => {
+        if (payload.collection !== collection) {
+          return;
+        }
+        if (payload.clientQueryId && payload.clientQueryId !== queryId) {
+          return;
+        }
+        canonicalQueryId = payload.queryId;
+      };
+      socket.on("query:subscribed", handleQuerySubscribed);
       socket.emit("subscribe:query", {collection, query, queryId});
     } else {
       socket.emit("subscribe:model", collection);
@@ -351,9 +369,12 @@ export const realtimeList = (collection: string, options?: RealtimeListOptions) 
 
     await cacheEntryRemoved;
     socket.off("sync", handleSync);
+    if (handleQuerySubscribed) {
+      socket.off("query:subscribed", handleQuerySubscribed);
+    }
 
     if (queryId) {
-      socket.emit("unsubscribe:query", {queryId});
+      socket.emit("unsubscribe:query", {queryId: canonicalQueryId ?? queryId});
     } else {
       socket.emit("unsubscribe:model", collection);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Enforce modelRouter permissions for realtime model, document, and query subscriptions.
- Apply modelRouter queryFilter before storing realtime query subscriptions and return the server-canonical queryId to clients.
- Use the canonical server queryId for RTK realtimeList cleanup.
- Re-check read permissions per recipient socket before emitting realtime payloads.
- Serialize websocket payloads through realtimeResponseHandler/modelRouter responseHandler with the recipient user context.
- Fail hard-delete realtime emissions closed when object-scoped read permissions need document context.
- Handle throwing queryFilter and per-socket responseHandler errors without crashing subscriptions or blocking other sockets.
- Share socket user derivation between realtime subscription and fanout code.

### Testing
- `BUN_TEST_DISABLE_DB=true cd api && bun run test src/realtime/realtime.test.ts`
- `cd api && bun run compile`
- `cd api && bun run lint`
- `cd rtk && bun test src/realtime.test.ts`
- `cd rtk && bun run compile`
- `cd rtk && bun run lint`
- `cd rtk && bun run test:coverage`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6aadf0c2-f8b7-480b-9523-cbed7ba4dd3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6aadf0c2-f8b7-480b-9523-cbed7ba4dd3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

