### PR TITLE
Deploy backend tasks service in us-central1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,7 @@ env:
   GCP_PROJECT_ID: flourish-terreno
   GCP_BACKEND_REGION: us-central1
   GCP_BACKEND_SERVICE: terreno-backend-example
+  GCP_TASKS_SERVICE: terreno-backend-example-tasks
   GCP_MCP_REGION: us-east1
   GCP_MCP_SERVICE: terreno-mcp
   TF_DEPLOYMENT: terreno-prod
@@ -41,6 +42,7 @@ jobs:
     outputs:
       terraform: ${{ steps.filter.outputs.terraform }}
       backend: ${{ steps.filter.outputs.backend }}
+      tasks: ${{ steps.filter.outputs.tasks }}
       mcp: ${{ steps.filter.outputs.mcp }}
     steps:
       - uses: actions/checkout@v6
@@ -52,6 +54,13 @@ jobs:
               - 'terraform/**'
               - '.github/workflows/cd.yml'
             backend:
+              - 'example-backend/**'
+              - 'api/**'
+              - 'api-health/**'
+              - 'admin-backend/**'
+              - 'ai/**'
+              - '.github/workflows/cd.yml'
+            tasks:
               - 'example-backend/**'
               - 'api/**'
               - 'api-health/**'
@@ -410,6 +419,73 @@ jobs:
               state: 'failure',
               description: 'Backend preview deployment failed'
             });
+
+  # ───────────────────────────── Backend tasks worker ─────────────────────────────
+
+  tasks-deploy-prod:
+    name: Tasks deploy (prod)
+    needs: [detect, terraform-apply]
+    if: |
+      always() &&
+      needs.detect.outputs.tasks == 'true' &&
+      github.event_name == 'push' &&
+      (needs.terraform-apply.result == 'success' || needs.terraform-apply.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate required vars
+        run: |
+          missing=()
+          [ -z "${{ vars.GCP_WIF_PROVIDER_PROD }}" ] && missing+=("GCP_WIF_PROVIDER_PROD")
+          [ -z "${{ vars.GCP_CD_DEPLOYER_SA_PROD }}" ] && missing+=("GCP_CD_DEPLOYER_SA_PROD")
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing required repository variables: ${missing[*]}"
+            exit 1
+          fi
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER_PROD }}
+          service_account: ${{ vars.GCP_CD_DEPLOYER_SA_PROD }}
+      - uses: google-github-actions/setup-gcloud@v3
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.GCP_BACKEND_REGION }}-docker.pkg.dev --quiet
+      - name: Build Docker image
+        run: |
+          docker build \
+            --file ./example-backend/Dockerfile \
+            --tag ${{ env.GCP_BACKEND_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GCP_TASKS_SERVICE }}/${{ env.GCP_TASKS_SERVICE }}:${{ github.sha }} \
+            --tag ${{ env.GCP_BACKEND_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GCP_TASKS_SERVICE }}/${{ env.GCP_TASKS_SERVICE }}:latest \
+            .
+      - name: Push Docker image
+        run: |
+          docker push ${{ env.GCP_BACKEND_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GCP_TASKS_SERVICE }}/${{ env.GCP_TASKS_SERVICE }}:${{ github.sha }}
+          docker push ${{ env.GCP_BACKEND_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GCP_TASKS_SERVICE }}/${{ env.GCP_TASKS_SERVICE }}:latest
+      - name: Deploy to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v3
+        with:
+          service: ${{ env.GCP_TASKS_SERVICE }}
+          region: ${{ env.GCP_BACKEND_REGION }}
+          image: ${{ env.GCP_BACKEND_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GCP_TASKS_SERVICE }}/${{ env.GCP_TASKS_SERVICE }}:${{ github.sha }}
+          tag: prod
+          env_vars: |
+            NODE_ENV=production
+            BACKEND_SERVICE=tasks
+            FLOURISH_SERVICE=${{ env.GCP_TASKS_SERVICE }}
+          secrets: |
+            MONGODB_URI=${{ env.GCP_BACKEND_SERVICE }}-mongodb-uri:latest
+            LANGFUSE_SECRET_KEY=${{ env.GCP_BACKEND_SERVICE }}-langfuse-secret-key:latest
+            LANGFUSE_PUBLIC_KEY=${{ env.GCP_BACKEND_SERVICE }}-langfuse-public-key:latest
+          flags: |
+            --port=3000
+            --memory=512Mi
+            --min-instances=0
+            --max-instances=10
+            --concurrency=80
+            --timeout=300
+            --allow-unauthenticated
 
   # ───────────────────────────── MCP server ─────────────────────────────
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -11,8 +11,8 @@ It is applied by **[Google Cloud Infrastructure Manager](https://cloud.google.co
   - `terraform-admin` — used by `cd.yml`'s terraform-* jobs (project-admin scope)
   - `gh-deployer` — used by `cd.yml`'s backend-deploy-* and mcp-deploy jobs with the narrow set of roles needed to push images and roll Cloud Run
 - Artifact Registry repos for each Cloud Run service
-- Cloud Run services (`terreno-backend-example`, `terreno-mcp`) — **structural definition only** (resources, scaling, IAM, labels). Image and env vars are still set by the CD workflows on every deploy; Terraform's `lifecycle.ignore_changes` keeps it out of the way.
-- Secret Manager containers for the backend's sensitive env vars: `terreno-backend-example-mongodb-uri`, `terreno-backend-example-langfuse-secret-key`, `terreno-backend-example-langfuse-public-key`. Values are seeded out-of-band; the deploy workflow mounts them via `secrets:` so plaintext never traverses GitHub Actions runners.
+- Cloud Run services (`terreno-backend-example`, `terreno-backend-example-tasks`, `terreno-mcp`) — **structural definition only** (resources, scaling, IAM, labels). Image and env vars are still set by the CD workflows on every deploy; Terraform's `lifecycle.ignore_changes` keeps it out of the way.
+- Secret Manager containers for the backend's sensitive env vars: `terreno-backend-example-mongodb-uri`, `terreno-backend-example-langfuse-secret-key`, `terreno-backend-example-langfuse-public-key`. Values are seeded out-of-band; the backend and tasks deploy workflows mount them via `secrets:` so plaintext never traverses GitHub Actions runners.
 
 The pre-existing `EXAMPLE_*` Secret Manager secrets (`EXAMPLE_MONGO_CONNECTION`, `EXAMPLE_TOKEN_SECRET`, `EXAMPLE_REFRESH_TOKEN_SECRET`) feeding `MONGO_URI`/`TOKEN_SECRET`/`REFRESH_TOKEN_SECRET` are not yet Terraform-managed but already use proper SM mounts. They can be imported in a follow-up. The MCP server's `SENTRY_DSN` is also still inline-from-GH-secret and could be migrated.
 
@@ -137,6 +137,15 @@ terraform import 'module.github_oidc.google_iam_workload_identity_pool_provider.
 ```
 
 After import, `terraform plan` should show only safe metadata updates on the imported resources (description, cleanup_policies, labels, attribute_mapping additions). Cloud Run env vars and image are excluded from the plan via `lifecycle.ignore_changes`.
+
+The tasks service and Artifact Registry repo are new Terraform-owned resources. If they were created manually before Terraform applies this configuration, import them with the same patterns:
+
+```bash
+terraform import 'module.tasks_service.google_cloud_run_v2_service.this' \
+  projects/flourish-terreno/locations/us-central1/services/terreno-backend-example-tasks
+terraform import 'module.tasks_artifact_registry.google_artifact_registry_repository.this' \
+  projects/flourish-terreno/locations/us-central1/repositories/terreno-backend-example-tasks
+```
 
 ## Adding a third service account
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -64,7 +64,7 @@ module "github_oidc" {
 }
 
 # ---------------------------------------------------------------------------
-# Example backend
+# Example backend + tasks worker
 #
 # Cloud Run service env vars + image are managed by the CD workflow
 # (deploy-example-gcp.yml), which sources values from GitHub Actions secrets.
@@ -78,6 +78,21 @@ module "backend_artifact_registry" {
   region        = var.backend_region
   repository_id = var.backend_service_name
   description   = "Container images for ${var.backend_service_name}."
+
+  writer_members = {
+    gh-deployer = "serviceAccount:${module.github_oidc.service_account_emails["gh-deployer"]}"
+  }
+
+  depends_on = [module.bootstrap]
+}
+
+module "tasks_artifact_registry" {
+  source = "./modules/artifact_registry"
+
+  project_id    = var.project_id
+  region        = var.backend_region
+  repository_id = var.tasks_service_name
+  description   = "Container images for ${var.tasks_service_name}."
 
   writer_members = {
     gh-deployer = "serviceAccount:${module.github_oidc.service_account_emails["gh-deployer"]}"
@@ -147,6 +162,35 @@ module "backend_service" {
 
   depends_on = [
     module.backend_artifact_registry,
+    module.backend_secret_mongodb_uri,
+    module.backend_secret_langfuse_secret_key,
+    module.backend_secret_langfuse_public_key,
+  ]
+}
+
+module "tasks_service" {
+  source = "./modules/cloud_run_service"
+
+  project_id            = var.project_id
+  region                = var.backend_region
+  service_name          = var.tasks_service_name
+  image                 = var.placeholder_image
+  port                  = 3000
+  memory                = "512Mi"
+  cpu                   = "1"
+  min_instances         = var.tasks_min_instances
+  max_instances         = var.tasks_max_instances
+  concurrency           = 80
+  timeout_seconds       = 300
+  allow_unauthenticated = true
+  labels                = local.common_labels
+
+  env = {
+    BACKEND_SERVICE = "tasks"
+  }
+
+  depends_on = [
+    module.tasks_artifact_registry,
     module.backend_secret_mongodb_uri,
     module.backend_secret_langfuse_secret_key,
     module.backend_secret_langfuse_public_key,

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -18,6 +18,11 @@ output "backend_url" {
   description = "Default URL of the example backend Cloud Run service."
 }
 
+output "tasks_url" {
+  value       = module.tasks_service.uri
+  description = "Default URL of the example backend tasks Cloud Run service."
+}
+
 output "mcp_url" {
   value       = module.mcp_service.uri
   description = "Default URL of the MCP Cloud Run service."
@@ -26,6 +31,11 @@ output "mcp_url" {
 output "backend_image_repo" {
   value       = module.backend_artifact_registry.docker_repo_url
   description = "Docker image prefix for the example backend."
+}
+
+output "tasks_image_repo" {
+  value       = module.tasks_artifact_registry.docker_repo_url
+  description = "Docker image prefix for the example backend tasks worker."
 }
 
 output "mcp_image_repo" {

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -9,4 +9,5 @@ github_repos = ["FlourishHealth/terreno"]
 backend_region       = "us-central1"
 mcp_region           = "us-east1"
 backend_service_name = "terreno-backend-example"
+tasks_service_name   = "terreno-backend-example-tasks"
 mcp_service_name     = "terreno-mcp"

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -11,3 +11,6 @@ mcp_region           = "us-east1"
 backend_service_name = "terreno-backend-example"
 tasks_service_name   = "terreno-backend-example-tasks"
 mcp_service_name     = "terreno-mcp"
+
+backend_min_instances = 0
+tasks_min_instances   = 0

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -46,6 +46,11 @@ variable "backend_service_name" {
   type        = string
 }
 
+variable "tasks_service_name" {
+  description = "Cloud Run service name for the example backend's background tasks worker."
+  type        = string
+}
+
 variable "mcp_service_name" {
   description = "Cloud Run service name for the MCP server."
   type        = string
@@ -65,6 +70,18 @@ variable "backend_min_instances" {
 
 variable "backend_max_instances" {
   description = "Max instances for the example backend."
+  type        = number
+  default     = 10
+}
+
+variable "tasks_min_instances" {
+  description = "Min instances for the example backend's background tasks worker."
+  type        = number
+  default     = 0
+}
+
+variable "tasks_max_instances" {
+  description = "Max instances for the example backend's background tasks worker."
   type        = number
   default     = 10
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Terraform ownership for a dedicated `terreno-backend-example-tasks` Cloud Run service and Artifact Registry repo in `us-central1`, then wires CD to build and deploy the backend image to that service with `BACKEND_SERVICE=tasks`. Explicitly pins all `us-central1` service minimum instance counts to `0` for both Terraform and CD deployment paths.

## Human Testing Steps

- [ ] Open a PR or merge a backend change and confirm the `Tasks deploy (prod)` job runs after Terraform apply succeeds or skips.
- [ ] In GCP, confirm `terreno-backend-example` and `terreno-backend-example-tasks` in `us-central1` both show minimum instances set to `0`.

## Changes

- Added Terraform variables, outputs, Artifact Registry repo, and Cloud Run service module for the tasks worker.
- Added a CD tasks deployment job using the tasks repo and service in `us-central1`.
- Explicitly set `backend_min_instances = 0` and `tasks_min_instances = 0` in `terraform.tfvars`.
- Updated Terraform documentation for the new tasks resources and optional imports.

## Automated Tests

- `terraform fmt -check -recursive`
- `terraform init -backend=false -input=false && terraform validate`
- YAML parse of `.github/workflows/cd.yml`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5942a8d-adbc-4a07-bccc-2eb437cfa16e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5942a8d-adbc-4a07-bccc-2eb437cfa16e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

