### PR TITLE
Shape offline mode implementation plan

### DIFF
--- a/docs/implementationPlans/README.md
+++ b/docs/implementationPlans/README.md
@@ -16,12 +16,14 @@ This directory contains detailed technical plans for major features **before imp
 ## Current Plans
 
 - **[Modular API (TerrenoApp)](ModularAPI.md)** — New fluent builder API to replace `setupServer` in `@terreno/api`
+- **[Offline Mode](offline-mode.md)** — Placeholder plan for offline queueing, replay, conflict handling, and UI surfaces
 
 ## Status Tracking
 
 | Plan | Status | Target Version | Discussion |
 |------|--------|----------------|------------|
 | Modular API | 📝 Planning | 2.0.0 | [#149](https://github.com/FlourishHealth/terreno/pull/149) |
+| Offline Mode | Placeholder | TBD | TBD |
 
 ## Process
 

--- a/docs/implementationPlans/offline-mode.md
+++ b/docs/implementationPlans/offline-mode.md
@@ -1,107 +1,311 @@
 # Implementation Plan: Offline Mode
 
-**Status:** Placeholder
-**Priority:** TBD
-**Effort:** TBD
-
-*This placeholder reserves the offline-mode planning surface. Before implementation begins, replace TBD sections with the shaped design, get engineering feedback, and tag Josh with the @ symbol for review.*
+**Status:** Draft - model/API alignment
+**Priority:** High
+**Effort:** Medium
 
 ## Context
 
-Terreno already has initial offline primitives in `@terreno/rtk`, including `offlineSlice`, `offlineMiddleware`, `useOfflineStatus`, and `useServerStatus`. This IP should decide whether offline mode means polishing those primitives, adding UI components around them, integrating them into the example app, or expanding backend conflict support.
+Terreno already has offline primitives in `@terreno/rtk`, including `offlineSlice`, `offlineMiddleware`, `offlineGate`, `useOfflineStatus`, and `useServerStatus`. The offline-mode plan should harden those primitives into an opt-in offline-first framework that starts with generated `modelRouter` CRUD endpoints, keeps local data through token refresh failures, and gives app teams reusable UI without blocking custom sync logic later.
+
+## Core Concept
+
+Offline mode v1 is a configurable client-side sync layer for modelRouter endpoints. Apps opt in per model/endpoint, RTK Query caches receive optimistic updates, mutations are queued in persisted Redux state while offline or auth-blocked, and queued work replays when connection and auth are healthy.
+
+The backend remains the existing modelRouter API. Backend work is limited to formalizing two modelRouter capabilities that are already present or aligned with Mongoose:
+
+- optimistic create with client-provided ObjectId-compatible `_id` values,
+- update conflict detection with `If-Unmodified-Since` / `X-Unmodified-Since-ISO` and a `409 Conflict` server document response.
 
 ## Models
 
-TBD.
+No new server-side Mongoose models are required for v1. Offline queue and conflict records are local client state in `@terreno/rtk` and should be persisted through the consuming app's Redux persistence configuration.
 
-Questions to answer:
-- Do queued mutation records need durable storage beyond Redux persistence?
-- Do conflict records need a server-side representation or are local-only records enough?
-- Are per-model sync metadata fields required, or can existing `created` and `updated` timestamps support conflict detection?
+### Client state: offline slice
+
+```typescript
+interface OfflineState {
+  connectionQuality: "online" | "spotty" | "offline";
+  queue: QueuedMutation[];
+  conflicts: ConflictRecord[];
+  isSyncing: boolean;
+  isReplayPausedForAuth: boolean;
+  lastHealthCheck?: HealthCheckSnapshot;
+}
+
+interface QueuedMutation {
+  id: string;
+  endpointName: string;
+  modelName: string;
+  operation: "create" | "update" | "delete" | "arrayPush" | "arrayUpdate" | "arrayRemove";
+  args: unknown;
+  body?: Record<string, unknown>;
+  optimisticId?: string;
+  serverId?: string;
+  idempotencyKey: string;
+  createdAt: string;
+  lastAttemptAt?: string;
+  attemptCount: number;
+  baseUpdatedAt?: string;
+  status: "queued" | "replaying" | "authBlocked" | "conflicted" | "failed";
+  error?: string;
+}
+
+interface ConflictRecord {
+  id: string;
+  queueId: string;
+  endpointName: string;
+  modelName: string;
+  operation: "update" | "delete" | "arrayUpdate" | "arrayRemove";
+  localArgs: unknown;
+  localBody?: Record<string, unknown>;
+  serverValue: unknown;
+  baseUpdatedAt?: string;
+  serverUpdatedAt?: string;
+  dismissed: boolean;
+  createdAt: string;
+}
+
+interface HealthCheckSnapshot {
+  checkedAt: string;
+  latencyMs?: number;
+  consecutiveFailures: number;
+  recentFailureRate: number;
+}
+```
+
+### Configuration model
+
+```typescript
+interface OfflineModelRouterConfig {
+  enabled: boolean;
+  models: OfflineModelConfig[];
+  connectionQuality?: ConnectionQualityConfig;
+  auth?: OfflineAuthConfig;
+}
+
+interface OfflineModelConfig {
+  modelName: string;
+  tagType: string;
+  endpoints: {
+    create?: OfflineEndpointConfig;
+    update?: OfflineEndpointConfig;
+    delete?: OfflineEndpointConfig;
+    arrayPush?: OfflineEndpointConfig;
+    arrayUpdate?: OfflineEndpointConfig;
+    arrayRemove?: OfflineEndpointConfig;
+  };
+  idStrategy?: OfflineIdStrategy;
+  conflictStrategy?: "manual" | "keepMine" | "useServer";
+}
+
+interface OfflineEndpointConfig {
+  endpointName: string;
+  enabled?: boolean;
+  optimisticUpdate?: OfflineOptimisticUpdate;
+}
+
+interface OfflineIdStrategy {
+  generateId?: () => string;
+  requestField?: string;
+  reconcile?: "assumeClientId" | "mapServerId";
+}
+
+interface ConnectionQualityConfig {
+  healthUrl?: string;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  spottyLatencyMs?: number;
+  offlineFailureCount?: number;
+  spottyFailureRate?: number;
+}
+
+interface OfflineAuthConfig {
+  pauseReplayWhileRefreshing?: boolean;
+  pauseReplayOnRefreshFailure?: boolean;
+  clearCacheOnLogoutOnly?: boolean;
+}
+```
+
+### ID strategy
+
+Default behavior:
+
+- generate an ObjectId-compatible string for optimistic creates,
+- send it as `_id` in the modelRouter create body,
+- assume the server returns the same ID,
+- keep cache keys stable from optimistic create through replay confirmation.
+
+Overrides:
+
+- apps can provide `generateId`,
+- apps can choose another request field,
+- apps can reconcile a server-returned ID if the backend does not preserve the client ID.
 
 ## APIs
 
-TBD.
+### Server API surface
 
-Questions to answer:
-- Which APIs must support offline mutation replay?
-- Should modelRouter expose a standard conflict response when `If-Unmodified-Since` or equivalent precondition checks fail?
-- Is a generic sync/status endpoint needed, or should apps rely on existing health checks?
+No custom sync endpoints for v1. Offline mode targets standard modelRouter endpoints only:
+
+| Method | Path | modelRouter operation | Offline behavior |
+| --- | --- | --- | --- |
+| `POST` | `/{resource}` | create | Queue and optimistically insert a local item when offline or spotty; default `_id` comes from client ID strategy. |
+| `PATCH` | `/{resource}/:id` | update | Queue and optimistically patch cache; replay with `If-Unmodified-Since` / `X-Unmodified-Since-ISO` when a base timestamp is known. |
+| `DELETE` | `/{resource}/:id` | delete | Queue and optimistically remove/mark local item based on app strategy. |
+| `POST` | `/{resource}/:id/:field` | array push | Queue and optimistically append item to cached field. |
+| `PATCH` | `/{resource}/:id/:field/:itemId` | array update | Queue and optimistically patch array item. |
+| `DELETE` | `/{resource}/:id/:field/:itemId` | array remove | Queue and optimistically remove array item. |
+
+### Backend requirements
+
+- modelRouter create should accept client-provided ObjectId-compatible `_id` values when the schema allows them.
+- modelRouter update should keep returning `409 Conflict` when precondition headers are older than the current server `updated` timestamp.
+- The conflict response should include the current server document in a stable response field.
+- No server-side queue, sync cursor, or batch replay endpoint is included in v1.
+
+### Client API surface
+
+```typescript
+const offlineMiddleware = createOfflineMiddleware({
+  api,
+  offline: {
+    enabled: true,
+    models: [
+      {
+        modelName: "Todo",
+        tagType: "todos",
+        endpoints: {
+          create: {endpointName: "postTodos"},
+          update: {endpointName: "patchTodosById"},
+          delete: {endpointName: "deleteTodosById"},
+        },
+      },
+    ],
+  },
+});
+```
+
+New or hardened exports from `@terreno/rtk`:
+
+- `createOfflineMiddleware(options)` - opt-in middleware with modelRouter config.
+- `offlineReducer` - persisted local queue/conflict state.
+- `useOfflineStatus()` - queue, sync, conflict, and auth-blocked state.
+- `useServerStatus(config)` - computes `online`, `spotty`, or `offline`.
+- `resolveConflict({conflictId, resolution})` - supports `resolution: "keepMine" | "useServer"`.
+- `selectConnectionQuality`, `selectQueuedMutations`, `selectConflicts`.
+
+### Auth behavior
+
+- Token refresh attempts continue using the existing mutex in `emptyApi`.
+- If refresh cannot complete because the network/server is unavailable, replay pauses and queued mutations move to `authBlocked` instead of failing permanently.
+- Cached RTK Query data, queued mutations, conflicts, and optimistic local records remain intact.
+- Cache/queue clearing only happens after an explicit logout action.
+
+### Conflict resolution behavior
+
+`useServer`:
+
+- remove the queued mutation,
+- patch the RTK Query cache with the server document,
+- mark the conflict resolved/dismissed.
+
+`keepMine`:
+
+- update the queued mutation's `baseUpdatedAt` to the server `updated` timestamp,
+- keep or reapply the local optimistic cache patch,
+- replay the mutation again with the new precondition headers.
 
 ## Notifications
 
-TBD.
+No push, email, or SMS notifications are required for v1.
 
-Likely candidates:
-- In-app banner while offline.
-- In-app sync progress indicator while queued mutations replay.
-- Conflict notification when a queued mutation cannot be applied cleanly.
+In-app notifications:
+
+- offline/spotty/syncing banner,
+- pending mutation count,
+- auth-blocked sync message when replay needs re-auth,
+- conflict notification with actions for "keep mine" and "use server".
 
 ## UI
 
-TBD.
+Reusable `@terreno/ui` components and hooks:
 
-Potential surfaces:
-- Reusable offline banner in `@terreno/ui`.
-- Example frontend integration using `useServerStatus`.
-- Conflict list/resolution UI for queued mutation failures.
-
-## Phases
-
-TBD.
-
-Suggested starting breakdown:
-1. Research existing offline primitives and test coverage.
-2. Shape the minimum framework API for app teams to enable offline mode.
-3. Add examples and documentation once the API surface is confirmed.
+- `OfflineBanner` evolves to render `online`, `spotty`, `offline`, `syncing`, and `authBlocked` states.
+- `OfflineConflictList` renders unresolved conflicts.
+- `OfflineConflictCard` shows local/server values and resolution buttons.
+- `useOfflineStatus` remains the low-level hook for custom app UI.
+- Example frontend wires the status monitor and banner at the root layout and shows conflicts on the todos screen.
 
 ## Feature Flags & Migrations
 
-TBD.
-
-Consider whether offline mode should be opt-in at the app/store level and whether any queue persistence migration is needed for existing consumers.
+- Offline mode is default off.
+- Apps enable it in store setup by mounting `offlineReducer` and adding `createOfflineMiddleware`.
+- Existing consumers are unaffected unless they opt in.
+- Queue persistence should include a version number so future changes can migrate or discard incompatible queue records safely.
+- No backend data migration is required.
 
 ## Activity Log & User Updates
 
-TBD.
+No new activity log system is required for v1. Replayed modelRouter mutations should behave like normal API mutations on the backend. A future version can add audit metadata such as `X-Terreno-Offline-Replay` if consuming apps need to distinguish offline-originated changes.
 
-Clarify whether replayed mutations should create normal activity log entries, special "synced from offline" entries, or no additional audit metadata.
+## Phases
+
+1. **RTK core hardening**
+   - Formalize modelRouter endpoint config.
+   - Add create ID strategy defaults and overrides.
+   - Add auth-blocked replay state.
+   - Add conflict resolution actions.
+   - Add queue persistence versioning.
+
+2. **Connection status and UI**
+   - Upgrade `useServerStatus` to emit `online`, `spotty`, and `offline`.
+   - Update `OfflineBanner`.
+   - Add conflict resolution UI components.
+
+3. **Backend formalization and tests**
+   - Add/verify modelRouter tests for client-provided IDs.
+   - Add/verify conflict response contract tests.
+   - Document modelRouter offline requirements.
+
+4. **Example app integration and docs**
+   - Configure todos for offline mode.
+   - Demonstrate optimistic create/update/delete.
+   - Demonstrate offline, spotty, auth-blocked, and conflict states.
 
 ## Not Included / Future Work
 
-TBD.
-
-Potential exclusions:
-- Full collaborative conflict resolution.
+- Custom route sync strategies.
+- Server-side mutation queues.
+- Batch sync/cursor endpoints.
 - Background sync while the app is closed.
 - Binary/file upload offline queues.
+- Multi-user collaborative merge UI beyond "keep mine" / "use server".
+- Local relational database adapters.
+
+## Risks & Mitigations
+
+- **Generic optimistic updates can become too magical:** Keep modelRouter defaults simple and expose per-endpoint custom optimistic update functions.
+- **Create ID reconciliation can break cache keys:** Default to client-provided ObjectId values and only support server ID remapping through an explicit strategy.
+- **Auth refresh failures can look like logout:** Introduce a separate auth-blocked replay state and reserve destructive clearing for explicit logout.
+- **Spotty detection can be noisy:** Make thresholds configurable and expose raw health metrics for app tuning.
+- **Conflict UI can balloon:** Limit v1 to "keep mine" and "use server"; defer field-level merge tooling.
 
 ## Acceptance Criteria
 
-Placeholder. Replace with concrete acceptance criteria after the full offline-mode scope is shaped.
+- Offline mode is opt-in and disabled by default.
+- A modelRouter-backed model can opt into offline create/update/delete through `@terreno/rtk` configuration.
+- Offline create uses a stable default client ID and supports a custom ID strategy.
+- Queued mutations persist through app reload when the consuming app persists the offline slice.
+- Failed token refresh pauses replay without clearing RTK Query cache or queued mutations.
+- Explicit logout clears auth and configured offline/cache state.
+- Conflicts from modelRouter `409` responses can be resolved with "keep mine" or "use server".
+- Connection status can represent `online`, `spotty`, and `offline` with configurable thresholds.
+- Reusable UI surfaces show offline/spotty/syncing/auth-blocked/conflict states.
+- Example frontend demonstrates offline todos with optimistic create/update/delete and conflict resolution.
 
 ---
 
-## Task List (Bot Consumption)
+## Alignment Question
 
-*Structured task breakdown placeholder. Expand into implementation tasks after research and shaping.*
-
-### Phase 0: Plan Completion
-
-- [ ] **Task 0.1**: Research existing offline-mode implementation
-  - Description: Review `rtk/src/offlineSlice.ts`, `rtk/src/offlineMiddleware.ts`, `rtk/src/useOfflineStatus.ts`, `rtk/src/useServerStatus.ts`, related tests, and any example app usage.
-  - Files: `rtk/src/*offline*`, `rtk/src/useServerStatus.ts`, relevant tests and docs
-  - Depends on: none
-  - Acceptance: Research notes identify current capabilities, gaps, and risky assumptions.
-
-- [ ] **Task 0.2**: Shape offline-mode scope
-  - Description: Decide the intended product/API scope for offline mode, including queue persistence, replay semantics, conflict handling, UI surfaces, and example app integration.
-  - Files: `docs/implementationPlans/offline-mode.md`
-  - Depends on: Task 0.1
-  - Acceptance: This placeholder IP is replaced with a concrete implementation plan.
-
-- [ ] **Task 0.3**: Generate implementation tasks
-  - Description: Create the final bot-consumable task list once the implementation plan is approved.
-  - Files: `docs/tasks/offline-mode.md`
-  - Depends on: Task 0.2
-  - Acceptance: Task list is specific enough for implementation agents to execute independently.
+Are these client models and the modelRouter-only API contract the right foundation before the task list is expanded?

--- a/docs/implementationPlans/offline-mode.md
+++ b/docs/implementationPlans/offline-mode.md
@@ -1,0 +1,107 @@
+# Implementation Plan: Offline Mode
+
+**Status:** Placeholder
+**Priority:** TBD
+**Effort:** TBD
+
+*This placeholder reserves the offline-mode planning surface. Before implementation begins, replace TBD sections with the shaped design, get engineering feedback, and tag Josh with the @ symbol for review.*
+
+## Context
+
+Terreno already has initial offline primitives in `@terreno/rtk`, including `offlineSlice`, `offlineMiddleware`, `useOfflineStatus`, and `useServerStatus`. This IP should decide whether offline mode means polishing those primitives, adding UI components around them, integrating them into the example app, or expanding backend conflict support.
+
+## Models
+
+TBD.
+
+Questions to answer:
+- Do queued mutation records need durable storage beyond Redux persistence?
+- Do conflict records need a server-side representation or are local-only records enough?
+- Are per-model sync metadata fields required, or can existing `created` and `updated` timestamps support conflict detection?
+
+## APIs
+
+TBD.
+
+Questions to answer:
+- Which APIs must support offline mutation replay?
+- Should modelRouter expose a standard conflict response when `If-Unmodified-Since` or equivalent precondition checks fail?
+- Is a generic sync/status endpoint needed, or should apps rely on existing health checks?
+
+## Notifications
+
+TBD.
+
+Likely candidates:
+- In-app banner while offline.
+- In-app sync progress indicator while queued mutations replay.
+- Conflict notification when a queued mutation cannot be applied cleanly.
+
+## UI
+
+TBD.
+
+Potential surfaces:
+- Reusable offline banner in `@terreno/ui`.
+- Example frontend integration using `useServerStatus`.
+- Conflict list/resolution UI for queued mutation failures.
+
+## Phases
+
+TBD.
+
+Suggested starting breakdown:
+1. Research existing offline primitives and test coverage.
+2. Shape the minimum framework API for app teams to enable offline mode.
+3. Add examples and documentation once the API surface is confirmed.
+
+## Feature Flags & Migrations
+
+TBD.
+
+Consider whether offline mode should be opt-in at the app/store level and whether any queue persistence migration is needed for existing consumers.
+
+## Activity Log & User Updates
+
+TBD.
+
+Clarify whether replayed mutations should create normal activity log entries, special "synced from offline" entries, or no additional audit metadata.
+
+## Not Included / Future Work
+
+TBD.
+
+Potential exclusions:
+- Full collaborative conflict resolution.
+- Background sync while the app is closed.
+- Binary/file upload offline queues.
+
+## Acceptance Criteria
+
+Placeholder. Replace with concrete acceptance criteria after the full offline-mode scope is shaped.
+
+---
+
+## Task List (Bot Consumption)
+
+*Structured task breakdown placeholder. Expand into implementation tasks after research and shaping.*
+
+### Phase 0: Plan Completion
+
+- [ ] **Task 0.1**: Research existing offline-mode implementation
+  - Description: Review `rtk/src/offlineSlice.ts`, `rtk/src/offlineMiddleware.ts`, `rtk/src/useOfflineStatus.ts`, `rtk/src/useServerStatus.ts`, related tests, and any example app usage.
+  - Files: `rtk/src/*offline*`, `rtk/src/useServerStatus.ts`, relevant tests and docs
+  - Depends on: none
+  - Acceptance: Research notes identify current capabilities, gaps, and risky assumptions.
+
+- [ ] **Task 0.2**: Shape offline-mode scope
+  - Description: Decide the intended product/API scope for offline mode, including queue persistence, replay semantics, conflict handling, UI surfaces, and example app integration.
+  - Files: `docs/implementationPlans/offline-mode.md`
+  - Depends on: Task 0.1
+  - Acceptance: This placeholder IP is replaced with a concrete implementation plan.
+
+- [ ] **Task 0.3**: Generate implementation tasks
+  - Description: Create the final bot-consumable task list once the implementation plan is approved.
+  - Files: `docs/tasks/offline-mode.md`
+  - Depends on: Task 0.2
+  - Acceptance: Task list is specific enough for implementation agents to execute independently.

--- a/docs/implementationPlans/offline-mode.md
+++ b/docs/implementationPlans/offline-mode.md
@@ -1,6 +1,6 @@
 # Implementation Plan: Offline Mode
 
-**Status:** Draft - model/API alignment
+**Status:** Approved for implementation tasking
 **Priority:** High
 **Effort:** Medium
 
@@ -306,6 +306,6 @@ No new activity log system is required for v1. Replayed modelRouter mutations sh
 
 ---
 
-## Alignment Question
+## Approval Notes
 
-Are these client models and the modelRouter-only API contract the right foundation before the task list is expanded?
+The modelRouter-only client/API foundation has been approved. Implementation tasks live in `docs/tasks/offline-mode.md`.

--- a/docs/tasks/offline-mode.md
+++ b/docs/tasks/offline-mode.md
@@ -1,23 +1,139 @@
 # Task List: Offline Mode
 
-*Placeholder task breakdown for completing the offline-mode implementation plan. Do not treat these as product implementation tasks until `docs/implementationPlans/offline-mode.md` is expanded and approved.*
+*Structured task breakdown for automated implementation. Each task should be independently implementable and testable.*
 
-## Phase 0: Plan Completion
+## Phase 1: RTK Core Offline Framework
 
-- [ ] **Task 0.1**: Research existing offline-mode implementation
-  - Description: Review current `@terreno/rtk` offline primitives, tests, exports, and example app usage.
-  - Files: `rtk/src/offlineSlice.ts`, `rtk/src/offlineMiddleware.ts`, `rtk/src/useOfflineStatus.ts`, `rtk/src/useServerStatus.ts`, related tests
+- [ ] **Task 1.1**: Formalize offline state and queue record types
+  - Description: Extend the offline slice state to represent connection quality, auth-blocked replay, queue record statuses, base timestamps, optimistic/server IDs, and persisted queue versioning. Keep the slice default inert until offline mode is mounted by a consuming app.
+  - Files: `rtk/src/offlineSlice.ts`, `rtk/src/useOfflineStatus.ts`, `rtk/src/index.ts`, related `rtk/src/*.test.ts`
   - Depends on: none
-  - Acceptance: Research notes capture existing capabilities, missing requirements, and open risks.
+  - Acceptance: Unit tests cover enqueue/dequeue/status transitions, conflict storage, auth-blocked state, queue version defaults, and selectors for `online`, `spotty`, `offline`, queued mutations, conflicts, and replay-paused state.
 
-- [ ] **Task 0.2**: Shape offline-mode scope
-  - Description: Decide the intended offline-mode surface across queue persistence, replay, conflicts, UI, examples, and docs.
-  - Files: `docs/implementationPlans/offline-mode.md`
-  - Depends on: Task 0.1
-  - Acceptance: Placeholder IP is replaced with a concrete implementation plan.
+- [ ] **Task 1.2**: Replace endpoint-name-only offline gating with modelRouter config
+  - Description: Introduce a typed `OfflineModelRouterConfig` that maps model names and modelRouter operations to generated RTK Query endpoint names. Preserve a migration path for existing endpoint-name configuration only if it is already shipped behavior; otherwise replace it with the modelRouter config.
+  - Files: `rtk/src/offlineGate.ts`, `rtk/src/offlineMiddleware.ts`, `rtk/src/index.ts`, `rtk/src/offlineGate.test.ts`
+  - Depends on: Task 1.1
+  - Acceptance: Tests prove disabled/default config never defers mutations, enabled modelRouter endpoints are deferred while offline, unconfigured custom routes are not deferred, and array operations can be configured separately from create/update/delete.
 
-- [ ] **Task 0.3**: Generate implementation tasks
-  - Description: Replace this placeholder task list with implementation-ready tasks after the plan is approved.
-  - Files: `docs/tasks/offline-mode.md`
-  - Depends on: Task 0.2
-  - Acceptance: Final task list contains specific files, dependencies, and verification steps for each task.
+- [ ] **Task 1.3**: Add optimistic create ID strategy
+  - Description: Add default ObjectId-compatible ID generation for optimistic modelRouter creates, inject the generated ID into the configured request field, and support per-model overrides for `generateId`, request field, and server ID reconciliation strategy.
+  - Files: `rtk/src/offlineMiddleware.ts`, `rtk/src/offlineGate.ts`, `rtk/src/offlineIds.ts` (new if useful), `rtk/src/index.ts`, related tests
+  - Depends on: Task 1.2
+  - Acceptance: Tests verify default IDs are stable and ObjectId-shaped, custom generators are used, optimistic create cache entries use the same local ID as the queued mutation, and a server-returned replacement ID can be mapped when explicitly configured.
+
+- [ ] **Task 1.4**: Harden optimistic cache update strategies
+  - Description: Make optimistic cache updates explicit per modelRouter operation while providing safe defaults for create, update, delete, array push, array update, and array remove. Expose an override hook so app teams can customize cache updates for complex list filters or response shapes.
+  - Files: `rtk/src/offlineMiddleware.ts`, `rtk/src/offlineOptimistic.ts` (new if useful), `rtk/src/useOfflineStatus.ts`, related tests
+  - Depends on: Task 1.3
+  - Acceptance: Tests cover optimistic insert, patch, remove, and array mutations against RTK Query cache entries, including rollback or conflict marking when replay fails with a non-network/non-auth error.
+
+- [ ] **Task 1.5**: Pause replay on auth refresh failure without clearing cache
+  - Description: Separate token-refresh failure from explicit logout. If refresh cannot complete because the server/network is unavailable or refresh returns a retryable failure, mark replay as auth-blocked and keep RTK Query cache, queue, conflicts, and optimistic records intact. Reserve destructive cleanup for the actual logout action.
+  - Files: `rtk/src/emptyApi.ts`, `rtk/src/authSlice.ts`, `rtk/src/offlineMiddleware.ts`, `rtk/src/offlineSlice.ts`, related tests
+  - Depends on: Task 1.1
+  - Acceptance: Tests simulate expired access tokens with unreachable refresh endpoint and verify queued mutations are held, cache data remains, and replay resumes after auth is refreshed; explicit logout still clears tokens and configured offline/cache state.
+
+- [ ] **Task 1.6**: Implement keep-mine and use-server conflict resolution
+  - Description: Add conflict resolution actions/helpers. `useServer` should discard the queued mutation and patch cache to the server value. `keepMine` should update the queued mutation with the latest server timestamp, reapply the local optimistic value, and retry replay with fresh precondition headers.
+  - Files: `rtk/src/offlineSlice.ts`, `rtk/src/offlineMiddleware.ts`, `rtk/src/useOfflineStatus.ts`, `rtk/src/index.ts`, related tests
+  - Depends on: Task 1.4
+  - Acceptance: Tests cover `409 Conflict` replay responses, stored local/server values, resolving with `useServer`, resolving with `keepMine`, and preventing duplicate conflict records for the same queued mutation.
+
+## Phase 2: Connection Quality and UI
+
+- [ ] **Task 2.1**: Upgrade server status monitoring to connection quality
+  - Description: Extend `useServerStatus` to compute `online`, `spotty`, and `offline` from browser/native reachability events, health-check failures, latency, and recent failure rate. Make health URL, interval, timeout, latency threshold, failure count, and failure-rate thresholds configurable.
+  - Files: `rtk/src/useServerStatus.ts`, `rtk/src/offlineSlice.ts`, `rtk/src/index.ts`, related tests
+  - Depends on: Task 1.1
+  - Acceptance: Tests cover all three connection states, threshold overrides, transition from spotty back to online, transition to offline after configured consecutive failures, and no polling when status monitoring is disabled.
+
+- [ ] **Task 2.2**: Expose richer offline status hooks
+  - Description: Expand `useOfflineStatus` to return connection quality, queue length, syncing state, auth-blocked state, conflicts, local-only helpers, and conflict resolution callbacks while preserving low-level selectors for custom UI.
+  - Files: `rtk/src/useOfflineStatus.ts`, `rtk/src/offlineSlice.ts`, `rtk/src/index.ts`, related tests
+  - Depends on: Task 1.6, Task 2.1
+  - Acceptance: Hook tests or focused unit tests verify returned state and callbacks for queued, syncing, auth-blocked, conflicted, local-only, and healthy states.
+
+- [ ] **Task 2.3**: Update offline banner for online, spotty, offline, syncing, and auth-blocked states
+  - Description: Evolve `OfflineBanner` so apps can show offline, spotty connection, syncing queued changes, pending changes, and auth-blocked sync messaging. Keep props simple enough for custom state sources.
+  - Files: `ui/src/OfflineBanner.tsx`, `ui/src/index.tsx`, `ui/src/OfflineBanner.test.tsx` (new if absent), `demo/stories/OfflineBanner.stories.tsx` (new or update)
+  - Depends on: Task 2.1
+  - Acceptance: UI tests or stories cover hidden/online, spotty, offline, syncing, pending queue, and auth-blocked variants with clear copy and accessible test IDs.
+
+- [ ] **Task 2.4**: Add conflict resolution UI components
+  - Description: Add reusable conflict UI that renders unresolved conflicts and lets users choose "Keep mine" or "Use server". Keep it generic by accepting display renderers for local and server values.
+  - Files: `ui/src/OfflineConflictList.tsx` (new), `ui/src/OfflineConflictCard.tsx` (new), `ui/src/index.tsx`, `ui/src/*.test.tsx`, `demo/stories/OfflineConflict*.stories.tsx`
+  - Depends on: Task 2.2
+  - Acceptance: Tests or stories cover no-conflict, single-conflict, multiple-conflict, keep-mine click, use-server click, dismissed/resolved conflict filtering, and custom value rendering.
+
+## Phase 3: modelRouter Backend Contract
+
+- [ ] **Task 3.1**: Verify client-provided modelRouter create IDs
+  - Description: Add backend tests that prove modelRouter create accepts a client-provided ObjectId-compatible `_id` when the schema allows it and rejects invalid IDs through existing validation/error handling.
+  - Files: `api/src/api.ts`, `api/src/tests/*.test.ts` or existing modelRouter test file, `api/src/tests.ts`
+  - Depends on: Task 1.3
+  - Acceptance: API tests pass for create with client `_id`, returned document keeps that `_id`, duplicate IDs fail safely, and invalid IDs return a clear validation/error response.
+
+- [ ] **Task 3.2**: Formalize conflict response tests for modelRouter updates
+  - Description: Add/extend modelRouter tests for `If-Unmodified-Since` and `X-Unmodified-Since-ISO` headers to guarantee stale updates return `409 Conflict` with the current server document and fresh updates succeed.
+  - Files: `api/src/api.ts`, `api/src/tests/*.test.ts` or existing modelRouter test file
+  - Depends on: none
+  - Acceptance: API tests cover conflict by HTTP-date header, conflict by ISO header, success with current timestamp, missing timestamp behavior, and response body shape consumed by `@terreno/rtk`.
+
+- [ ] **Task 3.3**: Document the modelRouter offline contract
+  - Description: Add docs for modelRouter offline compatibility: supported CRUD/array endpoints, client-provided IDs, conflict headers, expected `409` response shape, permissions behavior, and explicit non-support for custom sync endpoints in v1.
+  - Files: `api/README.md` or package docs, `rtk/README.md` or package docs, `docs/implementationPlans/offline-mode.md`
+  - Depends on: Task 3.1, Task 3.2
+  - Acceptance: Docs show a modelRouter route configuration and matching frontend offline config, and clearly state that custom route sync is future work.
+
+## Phase 4: Example App Integration
+
+- [ ] **Task 4.1**: Enable offline mode for example todos
+  - Description: Wire the example frontend store to mount the offline reducer, persist the offline slice, configure todos modelRouter endpoints for offline create/update/delete, and keep API cache persistence consistent with the offline plan.
+  - Files: `example-frontend/store/index.ts`, `example-frontend/store/sdk.ts`, `example-frontend/app/_layout.tsx`, `example-frontend/package.json` if scripts need updates
+  - Depends on: Task 1.6, Task 2.2
+  - Acceptance: Example app can create, update, and delete todos while offline; queued todos survive app reload when persistence is enabled; replay syncs after the backend is reachable again.
+
+- [ ] **Task 4.2**: Integrate connection banner and sync state in the example app
+  - Description: Add root-level status monitoring and display `OfflineBanner` for offline, spotty, syncing, pending queue, and auth-blocked states. Ensure copy is visible without disrupting auth navigation.
+  - Files: `example-frontend/app/_layout.tsx`, `example-frontend/app/(tabs)/_layout.tsx`, `example-frontend/app/(tabs)/index.tsx`
+  - Depends on: Task 2.3, Task 4.1
+  - Acceptance: Manual test can trigger offline/spotty/syncing/auth-blocked states and see the correct banner copy and pending queue count.
+
+- [ ] **Task 4.3**: Add example conflict resolution flow
+  - Description: Show unresolved todo conflicts in the example app and wire "Keep mine" / "Use server" actions to the RTK conflict resolution helpers.
+  - Files: `example-frontend/app/(tabs)/index.tsx`, `example-frontend/components/*` if a local wrapper is useful
+  - Depends on: Task 2.4, Task 4.1
+  - Acceptance: Manual test can create a stale update conflict, see local/server values, choose "Use server" to accept server state, and choose "Keep mine" to replay local state.
+
+- [ ] **Task 4.4**: Add example backend support tests or fixtures for offline scenarios
+  - Description: Ensure the example backend todo model and route can support client IDs and conflict timestamps. Add tests or fixtures that make the example integration verifiable without modifying generated SDK files manually.
+  - Files: `example-backend/src/models/todo.ts`, `example-backend/src/api/todos.ts`, `example-backend/src/**/*.test.ts`
+  - Depends on: Task 3.1, Task 3.2
+  - Acceptance: Example backend tests pass and confirm todos work with the modelRouter offline contract.
+
+## Phase 5: Verification, Documentation, and Release Readiness
+
+- [ ] **Task 5.1**: Add package-level offline mode docs
+  - Description: Write consumer documentation for enabling offline mode, configuring modelRouter endpoints, selecting ID strategy, configuring connection quality, handling auth-blocked replay, and rendering conflict UI.
+  - Files: `rtk/README.md`, `ui/README.md` if present, `docs/implementationPlans/offline-mode.md`
+  - Depends on: Task 1.6, Task 2.4, Task 3.3
+  - Acceptance: Docs include copy-pasteable store setup, model config, status hook usage, `OfflineBanner`, and conflict resolution examples.
+
+- [ ] **Task 5.2**: Add end-to-end manual verification guide
+  - Description: Document the exact local steps to verify offline create/update/delete, replay, auth-blocked behavior, spotty status, and conflict resolution using example backend and frontend.
+  - Files: `docs/offline-mode-verification.md` (new) or relevant docs directory, `docs/implementationPlans/offline-mode.md`
+  - Depends on: Task 4.3
+  - Acceptance: Guide lists setup commands, offline simulation steps, expected UI states, and cleanup steps; it does not require editing generated SDK files manually.
+
+- [ ] **Task 5.3**: Run focused validation suite
+  - Description: Run and fix failures for the focused packages touched by offline mode.
+  - Files: no source changes expected unless validation finds failures
+  - Depends on: Task 5.1, Task 5.2
+  - Acceptance: `bun run rtk:compile` or equivalent package compile passes, `bun run ui:test` passes for new UI tests, `bun run api:test` passes for modelRouter tests, and example package checks used by the repo pass or have documented blockers.
+
+- [ ] **Task 5.4**: Regenerate SDK only if backend API surface changes
+  - Description: If implementation changes OpenAPI output for modelRouter conflict responses or example backend route schemas, regenerate `example-frontend/store/openApiSdk.ts` using the SDK generation workflow. If no OpenAPI surface changed, explicitly skip this task in the implementation PR notes.
+  - Files: `example-frontend/store/openApiSdk.ts`, `example-frontend/openapi-config.ts`
+  - Depends on: Task 3.3, Task 4.4
+  - Acceptance: Generated SDK is updated only from the backend OpenAPI spec and never edited manually; PR notes state whether SDK regeneration was required.

--- a/docs/tasks/offline-mode.md
+++ b/docs/tasks/offline-mode.md
@@ -1,0 +1,23 @@
+# Task List: Offline Mode
+
+*Placeholder task breakdown for completing the offline-mode implementation plan. Do not treat these as product implementation tasks until `docs/implementationPlans/offline-mode.md` is expanded and approved.*
+
+## Phase 0: Plan Completion
+
+- [ ] **Task 0.1**: Research existing offline-mode implementation
+  - Description: Review current `@terreno/rtk` offline primitives, tests, exports, and example app usage.
+  - Files: `rtk/src/offlineSlice.ts`, `rtk/src/offlineMiddleware.ts`, `rtk/src/useOfflineStatus.ts`, `rtk/src/useServerStatus.ts`, related tests
+  - Depends on: none
+  - Acceptance: Research notes capture existing capabilities, missing requirements, and open risks.
+
+- [ ] **Task 0.2**: Shape offline-mode scope
+  - Description: Decide the intended offline-mode surface across queue persistence, replay, conflicts, UI, examples, and docs.
+  - Files: `docs/implementationPlans/offline-mode.md`
+  - Depends on: Task 0.1
+  - Acceptance: Placeholder IP is replaced with a concrete implementation plan.
+
+- [ ] **Task 0.3**: Generate implementation tasks
+  - Description: Replace this placeholder task list with implementation-ready tasks after the plan is approved.
+  - Files: `docs/tasks/offline-mode.md`
+  - Depends on: Task 0.2
+  - Acceptance: Final task list contains specific files, dependencies, and verification steps for each task.

--- a/research.md
+++ b/research.md
@@ -1,3 +1,153 @@
+# Research: Offline-First Mode for Terreno
+
+## Summary
+
+Terreno already has an offline foundation in `@terreno/rtk`: an `offlineSlice`, `createOfflineMiddleware`, a queue gate in `emptyApi`, server reachability probing, and a reusable `OfflineBanner` in `@terreno/ui`. The recommended direction is to harden those primitives into an opt-in offline-first framework for generated modelRouter CRUD endpoints before expanding into custom routes or domain-specific sync engines.
+
+The v1 shape should keep the backend API surface small. `modelRouter` already exposes the important REST contract: create, list, read, update, delete, array push, array update, and array remove. The offline layer can infer model semantics from generated RTK Query endpoint names and app-provided endpoint configuration. Backend changes should be limited to making conflict detection and client-provided create IDs explicit and documented for modelRouter.
+
+## Context
+
+- **Problem:** Apps using Terreno should keep core CRUD workflows usable when the network is offline or unreliable, without requiring every app to hand-roll queue persistence, optimistic updates, auth token handling, conflict UI, and connection banners.
+- **Business impact:** A reusable offline-first layer improves reliability for mobile/field workflows and makes Terreno apps feel faster by using RTK Query optimistic updates.
+- **Affected packages:** `@terreno/rtk`, `@terreno/ui`, `@terreno/api`, `example-frontend`, and `example-backend`.
+- **Constraints:** Default off, easy to enable, modelRouter-only v1, configurable connection quality, support custom ID strategies with good defaults, and avoid clearing RTK caches unless a user actually logs out.
+
+## Findings
+
+### Finding 1 - RTK already has a queue and offline state
+
+`rtk/src/offlineSlice.ts` defines local-only offline state:
+
+- `isOnline`
+- `queue`
+- `conflicts`
+- `isSyncing`
+- actions for enqueue/dequeue, conflict tracking, dismissing conflicts, and sync status
+
+This is the right home for a v1 client-side offline model. The gap is that queue records are still too endpoint-centric and not explicit enough about modelRouter operation semantics, local temporary IDs, auth-blocked replay, or conflict resolution actions.
+
+### Finding 2 - `createOfflineMiddleware` already intercepts and replays mutations
+
+`rtk/src/offlineMiddleware.ts` uses listener middleware to:
+
+- detect failed RTK Query mutations that look like network failures,
+- enqueue configured offline mutations,
+- apply an optimistic cache patch,
+- replay queued mutations when `setOnlineStatus(true)` fires,
+- add precondition headers for update conflict detection,
+- record conflict entries when replay receives a conflict response.
+
+The design should keep this middleware, but make its configuration more explicit:
+
+- modelRouter endpoint descriptors instead of only endpoint-name lists,
+- optimistic strategy hooks per model/endpoint,
+- ID generation hooks for creates,
+- conflict resolution helpers for "keep mine" and "use server",
+- replay pause states for auth refresh failures.
+
+### Finding 3 - `emptyApi` is the auth and offline gate integration point
+
+`rtk/src/emptyApi.ts` already combines:
+
+- base URL resolution,
+- token header injection,
+- token refresh with a mutex,
+- 401 retry handling,
+- mutation retry safety,
+- `shouldDeferOfflineMutation` for offline-configured mutations.
+
+The critical auth change is behavioral: failed refresh must not imply global cache reset. Queries/mutations should be held or marked auth-blocked while a refresh or re-auth attempt is in progress. The actual cache purge should only happen on an explicit `logout` action. This protects cached offline data and queued local changes from being lost during a train tunnel, expired access token, or temporarily unreachable refresh endpoint.
+
+### Finding 4 - Backend modelRouter already has conflict-detection primitives
+
+`api/src/api.ts` has modelRouter update handling for `If-Unmodified-Since` and `X-Unmodified-Since-ISO`. If the server document has changed since the client's known timestamp, the backend returns `409 Conflict` with the current server document.
+
+That makes Last-Writer-Wins and explicit conflict resolution possible without a separate sync endpoint. The plan should formalize:
+
+- which timestamp field is authoritative (`updated` by default),
+- which header the client sends for queued updates,
+- the shape of the `409` response,
+- how clients convert a conflict into "keep mine" or "use server".
+
+### Finding 5 - Existing UI components cover the first visible layer
+
+`ui/src/OfflineBanner.tsx` exists and the example frontend already demonstrates `useServerStatus` and `OfflineBanner`. This should evolve into a more complete but still simple UI package:
+
+- a status hook returning `online`, `spotty`, or `offline`,
+- an offline/sync banner that can render all three states,
+- a small conflict list/resolution component,
+- low-level hooks so apps can build custom UI.
+
+### Finding 6 - Connection quality should be derived, not hardcoded
+
+The user asked to "add all three but make it configurable." The three inputs should be:
+
+1. browser/native network reachability events,
+2. health-check success/failure,
+3. latency/intermittent failure metrics.
+
+The client should expose thresholds and polling intervals. A default profile can classify:
+
+- `online`: health checks succeed and latency is below threshold,
+- `spotty`: browser says online but health checks intermittently fail or latency is high,
+- `offline`: browser says offline or health checks repeatedly fail.
+
+### Finding 7 - Optimistic creates need a client ID strategy
+
+Optimistic creates need a stable local identifier before the server has confirmed the record. The plan should support:
+
+- default client-generated ObjectId-compatible IDs for Mongoose modelRouter creates,
+- an overridable `generateId` function per model,
+- an ID reconciliation map when a server returns a different ID,
+- local-only markers so UI can distinguish pending creates.
+
+The lowest-friction default is to generate ObjectId-shaped strings on the client and send them as `_id` for modelRouter create requests when enabled for a model. That keeps list/read/update cache keys stable and avoids temporary ID churn.
+
+## Options Considered
+
+| Option | Description | Pros | Cons | Recommendation |
+| --- | --- | --- | --- | --- |
+| Harden existing RTK offline primitives | Extend `createOfflineMiddleware`, `offlineSlice`, `useServerStatus`, and UI components | Smallest surface, fits current architecture, works with generated hooks | Requires careful generic configuration | Yes |
+| Add a backend sync endpoint | Add `/sync` APIs for batches, cursors, and conflict resolution | Powerful future model | Larger backend contract, harder to keep generic | Not for v1 |
+| Use a third-party offline database/sync library | Add WatermelonDB/Realm/etc. | Mature local DB semantics | Heavy dependency, different app architecture | No for v1 |
+| App-by-app custom queues | Let each app own offline behavior | Maximum flexibility | Duplicated bugs and inconsistent UX | No |
+
+## Recommendation
+
+Build offline-first v1 as an opt-in `@terreno/rtk` modelRouter offline framework:
+
+1. **ModelRouter-only support first.** Apps configure the modelRouter endpoints that can be queued and replayed. Custom route support remains a future extension point through strategy interfaces.
+2. **Client-only queue/conflict state.** Keep queue and conflicts in Redux persistence for v1; no server-side queue model.
+3. **Good ID defaults with overrides.** Generate ObjectId-compatible IDs for optimistic creates by default, but expose per-model `generateId`.
+4. **Auth is non-destructive.** Token refresh failures pause replay and mark sync as auth-blocked; caches and queues survive until explicit logout.
+5. **Explicit conflict resolution.** Record conflicts with local and server versions. "Use server" drops the queued local mutation and patches cache to server. "Keep mine" updates the queued mutation with the latest server timestamp and replays it.
+6. **Configurable connection quality.** `useServerStatus` becomes a richer status monitor using browser/network state, health checks, and latency/failure thresholds.
+7. **Reusable UI with escape hatches.** Provide banners/hooks/conflict components, but keep low-level selectors and actions exported for custom app UI.
+
+## Open Questions Answered
+
+- **Should v1 support custom routes?** No. Start with modelRouter only, but keep the strategy API capable of custom routes later.
+- **Should create IDs be configurable?** Yes, with a strong default.
+- **Should auth refresh clear caches?** No. Only explicit logout clears auth and cache state.
+- **What conflict choices are required?** Support "keep mine" and "use server" for v1.
+- **Should connection states include online, spotty, offline?** Yes, and the thresholds should be configurable.
+
+## References
+
+- `rtk/src/offlineSlice.ts`
+- `rtk/src/offlineMiddleware.ts`
+- `rtk/src/offlineGate.ts`
+- `rtk/src/useOfflineStatus.ts`
+- `rtk/src/useServerStatus.ts`
+- `rtk/src/emptyApi.ts`
+- `rtk/src/authSlice.ts`
+- `api/src/api.ts`
+- `ui/src/OfflineBanner.tsx`
+- `example-frontend/store/index.ts`
+- `example-frontend/app/_layout.tsx`
+- RTK Query manual cache update and optimistic update docs
+- RTK Query cache persistence/rehydration docs
 # Research: Consent Forms System for Terreno
 
 ## Summary


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replace the offline-mode placeholder IP with a shaped implementation plan and implementation-ready task breakdown for an opt-in offline-first modelRouter flow. The plan documents the client-side RTK queue/conflict model, the modelRouter-only API contract, default and custom optimistic create ID strategies, auth-blocked replay behavior, keep-mine/use-server conflict resolution, configurable online/spotty/offline connection quality, and concrete follow-up tasks.

## Human Testing Steps

- [ ] Open `docs/implementationPlans/offline-mode.md` and confirm the plan is marked approved for implementation tasking.
- [ ] Confirm the plan calls out auth refresh failures as replay pauses rather than cache-clearing logout events.
- [ ] Open `docs/tasks/offline-mode.md` and confirm tasks are specific, dependency-ordered, and map to RTK core, connection/UI, backend contract, example app, and verification work.

## Changes

- Saved offline-mode research in `research.md`.
- Replaced the offline-mode placeholder IP with a concrete shaped solution.
- Marked the modelRouter-only foundation approved for implementation tasking.
- Replaced the placeholder task list with phased implementation tasks and acceptance checks.

## Automated Tests

- No automated tests run; docs-only change.
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2653d25c-d888-4c6f-b417-e8f7d6b372c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2653d25c-d888-4c6f-b417-e8f7d6b372c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

