### PR TITLE
Fix TapToEdit Cancel

### DIFF
--- a/ui/src/TapToEdit.test.tsx
+++ b/ui/src/TapToEdit.test.tsx
@@ -212,6 +212,22 @@ describe("TapToEdit", () => {
     expect(setValue).toHaveBeenCalled();
   });
 
+  it("reverts to original value (not edited value) when Cancel is pressed", async () => {
+    const setValue = mock((_v: unknown) => {});
+    const {getByLabelText, getByText} = renderWithTheme(
+      <TapToEdit setValue={setValue} title="Name" value="Jane" />
+    );
+    await act(async () => {
+      fireEvent.press(getByLabelText("Edit"));
+    });
+    // Simulate user having changed the value during editing
+    setValue("Edited Value");
+    await act(async () => {
+      fireEvent.press(getByText("Cancel"));
+    });
+    expect(setValue).toHaveBeenLastCalledWith("Jane");
+  });
+
   it("clears value when Clear button is pressed", async () => {
     const setValue = mock(() => {});
     const onSave = mock(() => Promise.resolve());

--- a/ui/src/TapToEdit.tsx
+++ b/ui/src/TapToEdit.tsx
@@ -81,13 +81,8 @@ export const TapToEdit: FC<TapToEditProps> = ({
   ...fieldProps
 }) => {
   const [editing, setEditing] = useState(false);
-  const [initialValue, setInitialValue] = useState<unknown>();
+  const initialValueRef = useRef<unknown>(undefined);
   const helperText: string | undefined = propsHelperText;
-  // setInitialValue is called after initial render to handle the case where the value is updated
-  useEffect(() => {
-    setInitialValue(value);
-    // do not update if value changes
-  }, [value]);
 
   // TODO: Auto focus on input when editing for field types other than text for accessibility
   // biome-ignore lint/suspicious/noExplicitAny: inputRef references various RN input components (TextInput, etc.) depending on the field type
@@ -134,7 +129,7 @@ export const TapToEdit: FC<TapToEditProps> = ({
               <Button
                 onClick={(): void => {
                   if (setValue) {
-                    setValue(initialValue);
+                    setValue(initialValueRef.current);
                   }
                   setEditing(false);
                 }}
@@ -146,7 +141,6 @@ export const TapToEdit: FC<TapToEditProps> = ({
                   onClick={(): void => {
                     if (setValue) {
                       setValue("");
-                      setInitialValue("");
                     }
                     if (onSave) {
                       onSave("");
@@ -165,7 +159,6 @@ export const TapToEdit: FC<TapToEditProps> = ({
                     if (!onSave) {
                       console.error("No onSave provided for editable TapToEdit");
                     } else {
-                      setInitialValue(value);
                       await onSave(value);
                     }
                     setEditing(false);
@@ -275,7 +268,10 @@ export const TapToEdit: FC<TapToEditProps> = ({
                 accessibilityHint=""
                 accessibilityLabel="Edit"
                 marginLeft={2}
-                onClick={(): void => setEditing(true)}
+                onClick={(): void => {
+                  initialValueRef.current = value;
+                  setEditing(true);
+                }}
                 width={16}
               >
                 <Icon iconName="pencil" size="md" />


### PR DESCRIPTION
Fixes issue when pressing user presses cancel and edited state persists. Expect value to revert to initial state.

https://pr-655--terreno-demo.netlify.app/demo

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized UI edit/cancel behavior in TapToEdit with a focused test; no auth, data, or API changes.
> 
> **Overview**
> **TapToEdit** now snapshots the value when the user taps **Edit** and restores that snapshot on **Cancel**, instead of tracking a separate `initialValue` in state via a mount-only effect.
> 
> The old approach set `initialValue` once on first render and could drift from what the user was editing; **Cancel** could restore the wrong value. **Clear** no longer mutates the cancel baseline, and **Save** no longer overwrites it. A test asserts **Cancel** calls `setValue` with the pre-edit value (`"Jane"`) after a simulated in-session edit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71de26b89959acf2be4fa0644ba0a99c88cf22c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->