### PR TITLE
Add fingerprint gate workflow for example-frontend

### DIFF
--- a/.github/workflows/fingerprint-gate.yml
+++ b/.github/workflows/fingerprint-gate.yml
@@ -1,0 +1,131 @@
+name: Fingerprint Gate
+
+# Compares the PR's Expo fingerprint against master's. If the PR would change
+# the native fingerprint of example-frontend, this job FAILS until a reviewer
+# adds the `fingerprint-acknowledged` label, signalling they understand and
+# accept the cost (a fresh EAS dev build + reinstall for every developer).
+#
+# This is intentionally loud and intentionally rare. Most PRs only touch JS,
+# which leaves the fingerprint untouched and the job passes silently.
+#
+# Acknowledgement is per-fingerprint: if the PR is pushed to and the
+# fingerprint changes again, the label is auto-removed and re-acknowledgement
+# is required. The acknowledged hash pair is recorded in a hidden HTML marker
+# inside the sticky PR comment.
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+    paths:
+      - example-frontend/**
+      - ui/**
+      - rtk/**
+      - package.json
+      - bun.lock
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: fingerprint-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: Fingerprint gate / example-frontend
+    # Skip label events for unrelated labels — only ACK_LABEL changes matter.
+    if: |
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'fingerprint-acknowledged'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      ACK_LABEL: fingerprint-acknowledged
+      COMMENT_MARKER: "<!-- fingerprint-gate:example-frontend -->"
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          path: pr
+
+      - name: Validate required secrets
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          if [ -z "$EXPO_TOKEN" ]; then
+            echo "::error::Missing required secret EXPO_TOKEN"
+            exit 1
+          fi
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
+      - name: Cache bun install cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-fp-${{ runner.os }}-${{ hashFiles('pr/bun.lock') }}
+          restore-keys: |
+            bun-fp-${{ runner.os }}-
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install + compile (PR)
+        working-directory: pr
+        run: |
+          bun install --frozen-lockfile
+          bun run compile
+
+      - name: Compute PR fingerprint
+        id: pr_fp
+        working-directory: pr/example-frontend
+        run: |
+          set -euo pipefail
+          ios=$(eas fingerprint:generate --platform ios --non-interactive --json | jq -r '.hash')
+          android=$(eas fingerprint:generate --platform android --non-interactive --json | jq -r '.hash')
+          echo "iOS PR fingerprint:     $ios"
+          echo "Android PR fingerprint: $android"
+          echo "ios=$ios" >> "$GITHUB_OUTPUT"
+          echo "android=$android" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout master
+        uses: actions/checkout@v6
+        with:
+          ref: master
+          path: master
+
+      - name: Install + compile (master)
+        working-directory: master
+        run: |
+          bun install --frozen-lockfile
+          bun run compile
+
+      - name: Compute master fingerprint
+        id: master_fp
+        working-directory: master/example-frontend
+        run: |
+          set -euo pipefail
+          ios=$(eas fingerprint:generate --platform ios --non-interactive --json | jq -r '.hash')
+          android=$(eas fingerprint:generate --platform android --non-interactive --json | jq -r '.hash')
+          echo "iOS master fingerprint:     $ios"
+          echo "Android master fingerprint: $android"
+          echo "ios=$ios" >> "$GITHUB_OUTPUT"
+          echo "android=$android" >> "$GITHUB_OUTPUT"
+
+      - name: Evaluate gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_IOS: ${{ steps.pr_fp.outputs.ios }}
+          PR_ANDROID: ${{ steps.pr_fp.outputs.android }}
+          MASTER_IOS: ${{ steps.master_fp.outputs.ios }}
+          MASTER_ANDROID: ${{ steps.master_fp.outputs.android }}
+        run: pr/.github/workflows/scripts/fingerprint-gate.sh

--- a/.github/workflows/fingerprint-gate.yml
+++ b/.github/workflows/fingerprint-gate.yml
@@ -123,7 +123,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_IOS: ${{ steps.pr_fp.outputs.ios }}
           PR_ANDROID: ${{ steps.pr_fp.outputs.android }}
           MASTER_IOS: ${{ steps.master_fp.outputs.ios }}

--- a/.github/workflows/scripts/fingerprint-gate.sh
+++ b/.github/workflows/scripts/fingerprint-gate.sh
@@ -122,7 +122,12 @@ label_present=false
 has_ack_label && label_present=true
 
 # === Case 2: acknowledged for the current fingerprint state ===
-if $label_present && [ "$existing_ack" = "$current_ack" ]; then
+# Empty existing_ack also counts as "acknowledged at current fingerprint":
+# the reviewer added the label before any bot comment existed (e.g. they
+# labeled while the initial run was canceled by cancel-in-progress, or
+# someone manually deleted the bot's comment). Treat label-add as a
+# definitive ack at the current state and let Case 3 catch later drift.
+if $label_present && { [ -z "$existing_ack" ] || [ "$existing_ack" = "$current_ack" ]; }; then
   body=$(cat <<EOF
 $COMMENT_MARKER
 <!-- $current_ack -->

--- a/.github/workflows/scripts/fingerprint-gate.sh
+++ b/.github/workflows/scripts/fingerprint-gate.sh
@@ -12,7 +12,6 @@
 #   GH_TOKEN           GitHub token with pull-requests + issues write
 #   GITHUB_REPOSITORY  owner/repo
 #   PR_NUMBER          PR number
-#   PR_HEAD_SHA        PR head commit SHA (for the marker, not enforced here)
 #   PR_IOS             PR iOS fingerprint hash
 #   PR_ANDROID         PR Android fingerprint hash
 #   MASTER_IOS         master iOS fingerprint hash
@@ -25,7 +24,6 @@ set -euo pipefail
 : "${GH_TOKEN:?missing}"
 : "${GITHUB_REPOSITORY:?missing}"
 : "${PR_NUMBER:?missing}"
-: "${PR_HEAD_SHA:?missing}"
 : "${PR_IOS:?missing}"
 : "${PR_ANDROID:?missing}"
 : "${MASTER_IOS:?missing}"

--- a/.github/workflows/scripts/fingerprint-gate.sh
+++ b/.github/workflows/scripts/fingerprint-gate.sh
@@ -33,9 +33,13 @@ set -euo pipefail
 : "${ACK_LABEL:?missing}"
 : "${COMMENT_MARKER:?missing}"
 
+# Filter by author so a PR author can't seed a comment with a forged ack
+# marker that the gate then trusts. Anyone with write access can still edit
+# the bot's own comment body, but at that point they could self-add the
+# label too — same threat model.
 find_sticky_comment_id() {
   gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
-    --jq "map(select(.body | contains(\"$COMMENT_MARKER\"))) | first | .id // empty"
+    --jq "map(select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$COMMENT_MARKER\")))) | first | .id // empty"
 }
 
 read_existing_ack_marker() {
@@ -63,8 +67,10 @@ upsert_comment() {
 delete_sticky_comment() {
   local existing
   existing=$(find_sticky_comment_id)
-  [ -n "$existing" ] && gh api --method DELETE \
-    "repos/$GITHUB_REPOSITORY/issues/comments/$existing" >/dev/null
+  if [ -n "$existing" ]; then
+    gh api --method DELETE \
+      "repos/$GITHUB_REPOSITORY/issues/comments/$existing" >/dev/null
+  fi
 }
 
 ensure_label_exists() {

--- a/.github/workflows/scripts/fingerprint-gate.sh
+++ b/.github/workflows/scripts/fingerprint-gate.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Fingerprint gate: compares PR fingerprint to master's and decides whether
+# the gate passes. Manages the sticky PR comment, the per-fingerprint hidden
+# acknowledgement marker, and auto-removes a stale ACK_LABEL when the PR's
+# fingerprint changes after acknowledgement.
+#
+# Exits 0 when the gate passes (fingerprints match OR change is acknowledged
+# for the current fingerprint). Exits 1 to fail the GitHub Actions check when
+# a reviewer must acknowledge.
+#
+# Required env:
+#   GH_TOKEN           GitHub token with pull-requests + issues write
+#   GITHUB_REPOSITORY  owner/repo
+#   PR_NUMBER          PR number
+#   PR_HEAD_SHA        PR head commit SHA (for the marker, not enforced here)
+#   PR_IOS             PR iOS fingerprint hash
+#   PR_ANDROID         PR Android fingerprint hash
+#   MASTER_IOS         master iOS fingerprint hash
+#   MASTER_ANDROID     master Android fingerprint hash
+#   ACK_LABEL          Label name reviewers add to acknowledge
+#   COMMENT_MARKER     Hidden HTML marker identifying our sticky comment
+
+set -euo pipefail
+
+: "${GH_TOKEN:?missing}"
+: "${GITHUB_REPOSITORY:?missing}"
+: "${PR_NUMBER:?missing}"
+: "${PR_HEAD_SHA:?missing}"
+: "${PR_IOS:?missing}"
+: "${PR_ANDROID:?missing}"
+: "${MASTER_IOS:?missing}"
+: "${MASTER_ANDROID:?missing}"
+: "${ACK_LABEL:?missing}"
+: "${COMMENT_MARKER:?missing}"
+
+find_sticky_comment_id() {
+  gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
+    --jq "map(select(.body | contains(\"$COMMENT_MARKER\"))) | first | .id // empty"
+}
+
+read_existing_ack_marker() {
+  local comment_id="$1"
+  [ -z "$comment_id" ] && return 0
+  gh api "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
+    --jq '.body' \
+    | grep -oE 'fingerprint-gate-ack: ios=[a-f0-9]+ android=[a-f0-9]+' \
+    || true
+}
+
+upsert_comment() {
+  local body="$1"
+  local existing
+  existing=$(find_sticky_comment_id)
+  if [ -n "$existing" ]; then
+    gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$existing" \
+      -f body="$body" >/dev/null
+  else
+    gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+      -f body="$body" >/dev/null
+  fi
+}
+
+delete_sticky_comment() {
+  local existing
+  existing=$(find_sticky_comment_id)
+  [ -n "$existing" ] && gh api --method DELETE \
+    "repos/$GITHUB_REPOSITORY/issues/comments/$existing" >/dev/null
+}
+
+ensure_label_exists() {
+  if ! gh api "repos/$GITHUB_REPOSITORY/labels/$ACK_LABEL" >/dev/null 2>&1; then
+    gh api --method POST "repos/$GITHUB_REPOSITORY/labels" \
+      -f name="$ACK_LABEL" \
+      -f color="b60205" \
+      -f description="Reviewer has acknowledged a native fingerprint change in this PR." \
+      >/dev/null 2>&1 || true
+  fi
+}
+
+has_ack_label() {
+  gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
+    --jq "map(.name) | index(\"$ACK_LABEL\")" \
+    | grep -q '^[0-9]\+$'
+}
+
+remove_ack_label() {
+  gh api --method DELETE \
+    "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/$ACK_LABEL" \
+    >/dev/null 2>&1 || true
+}
+
+short() {
+  echo "${1:0:12}"
+}
+
+ensure_label_exists
+
+ios_short=$(short "$PR_IOS")
+android_short=$(short "$PR_ANDROID")
+master_ios_short=$(short "$MASTER_IOS")
+master_android_short=$(short "$MASTER_ANDROID")
+
+# === Case 1: fingerprints match master ===
+if [ "$PR_IOS" = "$MASTER_IOS" ] && [ "$PR_ANDROID" = "$MASTER_ANDROID" ]; then
+  echo "::notice::Fingerprint unchanged vs master — no native build needed."
+  delete_sticky_comment
+  exit 0
+fi
+
+# === Fingerprints differ — evaluate acknowledgement ===
+current_ack="fingerprint-gate-ack: ios=$PR_IOS android=$PR_ANDROID"
+existing_id=$(find_sticky_comment_id)
+existing_ack=""
+[ -n "$existing_id" ] && existing_ack=$(read_existing_ack_marker "$existing_id")
+label_present=false
+has_ack_label && label_present=true
+
+# === Case 2: acknowledged for the current fingerprint state ===
+if $label_present && [ "$existing_ack" = "$current_ack" ]; then
+  body=$(cat <<EOF
+$COMMENT_MARKER
+<!-- $current_ack -->
+
+### ✅ Native build change acknowledged — example-frontend
+
+A new EAS dev build will be produced for this PR. A reviewer has acknowledged that the change is intentional.
+
+| platform | master fingerprint | PR fingerprint |
+| --- | --- | --- |
+| iOS | \`$master_ios_short…\` | \`$ios_short…\` |
+| Android | \`$master_android_short…\` | \`$android_short…\` |
+
+Acknowledged via the \`$ACK_LABEL\` label. Removing the label, or pushing a commit that changes the fingerprint again, will re-block this PR.
+EOF
+)
+  upsert_comment "$body"
+  echo "::notice::Fingerprint change acknowledged via $ACK_LABEL label."
+  exit 0
+fi
+
+# === Case 3: label present but PR fingerprint changed since acknowledgement ===
+if $label_present && [ -n "$existing_ack" ] && [ "$existing_ack" != "$current_ack" ]; then
+  remove_ack_label
+  body=$(cat <<EOF
+$COMMENT_MARKER
+<!-- $current_ack -->
+
+### 🚨 Fingerprint changed AFTER acknowledgement — example-frontend
+
+**REQUIRES REVIEWER RE-ACKNOWLEDGEMENT**
+
+This PR was already acknowledged for a different fingerprint, but a new commit changed the native fingerprint again. The \`$ACK_LABEL\` label has been **automatically removed**.
+
+| platform | master fingerprint | PR fingerprint |
+| --- | --- | --- |
+| iOS | \`$master_ios_short…\` | \`$ios_short…\` |
+| Android | \`$master_android_short…\` | \`$android_short…\` |
+
+Re-review the native change and re-add the \`$ACK_LABEL\` label.
+EOF
+)
+  upsert_comment "$body"
+  echo "::error::Fingerprint changed after acknowledgement — re-acknowledgement required."
+  exit 1
+fi
+
+# === Case 4: change detected, no acknowledgement yet ===
+body=$(cat <<EOF
+$COMMENT_MARKER
+<!-- $current_ack -->
+
+### 🚨 Native build change detected — example-frontend
+
+**REQUIRES REVIEWER ACKNOWLEDGEMENT BEFORE MERGE**
+
+This PR changes the Expo native fingerprint of \`example-frontend\` vs \`master\`. Merging it will force a new EAS dev build, and every developer with a local checkout will need to install the new dev build before they can run the app.
+
+| platform | master fingerprint | PR fingerprint |
+| --- | --- | --- |
+| iOS | \`$master_ios_short…\` | \`$ios_short…\` |
+| Android | \`$master_android_short…\` | \`$android_short…\` |
+
+#### What a reviewer should do
+
+1. Confirm the native change is intentional (new dep with native code, plugin config, app.json / eas.json edit, Expo SDK bump, etc.).
+2. If it's intentional and accepted, add the **\`$ACK_LABEL\`** label to this PR.
+3. The \`Fingerprint gate / example-frontend\` check will turn green and the PR can be merged.
+
+> If you did not expect to change the native fingerprint, look for: a new dep with native code, an Expo config plugin change, an app.json / eas.json edit, or a bumped Expo SDK.
+EOF
+)
+upsert_comment "$body"
+echo "::error::Native fingerprint changed vs master. Add the '$ACK_LABEL' label after reviewing."
+exit 1


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that compares the Expo native fingerprint of `example-frontend` on the PR branch vs `master`. When the fingerprint changes (meaning a new EAS dev build will be required), the job fails loudly and blocks merge until a reviewer acknowledges it via the `fingerprint-acknowledged` label.

This is intentionally rare and loud — most PRs only touch JS and the job passes silently with no comment.

## Human Testing Steps

- [ ] Open a PR that changes the native fingerprint (e.g. add/remove a native dep or edit `app.json`/`eas.json`) — the `Fingerprint gate / example-frontend` check should fail and a 🚨 sticky comment should appear
- [ ] Open a PR with only JS changes — the check should pass silently with no comment
- [ ] On a fingerprint-changing PR, add the `fingerprint-acknowledged` label — the check should re-run and turn green, the comment should update to ✅
- [ ] While the label is present, push a new commit that changes the fingerprint again — the label should be auto-removed and the check should fail again requiring re-acknowledgement

## Changes

- `.github/workflows/fingerprint-gate.yml` — workflow triggered on PR open/sync/labeled/unlabeled for paths that affect `example-frontend`'s fingerprint; checks out PR and master separately, computes both fingerprints, delegates to the gate script
- `.github/workflows/scripts/fingerprint-gate.sh` — implements the four-case decision tree: (1) match → pass + delete any old comment, (2) acked at current hash → pass + green comment, (3) acked but hash drifted → auto-remove label + loud re-ack comment + fail, (4) changed + no ack → loud acknowledgement-required comment + fail; uses a hidden `<!-- fingerprint-gate-ack: ios=… android=… -->` marker in the sticky comment to track per-fingerprint acknowledgement
- Followup fixes from review:
  - `delete_sticky_comment` restructured with `if/then` to avoid a `set -e` short-circuit that would have failed the gate on the most common JS-only path
  - `find_sticky_comment_id` now filters to comments authored by `github-actions[bot]` so a PR author cannot seed a forged ack marker

## Automated Tests

- Bash syntax: `bash -n fingerprint-gate.sh` — passed
- YAML: valid
- Monorepo lint: passed (no issues in changed files)

## Next Step

Add `Fingerprint gate / example-frontend` as a **required status check** in branch protection for `master` to enforce the gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New CI-only workflow and bash script; no app runtime or auth changes. Main operational risk is false failures or CI cost from dual checkout + EAS fingerprint runs.
> 
> **Overview**
> Adds a **merge-blocking CI gate** for `example-frontend` that compares iOS/Android Expo fingerprints on the PR branch vs `master`. JS-only PRs pass with no comment; when either platform hash differs, the **`Fingerprint gate / example-frontend`** check fails until a reviewer adds **`fingerprint-acknowledged`**.
> 
> The workflow (`.github/workflows/fingerprint-gate.yml`) runs on relevant path changes, double-checkouts PR and `master`, installs/compiles both, runs `eas fingerprint:generate`, then delegates to **`fingerprint-gate.sh`**. That script implements pass/fail, sticky PR comments, auto-creates the ack label, stores per-hash acknowledgement in a hidden HTML marker, **auto-removes** the label if the fingerprint drifts after ack, and only trusts sticky comments from **`github-actions[bot]`** (not forged author comments).
> 
> This sits alongside existing **`eas-pr.yml`** fingerprint logic (fast vs slow EAS paths) but adds an explicit human acknowledgement step before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7821982b0ddd06b42b5c5fa96dae4ec6f10f0ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->