### PR TITLE
Fix consent markdown layout and example app launch issues

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -76,9 +76,9 @@
     {
       "label": "frontend (example)",
       "type": "shell",
-      "command": "bun run frontend:web",
+      "command": "bun run web",
       "options": {
-        "cwd": "${workspaceFolder}"
+        "cwd": "${workspaceFolder}/example-frontend"
       },
       "group": "build",
       "isBackground": true,
@@ -100,9 +100,9 @@
     {
       "label": "backend (example)",
       "type": "shell",
-      "command": "bun run backend:dev",
+      "command": "bun run dev",
       "options": {
-        "cwd": "${workspaceFolder}"
+        "cwd": "${workspaceFolder}/example-backend"
       },
       "group": "build",
       "isBackground": true,

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "admin-backend": {
       "name": "@terreno/admin-backend",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "@google-cloud/storage": "^7.15.0",
         "@terreno/api": "workspace:*",
@@ -36,7 +36,7 @@
     },
     "admin-frontend": {
       "name": "@terreno/admin-frontend",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "@terreno/ui": "workspace:*",
         "expo-router": "catalog:",
@@ -67,7 +67,7 @@
     },
     "ai": {
       "name": "@terreno/ai",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "@ai-sdk/mcp": "^1.0.21",
         "@google-cloud/storage": "^7.15.0",
@@ -101,7 +101,7 @@
     },
     "api": {
       "name": "@terreno/api",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "@sentry/bun": "^10.25.0",
         "@sentry/profiling-node": "^10.25.0",
@@ -173,7 +173,7 @@
     },
     "api-health": {
       "name": "@terreno/api-health",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "@terreno/api": "workspace:*",
         "express": "^5.2.1",
@@ -341,6 +341,7 @@
         "react": "catalog:",
         "react-dom": "catalog:",
         "react-native": "catalog:",
+        "react-native-gesture-handler": "catalog:",
         "react-native-reanimated": "catalog:",
         "react-native-web": "catalog:",
         "react-native-webview": "catalog:",
@@ -361,7 +362,7 @@
     },
     "feature-flags": {
       "name": "@terreno/feature-flags",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "@terreno/api": "workspace:*",
         "express": "^5.2.1",
@@ -401,7 +402,7 @@
     },
     "rtk": {
       "name": "@terreno/rtk",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "@better-auth/expo": "^1.2.8",
         "@react-native-async-storage/async-storage": "catalog:",
@@ -440,7 +441,7 @@
     },
     "ui": {
       "name": "@terreno/ui",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "@expo-google-fonts/nunito": "^0.4.2",
         "@expo-google-fonts/titillium-web": "^0.4.1",
@@ -1422,17 +1423,17 @@
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
-    "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@10.43.0", "", { "dependencies": { "@sentry/core": "10.43.0" } }, "sha512-8zYTnzhAPvNkVH1Irs62wl0J/c+0QcJ62TonKnzpSFUUD3V5qz8YDZbjIDGfxy+1EB9fO0sxtddKCzwTHF/MbQ=="],
+    "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@10.55.0", "", { "dependencies": { "@sentry/core": "10.55.0" } }, "sha512-zUvyBr13EK0evKsSTzwSimRzZ3P9kugS32dLCj3ea5gNN+/DFtU/GsMTdcIQDhusEDraIlH17AGgqJH5gUAv5w=="],
 
-    "@sentry-internal/feedback": ["@sentry-internal/feedback@10.43.0", "", { "dependencies": { "@sentry/core": "10.43.0" } }, "sha512-YoXuwluP6eOcQxTeTtaWb090++MrLyWOVsUTejzUQQ6LFL13Jwt+bDPF1kvBugMq4a7OHw/UNKQfd6//rZMn2g=="],
+    "@sentry-internal/feedback": ["@sentry-internal/feedback@10.55.0", "", { "dependencies": { "@sentry/core": "10.55.0" } }, "sha512-32X9WW1xs5DjCRlp89QJ/PLw4kbTIX6MsBDXN2RBN1nWBjm/2WcwXqO/v/WoIS4W2kTWXcZnQwalLSI22Fp33A=="],
 
     "@sentry-internal/node-cpu-profiler": ["@sentry-internal/node-cpu-profiler@2.2.0", "", { "dependencies": { "detect-libc": "^2.0.3", "node-abi": "^3.73.0" } }, "sha512-oLHVYurqZfADPh5hvmQYS5qx8t0UZzT2u6+/68VXsFruQEOnYJTODKgU3BVLmemRs3WE6kCJjPeFdHVYOQGSzQ=="],
 
-    "@sentry-internal/replay": ["@sentry-internal/replay@10.43.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.43.0", "@sentry/core": "10.43.0" } }, "sha512-khCXlGrlH1IU7P5zCEAJFestMeH97zDVCekj8OsNNDtN/1BmCJ46k6Xi0EqAUzdJgrOLJeLdoYdgtiIjovZ8Sg=="],
+    "@sentry-internal/replay": ["@sentry-internal/replay@10.55.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.55.0", "@sentry/core": "10.55.0" } }, "sha512-OkQpANGwYU5UKfwLk6Y+NpESRC8nrLBjawRDLwF6cJ8HpNScOuNNJDEJEGwXHVkJPH0pcIixsH8y0Qfcltq6Xw=="],
 
-    "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.43.0", "", { "dependencies": { "@sentry-internal/replay": "10.43.0", "@sentry/core": "10.43.0" } }, "sha512-ZIw1UNKOFXo1LbPCJPMAx9xv7D8TMZQusLDUgb6BsPQJj0igAuwd7KRGTkjjgnrwBp2O/sxcQFRhQhknWk7QPg=="],
+    "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.55.0", "", { "dependencies": { "@sentry-internal/replay": "10.55.0", "@sentry/core": "10.55.0" } }, "sha512-lu/y7k9cK7FZ/qJpL0fBX4WqK6IFa/+bTPhedEaC5UpzjUNP7BfXt0H+R7q9CHWmp20Ffh/wGfO3j7O+Tv2MAA=="],
 
-    "@sentry/browser": ["@sentry/browser@10.43.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.43.0", "@sentry-internal/feedback": "10.43.0", "@sentry-internal/replay": "10.43.0", "@sentry-internal/replay-canvas": "10.43.0", "@sentry/core": "10.43.0" } }, "sha512-2V3I3sXi3SMeiZpKixd9ztokSgK27cmvsD9J5oyOyjhGLTW/6QKCwHbKnluMgQMXq20nixQk5zN4wRjRUma3sg=="],
+    "@sentry/browser": ["@sentry/browser@10.55.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.55.0", "@sentry-internal/feedback": "10.55.0", "@sentry-internal/replay": "10.55.0", "@sentry-internal/replay-canvas": "10.55.0", "@sentry/core": "10.55.0" } }, "sha512-5n1kxmW1m4j16ZDV9kt+Zo5uafFnKTy7s5YyEcGnC45KnOiO1Gy+QFd3woXns1K5GNxpjF7oOOc6tXgZLuXnQQ=="],
 
     "@sentry/bun": ["@sentry/bun@10.43.0", "", { "dependencies": { "@sentry/core": "10.43.0", "@sentry/node": "10.43.0" } }, "sha512-BMWmJNU4Bl2AClcXUpOhR+ZFxl8bCg3k797ESqUC+vzDe13i81iwhh8NAN8kHEoRY771fh/bIqe8n6KKFKIr0A=="],
 
@@ -1446,7 +1447,7 @@
 
     "@sentry/profiling-node": ["@sentry/profiling-node@10.43.0", "", { "dependencies": { "@sentry-internal/node-cpu-profiler": "^2.2.0", "@sentry/core": "10.43.0", "@sentry/node": "10.43.0" }, "bin": { "sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js" } }, "sha512-mzd+1svmgWjqe4ROlLOjWtLg8DFt7p4tkox5UoLuSGEqVuBsDhNgZAotahhMZrKqRImP+JAmaHO0SWCDQEMPGw=="],
 
-    "@sentry/react": ["@sentry/react@10.43.0", "", { "dependencies": { "@sentry/browser": "10.43.0", "@sentry/core": "10.43.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-shvErEpJ41i0Q3lIZl0CDWYQ7m8yHLi7ECG0gFvN8zf8pEdl5grQIOoe3t/GIUzcpCcor16F148ATmKJJypc/Q=="],
+    "@sentry/react": ["@sentry/react@10.55.0", "", { "dependencies": { "@sentry/browser": "10.55.0", "@sentry/core": "10.55.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-cf6wI0W1FdrL/7d5FTHXUdTN5k5uRZ9AQu5QZxUujnxWN+DBxUWtow1HDD1zTEonQsCFyYuhXVu3w+qmBBW11A=="],
 
     "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
 
@@ -4304,6 +4305,16 @@
 
     "@react-native/dev-middleware/open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
 
+    "@sentry-internal/browser-utils/@sentry/core": ["@sentry/core@10.55.0", "", {}, "sha512-XUyoNtDSYCvgJnoNzlh+YeAXfIPhCRIXbhWqqM3GQ3AFtZICi85lkyfsrwXEl9wzlPGYnU+Eg8F4tOfScx+FcQ=="],
+
+    "@sentry-internal/feedback/@sentry/core": ["@sentry/core@10.55.0", "", {}, "sha512-XUyoNtDSYCvgJnoNzlh+YeAXfIPhCRIXbhWqqM3GQ3AFtZICi85lkyfsrwXEl9wzlPGYnU+Eg8F4tOfScx+FcQ=="],
+
+    "@sentry-internal/replay/@sentry/core": ["@sentry/core@10.55.0", "", {}, "sha512-XUyoNtDSYCvgJnoNzlh+YeAXfIPhCRIXbhWqqM3GQ3AFtZICi85lkyfsrwXEl9wzlPGYnU+Eg8F4tOfScx+FcQ=="],
+
+    "@sentry-internal/replay-canvas/@sentry/core": ["@sentry/core@10.55.0", "", {}, "sha512-XUyoNtDSYCvgJnoNzlh+YeAXfIPhCRIXbhWqqM3GQ3AFtZICi85lkyfsrwXEl9wzlPGYnU+Eg8F4tOfScx+FcQ=="],
+
+    "@sentry/browser/@sentry/core": ["@sentry/core@10.55.0", "", {}, "sha512-XUyoNtDSYCvgJnoNzlh+YeAXfIPhCRIXbhWqqM3GQ3AFtZICi85lkyfsrwXEl9wzlPGYnU+Eg8F4tOfScx+FcQ=="],
+
     "@sentry/node/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.211.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.211.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q=="],
 
     "@sentry/node/@opentelemetry/instrumentation-express": ["@opentelemetry/instrumentation-express@0.59.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.211.0", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-pMKV/qnHiW/Q6pmbKkxt0eIhuNEtvJ7sUAyee192HErlr+a1Jx+FZ3WjfmzhQL1geewyGEiPGkmjjAgNY8TgDA=="],
@@ -4315,6 +4326,8 @@
     "@sentry/node/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
     "@sentry/node-core/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
+
+    "@sentry/react/@sentry/core": ["@sentry/core@10.55.0", "", {}, "sha512-XUyoNtDSYCvgJnoNzlh+YeAXfIPhCRIXbhWqqM3GQ3AFtZICi85lkyfsrwXEl9wzlPGYnU+Eg8F4tOfScx+FcQ=="],
 
     "@sinonjs/samsam/type-detect": ["type-detect@4.1.0", "", {}, "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw=="],
 

--- a/example-backend/src/scripts/seed-test-data.ts
+++ b/example-backend/src/scripts/seed-test-data.ts
@@ -4,7 +4,7 @@
  * Run with: bun run src/scripts/seed-test-data.ts
  */
 
-import {logger} from "@terreno/api";
+import {ConsentForm, logger} from "@terreno/api";
 import mongoose from "mongoose";
 import {User} from "../models/user";
 import {connectToMongoDB} from "../utils/database";
@@ -30,6 +30,111 @@ const TEST_USERS: SeedUser[] = [
   },
 ];
 
+const CONSENT_FORMS = [
+  {
+    active: true,
+    agreeButtonText: "I Accept the Terms",
+    captureSignature: true,
+    content: new Map([
+      [
+        "en",
+        `# Terms of Service
+
+Welcome to our application. By using our service, you agree to the following terms...
+
+## 1. Acceptance of Terms
+
+By accessing or using our application, you agree to be bound by these Terms of Service.
+
+## 2. Use of Service
+
+You agree to use the service only for lawful purposes and in a way that does not infringe the rights of others.
+
+## 3. Privacy
+
+Your use of the service is also governed by our Privacy Policy.
+
+## 4. Changes to Terms
+
+We reserve the right to modify these terms at any time. We will notify you of any changes.`,
+      ],
+    ]),
+    order: 1,
+    required: true,
+    requireScrollToBottom: true,
+    slug: "terms-of-service",
+    title: "Terms of Service",
+    type: "terms",
+    version: 1,
+  },
+  {
+    active: true,
+    content: new Map([
+      [
+        "en",
+        `# Privacy Policy
+
+We are committed to protecting your personal information.
+
+## Information We Collect
+
+We collect information you provide directly to us, such as when you create an account.
+
+## How We Use Your Information
+
+We use the information we collect to provide, maintain, and improve our services.
+
+## Data Security
+
+We implement appropriate technical and organizational measures to protect your personal information.
+
+## Contact Us
+
+If you have any questions about this Privacy Policy, please contact us.`,
+      ],
+    ]),
+    order: 2,
+    required: true,
+    requireScrollToBottom: true,
+    slug: "privacy-policy",
+    title: "Privacy Policy",
+    type: "privacy",
+    version: 1,
+  },
+  {
+    active: true,
+    allowDecline: true,
+    content: new Map([
+      [
+        "en",
+        `# Data Collection Consent
+
+We would like to collect anonymized usage data to improve our services.
+
+## What We Collect
+
+- App usage patterns (screens visited, features used)
+- Device information (OS version, screen size)
+- Performance metrics (load times, error rates)
+
+## How It Helps
+
+This data helps us identify bugs, improve performance, and prioritize new features.
+
+## Your Choice
+
+This consent is optional. You can decline without affecting your use of the application. You can change your preference at any time in Settings.`,
+      ],
+    ]),
+    order: 3,
+    required: false,
+    slug: "data-collection",
+    title: "Data Collection Consent",
+    type: "research",
+    version: 1,
+  },
+];
+
 const seedUser = async (testUser: SeedUser): Promise<void> => {
   const existingUser = await User.findByEmail(testUser.email);
   if (existingUser) {
@@ -37,7 +142,6 @@ const seedUser = async (testUser: SeedUser): Promise<void> => {
     return;
   }
 
-  // Create test user using passport-local-mongoose's register method
   // biome-ignore lint/suspicious/noExplicitAny: passport-local-mongoose register is not typed on the model
   const user = await (User as any).register(
     {admin: testUser.admin ?? false, email: testUser.email, name: testUser.name},
@@ -45,6 +149,24 @@ const seedUser = async (testUser: SeedUser): Promise<void> => {
   );
 
   logger.info(`Test user created: ${user.email} (id: ${user._id})`);
+};
+
+const seedConsentForms = async (): Promise<void> => {
+  const slugs = CONSENT_FORMS.map((f) => f.slug);
+  const existing = await ConsentForm.find({slug: {$in: slugs}});
+  const existingSlugs = new Set(existing.map((f) => f.slug));
+
+  const toCreate = CONSENT_FORMS.filter((f) => !existingSlugs.has(f.slug));
+
+  if (toCreate.length === 0) {
+    logger.info(`All ${slugs.length} consent forms already exist`);
+    return;
+  }
+
+  await ConsentForm.create(toCreate);
+  logger.info(
+    `Seeded ${toCreate.length} consent form(s): ${toCreate.map((f) => f.slug).join(", ")}`
+  );
 };
 
 const main = async (): Promise<void> => {
@@ -55,6 +177,8 @@ const main = async (): Promise<void> => {
     for (const testUser of TEST_USERS) {
       await seedUser(testUser);
     }
+
+    await seedConsentForms();
 
     await mongoose.disconnect();
     logger.info("Done.");

--- a/example-frontend/app/_layout.tsx
+++ b/example-frontend/app/_layout.tsx
@@ -3,6 +3,7 @@ import {useFonts} from "expo-font";
 import {Stack, useRouter, useSegments} from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import {useEffect} from "react";
+import {GestureHandlerRootView} from "react-native-gesture-handler";
 import "react-native-reanimated";
 import {
   baseUrl,
@@ -67,13 +68,15 @@ const RootLayout = (): React.ReactElement | null => {
   }
 
   return (
-    <Provider store={store}>
-      <PersistGate loading={null} persistor={persistor}>
-        <TerrenoProvider openAPISpecUrl={`${baseUrl}/openapi.json`}>
-          <RootLayoutNav />
-        </TerrenoProvider>
-      </PersistGate>
-    </Provider>
+    <GestureHandlerRootView style={{flex: 1}}>
+      <Provider store={store}>
+        <PersistGate loading={null} persistor={persistor}>
+          <TerrenoProvider openAPISpecUrl={`${baseUrl}/openapi.json`}>
+            <RootLayoutNav />
+          </TerrenoProvider>
+        </PersistGate>
+      </Provider>
+    </GestureHandlerRootView>
   );
 };
 

--- a/example-frontend/metro.config.js
+++ b/example-frontend/metro.config.js
@@ -126,8 +126,9 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
     }
   }
 
-  // Exclude @sentry/react-native from web builds (it uses import.meta which isn't supported)
-  if (platform === "web" && (moduleName === "@sentry/react-native" || moduleName.startsWith("@sentry/react-native/"))) {
+  // @sentry/react-native uses TurboModuleRegistry.getEnforcing which hangs in Expo Go
+  // without a custom dev build. Exclude it so only @sentry/react (browser-only) is used.
+  if (moduleName === "@sentry/react-native" || moduleName.startsWith("@sentry/react-native/")) {
     return {
       type: "empty",
     };

--- a/example-frontend/package.json
+++ b/example-frontend/package.json
@@ -20,6 +20,7 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-native": "catalog:",
+    "react-native-gesture-handler": "catalog:",
     "react-native-reanimated": "catalog:",
     "react-native-web": "catalog:",
     "react-native-webview": "catalog:",

--- a/example-frontend/utils/sentry.ts
+++ b/example-frontend/utils/sentry.ts
@@ -1,13 +1,5 @@
-import * as SentryBrowser from "@sentry/react";
+import * as Sentry from "@sentry/react";
 import {Platform} from "react-native";
-
-// import {
-//   createRoutesFromChildren,
-//   matchRoutes,
-//   useLocation,
-//   useNavigationType,
-// } from "react-router-dom";
-// import * as SentryNative from "@sentry/react-native";
 
 const IsWeb = Platform.OS === "web";
 
@@ -34,42 +26,36 @@ const _IGNORE_ERRORS = [
   /^.*Zn is not a function*$/,
 ];
 
-// biome-ignore lint/suspicious/noExplicitAny: Sentry types
-export const reactNavigationIntegration: any | undefined = IsWeb ? undefined : undefined;
-// : (SentryNative?.reactNavigationIntegration?.() ?? undefined);
+// biome-ignore lint/suspicious/noExplicitAny: Sentry types vary across versions
+export const reactNavigationIntegration: any | undefined = undefined;
 
 export const setupUnhandledRejectionHandler = (): void => {
   if (IsWeb && typeof window !== "undefined") {
     window.addEventListener("unhandledrejection", (event) => {
       const error = event.reason;
       if (error && typeof error === "object" && "data" in error && "status" in error) {
-        // Prevent default handling
         event.preventDefault();
-        // Create error message similar to rtkQueryErrorMiddleware pattern
         const errorMessage = error.data?.title ?? error.data?.message ?? JSON.stringify(error.data);
         const message = `Unhandled Promise Rejection (${error.status}): ${errorMessage}`;
         console.warn(message, error);
-        // Don't capture 401/404 errors in Sentry
         if (error.status !== 401 && error.status !== 404) {
           captureException(new Error(message));
         }
       }
     });
-  } else if (global.ErrorUtils) {
-    // React Native handles promise rejections differently through the ErrorUtils global
+  } else if (global?.ErrorUtils) {
     const originalHandler = global.ErrorUtils.getGlobalHandler();
     global.ErrorUtils.setGlobalHandler((error: unknown) => {
       if (error && typeof error === "object" && "data" in error && "status" in error) {
-        const errorObject = error as {data?: {title?: string; message?: string}};
+        const errorObject = error as {data?: {title?: string; message?: string}; status?: number};
         const errorMessage =
           errorObject.data?.title ?? errorObject.data?.message ?? JSON.stringify(errorObject.data);
-        const message = `Unhandled Promise Rejection (${error.status}): ${errorMessage}`;
+        const message = `Unhandled Promise Rejection (${errorObject.status}): ${errorMessage}`;
         console.warn(message, error);
-        if (error.status !== 401 && error.status !== 404) {
+        if (errorObject.status !== 401 && errorObject.status !== 404) {
           captureException(new Error(message));
         }
       } else if (originalHandler) {
-        // Let React Native handle other types of errors
         originalHandler(error);
       }
     });
@@ -78,119 +64,75 @@ export const setupUnhandledRejectionHandler = (): void => {
 
 export const sentryInit = (environment: string, debug = false): void => {
   try {
-    if (IsWeb) {
-      if (SentryBrowser.isInitialized()) {
-        console.warn("Sentry already initialized, skipping init");
-        return;
-      }
-      SentryBrowser.init({
-        // Don't send events in development
-        beforeSend(event) {
-          if (process.env.NODE_ENV === "development") {
-            return null;
-          }
-          return event;
-        },
-        debug,
-        dsn: SENTRY_DSN,
-        environment,
-        integrations: [
-          // SentryBrowser.reactRouterV6BrowserTracingIntegration({
-          //   // createRoutesFromChildren,
-          //   // matchRoutes,
-          //   useEffect,
-          //   // useLocation,
-          //   // useNavigationType,
-          // }),
-          SentryBrowser.replayIntegration(),
-        ],
-        replaysOnErrorSampleRate: SENTRY_ERROR_SAMPLE_RATE,
-        replaysSessionSampleRate: 0.1,
-
-        // Set `tracePropagationTargets` to control for which URLs trace propagation should be
-        // enabled
-        tracePropagationTargets: [/https:\/\/api\.flourish\.health.*\//],
-        tracesSampleRate: SENTRY_TRACE_SAMPLE_RATE,
-      });
-    } else {
-      // if (!SentryNative) {
-      //   throw new Error("@sentry/react-native is not available");
-      // }
-      // SentryNative.init({
-      //   // Don't send events in development
-      //   // biome-ignore lint/suspicious/noExplicitAny: Sentry doesn't export this type.
-      //   beforeSend(event: any) {
-      //     if (process.env.NODE_ENV === "development") {
-      //       return null;
-      //     }
-      //     return event;
-      //   },
-      //   debug,
-      //   dsn: SENTRY_DSN,
-      //   enabled: process.env.NODE_ENV === "production",
-      //   environment,
-      //   ignoreErrors: IGNORE_ERRORS,
-      //   integrations: [reactNavigationIntegration],
-      //   tracesSampleRate: SENTRY_TRACE_SAMPLE_RATE,
-      // });
+    if (!IsWeb) {
+      // @sentry/react-native requires a custom dev build with native modules.
+      // Skip initialization when running in Expo Go.
+      return;
     }
+
+    if (Sentry.isInitialized()) {
+      console.warn("Sentry already initialized, skipping init");
+      return;
+    }
+    Sentry.init({
+      beforeSend(event) {
+        if (process.env.NODE_ENV === "development") {
+          return null;
+        }
+        return event;
+      },
+      debug,
+      dsn: SENTRY_DSN,
+      environment,
+      integrations: [Sentry.replayIntegration()],
+      replaysOnErrorSampleRate: SENTRY_ERROR_SAMPLE_RATE,
+      replaysSessionSampleRate: 0.1,
+      tracePropagationTargets: [/https:\/\/api\.flourish\.health.*\//],
+      tracesSampleRate: SENTRY_TRACE_SAMPLE_RATE,
+    });
   } catch (error) {
     captureException(error);
   }
 };
 
 export const captureException = (error: unknown | Error): void => {
-  if (IsWeb) {
-    if (SentryBrowser.isInitialized()) {
-      SentryBrowser.captureException(error);
-    } else {
-      console.error(`Sentry not initialized, captured exception`, error);
-    }
+  if (!IsWeb) {
+    return;
+  }
+  if (Sentry.isInitialized()) {
+    Sentry.captureException(error);
   } else {
-    // note that Sentry for React Native doesn't have an isInitialized method
-    // SentryNative.captureException(error);
+    console.error(`Sentry not initialized, captured exception`, error);
   }
 };
 
 export const captureEvent = (message: string, extra?: Record<string, string>): void => {
-  if (IsWeb) {
-    if (SentryBrowser.isInitialized()) {
-      SentryBrowser.captureEvent({
-        extra,
-        level: "debug", // Use 'info' to avoid triggering alerts
-        message,
-      });
-    } else {
-      console.error(`Sentry not initialized, captured event`, message, extra);
-    }
+  if (!IsWeb) {
+    return;
+  }
+  if (Sentry.isInitialized()) {
+    Sentry.captureEvent({
+      extra,
+      level: "debug",
+      message,
+    });
   } else {
-    // note that Sentry for React Native doesn't have an isInitialized method
-    // SentryNative.captureEvent({
-    //   extra,
-    //   level: "debug", // Use 'info' to avoid triggering alerts
-    //   message,
-    // });
+    console.error(`Sentry not initialized, captured event`, message, extra);
   }
 };
 
 export const captureMessage = (message: string, extra?: Record<string, string>): void => {
-  if (IsWeb) {
-    const scope = new SentryBrowser.Scope();
-    for (const [key, value] of Object.entries(extra ?? {})) {
-      scope.setExtra(key, value);
-    }
-    if (SentryBrowser.isInitialized()) {
-      SentryBrowser.captureMessage(message, scope);
-    } else {
-      console.error(`Sentry not initialized, captured message: ${message}`);
-    }
+  if (!IsWeb) {
+    return;
+  }
+  const scope = new Sentry.Scope();
+  for (const [key, value] of Object.entries(extra ?? {})) {
+    scope.setExtra(key, value);
+  }
+  if (Sentry.isInitialized()) {
+    Sentry.captureMessage(message, scope);
   } else {
-    // const scope = new SentryNative.Scope();
-    // for (const [key, value] of Object.entries(extra ?? {})) {
-    //   scope.setExtra(key, value);
-    // }
-    // // note that Sentry for React Native doesn't have an isInitialized method
-    // SentryNative.captureMessage(message, scope);
+    console.error(`Sentry not initialized, captured message: ${message}`);
   }
 };
 
@@ -200,11 +142,11 @@ export const pageOnError = (error: Error, stack: unknown): void => {
 };
 
 export const createSentryReduxEnhancer = (): unknown => {
-  if (IsWeb) {
-    return SentryBrowser.createReduxEnhancer();
-  } else {
-    // return SentryNative.createReduxEnhancer();
+  if (IsWeb && typeof Sentry.createReduxEnhancer === "function") {
+    return Sentry.createReduxEnhancer();
   }
+
+  return (next: unknown) => next;
 };
 
 export const sentrySetUser = (
@@ -213,11 +155,9 @@ export const sentrySetUser = (
     type?: string;
   } | null
 ): void => {
-  if (IsWeb) {
-    SentryBrowser.setUser(user);
-    SentryBrowser.setTag("userType", user?.type);
-  } else {
-    // SentryNative.setUser(user);
-    // SentryNative.setTag("userType", user?.type);
+  if (!IsWeb) {
+    return;
   }
+  Sentry.setUser(user);
+  Sentry.setTag("userType", user?.type);
 };

--- a/rtk/src/offlineSlice.ts
+++ b/rtk/src/offlineSlice.ts
@@ -1,4 +1,4 @@
-import {createSlice, type PayloadAction} from "@reduxjs/toolkit";
+import {createSelector, createSlice, type PayloadAction} from "@reduxjs/toolkit";
 import {REHYDRATE} from "redux-persist";
 
 import {IsWeb} from "./platform";
@@ -124,7 +124,9 @@ export const selectQueueLength = (state: {offline: OfflineState}): number =>
 export const selectConflicts = (state: {offline: OfflineState}): ConflictRecord[] =>
   state.offline.conflicts;
 
-export const selectUndismissedConflicts = (state: {offline: OfflineState}): ConflictRecord[] =>
-  state.offline.conflicts.filter((c) => !c.dismissed);
+export const selectUndismissedConflicts = createSelector(
+  selectConflicts,
+  (conflicts): ConflictRecord[] => conflicts.filter((c) => !c.dismissed)
+);
 
 export const selectIsSyncing = (state: {offline: OfflineState}): boolean => state.offline.isSyncing;

--- a/rtk/src/useServerStatus.ts
+++ b/rtk/src/useServerStatus.ts
@@ -96,7 +96,7 @@ export const useServerStatus = (options: ServerStatusOptions = {}): ServerStatus
 
   // Also respond to browser online/offline events for instant detection
   useEffect(() => {
-    if (skip || typeof window === "undefined") {
+    if (skip || typeof window === "undefined" || typeof window.addEventListener !== "function") {
       return;
     }
 

--- a/ui/src/ActionSheet.tsx
+++ b/ui/src/ActionSheet.tsx
@@ -580,48 +580,35 @@ export class ActionSheet extends Component<Props, State, unknown> {
     this.setState({
       keyboard: true,
     });
-    const ReactNativeVersion = require("react-native/Libraries/Core/ReactNativeVersion");
 
-    let v = ReactNativeVersion.version.major + ReactNativeVersion.version.minor;
-    v = parseInt(v, 10);
+    const keyboardHeight = event.endCoordinates.height;
+    const {height: windowHeight} = Dimensions.get("window");
 
-    if (v >= 63 || Platform.OS === "ios") {
-      const keyboardHeight = event.endCoordinates.height;
-      const {height: windowHeight} = Dimensions.get("window");
+    const currentlyFocusedField = TextInput.State.currentlyFocusedField
+      ? findNodeHandle(TextInput.State.currentlyFocusedField())
+      : TextInput.State.currentlyFocusedField();
 
-      const currentlyFocusedField = TextInput.State.currentlyFocusedField
-        ? findNodeHandle(TextInput.State.currentlyFocusedField())
-        : TextInput.State.currentlyFocusedField();
-
-      if (!currentlyFocusedField) {
-        return;
-      }
-
-      UIManager.measure(
-        currentlyFocusedField,
-        (_originX, _originY, _width, height, _pageX, pageY) => {
-          const fieldHeight = height;
-          const gap = windowHeight - keyboardHeight - (pageY + fieldHeight);
-          if (gap >= 0) {
-            return;
-          }
-          const toValue =
-            this.props.keyboardMode === "position" ? -(keyboardHeight + 15) : gap - 10;
-
-          Animated.timing(this.transformValue, {
-            duration: 250,
-            toValue,
-            useNativeDriver: true,
-          }).start();
-        }
-      );
-    } else {
-      Animated.timing(this.transformValue, {
-        duration: 250,
-        toValue: -10,
-        useNativeDriver: true,
-      }).start();
+    if (!currentlyFocusedField) {
+      return;
     }
+
+    UIManager.measure(
+      currentlyFocusedField,
+      (_originX, _originY, _width, height, _pageX, pageY) => {
+        const fieldHeight = height;
+        const gap = windowHeight - keyboardHeight - (pageY + fieldHeight);
+        if (gap >= 0) {
+          return;
+        }
+        const toValue = this.props.keyboardMode === "position" ? -(keyboardHeight + 15) : gap - 10;
+
+        Animated.timing(this.transformValue, {
+          duration: 250,
+          toValue,
+          useNativeDriver: true,
+        }).start();
+      }
+    );
   };
 
   /**

--- a/ui/src/MarkdownView.test.tsx
+++ b/ui/src/MarkdownView.test.tsx
@@ -1,4 +1,5 @@
 import {describe, expect, it} from "bun:test";
+import assert from "node:assert";
 
 import {MarkdownView} from "./MarkdownView";
 import {renderWithTheme} from "./test-utils";
@@ -36,6 +37,33 @@ describe("MarkdownView", () => {
       <MarkdownView>{"1. First\n2. Second\n3. Third"}</MarkdownView>
     );
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("keeps long consent ordered list markers on one line", () => {
+    const longConsentList = Array.from({length: 17}, (_, index) => {
+      return `${index + 1}. This consent item has enough text to wrap on narrow mobile screens.`;
+    }).join("\n");
+    const {toJSON} = renderWithTheme(<MarkdownView>{longConsentList}</MarkdownView>);
+    const serialized = JSON.stringify(toJSON());
+
+    assert.ok(serialized.includes('"minWidth":32'));
+    assert.ok(serialized.includes('"flexShrink":0'));
+    assert.ok(serialized.includes('"textAlign":"right"'));
+    assert.ok(serialized.includes("17"));
+  });
+
+  it("uses explicit markdown paragraph line height for wrapped mobile text", () => {
+    const {toJSON} = renderWithTheme(
+      <MarkdownView>
+        {
+          "This consent paragraph is intentionally long so it wraps across multiple lines on Android and keeps its measured height."
+        }
+      </MarkdownView>
+    );
+    const serialized = JSON.stringify(toJSON());
+
+    assert.ok(serialized.includes('"fontSize":14'));
+    assert.ok(serialized.includes('"lineHeight":20'));
   });
 
   it("renders code blocks", () => {

--- a/ui/src/MarkdownView.tsx
+++ b/ui/src/MarkdownView.tsx
@@ -49,11 +49,29 @@ export const MarkdownView: React.FC<{children: React.ReactNode; inverted?: boole
   });
 
   const monoFont = isWeb ? "monospace" : Platform.select({android: "monospace", ios: "Menlo"});
+  const textFontSize = isWeb ? 16 : 14;
+  const textLineHeight = isWeb ? 24 : 20;
+  const markdownTextStyle = {
+    fontFamily: "text-regular",
+    fontSize: textFontSize,
+    lineHeight: textLineHeight,
+    ...color,
+  };
 
   return (
     <Markdown
       style={{
-        body: {fontFamily: "text", ...color},
+        body: {width: "100%", ...markdownTextStyle},
+        bullet_list: {width: "100%"},
+        bullet_list_content: {flex: 1, flexShrink: 1, minWidth: 0},
+        bullet_list_icon: {
+          flexShrink: 0,
+          marginLeft: 0,
+          marginRight: 8,
+          minWidth: 16,
+          textAlign: "center",
+          ...markdownTextStyle,
+        },
         code_block: {
           backgroundColor: theme.surface.neutralLight,
           borderColor: theme.border.default,
@@ -85,13 +103,57 @@ export const MarkdownView: React.FC<{children: React.ReactNode; inverted?: boole
           padding: 8,
           ...color,
         },
-        heading1: {fontFamily: "heading-bold", fontSize: sizes.xl, ...color},
-        heading2: {fontFamily: "heading-bold", fontSize: sizes.lg, ...color},
-        heading3: {fontFamily: "heading-bold", fontSize: sizes.md, ...color},
-        heading4: {fontFamily: "heading-semibold", fontSize: sizes.sm, ...color},
+        heading1: {
+          fontFamily: "heading-bold",
+          fontSize: sizes.xl,
+          lineHeight: sizes.xl * 1.25,
+          ...color,
+        },
+        heading2: {
+          fontFamily: "heading-bold",
+          fontSize: sizes.lg,
+          lineHeight: sizes.lg * 1.25,
+          ...color,
+        },
+        heading3: {
+          fontFamily: "heading-bold",
+          fontSize: sizes.md,
+          lineHeight: sizes.md * 1.25,
+          ...color,
+        },
+        heading4: {
+          fontFamily: "heading-semibold",
+          fontSize: sizes.sm,
+          lineHeight: sizes.sm * 1.25,
+          ...color,
+        },
         // h5/h6 map to small as well for consistency, slightly smaller visually handled by weight
-        heading5: {fontFamily: "heading-semibold", fontSize: sizes.sm, ...color},
-        heading6: {fontFamily: "heading-semibold", fontSize: sizes.sm, ...color},
+        heading5: {
+          fontFamily: "heading-semibold",
+          fontSize: sizes.sm,
+          lineHeight: sizes.sm * 1.25,
+          ...color,
+        },
+        heading6: {
+          fontFamily: "heading-semibold",
+          fontSize: sizes.sm,
+          lineHeight: sizes.sm * 1.25,
+          ...color,
+        },
+        list_item: {alignItems: "flex-start", flexDirection: "row", width: "100%"},
+        ordered_list: {width: "100%"},
+        ordered_list_content: {flex: 1, flexShrink: 1, minWidth: 0},
+        ordered_list_icon: {
+          flexShrink: 0,
+          marginLeft: 0,
+          marginRight: 8,
+          minWidth: 32,
+          textAlign: "right",
+          ...markdownTextStyle,
+        },
+        paragraph: {flexShrink: 1, width: "100%", ...markdownTextStyle},
+        text: color,
+        textgroup: {flexShrink: 1, minWidth: 0},
       }}
     >
       {children}

--- a/ui/src/__snapshots__/MarkdownView.test.tsx.snap
+++ b/ui/src/__snapshots__/MarkdownView.test.tsx.snap
@@ -19,16 +19,23 @@ exports[`MarkdownView renders correctly with simple text 1`] = `
                 "style": [
                   {
                     "color": "#1C1C1C",
-                    "fontFamily": "text",
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
                   },
-                  {},
+                  {
+                    "color": "#1C1C1C",
+                  },
                 ],
               },
               "type": "Text",
             },
           ],
           "props": {
-            "style": {},
+            "style": {
+              "flexShrink": 1,
+              "minWidth": 0,
+            },
           },
           "type": "Text",
         },
@@ -37,6 +44,7 @@ exports[`MarkdownView renders correctly with simple text 1`] = `
         "style": {
           "alignItems": "flex-start",
           "flexDirection": "row",
+          "flexShrink": 1,
           "flexWrap": "wrap",
           "justifyContent": "flex-start",
           "marginBottom": 10,
@@ -49,7 +57,9 @@ exports[`MarkdownView renders correctly with simple text 1`] = `
     },
   ],
   "props": {
-    "style": {},
+    "style": {
+      "width": "100%",
+    },
     "testID": undefined,
   },
   "type": "View",
@@ -77,15 +87,21 @@ exports[`MarkdownView renders markdown headings 1`] = `
                     "color": "#1C1C1C",
                     "fontFamily": "heading-bold",
                     "fontSize": 28,
+                    "lineHeight": 35,
                   },
-                  {},
+                  {
+                    "color": "#1C1C1C",
+                  },
                 ],
               },
               "type": "Text",
             },
           ],
           "props": {
-            "style": {},
+            "style": {
+              "flexShrink": 1,
+              "minWidth": 0,
+            },
           },
           "type": "Text",
         },
@@ -115,15 +131,21 @@ exports[`MarkdownView renders markdown headings 1`] = `
                     "color": "#1C1C1C",
                     "fontFamily": "heading-bold",
                     "fontSize": 20,
+                    "lineHeight": 25,
                   },
-                  {},
+                  {
+                    "color": "#1C1C1C",
+                  },
                 ],
               },
               "type": "Text",
             },
           ],
           "props": {
-            "style": {},
+            "style": {
+              "flexShrink": 1,
+              "minWidth": 0,
+            },
           },
           "type": "Text",
         },
@@ -153,15 +175,21 @@ exports[`MarkdownView renders markdown headings 1`] = `
                     "color": "#1C1C1C",
                     "fontFamily": "heading-bold",
                     "fontSize": 16,
+                    "lineHeight": 20,
                   },
-                  {},
+                  {
+                    "color": "#1C1C1C",
+                  },
                 ],
               },
               "type": "Text",
             },
           ],
           "props": {
-            "style": {},
+            "style": {
+              "flexShrink": 1,
+              "minWidth": 0,
+            },
           },
           "type": "Text",
         },
@@ -176,7 +204,9 @@ exports[`MarkdownView renders markdown headings 1`] = `
     },
   ],
   "props": {
-    "style": {},
+    "style": {
+      "width": "100%",
+    },
     "testID": undefined,
   },
   "type": "View",
@@ -205,10 +235,14 @@ exports[`MarkdownView renders markdown bold and italic 1`] = `
                     "style": [
                       {
                         "color": "#1C1C1C",
-                        "fontFamily": "text",
+                        "fontFamily": "text-regular",
+                        "fontSize": 14,
                         "fontWeight": "bold",
+                        "lineHeight": 20,
                       },
-                      {},
+                      {
+                        "color": "#1C1C1C",
+                      },
                     ],
                   },
                   "type": "Text",
@@ -230,9 +264,13 @@ exports[`MarkdownView renders markdown bold and italic 1`] = `
                 "style": [
                   {
                     "color": "#1C1C1C",
-                    "fontFamily": "text",
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
                   },
-                  {},
+                  {
+                    "color": "#1C1C1C",
+                  },
                 ],
               },
               "type": "Text",
@@ -249,10 +287,14 @@ exports[`MarkdownView renders markdown bold and italic 1`] = `
                     "style": [
                       {
                         "color": "#1C1C1C",
-                        "fontFamily": "text",
+                        "fontFamily": "text-regular",
+                        "fontSize": 14,
                         "fontStyle": "italic",
+                        "lineHeight": 20,
                       },
-                      {},
+                      {
+                        "color": "#1C1C1C",
+                      },
                     ],
                   },
                   "type": "Text",
@@ -274,16 +316,23 @@ exports[`MarkdownView renders markdown bold and italic 1`] = `
                 "style": [
                   {
                     "color": "#1C1C1C",
-                    "fontFamily": "text",
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
                   },
-                  {},
+                  {
+                    "color": "#1C1C1C",
+                  },
                 ],
               },
               "type": "Text",
             },
           ],
           "props": {
-            "style": {},
+            "style": {
+              "flexShrink": 1,
+              "minWidth": 0,
+            },
           },
           "type": "Text",
         },
@@ -292,6 +341,7 @@ exports[`MarkdownView renders markdown bold and italic 1`] = `
         "style": {
           "alignItems": "flex-start",
           "flexDirection": "row",
+          "flexShrink": 1,
           "flexWrap": "wrap",
           "justifyContent": "flex-start",
           "marginBottom": 10,
@@ -304,7 +354,9 @@ exports[`MarkdownView renders markdown bold and italic 1`] = `
     },
   ],
   "props": {
-    "style": {},
+    "style": {
+      "width": "100%",
+    },
     "testID": undefined,
   },
   "type": "View",
@@ -331,11 +383,20 @@ exports[`MarkdownView renders markdown lists 1`] = `
                 "style": [
                   {
                     "color": "#1C1C1C",
-                    "fontFamily": "text",
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
                   },
                   {
-                    "marginLeft": 10,
-                    "marginRight": 10,
+                    "color": "#1C1C1C",
+                    "flexShrink": 0,
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginLeft": 0,
+                    "marginRight": 8,
+                    "minWidth": 16,
+                    "textAlign": "center",
                   },
                 ],
               },
@@ -356,16 +417,23 @@ exports[`MarkdownView renders markdown lists 1`] = `
                         "style": [
                           {
                             "color": "#1C1C1C",
-                            "fontFamily": "text",
+                            "fontFamily": "text-regular",
+                            "fontSize": 14,
+                            "lineHeight": 20,
                           },
-                          {},
+                          {
+                            "color": "#1C1C1C",
+                          },
                         ],
                       },
                       "type": "Text",
                     },
                   ],
                   "props": {
-                    "style": {},
+                    "style": {
+                      "flexShrink": 1,
+                      "minWidth": 0,
+                    },
                   },
                   "type": "Text",
                 },
@@ -373,6 +441,8 @@ exports[`MarkdownView renders markdown lists 1`] = `
               "props": {
                 "style": {
                   "flex": 1,
+                  "flexShrink": 1,
+                  "minWidth": 0,
                 },
                 "testID": undefined,
               },
@@ -381,8 +451,10 @@ exports[`MarkdownView renders markdown lists 1`] = `
           ],
           "props": {
             "style": {
+              "alignItems": "flex-start",
               "flexDirection": "row",
               "justifyContent": "flex-start",
+              "width": "100%",
             },
             "testID": undefined,
           },
@@ -401,11 +473,20 @@ exports[`MarkdownView renders markdown lists 1`] = `
                 "style": [
                   {
                     "color": "#1C1C1C",
-                    "fontFamily": "text",
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
                   },
                   {
-                    "marginLeft": 10,
-                    "marginRight": 10,
+                    "color": "#1C1C1C",
+                    "flexShrink": 0,
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginLeft": 0,
+                    "marginRight": 8,
+                    "minWidth": 16,
+                    "textAlign": "center",
                   },
                 ],
               },
@@ -426,16 +507,23 @@ exports[`MarkdownView renders markdown lists 1`] = `
                         "style": [
                           {
                             "color": "#1C1C1C",
-                            "fontFamily": "text",
+                            "fontFamily": "text-regular",
+                            "fontSize": 14,
+                            "lineHeight": 20,
                           },
-                          {},
+                          {
+                            "color": "#1C1C1C",
+                          },
                         ],
                       },
                       "type": "Text",
                     },
                   ],
                   "props": {
-                    "style": {},
+                    "style": {
+                      "flexShrink": 1,
+                      "minWidth": 0,
+                    },
                   },
                   "type": "Text",
                 },
@@ -443,6 +531,8 @@ exports[`MarkdownView renders markdown lists 1`] = `
               "props": {
                 "style": {
                   "flex": 1,
+                  "flexShrink": 1,
+                  "minWidth": 0,
                 },
                 "testID": undefined,
               },
@@ -451,8 +541,10 @@ exports[`MarkdownView renders markdown lists 1`] = `
           ],
           "props": {
             "style": {
+              "alignItems": "flex-start",
               "flexDirection": "row",
               "justifyContent": "flex-start",
+              "width": "100%",
             },
             "testID": undefined,
           },
@@ -471,11 +563,20 @@ exports[`MarkdownView renders markdown lists 1`] = `
                 "style": [
                   {
                     "color": "#1C1C1C",
-                    "fontFamily": "text",
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
                   },
                   {
-                    "marginLeft": 10,
-                    "marginRight": 10,
+                    "color": "#1C1C1C",
+                    "flexShrink": 0,
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginLeft": 0,
+                    "marginRight": 8,
+                    "minWidth": 16,
+                    "textAlign": "center",
                   },
                 ],
               },
@@ -496,16 +597,23 @@ exports[`MarkdownView renders markdown lists 1`] = `
                         "style": [
                           {
                             "color": "#1C1C1C",
-                            "fontFamily": "text",
+                            "fontFamily": "text-regular",
+                            "fontSize": 14,
+                            "lineHeight": 20,
                           },
-                          {},
+                          {
+                            "color": "#1C1C1C",
+                          },
                         ],
                       },
                       "type": "Text",
                     },
                   ],
                   "props": {
-                    "style": {},
+                    "style": {
+                      "flexShrink": 1,
+                      "minWidth": 0,
+                    },
                   },
                   "type": "Text",
                 },
@@ -513,6 +621,8 @@ exports[`MarkdownView renders markdown lists 1`] = `
               "props": {
                 "style": {
                   "flex": 1,
+                  "flexShrink": 1,
+                  "minWidth": 0,
                 },
                 "testID": undefined,
               },
@@ -521,8 +631,10 @@ exports[`MarkdownView renders markdown lists 1`] = `
           ],
           "props": {
             "style": {
+              "alignItems": "flex-start",
               "flexDirection": "row",
               "justifyContent": "flex-start",
+              "width": "100%",
             },
             "testID": undefined,
           },
@@ -530,14 +642,18 @@ exports[`MarkdownView renders markdown lists 1`] = `
         },
       ],
       "props": {
-        "style": {},
+        "style": {
+          "width": "100%",
+        },
         "testID": undefined,
       },
       "type": "View",
     },
   ],
   "props": {
-    "style": {},
+    "style": {
+      "width": "100%",
+    },
     "testID": undefined,
   },
   "type": "View",
@@ -563,16 +679,23 @@ exports[`MarkdownView renders with inverted colors 1`] = `
                 "style": [
                   {
                     "color": "#FFFFFF",
-                    "fontFamily": "text",
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
                   },
-                  {},
+                  {
+                    "color": "#FFFFFF",
+                  },
                 ],
               },
               "type": "Text",
             },
           ],
           "props": {
-            "style": {},
+            "style": {
+              "flexShrink": 1,
+              "minWidth": 0,
+            },
           },
           "type": "Text",
         },
@@ -581,6 +704,7 @@ exports[`MarkdownView renders with inverted colors 1`] = `
         "style": {
           "alignItems": "flex-start",
           "flexDirection": "row",
+          "flexShrink": 1,
           "flexWrap": "wrap",
           "justifyContent": "flex-start",
           "marginBottom": 10,
@@ -593,7 +717,9 @@ exports[`MarkdownView renders with inverted colors 1`] = `
     },
   ],
   "props": {
-    "style": {},
+    "style": {
+      "width": "100%",
+    },
     "testID": undefined,
   },
   "type": "View",
@@ -620,11 +746,20 @@ exports[`MarkdownView renders numbered lists 1`] = `
                 "style": [
                   {
                     "color": "#1C1C1C",
-                    "fontFamily": "text",
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
                   },
                   {
-                    "marginLeft": 10,
-                    "marginRight": 10,
+                    "color": "#1C1C1C",
+                    "flexShrink": 0,
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginLeft": 0,
+                    "marginRight": 8,
+                    "minWidth": 32,
+                    "textAlign": "right",
                   },
                 ],
               },
@@ -645,16 +780,23 @@ exports[`MarkdownView renders numbered lists 1`] = `
                         "style": [
                           {
                             "color": "#1C1C1C",
-                            "fontFamily": "text",
+                            "fontFamily": "text-regular",
+                            "fontSize": 14,
+                            "lineHeight": 20,
                           },
-                          {},
+                          {
+                            "color": "#1C1C1C",
+                          },
                         ],
                       },
                       "type": "Text",
                     },
                   ],
                   "props": {
-                    "style": {},
+                    "style": {
+                      "flexShrink": 1,
+                      "minWidth": 0,
+                    },
                   },
                   "type": "Text",
                 },
@@ -662,6 +804,8 @@ exports[`MarkdownView renders numbered lists 1`] = `
               "props": {
                 "style": {
                   "flex": 1,
+                  "flexShrink": 1,
+                  "minWidth": 0,
                 },
                 "testID": undefined,
               },
@@ -670,8 +814,10 @@ exports[`MarkdownView renders numbered lists 1`] = `
           ],
           "props": {
             "style": {
+              "alignItems": "flex-start",
               "flexDirection": "row",
               "justifyContent": "flex-start",
+              "width": "100%",
             },
             "testID": undefined,
           },
@@ -690,11 +836,20 @@ exports[`MarkdownView renders numbered lists 1`] = `
                 "style": [
                   {
                     "color": "#1C1C1C",
-                    "fontFamily": "text",
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
                   },
                   {
-                    "marginLeft": 10,
-                    "marginRight": 10,
+                    "color": "#1C1C1C",
+                    "flexShrink": 0,
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginLeft": 0,
+                    "marginRight": 8,
+                    "minWidth": 32,
+                    "textAlign": "right",
                   },
                 ],
               },
@@ -715,16 +870,23 @@ exports[`MarkdownView renders numbered lists 1`] = `
                         "style": [
                           {
                             "color": "#1C1C1C",
-                            "fontFamily": "text",
+                            "fontFamily": "text-regular",
+                            "fontSize": 14,
+                            "lineHeight": 20,
                           },
-                          {},
+                          {
+                            "color": "#1C1C1C",
+                          },
                         ],
                       },
                       "type": "Text",
                     },
                   ],
                   "props": {
-                    "style": {},
+                    "style": {
+                      "flexShrink": 1,
+                      "minWidth": 0,
+                    },
                   },
                   "type": "Text",
                 },
@@ -732,6 +894,8 @@ exports[`MarkdownView renders numbered lists 1`] = `
               "props": {
                 "style": {
                   "flex": 1,
+                  "flexShrink": 1,
+                  "minWidth": 0,
                 },
                 "testID": undefined,
               },
@@ -740,8 +904,10 @@ exports[`MarkdownView renders numbered lists 1`] = `
           ],
           "props": {
             "style": {
+              "alignItems": "flex-start",
               "flexDirection": "row",
               "justifyContent": "flex-start",
+              "width": "100%",
             },
             "testID": undefined,
           },
@@ -760,11 +926,20 @@ exports[`MarkdownView renders numbered lists 1`] = `
                 "style": [
                   {
                     "color": "#1C1C1C",
-                    "fontFamily": "text",
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
                   },
                   {
-                    "marginLeft": 10,
-                    "marginRight": 10,
+                    "color": "#1C1C1C",
+                    "flexShrink": 0,
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginLeft": 0,
+                    "marginRight": 8,
+                    "minWidth": 32,
+                    "textAlign": "right",
                   },
                 ],
               },
@@ -785,16 +960,23 @@ exports[`MarkdownView renders numbered lists 1`] = `
                         "style": [
                           {
                             "color": "#1C1C1C",
-                            "fontFamily": "text",
+                            "fontFamily": "text-regular",
+                            "fontSize": 14,
+                            "lineHeight": 20,
                           },
-                          {},
+                          {
+                            "color": "#1C1C1C",
+                          },
                         ],
                       },
                       "type": "Text",
                     },
                   ],
                   "props": {
-                    "style": {},
+                    "style": {
+                      "flexShrink": 1,
+                      "minWidth": 0,
+                    },
                   },
                   "type": "Text",
                 },
@@ -802,6 +984,8 @@ exports[`MarkdownView renders numbered lists 1`] = `
               "props": {
                 "style": {
                   "flex": 1,
+                  "flexShrink": 1,
+                  "minWidth": 0,
                 },
                 "testID": undefined,
               },
@@ -810,8 +994,10 @@ exports[`MarkdownView renders numbered lists 1`] = `
           ],
           "props": {
             "style": {
+              "alignItems": "flex-start",
               "flexDirection": "row",
               "justifyContent": "flex-start",
+              "width": "100%",
             },
             "testID": undefined,
           },
@@ -819,14 +1005,18 @@ exports[`MarkdownView renders numbered lists 1`] = `
         },
       ],
       "props": {
-        "style": {},
+        "style": {
+          "width": "100%",
+        },
         "testID": undefined,
       },
       "type": "View",
     },
   ],
   "props": {
-    "style": {},
+    "style": {
+      "width": "100%",
+    },
     "testID": undefined,
   },
   "type": "View",
@@ -846,7 +1036,9 @@ exports[`MarkdownView renders code blocks 1`] = `
         "style": [
           {
             "color": "#1C1C1C",
-            "fontFamily": "text",
+            "fontFamily": "text-regular",
+            "fontSize": 14,
+            "lineHeight": 20,
           },
           {
             "backgroundColor": "#D9D9D9",
@@ -864,7 +1056,9 @@ exports[`MarkdownView renders code blocks 1`] = `
     },
   ],
   "props": {
-    "style": {},
+    "style": {
+      "width": "100%",
+    },
     "testID": undefined,
   },
   "type": "View",
@@ -890,9 +1084,13 @@ exports[`MarkdownView renders inline code 1`] = `
                 "style": [
                   {
                     "color": "#1C1C1C",
-                    "fontFamily": "text",
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
                   },
-                  {},
+                  {
+                    "color": "#1C1C1C",
+                  },
                 ],
               },
               "type": "Text",
@@ -906,7 +1104,9 @@ exports[`MarkdownView renders inline code 1`] = `
                 "style": [
                   {
                     "color": "#1C1C1C",
-                    "fontFamily": "text",
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
                   },
                   {
                     "backgroundColor": "#D9D9D9",
@@ -933,16 +1133,23 @@ exports[`MarkdownView renders inline code 1`] = `
                 "style": [
                   {
                     "color": "#1C1C1C",
-                    "fontFamily": "text",
+                    "fontFamily": "text-regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
                   },
-                  {},
+                  {
+                    "color": "#1C1C1C",
+                  },
                 ],
               },
               "type": "Text",
             },
           ],
           "props": {
-            "style": {},
+            "style": {
+              "flexShrink": 1,
+              "minWidth": 0,
+            },
           },
           "type": "Text",
         },
@@ -951,6 +1158,7 @@ exports[`MarkdownView renders inline code 1`] = `
         "style": {
           "alignItems": "flex-start",
           "flexDirection": "row",
+          "flexShrink": 1,
           "flexWrap": "wrap",
           "justifyContent": "flex-start",
           "marginBottom": 10,
@@ -963,7 +1171,9 @@ exports[`MarkdownView renders inline code 1`] = `
     },
   ],
   "props": {
-    "style": {},
+    "style": {
+      "width": "100%",
+    },
     "testID": undefined,
   },
   "type": "View",

--- a/ui/src/bunSetup.ts
+++ b/ui/src/bunSetup.ts
@@ -1189,10 +1189,6 @@ mock.module("react-native/Libraries/vendor/core/ErrorUtils", () => ({
   },
 }));
 
-mock.module("react-native/Libraries/Core/ReactNativeVersion", () => ({
-  version: {major: 0, minor: 81, patch: 5},
-}));
-
 mock.module("react-native/Libraries/Core/NativeExceptionsManager", () => ({
   default: null,
 }));

--- a/ui/src/useConsentHistory.test.ts
+++ b/ui/src/useConsentHistory.test.ts
@@ -24,19 +24,21 @@ describe("useConsentHistory", () => {
       isLoading: queryResult.isLoading ?? false,
       refetch,
     }));
+    const injectEndpoints = mock((opts: MockInjectOpts) => {
+      const build = {
+        query: mock((def: MockQueryDef) => {
+          // Exercise the URL builder so the closure captures `base`
+          const url = def.query();
+          expect(url).toContain("/consents/my");
+          return "my-consents-query";
+        }),
+      };
+      opts.endpoints(build);
+      return {useGetMyConsentsQuery};
+    });
     const api = {
-      injectEndpoints: mock((opts: MockInjectOpts) => {
-        const build = {
-          query: mock((def: MockQueryDef) => {
-            // Exercise the URL builder so the closure captures `base`
-            const url = def.query();
-            expect(url).toContain("/consents/my");
-            return "my-consents-query";
-          }),
-        };
-        opts.endpoints(build);
-        return {useGetMyConsentsQuery};
-      }),
+      enhanceEndpoints: mock(() => api),
+      injectEndpoints,
     };
     return {api, refetch};
   };
@@ -84,6 +86,7 @@ describe("useConsentHistory", () => {
       refetch,
     }));
     const api = {
+      enhanceEndpoints: () => api,
       injectEndpoints: () => {
         injectCallCount += 1;
         return {useGetMyConsentsQuery};

--- a/ui/src/useConsentHistory.ts
+++ b/ui/src/useConsentHistory.ts
@@ -40,6 +40,7 @@ interface ConsentHistoryEnhancedApi {
 }
 
 interface ConsentHistoryApi {
+  enhanceEndpoints: (options: {addTagTypes: string[]}) => ConsentHistoryApi;
   injectEndpoints: (options: {
     endpoints: (build: ConsentHistoryQueryBuilder) => {getMyConsents: unknown};
     overrideExisting: boolean;
@@ -65,7 +66,7 @@ const getEnhancedApi = (api: ConsentHistoryApi, base: string): ConsentHistoryEnh
   if (cached) {
     return cached;
   }
-  const enhanced = api.injectEndpoints({
+  const enhanced = api.enhanceEndpoints({addTagTypes: ["MyConsents"]}).injectEndpoints({
     endpoints: (build) => ({
       getMyConsents: build.query({
         providesTags: ["MyConsents"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two related sets of changes for the consent experience in the example app:

1. **Consent markdown layout** — give markdown body text explicit mobile metrics and constrain list marker/content flex behavior so ordered markers stay on one line and wrapped paragraph text measures correctly.
2. **Example app launch fixes** — resolve a series of runtime errors that prevented the example app from launching on web and iOS, and seed standard consent forms so the flow can be exercised end to end.

## Human Testing Steps

- [x] Open a consent form with long ordered list items on a narrow mobile viewport and confirm markers like `16.` and `17.` stay on one line.
- [x] Open a consent form with long markdown paragraphs and confirm wrapped lines are not clipped.
- [ ] Run `bun run dev` (backend) and `bun run web` (example-frontend); confirm the web app loads past login with no `configureStore` / `addEventListener` / gesture-handler errors.
- [ ] Launch the example app on iOS (`bun run ios`); confirm it no longer hangs on startup.
- [ ] Run the backend seed script and confirm Terms of Service, Privacy Policy, and Data Collection consent forms are created.
- [ ] Confirm the consent history screen loads without the `MyConsents` tag-type warning.

## Changes

### Consent markdown layout
- Added explicit markdown text font size and line height for reliable native paragraph measurement.
- Added ordered and bullet list layout constraints for non-shrinking markers and wrapping content.
- Added regression coverage for 17-item ordered lists and long consent paragraphs.

### Example app launch fixes
- **Sentry**: scope `@sentry/react` to web only, add a no-op redux enhancer fallback, and skip Sentry on native to avoid the `RNSentry` TurboModule hang in Expo Go. Exclude `@sentry/react-native` from Metro bundling.
- **Gesture handler**: add `react-native-gesture-handler` dependency and wrap the app in `GestureHandlerRootView`.
- **rtk**: guard `window.addEventListener` in `useServerStatus` for native; memoize `selectUndismissedConflicts` with `createSelector` to stop unnecessary re-renders.
- **ui**: remove the deprecated `react-native/Libraries/Core/ReactNativeVersion` deep import in `ActionSheet`; register the `MyConsents` RTK Query tag via `enhanceEndpoints`.
- **backend**: seed Terms, Privacy, and a data-collection consent form in `seed-test-data.ts`.
- **vscode**: point the example tasks at the correct package directories.

## Automated Tests

- `bun test src/MarkdownView.test.tsx`
- `ui` lint + compile, plus `useConsentHistory` tests
- `rtk` and `example-backend` lint + compile
- Pre-existing failures unrelated to this branch: 2 `Banner` UI tests and websocket port-binding errors when the dev server is already running.

## Manual Evidence

[consent_markdown_layout_mobile_demo.mp4](https://cursor.com/agents/bc-2528d6ea-c193-4c86-b0e1-7916424e386e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsent_markdown_layout_mobile_demo.mp4)
[Consent numbered items 16 and 17](https://cursor.com/agents/bc-2528d6ea-c193-4c86-b0e1-7916424e386e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsent_numbered_items_16_17.webp)
[Consent bottom paragraph and agree button](https://cursor.com/agents/bc-2528d6ea-c193-4c86-b0e1-7916424e386e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsent_bottom_paragraph_agree.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2528d6ea-c193-4c86-b0e1-7916424e386e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2528d6ea-c193-4c86-b0e1-7916424e386e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>