### PR TITLE
[coverage] api/src/errors.ts

### DIFF
--- a/api/src/errors.test.ts
+++ b/api/src/errors.test.ts
@@ -7,6 +7,8 @@ import {
   APIError,
   apiErrorMiddleware,
   apiUnauthorizedMiddleware,
+  errorMessage,
+  errorStack,
   errorsPlugin,
   getAPIErrorBody,
   getDisableExternalErrorTracking,
@@ -151,6 +153,36 @@ describe("getDisableExternalErrorTracking", () => {
 
   it("returns undefined for an object missing the property", () => {
     expect(getDisableExternalErrorTracking({foo: "bar"})).toBeUndefined();
+  });
+});
+
+describe("errorMessage", () => {
+  it("returns the message from an Error instance", () => {
+    expect(errorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("returns the string representation of a non-Error value", () => {
+    expect(errorMessage("raw string")).toBe("raw string");
+    expect(errorMessage(42)).toBe("42");
+    expect(errorMessage(null)).toBe("null");
+  });
+});
+
+describe("errorStack", () => {
+  it("returns the stack trace from an Error with a stack", () => {
+    const err = new Error("fail");
+    expect(errorStack(err)).toBe(err.stack as string);
+  });
+
+  it("returns the string representation when error has no stack", () => {
+    const err = new Error("no-stack");
+    Object.defineProperty(err, "stack", {value: undefined});
+    expect(errorStack(err)).toBe("Error: no-stack");
+  });
+
+  it("returns the string representation of a non-Error value", () => {
+    expect(errorStack("plain")).toBe("plain");
+    expect(errorStack(123)).toBe("123");
   });
 });
 


### PR DESCRIPTION
## Summary
Adds test coverage for `errorMessage` and `errorStack` utility functions in `api/src/errors.ts`.

**Coverage improvement**: `errors.ts` line coverage improved from 97.65% to 100% (lines 174-178, 182-187 now covered).

### Changes
- Added `errorMessage` and `errorStack` to the import in `errors.test.ts`
- Added `describe("errorMessage")` block: tests Error instance and non-Error values (string, number, null)
- Added `describe("errorStack")` block: tests Error with stack, Error without stack, and non-Error values

### AI package note
For `@terreno/ai`, the only file below 100% is `src/routes/gpt.ts` (97.91%). The uncovered lines (387-392, 465-469, 591-592) are defensive code paths that are unreachable with the current Vercel AI SDK v6 — the SDK's `fullStream` emits `file` parts as `{type: 'file', file: GeneratedFile}` but the code references `part.base64`/`part.mediaType` directly, and the SDK always emits `finish-step` events making the post-loop text flush unreachable.

## Review & Testing Checklist for Human
- [ ] Verify `errorMessage` tests cover both Error and non-Error inputs
- [ ] Verify `errorStack` correctly handles the undefined-stack edge case

### Notes
All linter and TypeScript compiler checks pass locally.

Link to Devin session: https://app.devin.ai/sessions/8955a1756ce34698b573fa8297f974d5
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code or API behavior modifications.
> 
> **Overview**
> Adds unit tests in `errors.test.ts` for the existing `errorMessage` and `errorStack` helpers from `api/src/errors.ts`, importing them alongside the other error utilities.
> 
> **`errorMessage`** is covered for `Error` instances and non-`Error` values (string, number, null). **`errorStack`** is covered when an `Error` has a stack, when `stack` is forced to `undefined`, and for non-`Error` inputs. This is test-only coverage work (e.g. toward 100% line coverage on `errors.ts`); runtime behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b850d968a4658ed5a14547b06204ed6eb8b285c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->