### PR TITLE
[coverage] ui/src/Field.tsx

### DIFF
--- a/ui/src/Field.test.tsx
+++ b/ui/src/Field.test.tsx
@@ -125,4 +125,27 @@ describe("Field", () => {
     );
     expect(toJSON()).toMatchSnapshot();
   });
+
+  it("renders customSelect field", () => {
+    const {toJSON} = renderWithTheme(
+      <Field
+        label="Custom"
+        onChange={() => {}}
+        options={[
+          {label: "Option A", value: "a"},
+          {label: "Option B", value: "b"},
+        ]}
+        type="customSelect"
+        value="a"
+      />
+    );
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("renders signature field", () => {
+    const {toJSON} = renderWithTheme(
+      <Field label="Sign here" onChange={() => {}} type="signature" value="" />
+    );
+    expect(toJSON()).toMatchSnapshot();
+  });
 });

--- a/ui/src/__snapshots__/Field.test.tsx.snap
+++ b/ui/src/__snapshots__/Field.test.tsx.snap
@@ -4666,3 +4666,370 @@ exports[`Field renders phoneNumber field 1`] = `
   "type": "View",
 }
 `;
+
+exports[`Field renders customSelect field 1`] = `
+{
+  "$$typeof": Symbol(react.test.json),
+  "children": [
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            {
+              "$$typeof": Symbol(react.test.json),
+              "children": [
+                {
+                  "$$typeof": Symbol(react.test.json),
+                  "children": [
+                    {
+                      "$$typeof": Symbol(react.test.json),
+                      "children": [
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": null,
+                          "props": {
+                            "readOnly": true,
+                            "style": {
+                              "color": "#1C1C1C",
+                            },
+                            "testID": "text_input",
+                            "value": "Option A",
+                          },
+                          "type": "TextInput",
+                        },
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": null,
+                          "props": {
+                            "style": {
+                              "pointerEvents": "none",
+                            },
+                            "testID": "icon_container",
+                          },
+                          "type": "View",
+                        },
+                      ],
+                      "props": {
+                        "style": {
+                          "flexDirection": "row",
+                          "justifyContent": "space-between",
+                          "pointerEvents": "box-only",
+                          "width": "100%",
+                        },
+                        "testID": undefined,
+                      },
+                      "type": "View",
+                    },
+                  ],
+                  "props": {
+                    "onPress": [Function],
+                    "style": {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "justifyContent": "center",
+                      "minHeight": 40,
+                      "width": "95%",
+                    },
+                    "testID": "ios_touchable_wrapper",
+                  },
+                  "type": "Pressable",
+                },
+                {
+                  "$$typeof": Symbol(react.test.json),
+                  "children": [
+                    {
+                      "$$typeof": Symbol(react.test.json),
+                      "children": null,
+                      "props": {
+                        "aria-role": "button",
+                        "onPress": [Function],
+                        "style": {
+                          "flex": 1,
+                        },
+                        "testID": "ios_modal_top",
+                      },
+                      "type": "Pressable",
+                    },
+                    {
+                      "$$typeof": Symbol(react.test.json),
+                      "children": [
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": null,
+                          "props": {
+                            "style": {
+                              "flexDirection": "row",
+                            },
+                            "testID": undefined,
+                          },
+                          "type": "View",
+                        },
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": [
+                            {
+                              "$$typeof": Symbol(react.test.json),
+                              "children": [
+                                {
+                                  "$$typeof": Symbol(react.test.json),
+                                  "children": [
+                                    "Done",
+                                  ],
+                                  "props": {
+                                    "allowFontScaling": false,
+                                    "style": [
+                                      {
+                                        "color": "#007aff",
+                                        "fontSize": 17,
+                                        "fontWeight": "600",
+                                        "paddingRight": 11,
+                                        "paddingTop": 1,
+                                      },
+                                      {},
+                                    ],
+                                    "testID": "done_text",
+                                  },
+                                  "type": "Text",
+                                },
+                              ],
+                              "props": {
+                                "style": undefined,
+                                "testID": "needed_for_touchable",
+                              },
+                              "type": "View",
+                            },
+                          ],
+                          "props": {
+                            "hitSlop": {
+                              "bottom": 4,
+                              "left": 4,
+                              "right": 4,
+                              "top": 4,
+                            },
+                            "onPress": [Function],
+                            "onPressIn": [Function],
+                            "onPressOut": [Function],
+                            "testID": "done_button",
+                          },
+                          "type": "Pressable",
+                        },
+                      ],
+                      "props": {
+                        "style": {
+                          "alignItems": "center",
+                          "backgroundColor": "#f8f8f8",
+                          "borderTopColor": "#dedede",
+                          "borderTopWidth": 1,
+                          "flexDirection": "row",
+                          "height": 45,
+                          "justifyContent": "space-between",
+                          "paddingHorizontal": 10,
+                          "zIndex": 2,
+                        },
+                        "testID": "input_accessory_view",
+                      },
+                      "type": "View",
+                    },
+                    {
+                      "$$typeof": Symbol(react.test.json),
+                      "children": [
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": [
+                            {
+                              "$$typeof": Symbol(react.test.json),
+                              "children": null,
+                              "props": {
+                                "color": undefined,
+                                "label": "Please select an option.",
+                                "value": "",
+                              },
+                              "type": "Picker.Item",
+                            },
+                            {
+                              "$$typeof": Symbol(react.test.json),
+                              "children": null,
+                              "props": {
+                                "color": undefined,
+                                "label": "Option A",
+                                "value": "a",
+                              },
+                              "type": "Picker.Item",
+                            },
+                            {
+                              "$$typeof": Symbol(react.test.json),
+                              "children": null,
+                              "props": {
+                                "color": undefined,
+                                "label": "Option B",
+                                "value": "b",
+                              },
+                              "type": "Picker.Item",
+                            },
+                            {
+                              "$$typeof": Symbol(react.test.json),
+                              "children": null,
+                              "props": {
+                                "color": undefined,
+                                "label": "Custom",
+                                "value": "custom",
+                              },
+                              "type": "Picker.Item",
+                            },
+                          ],
+                          "props": {
+                            "onValueChange": [Function],
+                            "selectedValue": "a",
+                            "testID": "ios_picker",
+                          },
+                          "type": "Picker",
+                        },
+                      ],
+                      "props": {
+                        "style": [
+                          {
+                            "backgroundColor": "#d0d4da",
+                            "justifyContent": "center",
+                          },
+                          {
+                            "height": 215,
+                          },
+                        ],
+                        "testID": undefined,
+                      },
+                      "type": "View",
+                    },
+                  ],
+                  "props": {
+                    "animationType": undefined,
+                    "onOrientationChange": [Function],
+                    "supportedOrientations": [
+                      "portrait",
+                      "landscape",
+                    ],
+                    "testID": "ios_modal",
+                    "transparent": true,
+                    "visible": false,
+                  },
+                  "type": "Modal",
+                },
+              ],
+              "props": {
+                "style": [
+                  {
+                    "alignItems": "center",
+                    "alignSelf": "stretch",
+                    "borderRadius": 4,
+                    "borderWidth": 1,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "minHeight": 40,
+                    "width": "100%",
+                  },
+                  {
+                    "backgroundColor": "#FFFFFF",
+                    "borderColor": "#9A9A9A",
+                  },
+                  false,
+                ],
+                "testID": undefined,
+              },
+              "type": "View",
+            },
+          ],
+          "props": {
+            "style": {
+              "width": "100%",
+            },
+            "testID": undefined,
+          },
+          "type": "View",
+        },
+      ],
+      "props": {
+        "accessibilityHint": "Opens a dropdown menu. Select an option, or select custom to trigger popup to input a custom value",
+        "aria-label": "Select dropdown",
+        "aria-role": "button",
+        "style": undefined,
+        "testID": undefined,
+      },
+      "type": "View",
+    },
+  ],
+  "props": {
+    "accessibilityHint": "Select an option or input a custom value",
+    "aria-label": "Select dropdown with popup text input field",
+    "aria-role": "combobox",
+    "style": {
+      "width": "100%",
+    },
+    "testID": undefined,
+  },
+  "type": "View",
+}
+`;
+
+exports[`Field renders signature field 1`] = `
+{
+  "$$typeof": Symbol(react.test.json),
+  "children": [
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": null,
+          "props": {
+            "style": {
+              "backgroundColor": "#FFFFFF",
+            },
+            "testID": "signature-canvas",
+          },
+          "type": "View",
+        },
+      ],
+      "props": {
+        "style": {
+          "borderColor": "#9A9A9A",
+          "borderWidth": 1,
+          "maxWidth": 300,
+          "width": "100%",
+        },
+        "testID": undefined,
+      },
+      "type": "View",
+    },
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            "Clear",
+          ],
+          "props": {
+            "onPress": [Function],
+            "style": {
+              "color": "#0A7092",
+              "textDecorationLine": "underline",
+            },
+          },
+          "type": "Text",
+        },
+      ],
+      "props": {
+        "style": undefined,
+        "testID": undefined,
+      },
+      "type": "View",
+    },
+  ],
+  "props": {
+    "style": undefined,
+    "testID": undefined,
+  },
+  "type": "View",
+}
+`;


### PR DESCRIPTION
## Summary
Adds test coverage for `customSelect` and `signature` field type branches in `ui/src/Field.tsx`.

**Coverage improvement**: `Field.tsx` line coverage improved from 90.32% to 98.39%.

### Changes
- Added `it("renders customSelect field")` test with options and value props
- Added `it("renders signature field")` test
- Updated snapshots for the two new test cases

### RTK package note
For `@terreno/rtk`, the lowest coverage file is `src/constants.ts` (92.68%). The uncovered lines (10, 15, 23, 113-115) are all module-level code that only executes at import time when `AUTH_DEBUG`/`WEBSOCKETS_DEBUG` are `"true"` or when Expo tunnel is detected. These paths are already tested in `src/isolated/constants.isolated.ts` using `mock.module`, but bun's coverage tracker doesn't capture coverage for re-imported modules via `mock.module`. The file already exceeds the 90% target.

## Review & Testing Checklist for Human
- [ ] Verify `customSelect` snapshot looks correct
- [ ] Verify `signature` snapshot looks correct

### Notes
All linter and TypeScript compiler checks pass locally.

Link to Devin session: https://app.devin.ai/sessions/8955a1756ce34698b573fa8297f974d5
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime or API modifications.
> 
> **Overview**
> Adds snapshot tests in `Field.test.tsx` for **`customSelect`** and **`signature`** `Field` types so those dispatch branches in `Field.tsx` are exercised in CI.
> 
> Each new case follows the existing pattern (`renderWithTheme` + `toMatchSnapshot`). **`Field.test.tsx.snap`** gains two entries: custom select shows the picker UI with options plus a **Custom** entry; signature shows the canvas and **Clear** control. No production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f61e841ce54d54272b5f73709c273c8ffceec8ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->