### PR TITLE
[coverage] ui/src/PickerSelect.tsx - improve to 95%+

### DIFF
--- a/ui/src/PickerSelect.test.tsx
+++ b/ui/src/PickerSelect.test.tsx
@@ -308,6 +308,28 @@ describe("PickerSelect", () => {
         restoreDocument();
       }
     });
+
+    it("calls onValueChange when a web dropdown option is selected", async () => {
+      ensureDocument();
+      savedOS = PlatformModule.OS;
+      try {
+        PlatformModule.OS = "web";
+        const mockOnValueChange = mock(() => {});
+        const {getByTestId} = renderWithTheme(
+          <RNPickerSelect {...defaultProps} onValueChange={mockOnValueChange} value="1" />
+        );
+        await act(async () => {
+          fireEvent.press(getByTestId("web_picker"));
+        });
+        await act(async () => {
+          fireEvent.press(getByTestId("web_dropdown_option_2"));
+        });
+        expect(mockOnValueChange).toHaveBeenCalledWith("2", 2);
+      } finally {
+        PlatformModule.OS = savedOS;
+        restoreDocument();
+      }
+    });
   });
 
   describe("android rendering", () => {


### PR DESCRIPTION
## Summary
Add a test that exercises the `WebDropdownMenu` `onSelect` callback in `PickerSelect` (lines 651-657). This covers the web dropdown selection handler that maps the filtered menu index back to the original option index and calls `onValueChangeEvent`.

Previously uncovered: the `onSelect` callback that translates a WebDropdownMenu selection index into the original `options[]` index and forwards the original value to `onValueChange`.

Coverage after this change: **100% functions, 100% lines** (up from 96.97% / 98.55%).

## Review & Testing Checklist for Human
- [ ] Verify the new test assertion (`onValueChange` called with `"2", 2`) matches the expected index mapping when a placeholder is present

### Notes
The 2 pre-existing test failures in the suite are in `Banner` tests (unrelated to this change).

Link to Devin session: https://app.devin.ai/sessions/4e949dd251754db58951dbe4b2c2d673
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime behavior modifications.
> 
> **Overview**
> Adds a **web** integration test in `PickerSelect.test.tsx` that opens the web picker, selects `web_dropdown_option_2`, and asserts `onValueChange` is invoked with **`"2"` and index `2`** (accounting for placeholder offset in the options list).
> 
> This targets previously untested **`WebDropdownMenu` `onSelect`** wiring in `PickerSelect` and is intended to bring **`PickerSelect` coverage to ~100%** lines/functions. **No production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96430b0157a419f2fd83adf808675806d4312c37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->