### PR TITLE
Fix: wrap demo root layout GestureHandlerRootView

### DIFF
--- a/demo/app/_layout.tsx
+++ b/demo/app/_layout.tsx
@@ -1,12 +1,15 @@
 import {TerrenoProvider} from "@terreno/ui";
 import {Slot} from "expo-router";
+import {GestureHandlerRootView} from "react-native-gesture-handler";
 
 const RootLayout = () => {
   // TODO: Store dev/demo in AsyncStorage to persist.
   return (
-    <TerrenoProvider>
-      <Slot initialRouteName={process.env.NODE_ENV === "development" ? "dev" : "demo"} />
-    </TerrenoProvider>
+    <GestureHandlerRootView style={{flex: 1}}>
+      <TerrenoProvider>
+        <Slot initialRouteName={process.env.NODE_ENV === "development" ? "dev" : "demo"} />
+      </TerrenoProvider>
+    </GestureHandlerRootView>
   );
 };
 


### PR DESCRIPTION
fix Error 
```
NativeViewGestureHandler must be used as a descendant of GestureHandlerRootView
```
The demo was missing a GestureHandlerRootView wrapper in app/_layout.tsx. This was a latent bug that surfaced when testing this PR after running bun run compile on the ui package. ui/dist/ is gitignored, so the local build can fall behind the source. A fresh bun run compile brought the dist in sync with source, initialized gesture-handler, and iOS immediately crashed 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single layout wrapper change in the demo app; no auth, data, or production app routing changes.
> 
> **Overview**
> Wraps the demo app root in **`GestureHandlerRootView`** so gesture-handler components (e.g. **`NativeViewGestureHandler`**) have a required ancestor. Without it, iOS can crash with *NativeViewGestureHandler must be used as a descendant of GestureHandlerRootView* after a fresh **`@terreno/ui`** build brings gesture usage in sync with source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3e84c577e8e865e81433b8f7d414a54b29cd50f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->