### PR TITLE
fix: resolve 3 flaky test failures from mock leakage between test files

### DIFF
--- a/ui/src/Banner.test.tsx
+++ b/ui/src/Banner.test.tsx
@@ -1,4 +1,4 @@
-import {describe, expect, it, mock} from "bun:test";
+import {beforeEach, describe, expect, it, mock} from "bun:test";
 import {act, fireEvent, waitFor} from "@testing-library/react-native";
 import React from "react";
 
@@ -7,6 +7,10 @@ import {renderWithTheme} from "./test-utils";
 import {Unifier} from "./Unifier";
 
 describe("Banner", () => {
+  beforeEach(() => {
+    Unifier.storage.getItem = mock(() => Promise.resolve(null));
+    Unifier.storage.setItem = mock(() => Promise.resolve());
+  });
   it("renders correctly with default props", () => {
     const {toJSON} = renderWithTheme(<Banner id="test-banner" text="Test message" />);
     expect(toJSON()).toMatchSnapshot();

--- a/ui/src/SignatureField.test.tsx
+++ b/ui/src/SignatureField.test.tsx
@@ -6,10 +6,13 @@ import type {ReactTestInstance} from "react-test-renderer";
 import {SignatureField} from "./SignatureField";
 import {renderWithTheme} from "./test-utils";
 
-// Mock react-signature-canvas (used by Signature component)
+// Mock react-signature-canvas (used by Signature component).
+// Must NOT forward ref to the View so the snapshot shape matches the global
+// mock in bunSetup.ts — otherwise test-ordering leaks a `ref` prop into
+// Field.test.tsx snapshots.
 mock.module("react-signature-canvas", () => ({
-  default: forwardRef<View, {backgroundColor?: string}>(({backgroundColor}, ref) => (
-    <View ref={ref} style={{backgroundColor}} testID="signature-canvas" />
+  default: forwardRef<View, {backgroundColor?: string}>(({backgroundColor}, _ref) => (
+    <View style={{backgroundColor}} testID="signature-canvas" />
   )),
 }));
 

--- a/ui/src/__snapshots__/SignatureField.test.tsx.snap
+++ b/ui/src/__snapshots__/SignatureField.test.tsx.snap
@@ -33,9 +33,6 @@ exports[`SignatureField renders correctly with default props 1`] = `
                   "$$typeof": Symbol(react.test.json),
                   "children": null,
                   "props": {
-                    "ref": {
-                      "current": null,
-                    },
                     "style": {
                       "backgroundColor": "#FFFFFF",
                     },


### PR DESCRIPTION
## Summary
Fixes 3 flaky test failures on master caused by global mock leakage between concurrently-running test files:

**Banner tests (2 failures):** `useStoredState.test.tsx` replaces `Unifier.storage.getItem` with a rejecting mock in its tests, and this leaked into `Banner.test.tsx` which runs concurrently and calls `Unifier.storage.getItem` in its `useEffect`. Fixed by adding a `beforeEach` to Banner tests that resets storage mocks to sensible defaults.

**Field snapshot (1 failure):** `SignatureField.test.tsx` re-mocked `react-signature-canvas` with a ref-forwarding variant (`<View ref={ref} ...>`), which leaked into `Field.test.tsx` and caused the signature snapshot to include an unexpected `ref: {current: null}` prop. Fixed by making the SignatureField mock match the global mock in `bunSetup.ts` (receive ref via forwardRef but don't forward it to the View).

## Review & Testing Checklist for Human
- [ ] Run `cd ui && TZ=America/New_York bun test` — all 1658 tests should pass with 0 failures
- [ ] Verify the 3 previously-failing tests now pass: `Banner > renders dismissible banner with dismiss button`, `Banner > hides banner when dismiss button is clicked`, `Field > renders signature field`

### Notes
- Root cause was test-ordering-dependent mock pollution — bun runs test files in parallel and `mock.module()` / direct assignment to `Unifier.storage` modifies shared globals
- The SignatureField tests still work correctly; the mock just no longer forwards ref to the rendered View (matching bunSetup.ts), while Signature.test.tsx still has its own mock with `useImperativeHandle` for testing ref methods

Link to Devin session: https://app.devin.ai/sessions/a3406ae9081d45c18aa52e4081a5392d
Requested by: @joshgachnang

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production behavior; risk is limited to test maintenance if mocks diverge from real APIs.
> 
> **Overview**
> Stabilizes **Banner** and **Field** UI tests that were failing intermittently when Bun ran test files in parallel and shared mocks leaked across suites.
> 
> **Banner tests** now reset `Unifier.storage.getItem` and `setItem` in a `beforeEach` to resolving defaults, so dismiss/storage behavior is not affected by other files (e.g. `useStoredState.test.tsx`) that replace storage with rejecting mocks.
> 
> **SignatureField tests** adjust the local `react-signature-canvas` mock so it does not pass `ref` through to the stub `View`, aligning snapshot output with the global mock in `bunSetup.ts` and preventing a stray `ref` from breaking **Field** signature snapshots. The **SignatureField** default-props snapshot is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 951b2239aa04299a50701866eb28fa45491e9fbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->