### PR TITLE
feat(admin-spa): serve admin SPA from a Terreno backend (foundation)

### DIFF
--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -9,6 +9,7 @@ A monorepo containing shared packages for building full-stack applications with 
 - **rtk/** - Redux Toolkit Query utilities for API backends (`@terreno/rtk`)
 - **admin-backend/** - Admin panel backend plugin for @terreno/api (`@terreno/admin-backend`)
 - **admin-frontend/** - Admin panel frontend screens for @terreno/api backends (`@terreno/admin-frontend`)
+- **admin-spa/** - Opt-in Express plugin to serve a pre-built admin SPA from a Terreno backend (`@terreno/admin-spa`)
 - **demo/** - Demo app for showcasing and testing UI components
 - **example-frontend/** - Example Expo app demonstrating full stack usage
 - **example-backend/** - Example Express backend using @terreno/api

--- a/admin-spa/.gitignore
+++ b/admin-spa/.gitignore
@@ -1,0 +1,12 @@
+# Pre-built Expo web export (populated at publish time)
+dist/
+
+# Compiled server plugin output
+src/dist/
+
+# Generated RTK Query SDK
+store/openApiSdk.ts
+
+# Expo / Metro
+.expo/
+web-build/

--- a/admin-spa/README.md
+++ b/admin-spa/README.md
@@ -1,0 +1,106 @@
+# @terreno/admin-spa
+
+Opt-in package that lets any Terreno backend serve a pre-built admin SPA from the
+same Node process — no separate static-site deploy to GCS/Netlify/Cloudflare Pages.
+
+The default backend image stays small: React/Expo assets only ship in the npm
+tarball for consumers who actually register the plugin. The embedded admin use case
+(admin screens inside a consumer's main Expo app, as `example-frontend/app/admin/*`
+does) remains supported and unchanged.
+
+## What's here today
+
+This package currently ships the **backend serving plugin** (`AdminSpaServeApp`) and
+its runtime app-config contract. It serves a pre-built Expo Router static export
+(`dist/`) from a Terreno backend.
+
+> The SPA frontend itself (`app/`, `store/`, `components/`) and the
+> `@terreno/admin-frontend` `apiBase`/`routeBase` prop split it depends on are a
+> follow-up. Until the bundle is built, the plugin serves `app-config.json` and a
+> placeholder `index.html`, or proxies to a running Expo dev server via
+> `devProxyTarget`.
+
+## Install
+
+```bash
+bun add @terreno/admin-spa
+```
+
+`@terreno/api` is a peer dependency.
+
+## Register with a backend
+
+```typescript
+import {AdminSpaServeApp} from "@terreno/admin-spa";
+import {AdminApp} from "@terreno/admin-backend";
+import {BetterAuthApp, TerrenoApp} from "@terreno/api";
+
+new TerrenoApp({userModel: User})
+  .register(new BetterAuthApp({config: betterAuthConfig, userModel: User}))
+  .register(new AdminApp({models: [...]}))
+  .register(
+    new AdminSpaServeApp({
+      basePath: "/console", // default; non-breaking with the /admin API
+      appConfig: {
+        brandName: "Acme Admin",
+        logoUrl: "/static/logo.svg",
+        primaryColor: "#FF6B35",
+        providers: ["email", "google"],
+      },
+    })
+  )
+  .start();
+```
+
+Open `https://api.acme.com/console/` → admin UI. Same-origin → Better-Auth session
+cookies attach automatically, no CORS.
+
+## Options (`AdminSpaServeOptions`)
+
+| Option | Default | Description |
+|---|---|---|
+| `basePath` | `/console` | Path the SPA mounts at. The `/admin` API is untouched. |
+| `appConfig` | see below | Runtime config served at `${basePath}/app-config.json`. Merged over defaults. |
+| `distDir` | `<pkg>/dist` | Override the pre-built bundle directory (tests / custom builds). |
+| `devProxyTarget` | — | In dev, proxy all SPA paths to a running `expo start --web`, e.g. `http://localhost:8083`. |
+
+### App config
+
+`app-config.json` lets a single pre-built bundle be themed and pointed at the right
+auth/admin API paths per consumer without rebuilding. Defaults:
+
+```typescript
+{
+  brandName: "Terreno Admin",
+  primaryColor: "#2563EB",
+  providers: ["email"],
+  authBasePath: "/api/auth",
+  adminApiBasePath: "/admin",
+}
+```
+
+## How serving works
+
+- `${basePath}/_expo` and `${basePath}/assets` are served with
+  `Cache-Control: public, max-age=31536000, immutable`.
+- `${basePath}/app-config.json` and `index.html` are served with
+  `Cache-Control: no-store`.
+- `index.html`'s absolute `/_expo/` and `/assets/` references are rewritten once at
+  boot to `${basePath}/...`, so one pre-built bundle works at any `basePath`.
+- SPA fallback: both the bare `${basePath}` and `${basePath}/*splat` return
+  `index.html` (Express 5 named-splat convention).
+
+## Build / publish (follow-up)
+
+When the SPA frontend lands, `dist/` is produced by
+`bun expo export --platform web --output-dir dist` (run in `prepublishOnly`) and
+shipped via `files: ["src/dist/**", "dist/**"]`. A CI publish job must run the web
+export before `bun publish` so the tarball's `dist/` is populated.
+
+## Comparison with embedded admin-frontend
+
+| | Standalone SPA (`@terreno/admin-spa`) | Embedded (`@terreno/admin-frontend`) |
+|---|---|---|
+| Deploy | Served by the API process at `/console` | Bundled into the consumer's Expo app |
+| Backend footprint | Opt-in; no React in default image | n/a |
+| Auth | Better-Auth same-origin cookies | Consumer's existing auth |

--- a/admin-spa/biome.jsonc
+++ b/admin-spa/biome.jsonc
@@ -1,0 +1,20 @@
+{
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "extends": ["../biome.jsonc"],
+  "files": {
+    "includes": [
+      "package.json",
+      "src/**/*.ts",
+      "src/**/*.tsx",
+      "!!**/node_modules",
+      "!!node_modules",
+      "!!**/dist",
+      "!!dist",
+      "!!**/build",
+      "!!build",
+      "!!**/coverage",
+      "!!coverage"
+    ]
+  },
+  "root": true
+}

--- a/admin-spa/bunfig.toml
+++ b/admin-spa/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+root = "./src"
+coveragePathIgnorePatterns = ["**/*.test.ts", "dist/**", "src/dist/**", "**/node_modules/**"]

--- a/admin-spa/package.json
+++ b/admin-spa/package.json
@@ -1,0 +1,57 @@
+{
+  "author": "Josh Gachnang",
+  "bugs": {
+    "url": "https://github.com/FlourishHealth/terreno/issues"
+  },
+  "dependencies": {
+    "express": "^5.2.1",
+    "http-proxy-middleware": "^3.0.3"
+  },
+  "description": "Opt-in Express plugin that serves a pre-built admin SPA from a Terreno backend",
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@terreno/api": "workspace:*",
+    "@types/bun": "^1.2.4",
+    "@types/express": "^5.0.6",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0",
+    "typescript": "catalog:"
+  },
+  "files": [
+    "src/dist/**",
+    "dist/**"
+  ],
+  "homepage": "https://github.com/FlourishHealth/terreno#readme",
+  "keywords": [
+    "admin",
+    "api",
+    "express",
+    "spa",
+    "terreno"
+  ],
+  "license": "Apache-2.0",
+  "main": "./src/dist/index.js",
+  "name": "@terreno/admin-spa",
+  "peerDependencies": {
+    "@terreno/api": "workspace:*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/FlourishHealth/terreno.git"
+  },
+  "scripts": {
+    "compile": "tsc -p tsconfig.server.json",
+    "compile:watch": "tsc -p tsconfig.server.json -w",
+    "dev": "tsc -p tsconfig.server.json -w",
+    "lint": "biome check ./src",
+    "lint:fix": "biome check --write ./src",
+    "test": "bun test ./src",
+    "test:ci": "bun test ./src"
+  },
+  "type": "module",
+  "types": "./src/dist/index.d.ts",
+  "version": "0.1.0"
+}

--- a/admin-spa/src/appConfig.ts
+++ b/admin-spa/src/appConfig.ts
@@ -1,0 +1,38 @@
+/**
+ * Runtime configuration for the standalone admin SPA.
+ *
+ * Served by {@link AdminSpaServeApp} at `${basePath}/app-config.json` and fetched
+ * by the SPA on boot. This lets a single pre-built bundle be themed and pointed at
+ * the right auth/admin API paths per consumer without rebuilding.
+ */
+export interface AdminSpaAppConfig {
+  /** Brand name shown in the header. Default: "Terreno Admin". */
+  brandName: string;
+  /** Logo asset URL (absolute or relative). Optional. */
+  logoUrl?: string;
+  /** Primary brand color (hex). Default: "#2563EB". */
+  primaryColor: string;
+  /** Enabled login providers. Drives login screen rendering. Default: ["email"]. */
+  providers: ReadonlyArray<"email" | "google" | "github" | "apple">;
+  /** Base path of the better-auth routes on this same origin. Default: "/api/auth". */
+  authBasePath?: string;
+  /** Base path of the admin API on this same origin. Default: "/admin". */
+  adminApiBasePath?: string;
+}
+
+/**
+ * Default app-config values. Merged field-by-field with consumer-provided overrides
+ * so a partial `appConfig` only changes the fields it specifies.
+ */
+export const DEFAULT_APP_CONFIG: AdminSpaAppConfig = {
+  adminApiBasePath: "/admin",
+  authBasePath: "/api/auth",
+  brandName: "Terreno Admin",
+  primaryColor: "#2563EB",
+  providers: ["email"],
+};
+
+/** Merge consumer overrides over the defaults, returning a complete config. */
+export const resolveAppConfig = (overrides?: Partial<AdminSpaAppConfig>): AdminSpaAppConfig => {
+  return {...DEFAULT_APP_CONFIG, ...overrides};
+};

--- a/admin-spa/src/index.ts
+++ b/admin-spa/src/index.ts
@@ -1,0 +1,10 @@
+export {
+  type AdminSpaAppConfig,
+  DEFAULT_APP_CONFIG,
+  resolveAppConfig,
+} from "./appConfig";
+export {
+  AdminSpaServeApp,
+  type AdminSpaServeOptions,
+  rewriteIndexHtml,
+} from "./serve";

--- a/admin-spa/src/serve.test.ts
+++ b/admin-spa/src/serve.test.ts
@@ -1,0 +1,127 @@
+import {afterAll, beforeAll, describe, expect, it} from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import express from "express";
+import request from "supertest";
+import {DEFAULT_APP_CONFIG} from "./appConfig";
+import {AdminSpaServeApp, rewriteIndexHtml} from "./serve";
+
+const STUB_INDEX =
+  '<html><head><link href="/_expo/static/css/app.css"><script src="/_expo/static/js/web/entry.js"></script></head><body>STUB-SPA</body></html>';
+const STUB_ASSET = "CONTENT";
+
+let distDir: string;
+
+beforeAll(() => {
+  distDir = fs.mkdtempSync(path.join(os.tmpdir(), "admin-spa-dist-"));
+  fs.writeFileSync(path.join(distDir, "index.html"), STUB_INDEX);
+  const expoJsDir = path.join(distDir, "_expo", "static", "js", "web");
+  fs.mkdirSync(expoJsDir, {recursive: true});
+  fs.writeFileSync(path.join(expoJsDir, "foo.abc123.js"), STUB_ASSET);
+  const assetsDir = path.join(distDir, "assets");
+  fs.mkdirSync(assetsDir, {recursive: true});
+  fs.writeFileSync(path.join(assetsDir, "logo.png"), STUB_ASSET);
+});
+
+afterAll(() => {
+  fs.rmSync(distDir, {force: true, recursive: true});
+});
+
+const makeApp = (opts?: {
+  basePath?: string;
+  appConfig?: Record<string, unknown>;
+}): express.Application => {
+  const app = express();
+  new AdminSpaServeApp({
+    appConfig: opts?.appConfig,
+    basePath: opts?.basePath,
+    distDir,
+  }).register(app);
+  // A fallthrough 404 so requests outside basePath resolve.
+  app.use((_req, res) => res.status(404).send("not found"));
+  return app;
+};
+
+describe("rewriteIndexHtml", () => {
+  it("rewrites absolute /_expo/ and /assets/ refs to the basePath", () => {
+    const out = rewriteIndexHtml(STUB_INDEX, "/console");
+    expect(out).toContain('href="/console/_expo/static/css/app.css"');
+    expect(out).toContain('src="/console/_expo/static/js/web/entry.js"');
+    expect(out).not.toContain('href="/_expo/');
+  });
+
+  it("rewrites assets references too", () => {
+    const out = rewriteIndexHtml('<img src="/assets/logo.png">', "/admin-ui");
+    expect(out).toContain('src="/admin-ui/assets/logo.png"');
+  });
+});
+
+describe("AdminSpaServeApp", () => {
+  it("serves the SPA at the base path with no-store HTML", async () => {
+    const res = await request(makeApp()).get("/console/");
+    expect(res.status).toBe(200);
+    expect(res.text).toContain("STUB-SPA");
+    expect(res.headers["content-type"]).toContain("text/html");
+    expect(res.headers["cache-control"]).toBe("no-store");
+  });
+
+  it("serves the SPA at the bare base path (no trailing slash)", async () => {
+    const res = await request(makeApp()).get("/console");
+    expect(res.status).toBe(200);
+    expect(res.text).toContain("STUB-SPA");
+  });
+
+  it("falls back to index.html for deep SPA routes", async () => {
+    const res = await request(makeApp()).get("/console/users/abc123");
+    expect(res.status).toBe(200);
+    expect(res.text).toContain("STUB-SPA");
+  });
+
+  it("rewrites asset references in the served HTML", async () => {
+    const res = await request(makeApp()).get("/console/");
+    expect(res.text).toContain('src="/console/_expo/static/js/web/entry.js"');
+  });
+
+  it("serves hashed assets with an immutable long-lived cache header", async () => {
+    const res = await request(makeApp()).get("/console/_expo/static/js/web/foo.abc123.js");
+    expect(res.status).toBe(200);
+    expect(res.text).toBe(STUB_ASSET);
+    expect(res.headers["cache-control"]).toContain("max-age=31536000");
+    expect(res.headers["cache-control"]).toContain("immutable");
+  });
+
+  it("serves app-config.json with defaults and no-store", async () => {
+    const res = await request(makeApp()).get("/console/app-config.json");
+    expect(res.status).toBe(200);
+    expect(res.headers["cache-control"]).toBe("no-store");
+    expect(res.body.brandName).toBe(DEFAULT_APP_CONFIG.brandName);
+    expect(res.body.primaryColor).toBe("#2563EB");
+    expect(res.body.providers).toEqual(["email"]);
+  });
+
+  it("merges provided app-config over the defaults field-by-field", async () => {
+    const res = await request(
+      makeApp({appConfig: {brandName: "Acme Admin", providers: ["email", "google"]}})
+    ).get("/console/app-config.json");
+    expect(res.body.brandName).toBe("Acme Admin");
+    expect(res.body.providers).toEqual(["email", "google"]);
+    // Untouched field keeps its default.
+    expect(res.body.primaryColor).toBe("#2563EB");
+  });
+
+  it("honors a custom basePath", async () => {
+    const app = makeApp({basePath: "/admin-ui"});
+    const spa = await request(app).get("/admin-ui/");
+    expect(spa.status).toBe(200);
+    expect(spa.text).toContain("STUB-SPA");
+    const config = await request(app).get("/admin-ui/app-config.json");
+    expect(config.status).toBe(200);
+    expect(config.body.brandName).toBe(DEFAULT_APP_CONFIG.brandName);
+  });
+
+  it("does not handle requests outside the base path", async () => {
+    const res = await request(makeApp()).get("/unrelated");
+    expect(res.status).toBe(404);
+  });
+});

--- a/admin-spa/src/serve.ts
+++ b/admin-spa/src/serve.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
+import type {TerrenoPlugin} from "@terreno/api";
+import {logger} from "@terreno/api";
+import express from "express";
+import {type AdminSpaAppConfig, resolveAppConfig} from "./appConfig";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// Compiled file lives at src/dist/serve.js; the pre-built bundle lives at admin-spa/dist.
+const DIST_DIR = path.resolve(__dirname, "../../dist");
+
+const NO_STORE = "no-store";
+
+export interface AdminSpaServeOptions {
+  /** Path the SPA is mounted at. Default: "/console". Non-breaking with the AdminApp `/admin` API. */
+  basePath?: string;
+  /** Runtime config served at `${basePath}/app-config.json`. Merged with defaults. */
+  appConfig?: Partial<AdminSpaAppConfig>;
+  /** Override the directory the pre-built bundle is served from (used by tests/custom builds). */
+  distDir?: string;
+  /**
+   * In dev, proxy all SPA paths to a running `expo start --web` server, e.g.
+   * "http://localhost:8083". Avoids re-running `expo export` per change.
+   */
+  devProxyTarget?: string;
+}
+
+/**
+ * Rewrite the absolute `/_expo/` and `/assets/` references emitted by Expo's static
+ * web export so a single pre-built bundle works when mounted at any `basePath`.
+ */
+export const rewriteIndexHtml = (rawIndex: string, basePath: string): string => {
+  return rawIndex
+    .replaceAll('href="/_expo/', `href="${basePath}/_expo/`)
+    .replaceAll('src="/_expo/', `src="${basePath}/_expo/`)
+    .replaceAll('href="/assets/', `href="${basePath}/assets/`)
+    .replaceAll('src="/assets/', `src="${basePath}/assets/`);
+};
+
+/**
+ * Opt-in Express plugin that serves a pre-built admin SPA (Expo Router static export)
+ * from the same Node process as a Terreno backend. Mounts at `/console` by default.
+ *
+ * @example
+ * ```typescript
+ * new TerrenoApp({userModel: User})
+ *   .register(new BetterAuthApp({config, userModel: User}))
+ *   .register(new AdminApp({models: [...]}))
+ *   .register(new AdminSpaServeApp({basePath: "/console", appConfig: {brandName: "Acme"}}))
+ *   .start();
+ * ```
+ */
+export class AdminSpaServeApp implements TerrenoPlugin {
+  constructor(private readonly opts: AdminSpaServeOptions = {}) {}
+
+  register(app: express.Application): void {
+    const basePath = this.opts.basePath ?? "/console";
+    const distDir = this.opts.distDir ?? DIST_DIR;
+    const appConfig = resolveAppConfig(this.opts.appConfig);
+
+    // Dev proxy short-circuit: forward everything under basePath to `expo start --web`.
+    if (this.opts.devProxyTarget) {
+      // Lazy require so production deploys without the dev dependency don't break.
+      // biome-ignore lint/suspicious/noExplicitAny: dynamic require of optional dev dependency
+      const {createProxyMiddleware} = require("http-proxy-middleware") as any;
+      app.use(
+        basePath,
+        createProxyMiddleware({
+          changeOrigin: true,
+          pathRewrite: {[`^${basePath}`]: ""},
+          target: this.opts.devProxyTarget,
+          ws: true,
+        })
+      );
+      // app-config is still served by the plugin so the dev SPA reads it from the same path.
+      app.get(`${basePath}/app-config.json`, (_req, res) => {
+        res.set("Cache-Control", NO_STORE).json(appConfig);
+      });
+      logger.info(`Admin SPA dev-proxied to ${this.opts.devProxyTarget} at ${basePath}/`);
+      return;
+    }
+
+    // Read index.html once and rewrite absolute asset refs to the mounted basePath.
+    const indexHtmlPath = path.join(distDir, "index.html");
+    let indexHtml = "";
+    try {
+      indexHtml = rewriteIndexHtml(fs.readFileSync(indexHtmlPath, "utf-8"), basePath);
+    } catch {
+      logger.warn(
+        `Admin SPA: no pre-built bundle found at ${indexHtmlPath}. ` +
+          "Run `bun run --filter '@terreno/admin-spa' build:web` or set devProxyTarget."
+      );
+    }
+
+    // 1. Hashed asset directories — long cache, immutable.
+    const staticOpts = {immutable: true, maxAge: "365d"};
+    app.use(`${basePath}/_expo`, express.static(path.join(distDir, "_expo"), staticOpts));
+    app.use(`${basePath}/assets`, express.static(path.join(distDir, "assets"), staticOpts));
+
+    // 2. Runtime config — never cached.
+    app.get(`${basePath}/app-config.json`, (_req, res) => {
+      res.set("Cache-Control", NO_STORE).json(appConfig);
+    });
+
+    // 3. SPA fallback. Two registrations: bare basePath (no trailing slash) AND splat,
+    // matching the `/*name` Express 5 convention used elsewhere in the repo.
+    const serveSpa = (_req: express.Request, res: express.Response): void => {
+      res.set("Cache-Control", NO_STORE).type("html").send(indexHtml);
+    };
+    app.get(basePath, serveSpa);
+    app.get(`${basePath}/*splat`, serveSpa);
+
+    logger.info(`Admin SPA mounted at ${basePath}/`);
+  }
+}

--- a/admin-spa/tsconfig.server.json
+++ b/admin-spa/tsconfig.server.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["es2022", "dom"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": false,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "outDir": "./src/dist",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022"
+  },
+  "exclude": ["node_modules", "src/dist", "src/**/*.test.ts"],
+  "include": ["src/index.ts", "src/serve.ts", "src/appConfig.ts"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "admin-backend": {
       "name": "@terreno/admin-backend",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "dependencies": {
         "@google-cloud/storage": "^7.15.0",
         "@terreno/api": "workspace:*",
@@ -36,7 +36,7 @@
     },
     "admin-frontend": {
       "name": "@terreno/admin-frontend",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "dependencies": {
         "@terreno/ui": "workspace:*",
         "expo-router": "catalog:",
@@ -65,9 +65,29 @@
         "react-native-webview",
       ],
     },
+    "admin-spa": {
+      "name": "@terreno/admin-spa",
+      "version": "0.1.0",
+      "dependencies": {
+        "express": "^5.2.1",
+        "http-proxy-middleware": "^3.0.3",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "catalog:",
+        "@terreno/api": "workspace:*",
+        "@types/bun": "^1.2.4",
+        "@types/express": "^5.0.6",
+        "@types/supertest": "^6.0.2",
+        "supertest": "^7.0.0",
+        "typescript": "catalog:",
+      },
+      "peerDependencies": {
+        "@terreno/api": "workspace:*",
+      },
+    },
     "ai": {
       "name": "@terreno/ai",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "dependencies": {
         "@ai-sdk/mcp": "^1.0.21",
         "@google-cloud/storage": "^7.15.0",
@@ -101,7 +121,7 @@
     },
     "api": {
       "name": "@terreno/api",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "dependencies": {
         "@sentry/bun": "^10.25.0",
         "@sentry/profiling-node": "^10.25.0",
@@ -173,7 +193,7 @@
     },
     "api-health": {
       "name": "@terreno/api-health",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "dependencies": {
         "@terreno/api": "workspace:*",
         "express": "^5.2.1",
@@ -285,6 +305,7 @@
         "@socket.io/mongo-adapter": "^0.4.0",
         "@socket.io/redis-adapter": "^8.3.0",
         "@terreno/admin-backend": "workspace:*",
+        "@terreno/admin-spa": "workspace:*",
         "@terreno/ai": "workspace:*",
         "@terreno/api": "workspace:*",
         "@terreno/api-health": "workspace:*",
@@ -362,7 +383,7 @@
     },
     "feature-flags": {
       "name": "@terreno/feature-flags",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "dependencies": {
         "@terreno/api": "workspace:*",
         "express": "^5.2.1",
@@ -402,7 +423,7 @@
     },
     "rtk": {
       "name": "@terreno/rtk",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "dependencies": {
         "@better-auth/expo": "^1.2.8",
         "@react-native-async-storage/async-storage": "catalog:",
@@ -441,7 +462,7 @@
     },
     "ui": {
       "name": "@terreno/ui",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "dependencies": {
         "@expo-google-fonts/nunito": "^0.4.2",
         "@expo-google-fonts/titillium-web": "^0.4.1",
@@ -1281,7 +1302,7 @@
 
     "@opentelemetry/redis-common": ["@opentelemetry/redis-common@0.38.2", "", {}, "sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA=="],
 
-    "@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
 
     "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.213.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.213.0", "@opentelemetry/core": "2.6.0", "@opentelemetry/resources": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-00xlU3GZXo3kXKve4DLdrAL0NAFUaZ9appU/mn00S/5kSUdAvyYsORaDUfR04Mp2CLagAOhrzfUvYozY/EZX2g=="],
 
@@ -1566,6 +1587,8 @@
     "@terreno/admin-backend": ["@terreno/admin-backend@workspace:admin-backend"],
 
     "@terreno/admin-frontend": ["@terreno/admin-frontend@workspace:admin-frontend"],
+
+    "@terreno/admin-spa": ["@terreno/admin-spa@workspace:admin-spa"],
 
     "@terreno/ai": ["@terreno/ai@workspace:ai"],
 
@@ -2033,7 +2056,7 @@
 
     "builtin-modules": ["builtin-modules@3.3.0", "", {}, "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw=="],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "busboy": ["busboy@1.6.0", "", { "dependencies": { "streamsearch": "^1.1.0" } }, "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA=="],
 
@@ -2689,7 +2712,7 @@
 
     "http-proxy-agent": ["http-proxy-agent@5.0.0", "", { "dependencies": { "@tootallnate/once": "2", "agent-base": "6", "debug": "4" } }, "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w=="],
 
-    "http-proxy-middleware": ["http-proxy-middleware@2.0.9", "", { "dependencies": { "@types/http-proxy": "^1.17.8", "http-proxy": "^1.18.1", "is-glob": "^4.0.1", "is-plain-obj": "^3.0.0", "micromatch": "^4.0.2" }, "peerDependencies": { "@types/express": "^4.17.13" }, "optionalPeers": ["@types/express"] }, "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q=="],
+    "http-proxy-middleware": ["http-proxy-middleware@3.0.5", "", { "dependencies": { "@types/http-proxy": "^1.17.15", "debug": "^4.3.6", "http-proxy": "^1.18.1", "is-glob": "^4.0.3", "is-plain-object": "^5.0.0", "micromatch": "^4.0.8" } }, "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
@@ -2774,6 +2797,8 @@
     "is-path-inside": ["is-path-inside@4.0.0", "", {}, "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="],
 
     "is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
+
+    "is-plain-object": ["is-plain-object@5.0.0", "", {}, "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="],
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
@@ -3281,7 +3306,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@3.0.1", "", {}, "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag=="],
+    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
@@ -4151,6 +4176,8 @@
 
     "@expo/cli/glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
+    "@expo/cli/picomatch": ["picomatch@3.0.1", "", {}, "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag=="],
+
     "@expo/cli/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
 
     "@expo/cli/undici": ["undici@6.24.0", "", {}, "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA=="],
@@ -4219,17 +4246,35 @@
 
     "@opentelemetry/exporter-logs-otlp-proto/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.213.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/otlp-transformer": "0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MegxAP1/n09Ob2dQvY5NBDVjAFkZRuKtWKxYev1R2M8hrsgXzQGkaMgoEKeUOyQ0FUyYcO29UOnYdQWmWa0PXg=="],
 
+    "@opentelemetry/exporter-logs-otlp-proto/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
+
     "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.213.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/otlp-transformer": "0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MegxAP1/n09Ob2dQvY5NBDVjAFkZRuKtWKxYev1R2M8hrsgXzQGkaMgoEKeUOyQ0FUyYcO29UOnYdQWmWa0PXg=="],
+
+    "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
 
     "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.213.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/otlp-transformer": "0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MegxAP1/n09Ob2dQvY5NBDVjAFkZRuKtWKxYev1R2M8hrsgXzQGkaMgoEKeUOyQ0FUyYcO29UOnYdQWmWa0PXg=="],
 
+    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
+
     "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.213.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/otlp-transformer": "0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MegxAP1/n09Ob2dQvY5NBDVjAFkZRuKtWKxYev1R2M8hrsgXzQGkaMgoEKeUOyQ0FUyYcO29UOnYdQWmWa0PXg=="],
+
+    "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
+
+    "@opentelemetry/exporter-prometheus/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
 
     "@opentelemetry/exporter-trace-otlp-grpc/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.213.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/otlp-transformer": "0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MegxAP1/n09Ob2dQvY5NBDVjAFkZRuKtWKxYev1R2M8hrsgXzQGkaMgoEKeUOyQ0FUyYcO29UOnYdQWmWa0PXg=="],
 
+    "@opentelemetry/exporter-trace-otlp-grpc/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
+
     "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.213.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/otlp-transformer": "0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MegxAP1/n09Ob2dQvY5NBDVjAFkZRuKtWKxYev1R2M8hrsgXzQGkaMgoEKeUOyQ0FUyYcO29UOnYdQWmWa0PXg=="],
 
+    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
+
     "@opentelemetry/exporter-trace-otlp-proto/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.213.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/otlp-transformer": "0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MegxAP1/n09Ob2dQvY5NBDVjAFkZRuKtWKxYev1R2M8hrsgXzQGkaMgoEKeUOyQ0FUyYcO29UOnYdQWmWa0PXg=="],
+
+    "@opentelemetry/exporter-trace-otlp-proto/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
+
+    "@opentelemetry/exporter-zipkin/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
 
     "@opentelemetry/instrumentation/require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
@@ -4285,6 +4330,18 @@
 
     "@opentelemetry/otlp-grpc-exporter-base/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.213.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/otlp-transformer": "0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MegxAP1/n09Ob2dQvY5NBDVjAFkZRuKtWKxYev1R2M8hrsgXzQGkaMgoEKeUOyQ0FUyYcO29UOnYdQWmWa0PXg=="],
 
+    "@opentelemetry/otlp-transformer/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
+
+    "@opentelemetry/resources/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/sdk-logs/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
+
+    "@opentelemetry/sdk-metrics/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
+
+    "@opentelemetry/sdk-node/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
+
+    "@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
+
     "@paralleldrive/cuid2/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@prisma/instrumentation/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA=="],
@@ -4322,6 +4379,8 @@
     "@sentry/node/@opentelemetry/instrumentation-http": ["@opentelemetry/instrumentation-http@0.211.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/instrumentation": "0.211.0", "@opentelemetry/semantic-conventions": "^1.29.0", "forwarded-parse": "2.1.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-n0IaQ6oVll9PP84SjbOCwDjaJasWRHi6BLsbMLiT6tNj7QbVOkuA5sk/EfZczwI0j5uTKl1awQPivO/ldVtsqA=="],
 
     "@sentry/node/@opentelemetry/instrumentation-mongoose": ["@opentelemetry/instrumentation-mongoose@0.57.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.211.0", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MthiekrU/BAJc5JZoZeJmo0OTX6ycJMiP6sMOSRTkvz5BrPMYDqaJos0OgsLPL/HpcgHP7eo5pduETuLguOqcg=="],
+
+    "@sentry/node/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
 
     "@sentry/node/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
@@ -4366,8 +4425,6 @@
     "@types/request/form-data": ["form-data@2.5.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.35", "safe-buffer": "^5.2.1" } }, "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A=="],
 
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
-
-    "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "asn1.js/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
@@ -4457,6 +4514,8 @@
 
     "fbjs/promise": ["promise@7.3.1", "", { "dependencies": { "asap": "~2.0.3" } }, "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="],
 
+    "fdir/picomatch": ["picomatch@3.0.1", "", {}, "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag=="],
+
     "fork-ts-checker-webpack-plugin/cosmiconfig": ["cosmiconfig@6.0.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.1.0", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.7.2" } }, "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg=="],
 
     "fork-ts-checker-webpack-plugin/fs-extra": ["fs-extra@9.0.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^1.0.0" } }, "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g=="],
@@ -4505,10 +4564,6 @@
 
     "http-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
-    "http-proxy-middleware/@types/express": ["@types/express@4.17.25", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^4.17.33", "@types/qs": "*", "@types/serve-static": "^1" } }, "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw=="],
-
-    "http-proxy-middleware/is-plain-obj": ["is-plain-obj@3.0.0", "", {}, "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA=="],
-
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "is-path-in-cwd/is-path-inside": ["is-path-inside@2.1.0", "", { "dependencies": { "path-is-inside": "^1.0.2" } }, "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg=="],
@@ -4520,8 +4575,6 @@
     "jest-haste-map/jest-worker": ["jest-worker@29.7.0", "", { "dependencies": { "@types/node": "*", "jest-util": "^29.7.0", "merge-stream": "^2.0.0", "supports-color": "^8.0.0" } }, "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw=="],
 
     "jest-matcher-utils/pretty-format": ["pretty-format@30.3.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ=="],
-
-    "jest-util/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
@@ -4574,8 +4627,6 @@
     "metro-transform-worker/metro": ["metro@0.83.3", "", { "dependencies": { "@babel/code-frame": "^7.24.7", "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/parser": "^7.25.3", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "@babel/types": "^7.25.2", "accepts": "^1.3.7", "chalk": "^4.0.0", "ci-info": "^2.0.0", "connect": "^3.6.5", "debug": "^4.4.0", "error-stack-parser": "^2.0.6", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "hermes-parser": "0.32.0", "image-size": "^1.0.2", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "jsc-safe-url": "^0.2.2", "lodash.throttle": "^4.1.1", "metro-babel-transformer": "0.83.3", "metro-cache": "0.83.3", "metro-cache-key": "0.83.3", "metro-config": "0.83.3", "metro-core": "0.83.3", "metro-file-map": "0.83.3", "metro-resolver": "0.83.3", "metro-runtime": "0.83.3", "metro-source-map": "0.83.3", "metro-symbolicate": "0.83.3", "metro-transform-plugins": "0.83.3", "metro-transform-worker": "0.83.3", "mime-types": "^2.1.27", "nullthrows": "^1.1.1", "serialize-error": "^2.1.0", "source-map": "^0.5.6", "throat": "^5.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "bin": { "metro": "src/cli.js" } }, "sha512-+rP+/GieOzkt97hSJ0MrPOuAH/jpaS21ZDvL9DJ35QYRDlQcwzcvUlGUf79AnQxq/2NPiS/AULhhM4TKutIt8Q=="],
 
     "metro-transform-worker/metro-source-map": ["metro-source-map@0.83.3", "", { "dependencies": { "@babel/traverse": "^7.25.3", "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-symbolicate": "0.83.3", "nullthrows": "^1.1.1", "ob1": "0.83.3", "source-map": "^0.5.6", "vlq": "^1.0.0" } }, "sha512-xkC3qwUBh2psVZgVavo8+r2C9Igkk3DibiOXSAht1aYRRcztEZNFtAMtfSB7sdO2iFMx2Mlyu++cBxz/fhdzQg=="],
-
-    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "miller-rabin/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
@@ -4644,8 +4695,6 @@
     "react-native-web/memoize-one": ["memoize-one@6.0.0", "", {}, "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="],
 
     "react-native-worklets/@babel/preset-typescript": ["@babel/preset-typescript@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ=="],
-
-    "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "recursive-readdir/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
@@ -4728,6 +4777,8 @@
     "webpack-dev-server/@types/serve-static": ["@types/serve-static@1.15.10", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "<1" } }, "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw=="],
 
     "webpack-dev-server/express": ["express@4.22.1", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.3", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.14.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g=="],
+
+    "webpack-dev-server/http-proxy-middleware": ["http-proxy-middleware@2.0.9", "", { "dependencies": { "@types/http-proxy": "^1.17.8", "http-proxy": "^1.18.1", "is-glob": "^4.0.1", "is-plain-obj": "^3.0.0", "micromatch": "^4.0.2" }, "peerDependencies": { "@types/express": "^4.17.13" }, "optionalPeers": ["@types/express"] }, "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q=="],
 
     "webpack-dev-server/ipaddr.js": ["ipaddr.js@2.3.0", "", {}, "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg=="],
 
@@ -4967,8 +5018,6 @@
 
     "@opentelemetry/otlp-exporter-base/@opentelemetry/otlp-transformer/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.217.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A=="],
 
-    "@opentelemetry/otlp-exporter-base/@opentelemetry/otlp-transformer/@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
-
     "@opentelemetry/otlp-exporter-base/@opentelemetry/otlp-transformer/@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.217.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.217.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-BB+PcHItcZDL63dPMW+mJvwN9rk37wuIDjRxbVlg6pPDvDR/7GL7UJHbGsllgoggOoTimsKgENaWPoGch/oE1A=="],
 
     "@opentelemetry/otlp-exporter-base/@opentelemetry/otlp-transformer/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ=="],
@@ -5032,8 +5081,6 @@
     "@terreno/example-backend/@opentelemetry/sdk-node/@opentelemetry/propagator-b3": ["@opentelemetry/propagator-b3@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-RJid6E2CKyeGfKBzXKF21ejabGMHypFkPAh3qZ+NvI+SGjuIye79t3PmiqcDgtRzdKH6ynXzbfslQ8DfpRUg2A=="],
 
     "@terreno/example-backend/@opentelemetry/sdk-node/@opentelemetry/propagator-jaeger": ["@opentelemetry/propagator-jaeger@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q=="],
-
-    "@terreno/example-backend/@opentelemetry/sdk-node/@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
 
     "@terreno/example-backend/@opentelemetry/sdk-node/@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.217.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.217.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-BB+PcHItcZDL63dPMW+mJvwN9rk37wuIDjRxbVlg6pPDvDR/7GL7UJHbGsllgoggOoTimsKgENaWPoGch/oE1A=="],
 
@@ -5144,10 +5191,6 @@
     "http-assert/http-errors/depd": ["depd@1.1.2", "", {}, "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="],
 
     "http-assert/http-errors/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
-
-    "http-proxy-middleware/@types/express/@types/express-serve-static-core": ["@types/express-serve-static-core@4.19.8", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA=="],
-
-    "http-proxy-middleware/@types/express/@types/serve-static": ["@types/serve-static@1.15.10", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "<1" } }, "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw=="],
 
     "jest-diff/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
 
@@ -5323,6 +5366,8 @@
 
     "webpack-dev-server/express/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
+    "webpack-dev-server/http-proxy-middleware/is-plain-obj": ["is-plain-obj@3.0.0", "", {}, "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA=="],
+
     "webpack-dev-server/schema-utils/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
 
     "webpack-manifest-plugin/webpack-sources/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
@@ -5436,8 +5481,6 @@
     "fastmcp/yargs/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "fastmcp/yargs/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
-    "http-proxy-middleware/@types/express/@types/serve-static/@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
 
     "jest-diff/pretty-format/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
 

--- a/example-backend/package.json
+++ b/example-backend/package.json
@@ -17,6 +17,7 @@
     "@socket.io/mongo-adapter": "^0.4.0",
     "@socket.io/redis-adapter": "^8.3.0",
     "@terreno/admin-backend": "workspace:*",
+    "@terreno/admin-spa": "workspace:*",
     "@terreno/ai": "workspace:*",
     "@terreno/api": "workspace:*",
     "@terreno/api-health": "workspace:*",

--- a/example-backend/src/server.ts
+++ b/example-backend/src/server.ts
@@ -1,6 +1,7 @@
 import {LoggingWinston} from "@google-cloud/logging-winston";
 import * as Sentry from "@sentry/bun";
 import {AdminApp, DocumentStorageApp} from "@terreno/admin-backend";
+import {AdminSpaServeApp} from "@terreno/admin-spa";
 import {LangfuseApp} from "@terreno/ai";
 import {
   type AuthProvider,
@@ -341,6 +342,22 @@ export async function start(skipListen = false): Promise<express.Application> {
           supportedLocales: ["en", "es"],
         })
       );
+
+    // Register the standalone admin SPA serve plugin when opted in. Gated on an env
+    // flag so it stays off in tests and for backend-only consumers.
+    if (process.env.ADMIN_SPA_ENABLED === "true") {
+      terraApp.register(
+        new AdminSpaServeApp({
+          appConfig: {
+            brandName: "Terreno Example",
+            primaryColor: "#7C3AED",
+            providers: ["email", "google"],
+          },
+          basePath: "/console",
+          devProxyTarget: process.env.ADMIN_SPA_DEV_PROXY,
+        })
+      );
+    }
 
     // Register Better Auth plugin if configured
     if (betterAuthConfig) {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,10 @@
     "admin-backend:test": "bun run --filter '@terreno/admin-backend' test",
     "admin-frontend:compile": "bun run --filter '@terreno/admin-frontend' compile",
     "admin-frontend:lint": "bun run --filter '@terreno/admin-frontend' lint",
+    "admin-spa:build": "bun run --filter '@terreno/admin-spa' build:web",
+    "admin-spa:compile": "bun run --filter '@terreno/admin-spa' compile",
+    "admin-spa:lint": "bun run --filter '@terreno/admin-spa' lint",
+    "admin-spa:test": "bun run --filter '@terreno/admin-spa' test:ci",
     "ai:compile": "bun run --filter '@terreno/ai' compile",
     "ai:lint": "bun run --filter '@terreno/ai' lint",
     "ai:test": "bun run --filter '@terreno/ai' test",
@@ -141,6 +145,7 @@
   "workspaces": [
     "admin-backend",
     "admin-frontend",
+    "admin-spa",
     "ai",
     "api",
     "api-health",

--- a/rtk/src/constants.test.ts
+++ b/rtk/src/constants.test.ts
@@ -9,6 +9,7 @@ import {
   logAuth,
   logSocket,
   resolveBaseUrls,
+  SAME_ORIGIN_SENTINEL,
   setRealtimeDebug,
 } from "./constants";
 
@@ -186,6 +187,70 @@ describe("resolveBaseUrls", () => {
     expect(urls.baseUrl).toBe("https://backend.example.com");
     expect(urls.baseWebsocketsUrl).toBe("https://backend.example.com/");
     expect(urls.baseTasksUrl).toBe("https://backend.example.com/tasks");
+  });
+
+  it("resolves the same-origin sentinel to the window origin (https -> wss)", () => {
+    const urls = resolveBaseUrls({
+      expoConstants: {expoConfig: {extra: {BASE_URL: SAME_ORIGIN_SENTINEL}}},
+      isDev: false,
+      windowOrigin: "https://api.example.com",
+    });
+    expect(urls.baseUrl).toBe("https://api.example.com");
+    expect(urls.baseWebsocketsUrl).toBe("wss://api.example.com/");
+    expect(urls.baseTasksUrl).toBe("https://api.example.com/tasks");
+  });
+
+  it("resolves the same-origin sentinel to the window origin (http -> ws)", () => {
+    const urls = resolveBaseUrls({
+      expoConstants: {expoConfig: {extra: {BASE_URL: SAME_ORIGIN_SENTINEL}}},
+      isDev: false,
+      windowOrigin: "http://localhost:4000",
+    });
+    expect(urls.baseUrl).toBe("http://localhost:4000");
+    expect(urls.baseWebsocketsUrl).toBe("ws://localhost:4000/");
+    expect(urls.baseTasksUrl).toBe("http://localhost:4000/tasks");
+  });
+
+  it("resolves the same-origin sentinel even in dev mode when a window origin exists", () => {
+    const urls = resolveBaseUrls({
+      expoConstants: {
+        expoConfig: {extra: {BASE_URL: SAME_ORIGIN_SENTINEL}, hostUri: "10.0.0.5:8081"},
+      },
+      isDev: true,
+      windowOrigin: "https://admin.example.com",
+    });
+    expect(urls.baseUrl).toBe("https://admin.example.com");
+    expect(urls.baseWebsocketsUrl).toBe("wss://admin.example.com/");
+  });
+
+  it("falls back to existing resolution when the sentinel is set but no window origin", () => {
+    const urls = resolveBaseUrls({
+      expoConstants: {expoConfig: {extra: {BASE_URL: SAME_ORIGIN_SENTINEL}}},
+      isDev: false,
+    });
+    expect(urls.baseUrl).toBe("http://localhost:4000");
+    expect(urls.baseWebsocketsUrl).toBe("ws://localhost:4000/");
+  });
+
+  it("does not treat the sentinel as a literal base URL when a window origin is absent", () => {
+    const urls = resolveBaseUrls({
+      expoConstants: {
+        expoConfig: {extra: {BASE_URL: SAME_ORIGIN_SENTINEL}, hostUri: "172.16.0.3:8081"},
+      },
+      isDev: false,
+    });
+    // Sentinel ignored -> falls through to hostUri resolution, not the literal "__SAME_ORIGIN__".
+    expect(urls.baseUrl).toBe("http://172.16.0.3:4000");
+  });
+
+  it("leaves a non-sentinel BASE_URL unchanged when a window origin is present", () => {
+    const urls = resolveBaseUrls({
+      expoConstants: {expoConfig: {extra: {BASE_URL: "https://api.prod.com"}}},
+      isDev: false,
+      windowOrigin: "https://some-other-origin.com",
+    });
+    expect(urls.baseUrl).toBe("https://api.prod.com");
+    expect(urls.baseWebsocketsUrl).toBe("https://ws.prod.com/");
   });
 });
 

--- a/rtk/src/constants.ts
+++ b/rtk/src/constants.ts
@@ -65,6 +65,13 @@ export interface BaseUrls {
   baseTasksUrl: string;
 }
 
+/**
+ * Sentinel value for `BASE_URL`. When set in `app.json` `extra.BASE_URL`, the
+ * base URL resolves to the runtime page origin (`window.location.origin`).
+ * Used by same-origin deployments such as the standalone admin SPA.
+ */
+export const SAME_ORIGIN_SENTINEL = "__SAME_ORIGIN__";
+
 const LOCALHOST: BaseUrls = {
   baseTasksUrl: "http://localhost:4000/tasks",
   baseUrl: "http://localhost:4000",
@@ -79,11 +86,28 @@ export const resolveBaseUrls = (args: {
   envApiUrl?: string;
   expoConstants: ExpoConstantsShape;
   isDev: boolean;
+  // Defaults to globalThis.location.origin at the module-level call site.
+  // Injectable so the sentinel resolution can be unit tested without a DOM.
+  windowOrigin?: string;
 }): BaseUrls => {
   const hostUriPrefix = args.expoConstants.expoConfig?.hostUri?.split(":").shift();
   const experiencePrefix = args.expoConstants.experienceUrl?.split(":")[1];
   const baseFromExtra = args.expoConstants.expoConfig?.extra?.BASE_URL;
-  const base = args.envApiUrl || (!args.isDev ? baseFromExtra : undefined);
+
+  // Same-origin sentinel: resolves to the page origin at runtime, regardless of
+  // isDev. This check must run before the isDev branching below, otherwise the
+  // sentinel would be silently dead in dev mode (which gates baseFromExtra).
+  if (baseFromExtra === SAME_ORIGIN_SENTINEL && args.windowOrigin) {
+    const origin = args.windowOrigin;
+    return {
+      baseTasksUrl: `${origin}/tasks`,
+      baseUrl: origin,
+      baseWebsocketsUrl: `${origin.replace(/^http/, "ws")}/`,
+    };
+  }
+  // Never treat the sentinel as a literal base URL in the fallback path.
+  const resolvedBaseFromExtra = baseFromExtra === SAME_ORIGIN_SENTINEL ? undefined : baseFromExtra;
+  const base = args.envApiUrl || (!args.isDev ? resolvedBaseFromExtra : undefined);
   const host = args.isDev ? hostUriPrefix : !base ? hostUriPrefix : undefined;
   const experience = !base && !host ? experiencePrefix : undefined;
   if (base)
@@ -117,10 +141,17 @@ if (Constants.expoGoConfig?.debuggerHost?.includes("exp.direct")) {
 
 const isDev = typeof __DEV__ !== "undefined" && __DEV__;
 
+const windowOrigin =
+  typeof globalThis !== "undefined" &&
+  (globalThis as {location?: {origin?: string}}).location?.origin
+    ? (globalThis as {location?: {origin?: string}}).location?.origin
+    : undefined;
+
 const resolved = resolveBaseUrls({
   envApiUrl: process.env.EXPO_PUBLIC_API_URL,
   expoConstants: Constants as ExpoConstantsShape,
   isDev,
+  windowOrigin,
 });
 
 export const baseUrl = resolved.baseUrl;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the backend-serving foundation of the [admin-only / admin SPA implementation plan](docs/implementationPlans/admin-only.md): a new `@terreno/admin-spa` package whose `AdminSpaServeApp` Express plugin serves a pre-built admin SPA from the same Node process as a Terreno backend (default mount `/console`), plus the same-origin base-URL support in `@terreno/rtk` and an opt-in example-backend integration.

This delivers the verifiable, self-contained backend slice of the plan. The SPA frontend itself and the supporting `@terreno/admin-frontend` prop split are intentionally deferred (see "Deferred" below).

### Phases implemented
- **Phase 2 — `@terreno/rtk` same-origin sentinel.** Adds `SAME_ORIGIN_SENTINEL = "__SAME_ORIGIN__"` and a `windowOrigin` param to `resolveBaseUrls`. When `BASE_URL` is the sentinel and a window origin is present, base URLs resolve to the runtime page origin (`https`→`wss`, `http`→`ws`) regardless of `isDev`; falls back to existing resolution when no origin exists. Full unit coverage in `rtk/src/constants.test.ts`.
- **Phase 1 — Package scaffold.** New `admin-spa/` workspace (package.json, `tsconfig.server.json`, biome, bunfig, `.gitignore`), wired into root `workspaces` with `admin-spa:*` scripts.
- **Phase 3 — `AdminSpaServeApp` Express plugin.** Serves hashed `_expo`/`assets` immutably; `index.html` + `app-config.json` with `no-store`; rewrites absolute `/_expo/` and `/assets/` refs to the configured `basePath` so one bundle works anywhere; Express 5 `basePath` + `${basePath}/*splat` fallback; optional `devProxyTarget`. Covered by 11 supertest cases.
- **Phase 7 — example-backend integration.** Registers `AdminSpaServeApp` gated on `ADMIN_SPA_ENABLED === "true"` (off by default), forwarding `ADMIN_SPA_DEV_PROXY`.
- **Phase 8 (partial) — docs.** Package README + `CLAUDE.local.md` packages entry.

### Deferred (require the Expo web toolchain / large refactor)
- **Phase 0** — split `baseUrl` into `apiBase`/`routeBase` across `@terreno/admin-frontend` (prerequisite for SPA navigation).
- **Phases 4–6** — the Expo Router SPA (`app/`, gates, login/forbidden, store/sdk glue, wired admin screens).
- **Phase 8.5/8.6** — publish CI job + CI smoke (meaningful only once `dist/` is produced by the web export).

## Walkthrough

End-to-end smoke test booting `example-backend` with `ADMIN_SPA_ENABLED=true` against a real `TerrenoApp` (MongoDB running): the plugin mounts at `/console/`, serves the configured branding, and `no-store`-caches HTML/config.

[admin_spa_smoke.log](https://cursor.com/agents/bc-4d01d941-172f-458c-b220-04cdd8f477e2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_spa_smoke.log)

- `GET /console/app-config.json` → 200, `Cache-Control: no-store`, `{"brandName":"Terreno Example","primaryColor":"#7C3AED","providers":["email","google"], ...}`
- `GET /console/` → 200, `text/html`, `no-store`
- `GET /console/users/abc` → 200 (SPA fallback)

## Testing
- ✅ `bun run rtk:test` (208 pass — includes 6 new sentinel cases)
- ✅ `bun run admin-spa:test` (11 supertest cases pass)
- ✅ `bun run admin-spa:compile`, `bun run admin-spa:lint`
- ✅ `bun run --filter '@terreno/example-backend' compile`
- ✅ Manual boot smoke (see walkthrough): example-backend with `ADMIN_SPA_ENABLED=true` serves `/console/*` correctly.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d01d941-172f-458c-b220-04cdd8f477e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d01d941-172f-458c-b220-04cdd8f477e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

