### PR TITLE
Separate demo card preview and text areas

### DIFF
--- a/demo/components/DemoHomePage.tsx
+++ b/demo/components/DemoHomePage.tsx
@@ -2,12 +2,13 @@ import {DemoConfig, type DemoConfiguration} from "@config";
 import {Box, Heading, Text} from "@terreno/ui";
 import {useNavigation} from "expo-router";
 import React, {useCallback, useEffect} from "react";
-import {ScrollView} from "react-native";
+import {Pressable, ScrollView, View} from "react-native";
 
 const CARD_WIDTH = 300;
 const CARD_HEIGHT = 280;
 const CARD_PREVIEW_HEIGHT = 176;
-const CARD_TEXT_HEIGHT = 104;
+const CARD_DIVIDER_HEIGHT = 4;
+const CARD_TEXT_HEIGHT = 100;
 const CARD_DESCRIPTION_LINES = 2;
 
 interface DemoCardProps {
@@ -25,49 +26,48 @@ const DemoCard: React.FC<DemoCardProps> = ({config, onPress}) => {
   }
 
   return (
-    <Box
+    <Pressable
       accessibilityHint={`Open the ${config.name} component demo.`}
       accessibilityLabel={`${config.name} demo card`}
-      color="base"
-      dangerouslySetInlineStyle={{
-        __style: {
-          borderColor: "#ccc",
-          borderWidth: 1,
-        },
-      }}
-      direction="column"
-      display="flex"
-      height={CARD_HEIGHT}
-      margin={2}
-      maxHeight={CARD_HEIGHT}
-      maxWidth={CARD_WIDTH}
-      minHeight={CARD_HEIGHT}
-      onClick={handlePress}
-      overflow="hidden"
-      rounding="md"
-      width={CARD_WIDTH}
+      onPress={handlePress}
     >
-      <Box
-        alignItems="center"
-        color="neutralLight"
-        display="flex"
-        height={CARD_PREVIEW_HEIGHT}
-        justifyContent="center"
-        overflow="hidden"
-        padding={4}
-        width="100%"
+      <View
+        style={{
+          borderColor: "#ccc",
+          borderRadius: 4,
+          borderWidth: 1,
+          height: CARD_HEIGHT,
+          margin: 8,
+          maxHeight: CARD_HEIGHT,
+          maxWidth: CARD_WIDTH,
+          minHeight: CARD_HEIGHT,
+          overflow: "hidden",
+          width: CARD_WIDTH,
+        }}
       >
-        {config.demo({preview: true})}
-      </Box>
-      <Box borderTop="default" height={CARD_TEXT_HEIGHT} padding={4} width="100%">
-        <Box marginBottom={1}>
-          <Heading size="sm">{config.name}</Heading>
+        <Box
+          alignItems="center"
+          color="neutralLight"
+          display="flex"
+          height={CARD_PREVIEW_HEIGHT}
+          justifyContent="center"
+          overflow="hidden"
+          padding={4}
+          width="100%"
+        >
+          {config.demo({preview: true})}
         </Box>
-        <Text numberOfLines={CARD_DESCRIPTION_LINES} size="sm">
-          {config.shortDescription ?? config.description}
-        </Text>
-      </Box>
-    </Box>
+        <Box color="neutral" height={CARD_DIVIDER_HEIGHT} width="100%" />
+        <Box color="base" height={CARD_TEXT_HEIGHT} padding={4} width="100%">
+          <Box marginBottom={1}>
+            <Heading size="sm">{config.name}</Heading>
+          </Box>
+          <Text numberOfLines={CARD_DESCRIPTION_LINES} size="sm">
+            {config.shortDescription ?? config.description}
+          </Text>
+        </Box>
+      </View>
+    </Pressable>
   );
 };
 

--- a/demo/components/DemoHomePage.tsx
+++ b/demo/components/DemoHomePage.tsx
@@ -1,14 +1,81 @@
-import {DemoConfig} from "@config";
+import {DemoConfig, type DemoConfiguration} from "@config";
 import {Box, Heading, Text} from "@terreno/ui";
 import {useNavigation} from "expo-router";
-import {type FC, useEffect} from "react";
-import {Pressable, ScrollView, View} from "react-native";
+import React, {useCallback, useEffect} from "react";
+import {ScrollView} from "react-native";
 
-export const DemoHomePage: FC<{
+const CARD_WIDTH = 300;
+const CARD_HEIGHT = 280;
+const CARD_PREVIEW_HEIGHT = 176;
+const CARD_TEXT_HEIGHT = 104;
+const CARD_DESCRIPTION_LINES = 2;
+
+interface DemoCardProps {
+  config: DemoConfiguration;
+  onPress: (componentName: string) => void;
+}
+
+const DemoCard: React.FC<DemoCardProps> = ({config, onPress}) => {
+  const handlePress = useCallback(async (): Promise<void> => {
+    onPress(config.name);
+  }, [config.name, onPress]);
+
+  if (!config.name || !config.demo) {
+    return null;
+  }
+
+  return (
+    <Box
+      accessibilityHint={`Open the ${config.name} component demo.`}
+      accessibilityLabel={`${config.name} demo card`}
+      color="base"
+      dangerouslySetInlineStyle={{
+        __style: {
+          borderColor: "#ccc",
+          borderWidth: 1,
+        },
+      }}
+      direction="column"
+      display="flex"
+      height={CARD_HEIGHT}
+      margin={2}
+      maxHeight={CARD_HEIGHT}
+      maxWidth={CARD_WIDTH}
+      minHeight={CARD_HEIGHT}
+      onClick={handlePress}
+      overflow="hidden"
+      rounding="md"
+      width={CARD_WIDTH}
+    >
+      <Box
+        alignItems="center"
+        color="neutralLight"
+        display="flex"
+        height={CARD_PREVIEW_HEIGHT}
+        justifyContent="center"
+        overflow="hidden"
+        padding={4}
+        width="100%"
+      >
+        {config.demo({preview: true})}
+      </Box>
+      <Box borderTop="default" height={CARD_TEXT_HEIGHT} padding={4} width="100%">
+        <Box marginBottom={1}>
+          <Heading size="sm">{config.name}</Heading>
+        </Box>
+        <Text numberOfLines={CARD_DESCRIPTION_LINES} size="sm">
+          {config.shortDescription ?? config.description}
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+export const DemoHomePage: React.FC<{
   onPress: (componentName: string) => void;
 }> = ({onPress}) => {
   const navigation = useNavigation();
-  // Set the title
+  // Keep the browser title aligned with the demo index route.
   useEffect(() => {
     navigation.setOptions({title: "Terreno UI Demo"});
   }, [navigation]);
@@ -23,43 +90,9 @@ export const DemoHomePage: FC<{
       }}
       style={{padding: 20, width: "100%"}}
     >
-      {DemoConfig.map((c) => {
-        if (!c.name || !c.demo) {
-          return null;
-        }
-        return (
-          <Pressable key={c.name} onPress={() => onPress(c.name)}>
-            <View
-              style={{
-                borderColor: "#ccc",
-                borderRadius: 4,
-                borderWidth: 1,
-                flex: 1,
-                height: 280,
-                margin: 8,
-                maxHeight: 280,
-                maxWidth: 300,
-                minHeight: 280,
-                overflow: "hidden",
-                padding: 16,
-                width: 300,
-              }}
-            >
-              <Box flex="grow" width="100%">
-                {c.demo({preview: true})}
-              </Box>
-              <Box height={100} marginTop={4}>
-                <Box marginBottom={1}>
-                  <Heading size="sm">{c.name}</Heading>
-                </Box>
-                <Box>
-                  <Text>{c.shortDescription ?? c.description}</Text>
-                </Box>
-              </Box>
-            </View>
-          </Pressable>
-        );
-      })}
+      {DemoConfig.map((config) => (
+        <DemoCard config={config} key={config.name} onPress={onPress} />
+      ))}
     </ScrollView>
   );
 };

--- a/demo/stories/EmailField.stories.tsx
+++ b/demo/stories/EmailField.stories.tsx
@@ -1,8 +1,9 @@
 import {Box, EmailField, Text} from "@terreno/ui";
 import {type ReactElement, useState} from "react";
 
-export const EmailFieldDemo = (): ReactElement => {
+export const EmailFieldDemo = (props: {preview?: boolean}): ReactElement => {
   const [value, setValue] = useState("dwight@example.com");
+
   return (
     <>
       <EmailField
@@ -11,10 +12,12 @@ export const EmailFieldDemo = (): ReactElement => {
         title="Email"
         value={value}
       />
-      <Box marginTop={2}>
-        <Text>We only return correct email address back to the parent component.</Text>
-        <Text>Returned Value: {value}</Text>
-      </Box>
+      {!props.preview && (
+        <Box marginTop={2}>
+          <Text>We only return correct email address back to the parent component.</Text>
+          <Text>Returned Value: {value}</Text>
+        </Box>
+      )}
     </>
   );
 };

--- a/demo/stories/Heading.stories.tsx
+++ b/demo/stories/Heading.stories.tsx
@@ -4,6 +4,18 @@ import {View} from "react-native";
 
 import {StorybookContainer} from "./StorybookContainer";
 
+export const HeadingPreview = (): React.ReactElement => {
+  return (
+    <Box direction="column" gap={1} width="100%">
+      {renderHeadingText("Small heading", {size: "sm"})}
+      {renderHeadingText("Medium heading", {size: "md"})}
+      {renderHeadingText("Large heading", {size: "lg"})}
+      {renderHeadingText("Accent", {color: "accent"})}
+      {renderHeadingText("Error", {color: "error"})}
+    </Box>
+  );
+};
+
 export const renderHeadingText = (text: string, props: Partial<HeadingProps>) => {
   return (
     <Box paddingY={1} width="100%">

--- a/demo/stories/Page.stories.tsx
+++ b/demo/stories/Page.stories.tsx
@@ -1,8 +1,13 @@
-import {Page, type PageProps} from "@terreno/ui";
+import {Box, Page, type PageProps} from "@terreno/ui";
 import React from "react";
 
-export const PageDemo = (props: Partial<PageProps>): React.ReactElement => {
-  return <Page title="Page Title" {...props} />;
+export const PageDemo = (props: Partial<PageProps> & {preview?: boolean}): React.ReactElement => {
+  if (props.preview) {
+    return <Box />;
+  }
+
+  const {preview: _preview, ...pageProps} = props;
+  return <Page title="Page Title" {...pageProps} />;
 };
 
 export const PageLoadingBoolean = (): React.ReactElement => {

--- a/demo/stories/PhoneNumberField.stories.tsx
+++ b/demo/stories/PhoneNumberField.stories.tsx
@@ -1,8 +1,9 @@
 import {Box, PhoneNumberField, Text} from "@terreno/ui";
 import {type ReactElement, useState} from "react";
 
-export const PhoneNumberFieldDemo = (): ReactElement => {
+export const PhoneNumberFieldDemo = (props: {preview?: boolean}): ReactElement => {
   const [value, setValue] = useState("(608) 222-2222");
+
   return (
     <>
       <PhoneNumberField
@@ -11,10 +12,12 @@ export const PhoneNumberFieldDemo = (): ReactElement => {
         title="Phone Number"
         value={value}
       />
-      <Box marginTop={2}>
-        <Text>We only return correct phone numbers back to the parent component.</Text>
-        <Text>Returned Value: {value}</Text>
-      </Box>
+      {!props.preview && (
+        <Box marginTop={2}>
+          <Text>We only return correct phone numbers back to the parent component.</Text>
+          <Text>Returned Value: {value}</Text>
+        </Box>
+      )}
     </>
   );
 };

--- a/demo/stories/SidebarNavigation.stories.tsx
+++ b/demo/stories/SidebarNavigation.stories.tsx
@@ -9,11 +9,11 @@ export const SidebarNavigationDemo: FC<{
   itemBackgroundColor?: string;
   badgeStatus?: SidebarBadgeStatus;
 }> = ({preview, panelBackgroundColor, itemBackgroundColor, badgeStatus}) => {
+  const [activeRoute, setActiveRoute] = useState("index");
+
   if (preview) {
     return <Box />;
   }
-
-  const [activeRoute, setActiveRoute] = useState("index");
 
   const panelStyle = panelBackgroundColor ? {backgroundColor: panelBackgroundColor} : undefined;
   const itemStyle = itemBackgroundColor ? {backgroundColor: itemBackgroundColor} : undefined;

--- a/demo/stories/SidebarNavigation.stories.tsx
+++ b/demo/stories/SidebarNavigation.stories.tsx
@@ -4,10 +4,15 @@ import {router} from "expo-router";
 import {type FC, useState} from "react";
 
 export const SidebarNavigationDemo: FC<{
+  preview?: boolean;
   panelBackgroundColor?: string;
   itemBackgroundColor?: string;
   badgeStatus?: SidebarBadgeStatus;
-}> = ({panelBackgroundColor, itemBackgroundColor, badgeStatus}) => {
+}> = ({preview, panelBackgroundColor, itemBackgroundColor, badgeStatus}) => {
+  if (preview) {
+    return <Box />;
+  }
+
   const [activeRoute, setActiveRoute] = useState("index");
 
   const panelStyle = panelBackgroundColor ? {backgroundColor: panelBackgroundColor} : undefined;

--- a/demo/stories/Text.stories.tsx
+++ b/demo/stories/Text.stories.tsx
@@ -3,6 +3,21 @@ import type React from "react";
 
 import {StorybookContainer} from "./StorybookContainer";
 
+export const TextPreview = (): React.ReactElement => {
+  return (
+    <Box direction="column" gap={1} width="100%">
+      {renderText("Default text", {})}
+      {renderText("Small", {size: "sm"})}
+      {renderText("Large", {size: "lg"})}
+      {renderText("Bold", {bold: true})}
+      {renderText("Italic", {italic: true})}
+      {renderText("Accent", {color: "accent"})}
+      {renderText("Error", {color: "error"})}
+      {renderText("Success", {color: "success"})}
+    </Box>
+  );
+};
+
 export const renderText = (text: string, props: Partial<TextProps>) => {
   return (
     <Box key={text} paddingY={1} width="100%">

--- a/demo/story-config/EmailField.config.tsx
+++ b/demo/story-config/EmailField.config.tsx
@@ -27,7 +27,7 @@ export const EmailFieldConfiguration: DemoConfiguration = {
   demoOptions: {},
   stories: {
     "Email Field": {
-      render: EmailFieldDemo,
+      render: () => <EmailFieldDemo />,
     },
   },
 };

--- a/demo/story-config/Heading.config.tsx
+++ b/demo/story-config/Heading.config.tsx
@@ -1,5 +1,5 @@
 import {DemoConfiguration} from "@config";
-import {Headings, renderHeadingText} from "@stories";
+import {HeadingPreview, Headings, renderHeadingText} from "@stories";
 import {HeadingProps} from "@terreno/ui";
 
 export const HeadingConfiguration: DemoConfiguration = {
@@ -24,9 +24,12 @@ export const HeadingConfiguration: DemoConfiguration = {
     doNot: [],
   },
   props: {},
-  demo: (props: HeadingProps & {text: string}) => {
-    const {text, ...rest} = props;
-    return renderHeadingText(text, rest);
+  demo: (props: HeadingProps & {text?: string; preview?: boolean}) => {
+    if (props.preview) {
+      return <HeadingPreview />;
+    }
+    const {text, preview: _preview, ...rest} = props;
+    return renderHeadingText(text ?? "Heading", rest);
   },
   demoOptions: {},
   stories: {

--- a/demo/story-config/PhoneNumberField.config.tsx
+++ b/demo/story-config/PhoneNumberField.config.tsx
@@ -27,7 +27,7 @@ export const PhoneNumberConfiguration: DemoConfiguration = {
   demoOptions: {},
   stories: {
     "Phone Number Field": {
-      render: PhoneNumberFieldDemo,
+      render: () => <PhoneNumberFieldDemo />,
     },
   },
 };

--- a/demo/story-config/Text.config.tsx
+++ b/demo/story-config/Text.config.tsx
@@ -1,5 +1,5 @@
 import {DemoConfiguration} from "@config";
-import {renderText, TextLinks, Texts, Truncate} from "@stories";
+import {renderText, TextLinks, TextPreview, Texts, Truncate} from "@stories";
 import {Text, TextProps} from "@terreno/ui";
 
 export const TextConfiguration: DemoConfiguration = {
@@ -24,9 +24,12 @@ export const TextConfiguration: DemoConfiguration = {
     doNot: [],
   },
   props: {},
-  demo: (props: TextProps & {text: string}) => {
-    const {text, ...rest} = props;
-    return renderText(text, rest);
+  demo: (props: TextProps & {text?: string; preview?: boolean}) => {
+    if (props.preview) {
+      return <TextPreview />;
+    }
+    const {text, preview: _preview, ...rest} = props;
+    return renderText(text ?? "default", rest);
   },
   demoOptions: {},
   stories: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Split demo index cards into fixed preview and text sections.
- Added a visible divider strip between the preview and text sections.
- Limited card descriptions to two lines so card text stays shorter.
- Kept each card's preview, divider, and text sections attached during page scroll.

### Validation
- `bun run demo:lint`
- `bun run ui:compile && bun run demo:compile`
- Manual browser walkthrough of `http://localhost:8085/demo`

### Walkthrough
[demo_card_grid_fixed_sections_corrected.mp4](https://cursor.com/agents/bc-3c850555-63f3-46f1-89ac-50e248556dd0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_card_grid_fixed_sections_corrected.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c850555-63f3-46f1-89ac-50e248556dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c850555-63f3-46f1-89ac-50e248556dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

