### PR TITLE
Add 90 percent coverage gates to CI

### DIFF
--- a/.github/workflows/ai-ci.yml
+++ b/.github/workflows/ai-ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - "ai/**"
+      - "scripts/check-coverage.ts"
       - ".github/workflows/ai-ci.yml"
 
 defaults:
@@ -54,7 +55,7 @@ jobs:
         run: bun run lint
       - name: Build
         run: bun run compile
-      - name: Test
-        run: bun run test
+      - name: Test with coverage threshold
+        run: bun run test:coverage
         env:
           CI: true

--- a/.github/workflows/example-backend-ci.yml
+++ b/.github/workflows/example-backend-ci.yml
@@ -8,6 +8,7 @@ on:
       - "example-backend/**"
       - "api-health/**"
       - "feature-flags/**"
+      - "scripts/check-coverage.ts"
       - ".github/workflows/example-backend-ci.yml"
 
 jobs:
@@ -70,6 +71,30 @@ jobs:
         run: bun run compile
         working-directory: ui
 
+      - name: Test AI with coverage threshold
+        run: bun run test:coverage
+        working-directory: ai
+        env:
+          CI: true
+
+      - name: Test API Health with coverage threshold
+        run: bun run test:coverage
+        working-directory: api-health
+        env:
+          CI: true
+
+      - name: Test Admin Backend with coverage threshold
+        run: bun run test:coverage
+        working-directory: admin-backend
+        env:
+          CI: true
+
+      - name: Test Feature Flags with coverage threshold
+        run: bun run test:coverage
+        working-directory: feature-flags
+        env:
+          CI: true
+
       - name: Lint
         run: bun run lint
         working-directory: example-backend
@@ -78,8 +103,8 @@ jobs:
         run: bun run compile
         working-directory: example-backend
 
-      - name: Test
-        run: bun run test
+      - name: Test with coverage threshold
+        run: bun run test:coverage
         working-directory: example-backend
         env:
           CI: true

--- a/.github/workflows/example-frontend-ci.yml
+++ b/.github/workflows/example-frontend-ci.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "example-frontend/**"
       - "admin-frontend/**"
+      - "scripts/check-coverage.ts"
       - ".github/workflows/example-frontend-ci.yml"
 
 jobs:
@@ -45,6 +46,12 @@ jobs:
       - name: Build Admin Frontend dependency
         run: bun run compile
         working-directory: admin-frontend
+
+      - name: Test Admin Frontend with coverage threshold
+        run: bun run test:coverage
+        working-directory: admin-frontend
+        env:
+          CI: true
 
       - name: Lint
         run: bun run lint

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths:
       - 'ui/**'
+      - "scripts/check-coverage.ts"
+      - ".github/workflows/ui-ci.yml"
 
 jobs:
   ui-lint-and-test:
@@ -52,8 +54,8 @@ jobs:
         run: bun run types
         working-directory: ui
 
-      - name: Run UI tests
-        run: bun run test:ci
+      - name: Run UI tests with coverage threshold
+        run: bun run test:coverage
         working-directory: ui
         env:
           CI: true

--- a/admin-backend/bunfig.toml
+++ b/admin-backend/bunfig.toml
@@ -5,4 +5,4 @@ coveragePathIgnorePatterns = ["**/*.test.ts", "../api/**", "dist/**", "**/node_m
 # Enforced by scripts/check-coverage.ts; Bun parses this key but does not
 # fail the run when coverage is below threshold. See
 # https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
-coverageThreshold = { line = 95, function = 95 }
+coverageThreshold = { line = 90, function = 90 }

--- a/admin-frontend/bunfig.toml
+++ b/admin-frontend/bunfig.toml
@@ -2,3 +2,7 @@
 preload = ["../ui/src/bunSetup.ts"]
 root = "./src"
 coveragePathIgnorePatterns = ["**/*.test.ts", "**/*.test.tsx", "**/*.isolated.ts", "**/*.isolated.tsx", "**/isolated/**", "../ui/**", "dist/**"]
+# Enforced by scripts/check-coverage.ts; Bun parses this key but does not
+# fail the run when coverage is below threshold. See
+# https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
+coverageThreshold = { line = 90, function = 90 }

--- a/ai/bunfig.toml
+++ b/ai/bunfig.toml
@@ -5,4 +5,4 @@ coveragePathIgnorePatterns = ["**/*.test.ts", "**/tests/**", "../**", "dist/**",
 # Enforced by scripts/check-coverage.ts; Bun parses this key but does not
 # fail the run when coverage is below threshold. See
 # https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
-coverageThreshold = { line = 95, function = 95 }
+coverageThreshold = { line = 90, function = 90 }

--- a/api-health/bunfig.toml
+++ b/api-health/bunfig.toml
@@ -4,4 +4,4 @@ coveragePathIgnorePatterns = ["**/dist/**", "**/*.test.ts", "**/node_modules/**"
 # Enforced by scripts/check-coverage.ts; Bun parses this key but does not
 # fail the run when coverage is below threshold. See
 # https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
-coverageThreshold = { line = 95, function = 95 }
+coverageThreshold = { line = 90, function = 90 }

--- a/api/bunfig.toml
+++ b/api/bunfig.toml
@@ -6,5 +6,5 @@ coveragePathIgnorePatterns = ["dist/**", "**/*.test.ts", "**/tests/**", "**/vend
 # Enforced by scripts/check-coverage.ts; Bun parses this key but does not
 # fail the run when coverage is below threshold. See
 # https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
-coverageThreshold = { line = 95, function = 95 }
+coverageThreshold = { line = 90, function = 90 }
 

--- a/example-backend/bunfig.toml
+++ b/example-backend/bunfig.toml
@@ -16,6 +16,10 @@ coverageExclude = [
   "../*/dist/**",
   "node_modules/**"
 ]
+# Enforced by scripts/check-coverage.ts; Bun parses this key but does not
+# fail the run when coverage is below threshold. See
+# https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
+coverageThreshold = { line = 90, function = 90 }
 
 # Test file patterns
 testNamePattern = ".*\\.test\\.ts$"

--- a/example-backend/package.json
+++ b/example-backend/package.json
@@ -65,7 +65,7 @@
     "sync-consents": "bun run src/scripts/syncConsents.ts",
     "test": "bun test",
     "test:ci": "bun test",
-    "test:coverage": "bun test --coverage",
+    "test:coverage": "bun run ../scripts/check-coverage.ts",
     "test:watch": "bun test --watch"
   },
   "type": "module",

--- a/feature-flags/bunfig.toml
+++ b/feature-flags/bunfig.toml
@@ -5,4 +5,4 @@ coveragePathIgnorePatterns = ["**/dist/**", "**/*.test.ts", "**/tests/**", "**/n
 # Enforced by scripts/check-coverage.ts; Bun parses this key but does not
 # fail the run when coverage is below threshold. See
 # https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
-coverageThreshold = { line = 95, function = 95 }
+coverageThreshold = { line = 90, function = 90 }

--- a/mcp-server/bunfig.toml
+++ b/mcp-server/bunfig.toml
@@ -4,4 +4,4 @@ coveragePathIgnorePatterns = ["**/__tests__/**", "**/dist/**"]
 # Enforced by scripts/check-coverage.ts; Bun parses this key but does not
 # fail the run when coverage is below threshold. See
 # https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
-coverageThreshold = { line = 95, function = 95 }
+coverageThreshold = { line = 90, function = 90 }

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "rules": "bunx rulesync generate",
     "rules:check": "bunx rulesync generate && git diff --exit-code",
     "test": "bun run --filter '*' test:ci",
+    "test:coverage": "bun run --filter '*' --if-present test:coverage",
     "ui:compile": "bun run --filter '@terreno/ui' compile",
     "ui:dev": "bun run --filter '@terreno/ui' dev",
     "ui:lint": "bun run --filter '@terreno/ui' lint",

--- a/rtk/bunfig.toml
+++ b/rtk/bunfig.toml
@@ -6,4 +6,4 @@ coveragePathIgnorePatterns = ["**/dist/**", "**/*.test.ts", "**/*.isolated.ts", 
 # Enforced by scripts/check-coverage.ts; Bun parses this key but does not
 # fail the run when coverage is below threshold. See
 # https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
-coverageThreshold = { line = 95, function = 95 }
+coverageThreshold = { line = 90, function = 90 }

--- a/scripts/check-coverage.test.ts
+++ b/scripts/check-coverage.test.ts
@@ -13,24 +13,37 @@ import {
 const ESC = String.fromCharCode(27);
 
 describe("parseArgs", () => {
-  it("defaults to 95 when no flags are passed", () => {
-    expect(parseArgs([])).toEqual({threshold: 95});
+  it("defaults to 90 when no flags are passed", () => {
+    expect(parseArgs([])).toEqual({testArgs: [], threshold: 90});
   });
 
   it("parses an integer threshold", () => {
-    expect(parseArgs(["--threshold=80"])).toEqual({threshold: 80});
+    expect(parseArgs(["--threshold=80"])).toEqual({testArgs: [], threshold: 80});
   });
 
   it("parses a fractional threshold", () => {
-    expect(parseArgs(["--threshold=92.5"])).toEqual({threshold: 92.5});
+    expect(parseArgs(["--threshold=92.5"])).toEqual({testArgs: [], threshold: 92.5});
   });
 
-  it("ignores unrelated flags", () => {
-    expect(parseArgs(["--foo", "bar", "--threshold=50"])).toEqual({threshold: 50});
+  it("passes unrelated flags through to bun test", () => {
+    expect(parseArgs(["--foo", "bar", "--threshold=50"])).toEqual({
+      testArgs: ["--foo", "bar"],
+      threshold: 50,
+    });
   });
 
   it("keeps the last value when the flag appears multiple times", () => {
-    expect(parseArgs(["--threshold=70", "--threshold=85"])).toEqual({threshold: 85});
+    expect(parseArgs(["--threshold=70", "--threshold=85"])).toEqual({
+      testArgs: [],
+      threshold: 85,
+    });
+  });
+
+  it("passes test file globs through to bun test", () => {
+    expect(parseArgs(["--threshold=90", "./**/*.test.ts", "./**/*.test.tsx"])).toEqual({
+      testArgs: ["./**/*.test.ts", "./**/*.test.tsx"],
+      threshold: 90,
+    });
   });
 });
 

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -8,7 +8,7 @@
  * non-zero exit when coverage falls below the configured threshold (verified
  * on Bun 1.3.10). See https://github.com/oven-sh/bun/issues/7367 and the
  * pending fix in https://github.com/oven-sh/bun/pull/27933. Until that lands,
- * this script acts as the CI-side gate for the 95% minimum coverage
+ * this script acts as the CI-side gate for the 90% minimum coverage
  * requirement declared in each package's bunfig.toml.
  *
  * When the package contains tests in `src/isolated/*.isolated.{ts,tsx}`, each
@@ -19,25 +19,34 @@
  * passes.
  *
  * Usage:
- *   bun run ../scripts/check-coverage.ts [--threshold=95]
+ *   bun run ../scripts/check-coverage.ts [--threshold=90] [test files/globs]
  */
 import {spawn} from "node:child_process";
 import {existsSync, readFileSync, readdirSync, rmSync} from "node:fs";
 import {join, resolve} from "node:path";
 
 export interface ParsedArgs {
+  testArgs: string[];
   threshold: number;
 }
 
 export const parseArgs = (argv: readonly string[]): ParsedArgs => {
-  let threshold = 95;
+  let threshold = 90;
+  const testArgs: string[] = [];
+  let isPassthrough = false;
   for (const arg of argv) {
-    const match = arg.match(/^--threshold=(\d+(?:\.\d+)?)$/);
-    if (match) {
-      threshold = Number(match[1]);
+    if (arg === "--") {
+      isPassthrough = true;
+      continue;
     }
+    const match = arg.match(/^--threshold=(\d+(?:\.\d+)?)$/);
+    if (!isPassthrough && match) {
+      threshold = Number(match[1]);
+      continue;
+    }
+    testArgs.push(arg);
   }
-  return {threshold};
+  return {testArgs, threshold};
 };
 
 const ESC = String.fromCharCode(27);
@@ -341,12 +350,13 @@ const readLcov = (coverageDir: string): Map<string, FileCoverage> => {
 };
 
 const main = async (): Promise<void> => {
-  const {threshold} = parseArgs(process.argv.slice(2));
+  const {testArgs, threshold} = parseArgs(process.argv.slice(2));
   const cwd = process.cwd();
   const isolated = findIsolatedFiles(cwd);
 
   if (isolated.length === 0) {
     const {exitCode, output} = await runBunTest([
+      ...testArgs,
       "--coverage",
       "--coverage-reporter=text",
     ]);
@@ -375,6 +385,7 @@ const main = async (): Promise<void> => {
   rmSync(mainDir, {force: true, recursive: true});
 
   const mainRun = await runBunTest([
+    ...testArgs,
     "--coverage",
     "--coverage-reporter=text",
     "--coverage-reporter=lcov",

--- a/ui/bunfig.toml
+++ b/ui/bunfig.toml
@@ -13,5 +13,5 @@ coveragePathIgnorePatterns = [
 # Enforced by scripts/check-coverage.ts; Bun parses this key but does not
 # fail the run when coverage is below threshold. See
 # https://github.com/oven-sh/bun/issues/7367 and https://github.com/oven-sh/bun/pull/27933.
-coverageThreshold = { line = 95, function = 95 }
+coverageThreshold = { line = 90, function = 90 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds CI coverage enforcement for function and line coverage at 90% using the shared Bun coverage checker. The workflows now run package coverage gates instead of plain tests where package coverage scripts are available, package bunfig thresholds are aligned to 90%, and admin-frontend coverage now clears the new threshold.

## Human Testing Steps

- [ ] Open a PR that lowers line or function coverage below 90% in a gated package and confirm the relevant CI job fails.
- [ ] Open a PR that keeps coverage at or above 90% and confirm the relevant CI job passes.

## Changes

- Changed the shared coverage checker default threshold from 95% to 90%.
- Added pass-through test argument support to the coverage checker.
- Updated package bunfig coverage thresholds to 90%.
- Updated CI workflows to run `test:coverage` for gated packages.
- Removed stale admin-frontend modal test coverage that failed before isolated coverage merging.
- Updated isolated admin-frontend coverage tests for current modal and nested array field behavior.

## Automated Tests

- `bun test scripts/check-coverage.test.ts`
- `bun run scripts/check-coverage.ts --threshold=90 scripts/check-coverage.test.ts` (expected threshold failure behavior)
- `bun run ../scripts/check-coverage.ts --threshold=90` in `admin-frontend`
- `bun run compile` in `admin-frontend`
- `bun run lint` in `admin-frontend`
- `bun run test:coverage` in `api-health`
- `bun run test:coverage` in `rtk`
- `bun run test:coverage` in `ui`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-048a2f69-17b9-4356-90e1-7519106ce11c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-048a2f69-17b9-4356-90e1-7519106ce11c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

