### PR TITLE
Allow credentialed CORS preflights

### DIFF
--- a/api/src/terrenoApp.test.ts
+++ b/api/src/terrenoApp.test.ts
@@ -51,6 +51,22 @@ describe("TerrenoApp", () => {
 
       expect(app).toBeDefined();
     });
+
+    it("allows flourish-lb Netlify preflight requests by default", async () => {
+      const origin = "https://flourish-lb.netlify.app";
+      const app = new TerrenoApp({
+        skipListen: true,
+        userModel: typedUserModel,
+      }).build();
+
+      const res = await supertest(app)
+        .options("/version-check?platform=web&version=3497")
+        .set("Access-Control-Request-Method", "GET")
+        .set("Origin", origin);
+
+      expect(res.status).toBe(204);
+      expect(res.headers["access-control-allow-origin"]).toBe(origin);
+    });
   });
 
   describe("start", () => {

--- a/api/src/terrenoApp.ts
+++ b/api/src/terrenoApp.ts
@@ -39,6 +39,10 @@ type CorsOrigin =
       ) => void
     ) => void);
 
+const reflectRequestOrigin: CorsOrigin = (requestOrigin, callback) => {
+  callback(null, requestOrigin ?? true);
+};
+
 /**
  * Configuration options for TerrenoApp.
  */
@@ -261,7 +265,7 @@ export class TerrenoApp {
 
     app.use(requestContextMiddleware);
 
-    app.use(cors({credentials: true, origin: options.corsOrigin ?? "*"}));
+    app.use(cors({credentials: true, origin: options.corsOrigin ?? reflectRequestOrigin}));
 
     // Apply custom middleware before JSON parsing
     for (const fn of this.middlewareFns) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Reflect the request origin for TerrenoApp's default credentialed CORS policy so browser preflight responses include a concrete `Access-Control-Allow-Origin` value.
- Add a regression test for `https://flourish-lb.netlify.app` preflighting `/version-check?platform=web&version=3497`.

## Testing
- `BUN_TEST_DISABLE_DB=true bun test --preload ./src/tests/bunSetup.ts ./src/terrenoApp.test.ts -t "allows flourish-lb Netlify preflight requests by default"`
- `bun run compile` in `api/`
- `bun run lint` in `api/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dfa2f35-01b1-47ac-b88e-60103d8f3c31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dfa2f35-01b1-47ac-b88e-60103d8f3c31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

