### PR TITLE
Vertex Enterprise models + configurable model registry

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "admin-backend": {
       "name": "@terreno/admin-backend",
-      "version": "0.14.2",
+      "version": "0.15.0",
       "dependencies": {
         "@google-cloud/storage": "^7.15.0",
         "@terreno/api": "workspace:*",
@@ -36,7 +36,7 @@
     },
     "admin-frontend": {
       "name": "@terreno/admin-frontend",
-      "version": "0.14.2",
+      "version": "0.15.0",
       "dependencies": {
         "@terreno/ui": "workspace:*",
         "expo-router": "catalog:",
@@ -67,7 +67,7 @@
     },
     "ai": {
       "name": "@terreno/ai",
-      "version": "0.14.2",
+      "version": "0.15.0",
       "dependencies": {
         "@ai-sdk/mcp": "^1.0.21",
         "@google-cloud/storage": "^7.15.0",
@@ -101,7 +101,7 @@
     },
     "api": {
       "name": "@terreno/api",
-      "version": "0.14.2",
+      "version": "0.15.0",
       "dependencies": {
         "@sentry/bun": "^10.25.0",
         "@sentry/profiling-node": "^10.25.0",
@@ -173,7 +173,7 @@
     },
     "api-health": {
       "name": "@terreno/api-health",
-      "version": "0.14.2",
+      "version": "0.15.0",
       "dependencies": {
         "@terreno/api": "workspace:*",
         "express": "^5.2.1",
@@ -362,7 +362,7 @@
     },
     "feature-flags": {
       "name": "@terreno/feature-flags",
-      "version": "0.14.2",
+      "version": "0.15.0",
       "dependencies": {
         "@terreno/api": "workspace:*",
         "express": "^5.2.1",
@@ -402,7 +402,7 @@
     },
     "rtk": {
       "name": "@terreno/rtk",
-      "version": "0.14.2",
+      "version": "0.15.0",
       "dependencies": {
         "@better-auth/expo": "^1.2.8",
         "@react-native-async-storage/async-storage": "catalog:",
@@ -441,7 +441,7 @@
     },
     "ui": {
       "name": "@terreno/ui",
-      "version": "0.14.2",
+      "version": "0.15.0",
       "dependencies": {
         "@expo-google-fonts/nunito": "^0.4.2",
         "@expo-google-fonts/titillium-web": "^0.4.1",

--- a/example-backend/.env.example
+++ b/example-backend/.env.example
@@ -10,6 +10,12 @@ REFRESH_TOKEN_EXPIRES_IN=30d
 # AI Provider - Vertex AI (preferred, uses Application Default Credentials)
 # GOOGLE_VERTEX_PROJECT=your-gcp-project-id
 # GOOGLE_VERTEX_LOCATION=us-central1
+# GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS=true
+# GOOGLE_VERTEX_ENABLE_MAAS_MODELS=true
+# GOOGLE_VERTEX_DEFAULT_MODEL=gemini-3.5-flash
+# GOOGLE_VERTEX_TITLE_MODEL=gemini-3.1-flash-lite
+# VERTEX_MODEL_CATALOG_MODE=extend
+# VERTEX_EXTRA_MODEL_CATALOG_JSON=[{"id":"my-model","label":"My Model","provider":"gemini"}]
 
 # AI Provider - Gemini API (fallback, uses API key)
 # GEMINI_API_KEY=your-gemini-api-key

--- a/example-backend/.env.example
+++ b/example-backend/.env.example
@@ -7,15 +7,5 @@ SESSION_SECRET=dev-session-secret
 TOKEN_EXPIRES_IN=15m
 REFRESH_TOKEN_EXPIRES_IN=30d
 
-# AI Provider - Vertex AI (preferred, uses Application Default Credentials)
-# GOOGLE_VERTEX_PROJECT=your-gcp-project-id
-# GOOGLE_VERTEX_LOCATION=us-central1
-# GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS=true
-# GOOGLE_VERTEX_ENABLE_MAAS_MODELS=true
-# GOOGLE_VERTEX_DEFAULT_MODEL=gemini-3.5-flash
-# GOOGLE_VERTEX_TITLE_MODEL=gemini-3.1-flash-lite
-# VERTEX_MODEL_CATALOG_MODE=extend
-# VERTEX_EXTRA_MODEL_CATALOG_JSON=[{"id":"my-model","label":"My Model","provider":"gemini"}]
-
-# AI Provider - Gemini API (fallback, uses API key)
-# GEMINI_API_KEY=your-gemini-api-key
+# Vertex AI and Gemini settings are configured in the admin panel (App Configuration → vertexAi).
+# Enable Vertex, set project/region, model catalog, and optional Gemini API fallback there.

--- a/example-backend/src/__snapshots__/openapi.test.ts.snap
+++ b/example-backend/src/__snapshots__/openapi.test.ts.snap
@@ -6457,6 +6457,96 @@ exports[`OpenAPI spec generation matches snapshot 1`] = `
         ],
       },
     },
+    "/gpt/models": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "defaultModelId": {
+                          "type": "string",
+                        },
+                        "models": {
+                          "items": {
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                        "titleModelId": {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Success",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
+              },
+            },
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "The user must be authenticated",
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
+              },
+            },
+            "description": "The user is not allowed to perform this action on this document",
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
+              },
+            },
+            "description": "Document not found",
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIError",
+                },
+              },
+            },
+            "description": "The user is not allowed to perform this action on any document",
+          },
+        },
+        "summary": "List available AI models for chat",
+        "tags": [
+          "gpt",
+        ],
+      },
+    },
     "/gpt/prompt": {
       "post": {
         "requestBody": {

--- a/example-backend/src/api/ai.ts
+++ b/example-backend/src/api/ai.ts
@@ -10,17 +10,17 @@ import {
   preparePromptForAI,
 } from "@terreno/ai";
 import type {ModelRouterOptions} from "@terreno/api";
-import {APIError, logger} from "@terreno/api";
+import {APIError, asyncHandler, authenticateMiddleware, createOpenApiBuilder, logger} from "@terreno/api";
 import type {ImageModel, LanguageModel, Tool} from "ai";
 import {generateImage, tool, zodSchema} from "ai";
 import type express from "express";
 import {PDFDocument, rgb, StandardFonts} from "pdf-lib";
 import {z} from "zod";
 import {
-  DEFAULT_VERTEX_MODEL_ID,
   getVertexGeminiProvider,
+  getVertexModelPickerOptions,
+  getVertexModelRegistry,
   resolveVertexLanguageModel,
-  TITLE_VERTEX_MODEL_ID,
 } from "./vertexModels";
 
 /** A provider that creates language models and image models from model IDs. */
@@ -39,6 +39,15 @@ let aiServiceInstance: AIService | undefined;
 let mcpServiceInstance: MCPService | undefined;
 let fileStorageServiceInstance: FileStorageService | undefined;
 
+/** Clears cached AIService so the next request picks up registry changes. */
+export const resetAiServiceCache = (): void => {
+  aiServiceInstance = undefined;
+};
+
+const getDefaultModelId = (): string => getVertexModelRegistry().getDefaultModelId();
+
+const getTitleModelId = (): string => getVertexModelRegistry().getTitleModelId();
+
 export const getFileStorageService = (): FileStorageService | undefined =>
   fileStorageServiceInstance;
 
@@ -54,9 +63,6 @@ const getGoogleModule = (): GoogleModule | undefined => {
   }
 };
 
-const DEFAULT_MODEL = DEFAULT_VERTEX_MODEL_ID;
-const TITLE_MODEL_ID = TITLE_VERTEX_MODEL_ID;
-
 const isVertexConfigured = (): boolean => Boolean(process.env.GOOGLE_VERTEX_PROJECT);
 
 const getAiService = (): AIService | undefined => {
@@ -66,7 +72,7 @@ const getAiService = (): AIService | undefined => {
 
   // Prefer Vertex AI / Gemini Enterprise (Application Default Credentials)
   if (isVertexConfigured()) {
-    const defaultModel = resolveVertexLanguageModel(DEFAULT_MODEL);
+    const defaultModel = resolveVertexLanguageModel(getDefaultModelId());
     if (defaultModel) {
       aiServiceInstance = new AIService({
         model: defaultModel,
@@ -88,7 +94,7 @@ const getAiService = (): AIService | undefined => {
 
   const provider = google.createGoogleGenerativeAI({apiKey});
   aiServiceInstance = new AIService({
-    model: provider(DEFAULT_MODEL),
+    model: provider(getDefaultModelId()),
   });
   return aiServiceInstance;
 };
@@ -96,7 +102,7 @@ const getAiService = (): AIService | undefined => {
 /** Create a LanguageModel on the server side (Vertex / Gemini Enterprise or Gemini API key). */
 const createServerModel = (modelId?: string): LanguageModel | undefined => {
   if (isVertexConfigured()) {
-    const resolved = resolveVertexLanguageModel(modelId ?? DEFAULT_MODEL);
+    const resolved = resolveVertexLanguageModel(modelId ?? getDefaultModelId());
     if (resolved) {
       return resolved;
     }
@@ -106,7 +112,7 @@ const createServerModel = (modelId?: string): LanguageModel | undefined => {
   const apiKey = process.env.GEMINI_API_KEY;
   if (google && apiKey) {
     const provider = google.createGoogleGenerativeAI({apiKey});
-    return provider(modelId ?? DEFAULT_MODEL);
+    return provider(modelId ?? getDefaultModelId());
   }
 
   return undefined;
@@ -119,7 +125,7 @@ const createModelFromKey = (apiKey: string, modelId?: string) => {
     throw new APIError({status: 500, title: "Missing @ai-sdk/google dependency."});
   }
   const provider = google.createGoogleGenerativeAI({apiKey});
-  return provider(modelId ?? DEFAULT_MODEL);
+  return provider(modelId ?? getDefaultModelId());
 };
 
 const getMcpService = (): MCPService | undefined => {
@@ -519,6 +525,46 @@ export const addAiRoutes = (
   const mcpService = getMcpService();
   const fileStorageService = initFileStorageService();
 
+  router.get(
+    "/gpt/models",
+    [
+      authenticateMiddleware(),
+      createOpenApiBuilder(options ?? {})
+        .withTags(["gpt"])
+        .withSummary("List available AI models for chat")
+        .withResponse(200, {
+          data: {
+            properties: {
+              defaultModelId: {type: "string"},
+              models: {
+                items: {
+                  properties: {
+                    label: {type: "string"},
+                    value: {type: "string"},
+                  },
+                  type: "object",
+                },
+                type: "array",
+              },
+              titleModelId: {type: "string"},
+            },
+            type: "object",
+          },
+        })
+        .build(),
+    ],
+    asyncHandler(async (_req: express.Request, res: express.Response) => {
+      const registry = getVertexModelRegistry();
+      return res.json({
+        data: {
+          defaultModelId: registry.getDefaultModelId(),
+          models: getVertexModelPickerOptions(),
+          titleModelId: registry.getTitleModelId(),
+        },
+      });
+    })
+  );
+
   addGptHistoryRoutes(router, options);
   addGptRoutes(router, {
     aiService,
@@ -531,7 +577,7 @@ export const addAiRoutes = (
     maxSteps: 5,
     mcpService,
     openApiOptions: options,
-    titleModelId: TITLE_MODEL_ID,
+    titleModelId: getTitleModelId(),
     toolChoice: "auto",
     // biome-ignore lint/suspicious/noExplicitAny: Dual ai SDK resolution causes Tool type mismatch
     tools: getDemoTools() as any,

--- a/example-backend/src/api/ai.ts
+++ b/example-backend/src/api/ai.ts
@@ -16,6 +16,12 @@ import {generateImage, tool, zodSchema} from "ai";
 import type express from "express";
 import {PDFDocument, rgb, StandardFonts} from "pdf-lib";
 import {z} from "zod";
+import {
+  DEFAULT_VERTEX_MODEL_ID,
+  getVertexGeminiProvider,
+  resolveVertexLanguageModel,
+  TITLE_VERTEX_MODEL_ID,
+} from "./vertexModels";
 
 /** A provider that creates language models and image models from model IDs. */
 interface AIProvider {
@@ -27,11 +33,6 @@ interface AIProvider {
 interface GoogleModule {
   createGoogleGenerativeAI: (opts: {apiKey: string}) => AIProvider;
   google: AIProvider;
-}
-
-/** The subset of @ai-sdk/google-vertex we use (loaded dynamically). */
-interface VertexModule {
-  createVertex: (opts: {location: string; project: string}) => AIProvider;
 }
 
 let aiServiceInstance: AIService | undefined;
@@ -53,45 +54,25 @@ const getGoogleModule = (): GoogleModule | undefined => {
   }
 };
 
-const getVertexModule = (): VertexModule | undefined => {
-  try {
-    return require("@ai-sdk/google-vertex") as VertexModule;
-  } catch {
-    return undefined;
-  }
-};
+const DEFAULT_MODEL = DEFAULT_VERTEX_MODEL_ID;
+const TITLE_MODEL_ID = TITLE_VERTEX_MODEL_ID;
 
-const DEFAULT_MODEL = "gemini-2.5-flash";
-
-let vertexProviderInstance: AIProvider | undefined;
-
-const getVertexProvider = (): AIProvider | undefined => {
-  if (vertexProviderInstance) {
-    return vertexProviderInstance;
-  }
-  const vertexModule = getVertexModule();
-  if (!vertexModule || !process.env.GOOGLE_VERTEX_PROJECT) {
-    return undefined;
-  }
-  vertexProviderInstance = vertexModule.createVertex({
-    location: process.env.GOOGLE_VERTEX_LOCATION ?? "us-central1",
-    project: process.env.GOOGLE_VERTEX_PROJECT,
-  });
-  return vertexProviderInstance;
-};
+const isVertexConfigured = (): boolean => Boolean(process.env.GOOGLE_VERTEX_PROJECT);
 
 const getAiService = (): AIService | undefined => {
   if (aiServiceInstance) {
     return aiServiceInstance;
   }
 
-  // Prefer Vertex AI (uses Application Default Credentials)
-  const vertexProvider = getVertexProvider();
-  if (vertexProvider) {
-    aiServiceInstance = new AIService({
-      model: vertexProvider(DEFAULT_MODEL),
-    });
-    return aiServiceInstance;
+  // Prefer Vertex AI / Gemini Enterprise (Application Default Credentials)
+  if (isVertexConfigured()) {
+    const defaultModel = resolveVertexLanguageModel(DEFAULT_MODEL);
+    if (defaultModel) {
+      aiServiceInstance = new AIService({
+        model: defaultModel,
+      });
+      return aiServiceInstance;
+    }
   }
 
   // Fall back to Gemini API key
@@ -112,11 +93,13 @@ const getAiService = (): AIService | undefined => {
   return aiServiceInstance;
 };
 
-/** Create a LanguageModel on the server side (Vertex AI or Gemini API key). Returns undefined if no provider is configured (falls through to demo mode). */
-const createServerModel = (modelId?: string) => {
-  const vertexProvider = getVertexProvider();
-  if (vertexProvider) {
-    return vertexProvider(modelId ?? DEFAULT_MODEL);
+/** Create a LanguageModel on the server side (Vertex / Gemini Enterprise or Gemini API key). */
+const createServerModel = (modelId?: string): LanguageModel | undefined => {
+  if (isVertexConfigured()) {
+    const resolved = resolveVertexLanguageModel(modelId ?? DEFAULT_MODEL);
+    if (resolved) {
+      return resolved;
+    }
   }
 
   const google = getGoogleModule();
@@ -347,11 +330,11 @@ const generatePdfBytes = async ({
   return pdfDoc.save();
 };
 
-const createImageModel = (apiKey?: string) => {
-  // Prefer Vertex AI for image generation
-  const vertexProvider = getVertexProvider();
-  if (vertexProvider && !apiKey) {
-    return vertexProvider.image("imagen-4.0-fast-generate-001");
+const createImageModel = (apiKey?: string): ImageModel => {
+  // Prefer Vertex AI for image generation (Gemini provider only)
+  const vertexGemini = getVertexGeminiProvider();
+  if (vertexGemini && !apiKey) {
+    return vertexGemini.image("imagen-4.0-fast-generate-001");
   }
 
   // Fall back to Gemini API with the provided key
@@ -520,7 +503,7 @@ const getDemoTools = (): Record<string, Tool> => {
   };
 
   // Add server-side image generation when Vertex AI or a server API key is available
-  if (getVertexProvider() || process.env.GEMINI_API_KEY) {
+  if (isVertexConfigured() || process.env.GEMINI_API_KEY) {
     tools.generate_image = createImageTool();
   }
 
@@ -548,6 +531,7 @@ export const addAiRoutes = (
     maxSteps: 5,
     mcpService,
     openApiOptions: options,
+    titleModelId: TITLE_MODEL_ID,
     toolChoice: "auto",
     // biome-ignore lint/suspicious/noExplicitAny: Dual ai SDK resolution causes Tool type mismatch
     tools: getDemoTools() as any,

--- a/example-backend/src/api/ai.ts
+++ b/example-backend/src/api/ai.ts
@@ -23,8 +23,8 @@ import type express from "express";
 import {PDFDocument, rgb, StandardFonts} from "pdf-lib";
 import {z} from "zod";
 import {
+  buildGptModelsResponseData,
   getVertexGeminiProvider,
-  getVertexModelPickerOptions,
   getVertexModelRegistry,
   getVertexProviderBundle,
   resolveVertexLanguageModel,
@@ -560,23 +560,7 @@ export const addAiRoutes = (
         .build(),
     ],
     asyncHandler(async (_req: express.Request, res: express.Response) => {
-      const registry = getVertexModelRegistry();
-      const models = getVertexModelPickerOptions();
-      const configuredDefault = registry.getDefaultModelId();
-      const configuredTitle = registry.getTitleModelId();
-      const modelIds = new Set(models.map((model) => model.value));
-      const defaultModelId = modelIds.has(configuredDefault)
-        ? configuredDefault
-        : (models[0]?.value ?? configuredDefault);
-      const titleModelId = modelIds.has(configuredTitle) ? configuredTitle : defaultModelId;
-
-      return res.json({
-        data: {
-          defaultModelId,
-          models,
-          titleModelId,
-        },
-      });
+      return res.json({data: buildGptModelsResponseData(getVertexModelRegistry())});
     })
   );
 

--- a/example-backend/src/api/ai.ts
+++ b/example-backend/src/api/ai.ts
@@ -22,6 +22,7 @@ import {generateImage, tool, zodSchema} from "ai";
 import type express from "express";
 import {PDFDocument, rgb, StandardFonts} from "pdf-lib";
 import {z} from "zod";
+import {getVertexAdminSettings, isVertexAiEnabled} from "../vertexAdminSettings";
 import {
   buildGptModelsResponseData,
   getVertexGeminiProvider,
@@ -70,7 +71,15 @@ const getGoogleModule = (): GoogleModule | undefined => {
   }
 };
 
-const isVertexConfigured = (): boolean => Boolean(process.env.GOOGLE_VERTEX_PROJECT);
+const isVertexConfigured = (): boolean => isVertexAiEnabled();
+
+const getGeminiApiKey = (): string | undefined => {
+  const apiKey = getVertexAdminSettings().geminiApiKey.trim();
+  if (!apiKey) {
+    return undefined;
+  }
+  return apiKey;
+};
 
 const getAiService = (): AIService | undefined => {
   if (aiServiceInstance) {
@@ -94,7 +103,7 @@ const getAiService = (): AIService | undefined => {
     return undefined;
   }
 
-  const apiKey = process.env.GEMINI_API_KEY;
+  const apiKey = getGeminiApiKey();
   if (!apiKey) {
     return undefined;
   }
@@ -115,7 +124,7 @@ const createServerModel = (modelId?: string): LanguageModel | undefined => {
   }
 
   const google = getGoogleModule();
-  const apiKey = process.env.GEMINI_API_KEY;
+  const apiKey = getGeminiApiKey();
   if (google && apiKey) {
     const provider = google.createGoogleGenerativeAI({apiKey});
     return provider(resolvedId);
@@ -354,7 +363,7 @@ const createImageModel = (apiKey?: string): ImageModel => {
   if (!google) {
     throw new APIError({status: 500, title: "Missing @ai-sdk/google dependency."});
   }
-  const effectiveKey = apiKey ?? process.env.GEMINI_API_KEY;
+  const effectiveKey = apiKey ?? getGeminiApiKey();
   if (!effectiveKey) {
     throw new APIError({status: 500, title: "No API key available for image generation."});
   }
@@ -515,7 +524,7 @@ const getDemoTools = (): Record<string, Tool> => {
   };
 
   // Add server-side image generation only when a provider is actually available
-  if (getVertexProviderBundle() || process.env.GEMINI_API_KEY) {
+  if (getVertexProviderBundle() || getGeminiApiKey()) {
     tools.generate_image = createImageTool();
   }
 

--- a/example-backend/src/api/ai.ts
+++ b/example-backend/src/api/ai.ts
@@ -515,7 +515,7 @@ const getDemoTools = (): Record<string, Tool> => {
   };
 
   // Add server-side image generation only when a provider is actually available
-  if (getVertexGeminiProvider() || process.env.GEMINI_API_KEY) {
+  if (getVertexProviderBundle() || process.env.GEMINI_API_KEY) {
     tools.generate_image = createImageTool();
   }
 

--- a/example-backend/src/api/ai.ts
+++ b/example-backend/src/api/ai.ts
@@ -109,13 +109,8 @@ const getAiService = (): AIService | undefined => {
 /** Create a LanguageModel on the server side (Vertex / Gemini Enterprise or Gemini API key). */
 const createServerModel = (modelId?: string): LanguageModel | undefined => {
   const resolvedId = modelId ?? getDefaultModelId();
-  const vertexBundle = getVertexProviderBundle();
 
-  if (vertexBundle) {
-    const registry = getVertexModelRegistry();
-    if (!registry.isModelAllowed(resolvedId)) {
-      return undefined;
-    }
+  if (getVertexProviderBundle()) {
     return resolveVertexLanguageModel(resolvedId);
   }
 

--- a/example-backend/src/api/ai.ts
+++ b/example-backend/src/api/ai.ts
@@ -10,7 +10,13 @@ import {
   preparePromptForAI,
 } from "@terreno/ai";
 import type {ModelRouterOptions} from "@terreno/api";
-import {APIError, asyncHandler, authenticateMiddleware, createOpenApiBuilder, logger} from "@terreno/api";
+import {
+  APIError,
+  asyncHandler,
+  authenticateMiddleware,
+  createOpenApiBuilder,
+  logger,
+} from "@terreno/api";
 import type {ImageModel, LanguageModel, Tool} from "ai";
 import {generateImage, tool, zodSchema} from "ai";
 import type express from "express";
@@ -20,6 +26,7 @@ import {
   getVertexGeminiProvider,
   getVertexModelPickerOptions,
   getVertexModelRegistry,
+  getVertexProviderBundle,
   resolveVertexLanguageModel,
 } from "./vertexModels";
 
@@ -101,18 +108,22 @@ const getAiService = (): AIService | undefined => {
 
 /** Create a LanguageModel on the server side (Vertex / Gemini Enterprise or Gemini API key). */
 const createServerModel = (modelId?: string): LanguageModel | undefined => {
-  if (isVertexConfigured()) {
-    const resolved = resolveVertexLanguageModel(modelId ?? getDefaultModelId());
-    if (resolved) {
-      return resolved;
+  const resolvedId = modelId ?? getDefaultModelId();
+  const vertexBundle = getVertexProviderBundle();
+
+  if (vertexBundle) {
+    const registry = getVertexModelRegistry();
+    if (!registry.isModelAllowed(resolvedId)) {
+      return undefined;
     }
+    return resolveVertexLanguageModel(resolvedId);
   }
 
   const google = getGoogleModule();
   const apiKey = process.env.GEMINI_API_KEY;
   if (google && apiKey) {
     const provider = google.createGoogleGenerativeAI({apiKey});
-    return provider(modelId ?? getDefaultModelId());
+    return provider(resolvedId);
   }
 
   return undefined;
@@ -508,8 +519,8 @@ const getDemoTools = (): Record<string, Tool> => {
     }),
   };
 
-  // Add server-side image generation when Vertex AI or a server API key is available
-  if (isVertexConfigured() || process.env.GEMINI_API_KEY) {
+  // Add server-side image generation only when a provider is actually available
+  if (getVertexGeminiProvider() || process.env.GEMINI_API_KEY) {
     tools.generate_image = createImageTool();
   }
 

--- a/example-backend/src/api/ai.ts
+++ b/example-backend/src/api/ai.ts
@@ -566,11 +566,20 @@ export const addAiRoutes = (
     ],
     asyncHandler(async (_req: express.Request, res: express.Response) => {
       const registry = getVertexModelRegistry();
+      const models = getVertexModelPickerOptions();
+      const configuredDefault = registry.getDefaultModelId();
+      const configuredTitle = registry.getTitleModelId();
+      const modelIds = new Set(models.map((model) => model.value));
+      const defaultModelId = modelIds.has(configuredDefault)
+        ? configuredDefault
+        : (models[0]?.value ?? configuredDefault);
+      const titleModelId = modelIds.has(configuredTitle) ? configuredTitle : defaultModelId;
+
       return res.json({
         data: {
-          defaultModelId: registry.getDefaultModelId(),
-          models: getVertexModelPickerOptions(),
-          titleModelId: registry.getTitleModelId(),
+          defaultModelId,
+          models,
+          titleModelId,
         },
       });
     })

--- a/example-backend/src/api/vertexModels.test.ts
+++ b/example-backend/src/api/vertexModels.test.ts
@@ -1,9 +1,13 @@
 import {afterEach, describe, expect, it} from "bun:test";
 import {
+  configureVertexModels,
   DEFAULT_VERTEX_MODEL_ID,
   getEnabledVertexModelCatalog,
+  getVertexModelPickerOptions,
+  getVertexModelRegistry,
   inferVertexModelProvider,
   isVertexModelAllowed,
+  resetVertexModels,
   TITLE_VERTEX_MODEL_ID,
 } from "./vertexModels";
 
@@ -22,6 +26,7 @@ describe("vertexModels", () => {
   afterEach(() => {
     restoreEnvVar("GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS", originalAnthropicFlag);
     restoreEnvVar("GOOGLE_VERTEX_ENABLE_MAAS_MODELS", originalMaasFlag);
+    resetVertexModels();
   });
 
   it("uses expected default and title model ids", () => {
@@ -64,5 +69,46 @@ describe("vertexModels", () => {
   it("allows unknown gemini-shaped ids for forward compatibility", () => {
     expect(isVertexModelAllowed("gemini-9-experimental")).toBe(true);
     expect(isVertexModelAllowed("claude-custom@20260101")).toBe(false);
+  });
+
+  it("configureVertexModels replaces defaults and catalog in replace mode", () => {
+    configureVertexModels({
+      allowUnknownGeminiModels: false,
+      catalog: [{id: "custom-gemini", label: "Custom Gemini", provider: "gemini"}],
+      catalogMode: "replace",
+      defaultModelId: "custom-gemini",
+      titleModelId: "custom-gemini",
+    });
+
+    const registry = getVertexModelRegistry();
+    expect(registry.getDefaultModelId()).toBe("custom-gemini");
+    expect(registry.getTitleModelId()).toBe("custom-gemini");
+    expect(getVertexModelPickerOptions()).toEqual([{label: "Custom Gemini", value: "custom-gemini"}]);
+    expect(isVertexModelAllowed("gemini-3.5-flash")).toBe(false);
+    expect(isVertexModelAllowed("custom-gemini")).toBe(true);
+  });
+
+  it("configureVertexModels merges additional catalog entries in extend mode", () => {
+    configureVertexModels({
+      additionalCatalog: [
+        {id: "partner-model-v1", label: "Partner Model", provider: "gemini"},
+      ],
+      catalogMode: "extend",
+    });
+
+    const ids = getEnabledVertexModelCatalog().map((entry) => entry.id);
+    expect(ids).toContain("gemini-3.5-flash");
+    expect(ids).toContain("partner-model-v1");
+  });
+
+  it("honors strict allowlist flags from configureVertexModels", () => {
+    configureVertexModels({
+      allowUnknownAnthropicModels: true,
+      allowUnknownGeminiModels: false,
+      isAnthropicEnabled: () => true,
+    });
+
+    expect(isVertexModelAllowed("gemini-9-experimental")).toBe(false);
+    expect(isVertexModelAllowed("claude-custom-2026")).toBe(true);
   });
 });

--- a/example-backend/src/api/vertexModels.test.ts
+++ b/example-backend/src/api/vertexModels.test.ts
@@ -1,6 +1,8 @@
 import {afterEach, describe, expect, it} from "bun:test";
 import {
+  buildGptModelsResponseData,
   configureVertexModels,
+  createVertexModelRegistry,
   DEFAULT_VERTEX_MODEL_ID,
   getEnabledVertexModelCatalog,
   getVertexModelPickerOptions,
@@ -123,6 +125,31 @@ describe("vertexModels", () => {
     expect(registry.needsMaasProvider()).toBe(false);
     expect(isVertexModelAllowed("claude-opus-4-6")).toBe(true);
     expect(isVertexModelAllowed("claude-sonnet-4-6")).toBe(false);
+  });
+
+  it("buildGptModelsResponseData falls back when default is not enabled", () => {
+    process.env.GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS = "true";
+
+    const registry = createVertexModelRegistry({
+      catalog: [
+        {
+          id: "claude-opus-4-6",
+          label: "Claude Opus 4.6 (Vertex)",
+          provider: "anthropic",
+          requiresFeatureFlag: "anthropic",
+        },
+      ],
+      catalogMode: "replace",
+      defaultModelId: "gemini-3.5-flash",
+      titleModelId: "gemini-3.1-flash-lite",
+    });
+
+    const response = buildGptModelsResponseData(registry);
+    expect(response.models).toEqual([
+      {label: "Claude Opus 4.6 (Vertex)", value: "claude-opus-4-6"},
+    ]);
+    expect(response.defaultModelId).toBe("claude-opus-4-6");
+    expect(response.titleModelId).toBe("claude-opus-4-6");
   });
 
   it("honors strict allowlist flags from configureVertexModels", () => {

--- a/example-backend/src/api/vertexModels.test.ts
+++ b/example-backend/src/api/vertexModels.test.ts
@@ -13,21 +13,8 @@ import {
   TITLE_VERTEX_MODEL_ID,
 } from "./vertexModels";
 
-const restoreEnvVar = (key: string, original: string | undefined): void => {
-  if (original === undefined) {
-    delete process.env[key];
-    return;
-  }
-  process.env[key] = original;
-};
-
 describe("vertexModels", () => {
-  const originalAnthropicFlag = process.env.GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS;
-  const originalMaasFlag = process.env.GOOGLE_VERTEX_ENABLE_MAAS_MODELS;
-
   afterEach(() => {
-    restoreEnvVar("GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS", originalAnthropicFlag);
-    restoreEnvVar("GOOGLE_VERTEX_ENABLE_MAAS_MODELS", originalMaasFlag);
     resetVertexModels();
   });
 
@@ -43,9 +30,11 @@ describe("vertexModels", () => {
     expect(inferVertexModelProvider("deepseek-ai/deepseek-v3.2-maas")).toBe("maas");
   });
 
-  it("excludes anthropic and maas catalog entries unless feature flags are set", () => {
-    delete process.env.GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS;
-    delete process.env.GOOGLE_VERTEX_ENABLE_MAAS_MODELS;
+  it("excludes anthropic and maas catalog entries unless provider toggles are on", () => {
+    configureVertexModels({
+      isAnthropicEnabled: () => false,
+      isMaasEnabled: () => false,
+    });
 
     const ids = getEnabledVertexModelCatalog().map((entry) => entry.id);
     expect(ids).toContain("gemini-3.5-flash");
@@ -53,22 +42,32 @@ describe("vertexModels", () => {
     expect(ids).not.toContain("openai/gpt-oss-20b-maas");
   });
 
-  it("includes optional models when feature flags are enabled", () => {
-    process.env.GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS = "true";
-    process.env.GOOGLE_VERTEX_ENABLE_MAAS_MODELS = "true";
+  it("includes optional models when provider toggles are enabled", () => {
+    configureVertexModels({
+      isAnthropicEnabled: () => true,
+      isMaasEnabled: () => true,
+    });
 
     const ids = getEnabledVertexModelCatalog().map((entry) => entry.id);
     expect(ids).toContain("claude-sonnet-4-6");
     expect(ids).toContain("openai/gpt-oss-20b-maas");
   });
 
-  it("blocks catalog anthropic models when feature flag is off", () => {
-    delete process.env.GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS;
+  it("blocks catalog anthropic models when anthropic toggle is off", () => {
+    configureVertexModels({
+      isAnthropicEnabled: () => false,
+      isMaasEnabled: () => false,
+    });
     expect(isVertexModelAllowed("claude-sonnet-4-6")).toBe(false);
     expect(isVertexModelAllowed("gemini-3.1-pro-preview")).toBe(true);
   });
 
   it("allows unknown gemini-shaped ids for forward compatibility", () => {
+    configureVertexModels({
+      allowUnknownGeminiModels: true,
+      isAnthropicEnabled: () => false,
+      isMaasEnabled: () => false,
+    });
     expect(isVertexModelAllowed("gemini-9-experimental")).toBe(true);
     expect(isVertexModelAllowed("claude-custom@20260101")).toBe(false);
   });
@@ -79,6 +78,8 @@ describe("vertexModels", () => {
       catalog: [{id: "custom-gemini", label: "Custom Gemini", provider: "gemini"}],
       catalogMode: "replace",
       defaultModelId: "custom-gemini",
+      isAnthropicEnabled: () => false,
+      isMaasEnabled: () => false,
       titleModelId: "custom-gemini",
     });
 
@@ -96,6 +97,8 @@ describe("vertexModels", () => {
     configureVertexModels({
       additionalCatalog: [{id: "partner-model-v1", label: "Partner Model", provider: "gemini"}],
       catalogMode: "extend",
+      isAnthropicEnabled: () => false,
+      isMaasEnabled: () => false,
     });
 
     const ids = getEnabledVertexModelCatalog().map((entry) => entry.id);
@@ -104,8 +107,6 @@ describe("vertexModels", () => {
   });
 
   it("needsAnthropicProvider when replace catalog has only custom anthropic models", () => {
-    process.env.GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS = "true";
-
     configureVertexModels({
       allowUnknownAnthropicModels: false,
       allowUnknownGeminiModels: false,
@@ -118,6 +119,8 @@ describe("vertexModels", () => {
         },
       ],
       catalogMode: "replace",
+      isAnthropicEnabled: () => true,
+      isMaasEnabled: () => false,
     });
 
     const registry = getVertexModelRegistry();
@@ -128,8 +131,6 @@ describe("vertexModels", () => {
   });
 
   it("buildGptModelsResponseData falls back when default is not enabled", () => {
-    process.env.GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS = "true";
-
     const registry = createVertexModelRegistry({
       catalog: [
         {
@@ -141,6 +142,8 @@ describe("vertexModels", () => {
       ],
       catalogMode: "replace",
       defaultModelId: "gemini-3.5-flash",
+      isAnthropicEnabled: () => true,
+      isMaasEnabled: () => false,
       titleModelId: "gemini-3.1-flash-lite",
     });
 
@@ -157,6 +160,7 @@ describe("vertexModels", () => {
       allowUnknownAnthropicModels: true,
       allowUnknownGeminiModels: false,
       isAnthropicEnabled: () => true,
+      isMaasEnabled: () => false,
     });
 
     expect(isVertexModelAllowed("gemini-9-experimental")).toBe(false);

--- a/example-backend/src/api/vertexModels.test.ts
+++ b/example-backend/src/api/vertexModels.test.ts
@@ -1,0 +1,68 @@
+import {afterEach, describe, expect, it} from "bun:test";
+import {
+  DEFAULT_VERTEX_MODEL_ID,
+  getEnabledVertexModelCatalog,
+  inferVertexModelProvider,
+  isVertexModelAllowed,
+  TITLE_VERTEX_MODEL_ID,
+} from "./vertexModels";
+
+const restoreEnvVar = (key: string, original: string | undefined): void => {
+  if (original === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = original;
+};
+
+describe("vertexModels", () => {
+  const originalAnthropicFlag = process.env.GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS;
+  const originalMaasFlag = process.env.GOOGLE_VERTEX_ENABLE_MAAS_MODELS;
+
+  afterEach(() => {
+    restoreEnvVar("GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS", originalAnthropicFlag);
+    restoreEnvVar("GOOGLE_VERTEX_ENABLE_MAAS_MODELS", originalMaasFlag);
+  });
+
+  it("uses expected default and title model ids", () => {
+    expect(DEFAULT_VERTEX_MODEL_ID).toBe("gemini-3.5-flash");
+    expect(TITLE_VERTEX_MODEL_ID).toBe("gemini-3.1-flash-lite");
+  });
+
+  it("infers provider kind from model id shape", () => {
+    expect(inferVertexModelProvider("gemini-3.5-flash")).toBe("gemini");
+    expect(inferVertexModelProvider("claude-sonnet-4-6")).toBe("anthropic");
+    expect(inferVertexModelProvider("openai/gpt-oss-20b-maas")).toBe("maas");
+    expect(inferVertexModelProvider("deepseek-ai/deepseek-v3.2-maas")).toBe("maas");
+  });
+
+  it("excludes anthropic and maas catalog entries unless feature flags are set", () => {
+    delete process.env.GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS;
+    delete process.env.GOOGLE_VERTEX_ENABLE_MAAS_MODELS;
+
+    const ids = getEnabledVertexModelCatalog().map((entry) => entry.id);
+    expect(ids).toContain("gemini-3.5-flash");
+    expect(ids).not.toContain("claude-sonnet-4-6");
+    expect(ids).not.toContain("openai/gpt-oss-20b-maas");
+  });
+
+  it("includes optional models when feature flags are enabled", () => {
+    process.env.GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS = "true";
+    process.env.GOOGLE_VERTEX_ENABLE_MAAS_MODELS = "true";
+
+    const ids = getEnabledVertexModelCatalog().map((entry) => entry.id);
+    expect(ids).toContain("claude-sonnet-4-6");
+    expect(ids).toContain("openai/gpt-oss-20b-maas");
+  });
+
+  it("blocks catalog anthropic models when feature flag is off", () => {
+    delete process.env.GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS;
+    expect(isVertexModelAllowed("claude-sonnet-4-6")).toBe(false);
+    expect(isVertexModelAllowed("gemini-3.1-pro-preview")).toBe(true);
+  });
+
+  it("allows unknown gemini-shaped ids for forward compatibility", () => {
+    expect(isVertexModelAllowed("gemini-9-experimental")).toBe(true);
+    expect(isVertexModelAllowed("claude-custom@20260101")).toBe(false);
+  });
+});

--- a/example-backend/src/api/vertexModels.test.ts
+++ b/example-backend/src/api/vertexModels.test.ts
@@ -83,22 +83,46 @@ describe("vertexModels", () => {
     const registry = getVertexModelRegistry();
     expect(registry.getDefaultModelId()).toBe("custom-gemini");
     expect(registry.getTitleModelId()).toBe("custom-gemini");
-    expect(getVertexModelPickerOptions()).toEqual([{label: "Custom Gemini", value: "custom-gemini"}]);
+    expect(getVertexModelPickerOptions()).toEqual([
+      {label: "Custom Gemini", value: "custom-gemini"},
+    ]);
     expect(isVertexModelAllowed("gemini-3.5-flash")).toBe(false);
     expect(isVertexModelAllowed("custom-gemini")).toBe(true);
   });
 
   it("configureVertexModels merges additional catalog entries in extend mode", () => {
     configureVertexModels({
-      additionalCatalog: [
-        {id: "partner-model-v1", label: "Partner Model", provider: "gemini"},
-      ],
+      additionalCatalog: [{id: "partner-model-v1", label: "Partner Model", provider: "gemini"}],
       catalogMode: "extend",
     });
 
     const ids = getEnabledVertexModelCatalog().map((entry) => entry.id);
     expect(ids).toContain("gemini-3.5-flash");
     expect(ids).toContain("partner-model-v1");
+  });
+
+  it("needsAnthropicProvider when replace catalog has only custom anthropic models", () => {
+    process.env.GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS = "true";
+
+    configureVertexModels({
+      allowUnknownAnthropicModels: false,
+      allowUnknownGeminiModels: false,
+      catalog: [
+        {
+          id: "claude-opus-4-6",
+          label: "Claude Opus 4.6 (Vertex)",
+          provider: "anthropic",
+          requiresFeatureFlag: "anthropic",
+        },
+      ],
+      catalogMode: "replace",
+    });
+
+    const registry = getVertexModelRegistry();
+    expect(registry.needsAnthropicProvider()).toBe(true);
+    expect(registry.needsMaasProvider()).toBe(false);
+    expect(isVertexModelAllowed("claude-opus-4-6")).toBe(true);
+    expect(isVertexModelAllowed("claude-sonnet-4-6")).toBe(false);
   });
 
   it("honors strict allowlist flags from configureVertexModels", () => {

--- a/example-backend/src/api/vertexModels.ts
+++ b/example-backend/src/api/vertexModels.ts
@@ -279,6 +279,28 @@ export const getEnabledVertexModelCatalog = (): VertexModelEntry[] =>
 export const getVertexModelPickerOptions = (): VertexModelPickerOption[] =>
   getVertexModelRegistry().getPickerOptions();
 
+export interface GptModelsResponseData {
+  defaultModelId: string;
+  models: VertexModelPickerOption[];
+  titleModelId: string;
+}
+
+/** Build API payload for GET /gpt/models with enabled-model fallbacks. */
+export const buildGptModelsResponseData = (
+  registry: VertexModelRegistry
+): GptModelsResponseData => {
+  const models = registry.getPickerOptions();
+  const configuredDefault = registry.getDefaultModelId();
+  const configuredTitle = registry.getTitleModelId();
+  const modelIds = new Set(models.map((model) => model.value));
+  const defaultModelId = modelIds.has(configuredDefault)
+    ? configuredDefault
+    : (models[0]?.value ?? configuredDefault);
+  const titleModelId = modelIds.has(configuredTitle) ? configuredTitle : defaultModelId;
+
+  return {defaultModelId, models, titleModelId};
+};
+
 export const isVertexModelAllowed = (modelId: string): boolean =>
   getVertexModelRegistry().isModelAllowed(modelId);
 

--- a/example-backend/src/api/vertexModels.ts
+++ b/example-backend/src/api/vertexModels.ts
@@ -1,4 +1,5 @@
 import type {ImageModel, LanguageModel} from "ai";
+import {getVertexAdminSettings, isVertexAiEnabled} from "../vertexAdminSettings";
 
 /** Vertex / Gemini Enterprise Agent Platform model provider kind. */
 export type VertexModelProviderKind = "gemini" | "anthropic" | "maas";
@@ -7,7 +8,7 @@ export interface VertexModelEntry {
   id: string;
   label: string;
   provider: VertexModelProviderKind;
-  /** When true, only listed when the matching GOOGLE_VERTEX_ENABLE_* env is set. */
+  /** When set, entry is gated by the matching admin provider toggle. */
   requiresFeatureFlag?: "anthropic" | "maas";
 }
 
@@ -79,11 +80,19 @@ export const DEFAULT_VERTEX_MODEL_ID = "gemini-3.5-flash";
 /** Lightweight model for auto-generated conversation titles. */
 export const TITLE_VERTEX_MODEL_ID = "gemini-3.1-flash-lite";
 
-const defaultIsAnthropicFeatureEnabled = (): boolean =>
-  process.env.GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS === "true";
-
-const defaultIsMaasFeatureEnabled = (): boolean =>
-  process.env.GOOGLE_VERTEX_ENABLE_MAAS_MODELS === "true";
+const isEntryEnabledForProviderToggles = (
+  entry: VertexModelEntry,
+  isAnthropicEnabled: () => boolean,
+  isMaasEnabled: () => boolean
+): boolean => {
+  if (entry.provider === "anthropic" || entry.requiresFeatureFlag === "anthropic") {
+    return isAnthropicEnabled();
+  }
+  if (entry.provider === "maas" || entry.requiresFeatureFlag === "maas") {
+    return isMaasEnabled();
+  }
+  return true;
+};
 
 const mergeCatalogEntries = (...groups: VertexModelEntry[][]): VertexModelEntry[] => {
   const byId = new Map<string, VertexModelEntry>();
@@ -111,19 +120,11 @@ const resolveCatalog = (options: VertexModelRegistryOptions): VertexModelEntry[]
 /** Map catalog entries to UI picker options (enabled entries only). */
 const vertexCatalogToPickerOptions = (
   entries: VertexModelEntry[],
-  isAnthropicEnabled: () => boolean = defaultIsAnthropicFeatureEnabled,
-  isMaasEnabled: () => boolean = defaultIsMaasFeatureEnabled
+  isAnthropicEnabled: () => boolean,
+  isMaasEnabled: () => boolean
 ): VertexModelPickerOption[] =>
   entries
-    .filter((entry) => {
-      if (entry.requiresFeatureFlag === "anthropic") {
-        return isAnthropicEnabled();
-      }
-      if (entry.requiresFeatureFlag === "maas") {
-        return isMaasEnabled();
-      }
-      return true;
-    })
+    .filter((entry) => isEntryEnabledForProviderToggles(entry, isAnthropicEnabled, isMaasEnabled))
     .map((entry) => ({label: entry.label, value: entry.id}));
 
 /**
@@ -174,8 +175,8 @@ export class VertexModelRegistry {
     this.allowUnknownGeminiModels = options.allowUnknownGeminiModels ?? true;
     this.allowUnknownAnthropicModels = options.allowUnknownAnthropicModels ?? false;
     this.allowUnknownMaasModels = options.allowUnknownMaasModels ?? false;
-    this.isAnthropicEnabled = options.isAnthropicEnabled ?? defaultIsAnthropicFeatureEnabled;
-    this.isMaasEnabled = options.isMaasEnabled ?? defaultIsMaasFeatureEnabled;
+    this.isAnthropicEnabled = options.isAnthropicEnabled ?? (() => false);
+    this.isMaasEnabled = options.isMaasEnabled ?? (() => false);
   }
 
   getDefaultModelId = (): string => this.defaultModelId;
@@ -186,15 +187,9 @@ export class VertexModelRegistry {
 
   /** Models exposed in API/UI given current env flags. */
   getEnabledCatalog = (): VertexModelEntry[] =>
-    this.catalog.filter((entry) => {
-      if (entry.requiresFeatureFlag === "anthropic") {
-        return this.isAnthropicEnabled();
-      }
-      if (entry.requiresFeatureFlag === "maas") {
-        return this.isMaasEnabled();
-      }
-      return true;
-    });
+    this.catalog.filter((entry) =>
+      isEntryEnabledForProviderToggles(entry, this.isAnthropicEnabled, this.isMaasEnabled)
+    );
 
   getPickerOptions = (): VertexModelPickerOption[] =>
     vertexCatalogToPickerOptions(this.catalog, this.isAnthropicEnabled, this.isMaasEnabled);
@@ -228,13 +223,7 @@ export class VertexModelRegistry {
   isModelAllowed = (modelId: string): boolean => {
     const entry = this.catalogById.get(modelId);
     if (entry) {
-      if (entry.requiresFeatureFlag === "anthropic") {
-        return this.isAnthropicEnabled();
-      }
-      if (entry.requiresFeatureFlag === "maas") {
-        return this.isMaasEnabled();
-      }
-      return true;
+      return isEntryEnabledForProviderToggles(entry, this.isAnthropicEnabled, this.isMaasEnabled);
     }
 
     const providerKind = this.inferProvider(modelId);
@@ -355,12 +344,16 @@ interface VertexProviderBundle {
 
 let vertexProviderBundle: VertexProviderBundle | undefined;
 
-const getVertexProject = (): string | undefined => process.env.GOOGLE_VERTEX_PROJECT;
+const getVertexProject = (): string | undefined => {
+  if (!isVertexAiEnabled()) {
+    return undefined;
+  }
+  return getVertexAdminSettings().projectId;
+};
 
-const getGeminiLocation = (): string => process.env.GOOGLE_VERTEX_LOCATION ?? "us-central1";
+const getGeminiLocation = (): string => getVertexAdminSettings().location;
 
-const getAnthropicLocation = (): string =>
-  process.env.GOOGLE_VERTEX_ANTHROPIC_LOCATION ?? "us-east5";
+const getAnthropicLocation = (): string => getVertexAdminSettings().anthropicLocation;
 
 /** Lazy-init Vertex providers (Gemini, Anthropic, MaaS) for Gemini Enterprise. */
 export const getVertexProviderBundle = (): VertexProviderBundle | undefined => {

--- a/example-backend/src/api/vertexModels.ts
+++ b/example-backend/src/api/vertexModels.ts
@@ -200,7 +200,33 @@ export class VertexModelRegistry {
     });
 
   getPickerOptions = (): VertexModelPickerOption[] =>
-    vertexCatalogToPickerOptions(this.getEnabledCatalog(), this.isAnthropicEnabled, this.isMaasEnabled);
+    vertexCatalogToPickerOptions(
+      this.getEnabledCatalog(),
+      this.isAnthropicEnabled,
+      this.isMaasEnabled
+    );
+
+  /** Whether the Anthropic Vertex SDK should be initialized for the active catalog/allowlist. */
+  needsAnthropicProvider = (): boolean => {
+    if (!this.isAnthropicEnabled()) {
+      return false;
+    }
+    if (this.getEnabledCatalog().some((entry) => entry.provider === "anthropic")) {
+      return true;
+    }
+    return this.allowUnknownAnthropicModels;
+  };
+
+  /** Whether the MaaS Vertex SDK should be initialized for the active catalog/allowlist. */
+  needsMaasProvider = (): boolean => {
+    if (!this.isMaasEnabled()) {
+      return false;
+    }
+    if (this.getEnabledCatalog().some((entry) => entry.provider === "maas")) {
+      return true;
+    }
+    return this.allowUnknownMaasModels;
+  };
 
   inferProvider = (modelId: string): VertexModelProviderKind =>
     inferVertexModelProvider(modelId, this.catalogById);
@@ -230,8 +256,9 @@ export class VertexModelRegistry {
 }
 
 /** Create an isolated registry (does not affect the process-wide default). */
-export const createVertexModelRegistry = (options?: VertexModelRegistryOptions): VertexModelRegistry =>
-  new VertexModelRegistry(options);
+export const createVertexModelRegistry = (
+  options?: VertexModelRegistryOptions
+): VertexModelRegistry => new VertexModelRegistry(options);
 
 let activeRegistry: VertexModelRegistry = createVertexModelRegistry();
 
@@ -352,7 +379,7 @@ export const getVertexProviderBundle = (): VertexProviderBundle | undefined => {
   };
 
   const anthropicModule = getVertexAnthropicModule();
-  if (anthropicModule && registry.isModelAllowed("claude-sonnet-4-6")) {
+  if (anthropicModule && registry.needsAnthropicProvider()) {
     bundle.anthropic = anthropicModule.createVertexAnthropic({
       location: getAnthropicLocation(),
       project,
@@ -360,7 +387,7 @@ export const getVertexProviderBundle = (): VertexProviderBundle | undefined => {
   }
 
   const maasModule = getVertexMaasModule();
-  if (maasModule && registry.isModelAllowed("openai/gpt-oss-20b-maas")) {
+  if (maasModule && registry.needsMaasProvider()) {
     bundle.maas = maasModule.createVertexMaas({
       location: getGeminiLocation(),
       project,

--- a/example-backend/src/api/vertexModels.ts
+++ b/example-backend/src/api/vertexModels.ts
@@ -1,0 +1,246 @@
+import type {ImageModel, LanguageModel} from "ai";
+
+/** Vertex / Gemini Enterprise Agent Platform model provider kind. */
+export type VertexModelProviderKind = "gemini" | "anthropic" | "maas";
+
+export interface VertexModelEntry {
+  id: string;
+  label: string;
+  provider: VertexModelProviderKind;
+  /** When true, only listed when the matching GOOGLE_VERTEX_ENABLE_* env is set. */
+  requiresFeatureFlag?: "anthropic" | "maas";
+}
+
+/** Default chat model (Gemini on Vertex Model Garden). */
+export const DEFAULT_VERTEX_MODEL_ID = "gemini-3.5-flash";
+
+/** Lightweight model for auto-generated conversation titles. */
+export const TITLE_VERTEX_MODEL_ID = "gemini-3.1-flash-lite";
+
+/**
+ * Curated models for the example app via Gemini Enterprise Agent Platform (Vertex AI).
+ * @see https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/model-versions
+ */
+export const VERTEX_MODEL_CATALOG: VertexModelEntry[] = [
+  {id: "gemini-3.5-flash", label: "Gemini 3.5 Flash", provider: "gemini"},
+  {id: "gemini-3.1-flash-lite", label: "Gemini 3.1 Flash Lite", provider: "gemini"},
+  {id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro Preview", provider: "gemini"},
+  {id: "gemini-2.5-flash", label: "Gemini 2.5 Flash", provider: "gemini"},
+  {id: "gemini-2.5-pro", label: "Gemini 2.5 Pro", provider: "gemini"},
+  {
+    id: "claude-sonnet-4-6",
+    label: "Claude Sonnet 4.6 (Vertex)",
+    provider: "anthropic",
+    requiresFeatureFlag: "anthropic",
+  },
+  {
+    id: "claude-opus-4-6",
+    label: "Claude Opus 4.6 (Vertex)",
+    provider: "anthropic",
+    requiresFeatureFlag: "anthropic",
+  },
+  {
+    id: "openai/gpt-oss-20b-maas",
+    label: "GPT-OSS 20B (Vertex MaaS)",
+    provider: "maas",
+    requiresFeatureFlag: "maas",
+  },
+];
+
+const isAnthropicFeatureEnabled = (): boolean =>
+  process.env.GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS === "true";
+
+const isMaasFeatureEnabled = (): boolean => process.env.GOOGLE_VERTEX_ENABLE_MAAS_MODELS === "true";
+
+/** Models exposed in API/UI given current env flags. */
+export const getEnabledVertexModelCatalog = (): VertexModelEntry[] =>
+  VERTEX_MODEL_CATALOG.filter((entry) => {
+    if (entry.requiresFeatureFlag === "anthropic") {
+      return isAnthropicFeatureEnabled();
+    }
+    if (entry.requiresFeatureFlag === "maas") {
+      return isMaasFeatureEnabled();
+    }
+    return true;
+  });
+
+const catalogById = (): Map<string, VertexModelEntry> =>
+  new Map(VERTEX_MODEL_CATALOG.map((entry) => [entry.id, entry]));
+
+/**
+ * Infer provider from a raw model id when not in the catalog (e.g. custom Vertex ids).
+ * Gemini Enterprise Model Garden routes third-party models by id shape.
+ */
+export const inferVertexModelProvider = (modelId: string): VertexModelProviderKind => {
+  const catalogEntry = catalogById().get(modelId);
+  if (catalogEntry) {
+    return catalogEntry.provider;
+  }
+
+  const normalized = modelId.toLowerCase();
+  if (normalized.startsWith("claude-")) {
+    return "anthropic";
+  }
+  if (
+    normalized.includes("-maas") ||
+    normalized.startsWith("openai/") ||
+    normalized.startsWith("deepseek-ai/") ||
+    normalized.startsWith("meta/") ||
+    normalized.startsWith("qwen/")
+  ) {
+    return "maas";
+  }
+  return "gemini";
+};
+
+/** Whether this model id is allowed for server-side Vertex routing. */
+export const isVertexModelAllowed = (modelId: string): boolean => {
+  const entry = catalogById().get(modelId);
+  if (!entry) {
+    return inferVertexModelProvider(modelId) === "gemini";
+  }
+  if (entry.requiresFeatureFlag === "anthropic") {
+    return isAnthropicFeatureEnabled();
+  }
+  if (entry.requiresFeatureFlag === "maas") {
+    return isMaasFeatureEnabled();
+  }
+  return true;
+};
+
+type LanguageModelFactory = (modelId: string) => LanguageModel;
+
+interface VertexGeminiProvider {
+  (modelId: string): LanguageModel;
+  image: (modelId: string) => ImageModel;
+}
+
+interface VertexGeminiModule {
+  createVertex: (opts: {location: string; project: string}) => VertexGeminiProvider;
+}
+
+interface VertexAnthropicModule {
+  createVertexAnthropic: (opts: {location: string; project: string}) => LanguageModelFactory;
+}
+
+interface VertexMaasModule {
+  createVertexMaas: (opts: {location: string; project: string}) => LanguageModelFactory;
+}
+
+const getVertexGeminiModule = (): VertexGeminiModule | undefined => {
+  try {
+    return require("@ai-sdk/google-vertex") as VertexGeminiModule;
+  } catch {
+    return undefined;
+  }
+};
+
+const getVertexAnthropicModule = (): VertexAnthropicModule | undefined => {
+  try {
+    return require("@ai-sdk/google-vertex/anthropic") as VertexAnthropicModule;
+  } catch {
+    return undefined;
+  }
+};
+
+const getVertexMaasModule = (): VertexMaasModule | undefined => {
+  try {
+    return require("@ai-sdk/google-vertex/maas") as VertexMaasModule;
+  } catch {
+    return undefined;
+  }
+};
+
+interface VertexProviderBundle {
+  gemini: VertexGeminiProvider;
+  anthropic?: LanguageModelFactory;
+  maas?: LanguageModelFactory;
+}
+
+let vertexProviderBundle: VertexProviderBundle | undefined;
+
+const getVertexProject = (): string | undefined => process.env.GOOGLE_VERTEX_PROJECT;
+
+const getGeminiLocation = (): string => process.env.GOOGLE_VERTEX_LOCATION ?? "us-central1";
+
+const getAnthropicLocation = (): string =>
+  process.env.GOOGLE_VERTEX_ANTHROPIC_LOCATION ?? "us-east5";
+
+/** Lazy-init Vertex providers (Gemini, Anthropic, MaaS) for Gemini Enterprise. */
+export const getVertexProviderBundle = (): VertexProviderBundle | undefined => {
+  if (vertexProviderBundle) {
+    return vertexProviderBundle;
+  }
+
+  const project = getVertexProject();
+  if (!project) {
+    return undefined;
+  }
+
+  const geminiModule = getVertexGeminiModule();
+  if (!geminiModule) {
+    return undefined;
+  }
+
+  const bundle: VertexProviderBundle = {
+    gemini: geminiModule.createVertex({
+      location: getGeminiLocation(),
+      project,
+    }),
+  };
+
+  const anthropicModule = getVertexAnthropicModule();
+  if (anthropicModule && isAnthropicFeatureEnabled()) {
+    bundle.anthropic = anthropicModule.createVertexAnthropic({
+      location: getAnthropicLocation(),
+      project,
+    });
+  }
+
+  const maasModule = getVertexMaasModule();
+  if (maasModule && isMaasFeatureEnabled()) {
+    bundle.maas = maasModule.createVertexMaas({
+      location: getGeminiLocation(),
+      project,
+    });
+  }
+
+  vertexProviderBundle = bundle;
+  return vertexProviderBundle;
+};
+
+/** Resolve a model id to a Vertex LanguageModel, or undefined if Vertex/disabled. */
+export const resolveVertexLanguageModel = (modelId: string): LanguageModel | undefined => {
+  const bundle = getVertexProviderBundle();
+  if (!bundle) {
+    return undefined;
+  }
+
+  if (!isVertexModelAllowed(modelId)) {
+    return undefined;
+  }
+
+  const providerKind = inferVertexModelProvider(modelId);
+
+  if (providerKind === "anthropic") {
+    if (!bundle.anthropic) {
+      return undefined;
+    }
+    return bundle.anthropic(modelId);
+  }
+
+  if (providerKind === "maas") {
+    if (!bundle.maas) {
+      return undefined;
+    }
+    return bundle.maas(modelId);
+  }
+
+  return bundle.gemini(modelId);
+};
+
+/** Gemini Vertex provider (language + Imagen image models). */
+export const getVertexGeminiProvider = (): VertexGeminiProvider | undefined => {
+  const bundle = getVertexProviderBundle();
+  return bundle?.gemini;
+};

--- a/example-backend/src/api/vertexModels.ts
+++ b/example-backend/src/api/vertexModels.ts
@@ -11,17 +11,43 @@ export interface VertexModelEntry {
   requiresFeatureFlag?: "anthropic" | "maas";
 }
 
-/** Default chat model (Gemini on Vertex Model Garden). */
-export const DEFAULT_VERTEX_MODEL_ID = "gemini-3.5-flash";
+export interface VertexModelPickerOption {
+  label: string;
+  value: string;
+}
 
-/** Lightweight model for auto-generated conversation titles. */
-export const TITLE_VERTEX_MODEL_ID = "gemini-3.1-flash-lite";
+/** How {@link VertexModelRegistryOptions.catalog} and {@link VertexModelRegistryOptions.additionalCatalog} combine. */
+export type VertexModelCatalogMode = "extend" | "replace";
+
+export interface VertexModelRegistryOptions {
+  /**
+   * When `replace`, `catalog` is the full allowlist (defaults omitted unless `includeDefaultCatalog` is true).
+   * When `extend` (default), `catalog` merges on top of defaults / `additionalCatalog`.
+   */
+  catalogMode?: VertexModelCatalogMode;
+  /** Base or replacement catalog entries (see `catalogMode`). */
+  catalog?: VertexModelEntry[];
+  /** Extra entries merged after the base catalog; later `id` wins. */
+  additionalCatalog?: VertexModelEntry[];
+  /** When `catalogMode` is `replace`, also merge {@link DEFAULT_VERTEX_MODEL_CATALOG} first. Default false. */
+  includeDefaultCatalog?: boolean;
+  defaultModelId?: string;
+  titleModelId?: string;
+  /** Allow gemini-shaped ids not in the catalog. Default true. */
+  allowUnknownGeminiModels?: boolean;
+  /** Allow claude-shaped ids not in the catalog when Anthropic is enabled. Default false. */
+  allowUnknownAnthropicModels?: boolean;
+  /** Allow MaaS-shaped ids not in the catalog when MaaS is enabled. Default false. */
+  allowUnknownMaasModels?: boolean;
+  isAnthropicEnabled?: () => boolean;
+  isMaasEnabled?: () => boolean;
+}
 
 /**
  * Curated models for the example app via Gemini Enterprise Agent Platform (Vertex AI).
  * @see https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/model-versions
  */
-export const VERTEX_MODEL_CATALOG: VertexModelEntry[] = [
+export const DEFAULT_VERTEX_MODEL_CATALOG: VertexModelEntry[] = [
   {id: "gemini-3.5-flash", label: "Gemini 3.5 Flash", provider: "gemini"},
   {id: "gemini-3.1-flash-lite", label: "Gemini 3.1 Flash Lite", provider: "gemini"},
   {id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro Preview", provider: "gemini"},
@@ -47,32 +73,71 @@ export const VERTEX_MODEL_CATALOG: VertexModelEntry[] = [
   },
 ];
 
-const isAnthropicFeatureEnabled = (): boolean =>
+/** Default chat model (Gemini on Vertex Model Garden). */
+export const DEFAULT_VERTEX_MODEL_ID = "gemini-3.5-flash";
+
+/** Lightweight model for auto-generated conversation titles. */
+export const TITLE_VERTEX_MODEL_ID = "gemini-3.1-flash-lite";
+
+/** @deprecated Use {@link DEFAULT_VERTEX_MODEL_CATALOG}. Kept for backward compatibility. */
+export const VERTEX_MODEL_CATALOG = DEFAULT_VERTEX_MODEL_CATALOG;
+
+const defaultIsAnthropicFeatureEnabled = (): boolean =>
   process.env.GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS === "true";
 
-const isMaasFeatureEnabled = (): boolean => process.env.GOOGLE_VERTEX_ENABLE_MAAS_MODELS === "true";
+const defaultIsMaasFeatureEnabled = (): boolean =>
+  process.env.GOOGLE_VERTEX_ENABLE_MAAS_MODELS === "true";
 
-/** Models exposed in API/UI given current env flags. */
-export const getEnabledVertexModelCatalog = (): VertexModelEntry[] =>
-  VERTEX_MODEL_CATALOG.filter((entry) => {
-    if (entry.requiresFeatureFlag === "anthropic") {
-      return isAnthropicFeatureEnabled();
+const mergeCatalogEntries = (...groups: VertexModelEntry[][]): VertexModelEntry[] => {
+  const byId = new Map<string, VertexModelEntry>();
+  for (const group of groups) {
+    for (const entry of group) {
+      byId.set(entry.id, entry);
     }
-    if (entry.requiresFeatureFlag === "maas") {
-      return isMaasFeatureEnabled();
-    }
-    return true;
-  });
+  }
+  return [...byId.values()];
+};
 
-const catalogById = (): Map<string, VertexModelEntry> =>
-  new Map(VERTEX_MODEL_CATALOG.map((entry) => [entry.id, entry]));
+const resolveCatalog = (options: VertexModelRegistryOptions): VertexModelEntry[] => {
+  const mode = options.catalogMode ?? "extend";
+  const catalog = options.catalog ?? [];
+  const additional = options.additionalCatalog ?? [];
+
+  if (mode === "replace") {
+    const base = options.includeDefaultCatalog ? DEFAULT_VERTEX_MODEL_CATALOG : [];
+    return mergeCatalogEntries(base, catalog, additional);
+  }
+
+  return mergeCatalogEntries(DEFAULT_VERTEX_MODEL_CATALOG, catalog, additional);
+};
+
+/** Map catalog entries to UI picker options (enabled entries only). */
+export const vertexCatalogToPickerOptions = (
+  entries: VertexModelEntry[],
+  isAnthropicEnabled: () => boolean = defaultIsAnthropicFeatureEnabled,
+  isMaasEnabled: () => boolean = defaultIsMaasFeatureEnabled
+): VertexModelPickerOption[] =>
+  entries
+    .filter((entry) => {
+      if (entry.requiresFeatureFlag === "anthropic") {
+        return isAnthropicEnabled();
+      }
+      if (entry.requiresFeatureFlag === "maas") {
+        return isMaasEnabled();
+      }
+      return true;
+    })
+    .map((entry) => ({label: entry.label, value: entry.id}));
 
 /**
  * Infer provider from a raw model id when not in the catalog (e.g. custom Vertex ids).
  * Gemini Enterprise Model Garden routes third-party models by id shape.
  */
-export const inferVertexModelProvider = (modelId: string): VertexModelProviderKind => {
-  const catalogEntry = catalogById().get(modelId);
+export const inferVertexModelProvider = (
+  modelId: string,
+  catalogById?: Map<string, VertexModelEntry>
+): VertexModelProviderKind => {
+  const catalogEntry = catalogById?.get(modelId);
   if (catalogEntry) {
     return catalogEntry.provider;
   }
@@ -93,20 +158,115 @@ export const inferVertexModelProvider = (modelId: string): VertexModelProviderKi
   return "gemini";
 };
 
-/** Whether this model id is allowed for server-side Vertex routing. */
-export const isVertexModelAllowed = (modelId: string): boolean => {
-  const entry = catalogById().get(modelId);
-  if (!entry) {
-    return inferVertexModelProvider(modelId) === "gemini";
+export class VertexModelRegistry {
+  private readonly catalog: VertexModelEntry[];
+  private readonly catalogById: Map<string, VertexModelEntry>;
+  private readonly defaultModelId: string;
+  private readonly titleModelId: string;
+  private readonly allowUnknownGeminiModels: boolean;
+  private readonly allowUnknownAnthropicModels: boolean;
+  private readonly allowUnknownMaasModels: boolean;
+  private readonly isAnthropicEnabled: () => boolean;
+  private readonly isMaasEnabled: () => boolean;
+
+  constructor(options: VertexModelRegistryOptions = {}) {
+    this.catalog = resolveCatalog(options);
+    this.catalogById = new Map(this.catalog.map((entry) => [entry.id, entry]));
+    this.defaultModelId = options.defaultModelId ?? DEFAULT_VERTEX_MODEL_ID;
+    this.titleModelId = options.titleModelId ?? TITLE_VERTEX_MODEL_ID;
+    this.allowUnknownGeminiModels = options.allowUnknownGeminiModels ?? true;
+    this.allowUnknownAnthropicModels = options.allowUnknownAnthropicModels ?? false;
+    this.allowUnknownMaasModels = options.allowUnknownMaasModels ?? false;
+    this.isAnthropicEnabled = options.isAnthropicEnabled ?? defaultIsAnthropicFeatureEnabled;
+    this.isMaasEnabled = options.isMaasEnabled ?? defaultIsMaasFeatureEnabled;
   }
-  if (entry.requiresFeatureFlag === "anthropic") {
-    return isAnthropicFeatureEnabled();
-  }
-  if (entry.requiresFeatureFlag === "maas") {
-    return isMaasFeatureEnabled();
-  }
-  return true;
+
+  getDefaultModelId = (): string => this.defaultModelId;
+
+  getTitleModelId = (): string => this.titleModelId;
+
+  getCatalog = (): VertexModelEntry[] => [...this.catalog];
+
+  /** Models exposed in API/UI given current env flags. */
+  getEnabledCatalog = (): VertexModelEntry[] =>
+    this.catalog.filter((entry) => {
+      if (entry.requiresFeatureFlag === "anthropic") {
+        return this.isAnthropicEnabled();
+      }
+      if (entry.requiresFeatureFlag === "maas") {
+        return this.isMaasEnabled();
+      }
+      return true;
+    });
+
+  getPickerOptions = (): VertexModelPickerOption[] =>
+    vertexCatalogToPickerOptions(this.getEnabledCatalog(), this.isAnthropicEnabled, this.isMaasEnabled);
+
+  inferProvider = (modelId: string): VertexModelProviderKind =>
+    inferVertexModelProvider(modelId, this.catalogById);
+
+  /** Whether this model id is allowed for server-side Vertex routing. */
+  isModelAllowed = (modelId: string): boolean => {
+    const entry = this.catalogById.get(modelId);
+    if (entry) {
+      if (entry.requiresFeatureFlag === "anthropic") {
+        return this.isAnthropicEnabled();
+      }
+      if (entry.requiresFeatureFlag === "maas") {
+        return this.isMaasEnabled();
+      }
+      return true;
+    }
+
+    const providerKind = this.inferProvider(modelId);
+    if (providerKind === "gemini") {
+      return this.allowUnknownGeminiModels;
+    }
+    if (providerKind === "anthropic") {
+      return this.allowUnknownAnthropicModels && this.isAnthropicEnabled();
+    }
+    return this.allowUnknownMaasModels && this.isMaasEnabled();
+  };
+}
+
+/** Create an isolated registry (does not affect the process-wide default). */
+export const createVertexModelRegistry = (options?: VertexModelRegistryOptions): VertexModelRegistry =>
+  new VertexModelRegistry(options);
+
+let activeRegistry: VertexModelRegistry = createVertexModelRegistry();
+
+/** Process-wide Vertex model registry used by {@link resolveVertexLanguageModel} and helpers. */
+export const getVertexModelRegistry = (): VertexModelRegistry => activeRegistry;
+
+/**
+ * Replace the process-wide registry (e.g. at app startup).
+ * Resets cached Vertex SDK providers so new feature-flag handlers apply.
+ */
+export const configureVertexModels = (options: VertexModelRegistryOptions): VertexModelRegistry => {
+  activeRegistry = createVertexModelRegistry(options);
+  vertexProviderBundle = undefined;
+  return activeRegistry;
 };
+
+/** Reset to built-in defaults (mostly for tests). */
+export const resetVertexModels = (): VertexModelRegistry => configureVertexModels({});
+
+// --- Module-level helpers delegating to active registry ---
+
+export const getEnabledVertexModelCatalog = (): VertexModelEntry[] =>
+  getVertexModelRegistry().getEnabledCatalog();
+
+export const getVertexModelPickerOptions = (): VertexModelPickerOption[] =>
+  getVertexModelRegistry().getPickerOptions();
+
+export const isVertexModelAllowed = (modelId: string): boolean =>
+  getVertexModelRegistry().isModelAllowed(modelId);
+
+export const inferVertexModelProviderFromRegistry = (modelId: string): VertexModelProviderKind =>
+  getVertexModelRegistry().inferProvider(modelId);
+
+// Re-export with legacy name used by tests
+export {inferVertexModelProviderFromRegistry as inferVertexModelProviderForActiveRegistry};
 
 type LanguageModelFactory = (modelId: string) => LanguageModel;
 
@@ -182,6 +342,8 @@ export const getVertexProviderBundle = (): VertexProviderBundle | undefined => {
     return undefined;
   }
 
+  const registry = getVertexModelRegistry();
+
   const bundle: VertexProviderBundle = {
     gemini: geminiModule.createVertex({
       location: getGeminiLocation(),
@@ -190,7 +352,7 @@ export const getVertexProviderBundle = (): VertexProviderBundle | undefined => {
   };
 
   const anthropicModule = getVertexAnthropicModule();
-  if (anthropicModule && isAnthropicFeatureEnabled()) {
+  if (anthropicModule && registry.isModelAllowed("claude-sonnet-4-6")) {
     bundle.anthropic = anthropicModule.createVertexAnthropic({
       location: getAnthropicLocation(),
       project,
@@ -198,7 +360,7 @@ export const getVertexProviderBundle = (): VertexProviderBundle | undefined => {
   }
 
   const maasModule = getVertexMaasModule();
-  if (maasModule && isMaasFeatureEnabled()) {
+  if (maasModule && registry.isModelAllowed("openai/gpt-oss-20b-maas")) {
     bundle.maas = maasModule.createVertexMaas({
       location: getGeminiLocation(),
       project,
@@ -216,11 +378,12 @@ export const resolveVertexLanguageModel = (modelId: string): LanguageModel | und
     return undefined;
   }
 
-  if (!isVertexModelAllowed(modelId)) {
+  const registry = getVertexModelRegistry();
+  if (!registry.isModelAllowed(modelId)) {
     return undefined;
   }
 
-  const providerKind = inferVertexModelProvider(modelId);
+  const providerKind = registry.inferProvider(modelId);
 
   if (providerKind === "anthropic") {
     if (!bundle.anthropic) {

--- a/example-backend/src/api/vertexModels.ts
+++ b/example-backend/src/api/vertexModels.ts
@@ -109,7 +109,7 @@ const resolveCatalog = (options: VertexModelRegistryOptions): VertexModelEntry[]
 };
 
 /** Map catalog entries to UI picker options (enabled entries only). */
-export const vertexCatalogToPickerOptions = (
+const vertexCatalogToPickerOptions = (
   entries: VertexModelEntry[],
   isAnthropicEnabled: () => boolean = defaultIsAnthropicFeatureEnabled,
   isMaasEnabled: () => boolean = defaultIsMaasFeatureEnabled

--- a/example-backend/src/api/vertexModels.ts
+++ b/example-backend/src/api/vertexModels.ts
@@ -200,11 +200,7 @@ export class VertexModelRegistry {
     });
 
   getPickerOptions = (): VertexModelPickerOption[] =>
-    vertexCatalogToPickerOptions(
-      this.getEnabledCatalog(),
-      this.isAnthropicEnabled,
-      this.isMaasEnabled
-    );
+    vertexCatalogToPickerOptions(this.catalog, this.isAnthropicEnabled, this.isMaasEnabled);
 
   /** Whether the Anthropic Vertex SDK should be initialized for the active catalog/allowlist. */
   needsAnthropicProvider = (): boolean => {
@@ -288,12 +284,6 @@ export const getVertexModelPickerOptions = (): VertexModelPickerOption[] =>
 
 export const isVertexModelAllowed = (modelId: string): boolean =>
   getVertexModelRegistry().isModelAllowed(modelId);
-
-export const inferVertexModelProviderFromRegistry = (modelId: string): VertexModelProviderKind =>
-  getVertexModelRegistry().inferProvider(modelId);
-
-// Re-export with legacy name used by tests
-export {inferVertexModelProviderFromRegistry as inferVertexModelProviderForActiveRegistry};
 
 type LanguageModelFactory = (modelId: string) => LanguageModel;
 

--- a/example-backend/src/api/vertexModels.ts
+++ b/example-backend/src/api/vertexModels.ts
@@ -79,9 +79,6 @@ export const DEFAULT_VERTEX_MODEL_ID = "gemini-3.5-flash";
 /** Lightweight model for auto-generated conversation titles. */
 export const TITLE_VERTEX_MODEL_ID = "gemini-3.1-flash-lite";
 
-/** @deprecated Use {@link DEFAULT_VERTEX_MODEL_CATALOG}. Kept for backward compatibility. */
-export const VERTEX_MODEL_CATALOG = DEFAULT_VERTEX_MODEL_CATALOG;
-
 const defaultIsAnthropicFeatureEnabled = (): boolean =>
   process.env.GOOGLE_VERTEX_ENABLE_ANTHROPIC_MODELS === "true";
 

--- a/example-backend/src/models/appConfiguration.ts
+++ b/example-backend/src/models/appConfiguration.ts
@@ -88,6 +88,112 @@ const debugSchema = new Schema(
   {_id: false}
 );
 
+const vertexModelCatalogEntrySchema = new Schema(
+  {
+    id: {
+      description: "Vertex model id (e.g. gemini-3.5-flash, claude-sonnet-4-6)",
+      required: true,
+      type: String,
+    },
+    label: {
+      description: "Display label in the chat model picker",
+      required: true,
+      type: String,
+    },
+    provider: {
+      description: "Model provider on Vertex",
+      enum: ["gemini", "anthropic", "maas"],
+      required: true,
+      type: String,
+    },
+  },
+  {_id: false}
+);
+
+const vertexAiSchema = new Schema(
+  {
+    additionalCatalog: {
+      default: [],
+      description: "Extra models merged into the Vertex catalog (admin-managed)",
+      type: [vertexModelCatalogEntrySchema],
+    },
+    allowUnknownAnthropicModels: {
+      default: false,
+      description: "Allow Claude-shaped model ids not listed in the catalog",
+      type: Boolean,
+    },
+    allowUnknownGeminiModels: {
+      default: true,
+      description: "Allow Gemini-shaped model ids not listed in the catalog",
+      type: Boolean,
+    },
+    allowUnknownMaasModels: {
+      default: false,
+      description: "Allow MaaS-shaped model ids not listed in the catalog",
+      type: Boolean,
+    },
+    anthropicLocation: {
+      default: "us-east5",
+      description: "Google Cloud region for Vertex Anthropic models",
+      type: String,
+    },
+    catalogMode: {
+      default: "extend",
+      description: "How additionalCatalog combines with defaults (extend or replace)",
+      enum: ["extend", "replace"],
+      type: String,
+    },
+    defaultModelId: {
+      default: "gemini-3.5-flash",
+      description: "Default chat model id for new conversations",
+      type: String,
+    },
+    enableAnthropicModels: {
+      default: false,
+      description: "Expose Anthropic (Claude) models from the Vertex catalog",
+      type: Boolean,
+    },
+    enabled: {
+      default: false,
+      description: "Use Vertex AI for server-side chat (requires project id and ADC)",
+      type: Boolean,
+    },
+    enableMaasModels: {
+      default: false,
+      description: "Expose MaaS (open-weight) models from the Vertex catalog",
+      type: Boolean,
+    },
+    geminiApiKey: {
+      default: "",
+      description: "Gemini API key fallback when Vertex is disabled or unavailable",
+      secret: true,
+      secretName: "gemini-api-key",
+      type: String,
+    },
+    includeDefaultCatalog: {
+      default: true,
+      description: "When catalog mode is replace, also include the built-in default catalog",
+      type: Boolean,
+    },
+    location: {
+      default: "us-central1",
+      description: "Google Cloud region for Vertex Gemini and MaaS models",
+      type: String,
+    },
+    projectId: {
+      default: "",
+      description: "Google Cloud project id for Vertex AI",
+      type: String,
+    },
+    titleModelId: {
+      default: "gemini-3.1-flash-lite",
+      description: "Model id used to auto-generate conversation titles",
+      type: String,
+    },
+  },
+  {_id: false}
+);
+
 export interface AppConfigDocument {
   general: {
     appName: string;
@@ -106,6 +212,27 @@ export interface AppConfigDocument {
   };
   debug: {
     websocketsDebug: boolean;
+  };
+  vertexAi: {
+    additionalCatalog: Array<{
+      id: string;
+      label: string;
+      provider: "gemini" | "anthropic" | "maas";
+    }>;
+    allowUnknownAnthropicModels: boolean;
+    allowUnknownGeminiModels: boolean;
+    allowUnknownMaasModels: boolean;
+    anthropicLocation: string;
+    catalogMode: "extend" | "replace";
+    defaultModelId: string;
+    enableAnthropicModels: boolean;
+    enableMaasModels: boolean;
+    enabled: boolean;
+    geminiApiKey: string;
+    includeDefaultCatalog: boolean;
+    location: string;
+    projectId: string;
+    titleModelId: string;
   };
 }
 
@@ -127,12 +254,22 @@ const appConfigSchema = new Schema<AppConfigDocument>(
       description: "Notification preferences and channels",
       type: notificationsSchema,
     },
+    vertexAi: {
+      description: "Vertex AI model catalog, defaults, and provider settings",
+      type: vertexAiSchema,
+    },
   },
   {strict: "throw", toJSON: {virtuals: true}, toObject: {virtuals: true}}
 );
 
 appConfigSchema.plugin(configurationPlugin);
 appConfigSchema.plugin(createdUpdatedPlugin);
+
+appConfigSchema.post("save", () => {
+  void import("../vertexModelConfig").then((module) =>
+    module.configureExampleVertexModelsFromAdmin()
+  );
+});
 
 export const AppConfiguration = mongoose.model<AppConfigDocument>(
   "AppConfiguration",

--- a/example-backend/src/server.ts
+++ b/example-backend/src/server.ts
@@ -36,7 +36,7 @@ import {Todo} from "./models/todo";
 import {User} from "./models/user";
 import {seedFeatureFlags} from "./scripts/seed-feature-flags";
 import {connectToMongoDB} from "./utils/database";
-import {configureExampleVertexModels} from "./vertexModelConfig";
+import {configureExampleVertexModelsFromAdmin} from "./vertexModelConfig";
 
 const BOOT_START_TIME = process.hrtime();
 
@@ -117,7 +117,7 @@ export async function start(skipListen = false): Promise<express.Application> {
     logger.warn(`Failed to sync consent forms on startup: ${err}`);
   });
 
-  configureExampleVertexModels();
+  await configureExampleVertexModelsFromAdmin();
 
   // Enable OpenAPI request validation. Strips unknown properties and logs them.
   configureOpenApiValidator({

--- a/example-backend/src/server.ts
+++ b/example-backend/src/server.ts
@@ -36,6 +36,7 @@ import {Todo} from "./models/todo";
 import {User} from "./models/user";
 import {seedFeatureFlags} from "./scripts/seed-feature-flags";
 import {connectToMongoDB} from "./utils/database";
+import {configureExampleVertexModels} from "./vertexModelConfig";
 
 const BOOT_START_TIME = process.hrtime();
 
@@ -115,6 +116,8 @@ export async function start(skipListen = false): Promise<express.Application> {
   await syncConsents(consentDefinitions).catch((err: unknown) => {
     logger.warn(`Failed to sync consent forms on startup: ${err}`);
   });
+
+  configureExampleVertexModels();
 
   // Enable OpenAPI request validation. Strips unknown properties and logs them.
   configureOpenApiValidator({

--- a/example-backend/src/tests/setup.ts
+++ b/example-backend/src/tests/setup.ts
@@ -1,6 +1,7 @@
 import {afterAll, afterEach, beforeAll} from "bun:test";
 import {logger} from "@terreno/api";
 import mongoose from "mongoose";
+import {DEFAULT_VERTEX_ADMIN_SETTINGS, setVertexAdminSettings} from "../vertexAdminSettings";
 
 // Test database URI
 const TEST_MONGO_URI =
@@ -21,7 +22,10 @@ beforeAll(async () => {
   process.env.GCP_SERVICE_ACCOUNT_EMAIL = "TESTserviceAccountEmail@terreno-example.test";
   process.env.GCP_TASKS_NOTIFICATIONS_QUEUE = "TESTnotificationsQueue";
   process.env.GCP_TASK_PROCESSOR_QUEUE = "TESTtaskProcessorQueue";
-  process.env.GEMINI_API_KEY = "test-api-key";
+  setVertexAdminSettings({
+    ...DEFAULT_VERTEX_ADMIN_SETTINGS,
+    geminiApiKey: "test-api-key",
+  });
   process.env.SLACK_WEBHOOKS = '{"default": "http://localhost:3000/slack/TEST"}';
   process.env.GOOGLE_CHAT_WEBHOOKS = '{"default": "http://localhost:3000/googleChat/TEST"}';
   process.env.TOKEN_EXPIRES_IN = "1h";

--- a/example-backend/src/vertexAdminSettings.ts
+++ b/example-backend/src/vertexAdminSettings.ts
@@ -1,0 +1,52 @@
+import type {VertexModelEntry} from "./api/vertexModels";
+
+export interface VertexAdminSettings {
+  additionalCatalog: VertexModelEntry[];
+  allowUnknownAnthropicModels: boolean;
+  allowUnknownGeminiModels: boolean;
+  allowUnknownMaasModels: boolean;
+  anthropicLocation: string;
+  catalogMode: "extend" | "replace";
+  defaultModelId: string;
+  enableAnthropicModels: boolean;
+  enableMaasModels: boolean;
+  enabled: boolean;
+  geminiApiKey: string;
+  includeDefaultCatalog: boolean;
+  location: string;
+  projectId: string;
+  titleModelId: string;
+}
+
+export const DEFAULT_VERTEX_ADMIN_SETTINGS: VertexAdminSettings = {
+  additionalCatalog: [],
+  allowUnknownAnthropicModels: false,
+  allowUnknownGeminiModels: true,
+  allowUnknownMaasModels: false,
+  anthropicLocation: "us-east5",
+  catalogMode: "extend",
+  defaultModelId: "gemini-3.5-flash",
+  enableAnthropicModels: false,
+  enabled: false,
+  enableMaasModels: false,
+  geminiApiKey: "",
+  includeDefaultCatalog: true,
+  location: "us-central1",
+  projectId: "",
+  titleModelId: "gemini-3.1-flash-lite",
+};
+
+let activeVertexAdminSettings: VertexAdminSettings = {...DEFAULT_VERTEX_ADMIN_SETTINGS};
+
+export const getVertexAdminSettings = (): VertexAdminSettings => activeVertexAdminSettings;
+
+export const setVertexAdminSettings = (settings: VertexAdminSettings): void => {
+  activeVertexAdminSettings = settings;
+};
+
+export const resetVertexAdminSettings = (): void => {
+  activeVertexAdminSettings = {...DEFAULT_VERTEX_ADMIN_SETTINGS};
+};
+
+export const isVertexAiEnabled = (): boolean =>
+  activeVertexAdminSettings.enabled && activeVertexAdminSettings.projectId.length > 0;

--- a/example-backend/src/vertexModelConfig.test.ts
+++ b/example-backend/src/vertexModelConfig.test.ts
@@ -79,6 +79,17 @@ describe("vertexModelConfig", () => {
     expect(buildExampleVertexModelRegistryOptions().additionalCatalog).toBeUndefined();
   });
 
+  it("filters malformed entries from VERTEX_EXTRA_MODEL_CATALOG_JSON", () => {
+    process.env.VERTEX_EXTRA_MODEL_CATALOG_JSON = JSON.stringify([
+      {id: "partner-v1", label: "Partner", provider: "gemini"},
+      {id: "bad", label: "Bad", provider: "unknown"},
+      {label: "Missing id", provider: "gemini"},
+    ]);
+    expect(buildExampleVertexModelRegistryOptions().additionalCatalog).toEqual([
+      {id: "partner-v1", label: "Partner", provider: "gemini"},
+    ]);
+  });
+
   it("passes through default and title model env vars", () => {
     process.env.GOOGLE_VERTEX_DEFAULT_MODEL = "gemini-2.5-flash";
     process.env.GOOGLE_VERTEX_TITLE_MODEL = "gemini-2.5-flash";

--- a/example-backend/src/vertexModelConfig.test.ts
+++ b/example-backend/src/vertexModelConfig.test.ts
@@ -1,100 +1,65 @@
 import {afterEach, describe, expect, it} from "bun:test";
 import {resetVertexModels} from "./api/vertexModels";
-import {buildExampleVertexModelRegistryOptions} from "./vertexModelConfig";
-
-const restoreEnvVar = (key: string, original: string | undefined): void => {
-  if (original === undefined) {
-    delete process.env[key];
-    return;
-  }
-  process.env[key] = original;
-};
+import {resetVertexAdminSettings} from "./vertexAdminSettings";
+import {
+  buildExampleVertexModelRegistryOptions,
+  buildVertexAdminSettingsFromAppConfig,
+} from "./vertexModelConfig";
 
 describe("vertexModelConfig", () => {
-  const envKeys = [
-    "GOOGLE_VERTEX_ALLOW_UNKNOWN_ANTHROPIC_MODELS",
-    "GOOGLE_VERTEX_ALLOW_UNKNOWN_GEMINI_MODELS",
-    "GOOGLE_VERTEX_ALLOW_UNKNOWN_MAAS_MODELS",
-    "VERTEX_MODEL_CATALOG_MODE",
-    "VERTEX_EXTRA_MODEL_CATALOG_JSON",
-    "GOOGLE_VERTEX_DEFAULT_MODEL",
-    "GOOGLE_VERTEX_TITLE_MODEL",
-    "VERTEX_INCLUDE_DEFAULT_CATALOG",
-  ] as const;
-
-  const originalEnv: Record<string, string | undefined> = {};
-
   afterEach(() => {
-    for (const key of envKeys) {
-      restoreEnvVar(key, originalEnv[key]);
-    }
+    resetVertexAdminSettings();
     resetVertexModels();
   });
 
-  for (const key of envKeys) {
-    originalEnv[key] = process.env[key];
-  }
+  it("builds admin settings from vertexAi config document shape", () => {
+    const admin = buildVertexAdminSettingsFromAppConfig({
+      additionalCatalog: [{id: "partner-v1", label: "Partner", provider: "gemini"}],
+      allowUnknownGeminiModels: false,
+      catalogMode: "replace",
+      defaultModelId: "gemini-2.5-flash",
+      enableAnthropicModels: true,
+      enabled: true,
+      enableMaasModels: false,
+      geminiApiKey: "test-key",
+      projectId: "my-gcp-project",
+      titleModelId: "gemini-2.5-flash",
+    });
 
-  it("defaults allowUnknownGeminiModels to true when env is unset", () => {
-    delete process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_GEMINI_MODELS;
-    expect(buildExampleVertexModelRegistryOptions().allowUnknownGeminiModels).toBe(true);
-  });
-
-  it("parses boolean env as true only for true or 1", () => {
-    process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_GEMINI_MODELS = "true";
-    expect(buildExampleVertexModelRegistryOptions().allowUnknownGeminiModels).toBe(true);
-
-    process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_GEMINI_MODELS = "1";
-    expect(buildExampleVertexModelRegistryOptions().allowUnknownGeminiModels).toBe(true);
-
-    process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_GEMINI_MODELS = "";
-    expect(buildExampleVertexModelRegistryOptions().allowUnknownGeminiModels).toBe(false);
-
-    process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_GEMINI_MODELS = "false";
-    expect(buildExampleVertexModelRegistryOptions().allowUnknownGeminiModels).toBe(false);
-  });
-
-  it("uses replace catalog mode when VERTEX_MODEL_CATALOG_MODE is replace", () => {
-    process.env.VERTEX_MODEL_CATALOG_MODE = "replace";
-    expect(buildExampleVertexModelRegistryOptions().catalogMode).toBe("replace");
-
-    process.env.VERTEX_MODEL_CATALOG_MODE = "extend";
-    expect(buildExampleVertexModelRegistryOptions().catalogMode).toBe("extend");
-  });
-
-  it("parses VERTEX_EXTRA_MODEL_CATALOG_JSON when valid", () => {
-    process.env.VERTEX_EXTRA_MODEL_CATALOG_JSON = JSON.stringify([
+    expect(admin.enabled).toBe(true);
+    expect(admin.projectId).toBe("my-gcp-project");
+    expect(admin.enableAnthropicModels).toBe(true);
+    expect(admin.allowUnknownGeminiModels).toBe(false);
+    expect(admin.catalogMode).toBe("replace");
+    expect(admin.additionalCatalog).toEqual([
       {id: "partner-v1", label: "Partner", provider: "gemini"},
     ]);
-    expect(buildExampleVertexModelRegistryOptions().additionalCatalog).toEqual([
-      {id: "partner-v1", label: "Partner", provider: "gemini"},
-    ]);
+    expect(admin.geminiApiKey).toBe("test-key");
   });
 
-  it("ignores invalid VERTEX_EXTRA_MODEL_CATALOG_JSON", () => {
-    process.env.VERTEX_EXTRA_MODEL_CATALOG_JSON = "not-json";
-    expect(buildExampleVertexModelRegistryOptions().additionalCatalog).toBeUndefined();
+  it("filters malformed additional catalog entries", () => {
+    const admin = buildVertexAdminSettingsFromAppConfig({
+      additionalCatalog: [
+        {id: "partner-v1", label: "Partner", provider: "gemini"},
+        {id: "bad", label: "Bad", provider: "unknown"},
+        {label: "Missing id", provider: "gemini"},
+      ],
+    });
 
-    process.env.VERTEX_EXTRA_MODEL_CATALOG_JSON = JSON.stringify({id: "not-array"});
-    expect(buildExampleVertexModelRegistryOptions().additionalCatalog).toBeUndefined();
-  });
-
-  it("filters malformed entries from VERTEX_EXTRA_MODEL_CATALOG_JSON", () => {
-    process.env.VERTEX_EXTRA_MODEL_CATALOG_JSON = JSON.stringify([
-      {id: "partner-v1", label: "Partner", provider: "gemini"},
-      {id: "bad", label: "Bad", provider: "unknown"},
-      {label: "Missing id", provider: "gemini"},
-    ]);
-    expect(buildExampleVertexModelRegistryOptions().additionalCatalog).toEqual([
+    expect(admin.additionalCatalog).toEqual([
       {id: "partner-v1", label: "Partner", provider: "gemini"},
     ]);
   });
 
-  it("passes through default and title model env vars", () => {
-    process.env.GOOGLE_VERTEX_DEFAULT_MODEL = "gemini-2.5-flash";
-    process.env.GOOGLE_VERTEX_TITLE_MODEL = "gemini-2.5-flash";
-    const options = buildExampleVertexModelRegistryOptions();
-    expect(options.defaultModelId).toBe("gemini-2.5-flash");
-    expect(options.titleModelId).toBe("gemini-2.5-flash");
+  it("builds registry options from admin settings", () => {
+    const admin = buildVertexAdminSettingsFromAppConfig({
+      enableAnthropicModels: true,
+      enableMaasModels: true,
+    });
+    const options = buildExampleVertexModelRegistryOptions(admin);
+
+    expect(options.isAnthropicEnabled?.()).toBe(true);
+    expect(options.isMaasEnabled?.()).toBe(true);
+    expect(options.catalogMode).toBe("extend");
   });
 });

--- a/example-backend/src/vertexModelConfig.test.ts
+++ b/example-backend/src/vertexModelConfig.test.ts
@@ -1,0 +1,89 @@
+import {afterEach, describe, expect, it} from "bun:test";
+import {resetVertexModels} from "./api/vertexModels";
+import {buildExampleVertexModelRegistryOptions} from "./vertexModelConfig";
+
+const restoreEnvVar = (key: string, original: string | undefined): void => {
+  if (original === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = original;
+};
+
+describe("vertexModelConfig", () => {
+  const envKeys = [
+    "GOOGLE_VERTEX_ALLOW_UNKNOWN_ANTHROPIC_MODELS",
+    "GOOGLE_VERTEX_ALLOW_UNKNOWN_GEMINI_MODELS",
+    "GOOGLE_VERTEX_ALLOW_UNKNOWN_MAAS_MODELS",
+    "VERTEX_MODEL_CATALOG_MODE",
+    "VERTEX_EXTRA_MODEL_CATALOG_JSON",
+    "GOOGLE_VERTEX_DEFAULT_MODEL",
+    "GOOGLE_VERTEX_TITLE_MODEL",
+    "VERTEX_INCLUDE_DEFAULT_CATALOG",
+  ] as const;
+
+  const originalEnv: Record<string, string | undefined> = {};
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      restoreEnvVar(key, originalEnv[key]);
+    }
+    resetVertexModels();
+  });
+
+  for (const key of envKeys) {
+    originalEnv[key] = process.env[key];
+  }
+
+  it("defaults allowUnknownGeminiModels to true when env is unset", () => {
+    delete process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_GEMINI_MODELS;
+    expect(buildExampleVertexModelRegistryOptions().allowUnknownGeminiModels).toBe(true);
+  });
+
+  it("parses boolean env as true only for true or 1", () => {
+    process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_GEMINI_MODELS = "true";
+    expect(buildExampleVertexModelRegistryOptions().allowUnknownGeminiModels).toBe(true);
+
+    process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_GEMINI_MODELS = "1";
+    expect(buildExampleVertexModelRegistryOptions().allowUnknownGeminiModels).toBe(true);
+
+    process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_GEMINI_MODELS = "";
+    expect(buildExampleVertexModelRegistryOptions().allowUnknownGeminiModels).toBe(false);
+
+    process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_GEMINI_MODELS = "false";
+    expect(buildExampleVertexModelRegistryOptions().allowUnknownGeminiModels).toBe(false);
+  });
+
+  it("uses replace catalog mode when VERTEX_MODEL_CATALOG_MODE is replace", () => {
+    process.env.VERTEX_MODEL_CATALOG_MODE = "replace";
+    expect(buildExampleVertexModelRegistryOptions().catalogMode).toBe("replace");
+
+    process.env.VERTEX_MODEL_CATALOG_MODE = "extend";
+    expect(buildExampleVertexModelRegistryOptions().catalogMode).toBe("extend");
+  });
+
+  it("parses VERTEX_EXTRA_MODEL_CATALOG_JSON when valid", () => {
+    process.env.VERTEX_EXTRA_MODEL_CATALOG_JSON = JSON.stringify([
+      {id: "partner-v1", label: "Partner", provider: "gemini"},
+    ]);
+    expect(buildExampleVertexModelRegistryOptions().additionalCatalog).toEqual([
+      {id: "partner-v1", label: "Partner", provider: "gemini"},
+    ]);
+  });
+
+  it("ignores invalid VERTEX_EXTRA_MODEL_CATALOG_JSON", () => {
+    process.env.VERTEX_EXTRA_MODEL_CATALOG_JSON = "not-json";
+    expect(buildExampleVertexModelRegistryOptions().additionalCatalog).toBeUndefined();
+
+    process.env.VERTEX_EXTRA_MODEL_CATALOG_JSON = JSON.stringify({id: "not-array"});
+    expect(buildExampleVertexModelRegistryOptions().additionalCatalog).toBeUndefined();
+  });
+
+  it("passes through default and title model env vars", () => {
+    process.env.GOOGLE_VERTEX_DEFAULT_MODEL = "gemini-2.5-flash";
+    process.env.GOOGLE_VERTEX_TITLE_MODEL = "gemini-2.5-flash";
+    const options = buildExampleVertexModelRegistryOptions();
+    expect(options.defaultModelId).toBe("gemini-2.5-flash");
+    expect(options.titleModelId).toBe("gemini-2.5-flash");
+  });
+});

--- a/example-backend/src/vertexModelConfig.ts
+++ b/example-backend/src/vertexModelConfig.ts
@@ -1,6 +1,34 @@
 import {resetAiServiceCache} from "./api/ai";
-import type {VertexModelEntry, VertexModelRegistryOptions} from "./api/vertexModels";
+import type {
+  VertexModelEntry,
+  VertexModelProviderKind,
+  VertexModelRegistryOptions,
+} from "./api/vertexModels";
 import {configureVertexModels} from "./api/vertexModels";
+
+const isVertexProviderKind = (value: unknown): value is VertexModelProviderKind =>
+  value === "gemini" || value === "anthropic" || value === "maas";
+
+const isVertexModelEntry = (value: unknown): value is VertexModelEntry => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const entry = value as Record<string, unknown>;
+  if (typeof entry.id !== "string" || typeof entry.label !== "string") {
+    return false;
+  }
+  if (!isVertexProviderKind(entry.provider)) {
+    return false;
+  }
+  if (
+    entry.requiresFeatureFlag !== undefined &&
+    entry.requiresFeatureFlag !== "anthropic" &&
+    entry.requiresFeatureFlag !== "maas"
+  ) {
+    return false;
+  }
+  return true;
+};
 
 const parseBooleanEnv = (value: string | undefined, defaultValue: boolean): boolean => {
   if (value === undefined) {
@@ -20,7 +48,11 @@ const parseExtraCatalogFromEnv = (): VertexModelEntry[] | undefined => {
     if (!Array.isArray(parsed)) {
       return undefined;
     }
-    return parsed as VertexModelEntry[];
+    const entries = parsed.filter(isVertexModelEntry);
+    if (entries.length === 0) {
+      return undefined;
+    }
+    return entries;
   } catch {
     return undefined;
   }

--- a/example-backend/src/vertexModelConfig.ts
+++ b/example-backend/src/vertexModelConfig.ts
@@ -1,6 +1,6 @@
+import {resetAiServiceCache} from "./api/ai";
 import type {VertexModelEntry, VertexModelRegistryOptions} from "./api/vertexModels";
 import {configureVertexModels} from "./api/vertexModels";
-import {resetAiServiceCache} from "./api/ai";
 
 const parseBooleanEnv = (value: string | undefined, defaultValue: boolean): boolean => {
   if (value === undefined) {
@@ -43,7 +43,10 @@ export const buildExampleVertexModelRegistryOptions = (): VertexModelRegistryOpt
       process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_GEMINI_MODELS,
       true
     ),
-    allowUnknownMaasModels: parseBooleanEnv(process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_MAAS_MODELS, false),
+    allowUnknownMaasModels: parseBooleanEnv(
+      process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_MAAS_MODELS,
+      false
+    ),
     catalogMode: process.env.VERTEX_MODEL_CATALOG_MODE === "replace" ? "replace" : "extend",
     defaultModelId: process.env.GOOGLE_VERTEX_DEFAULT_MODEL,
     includeDefaultCatalog: process.env.VERTEX_INCLUDE_DEFAULT_CATALOG !== "false",

--- a/example-backend/src/vertexModelConfig.ts
+++ b/example-backend/src/vertexModelConfig.ts
@@ -1,0 +1,58 @@
+import type {VertexModelEntry, VertexModelRegistryOptions} from "./api/vertexModels";
+import {configureVertexModels} from "./api/vertexModels";
+import {resetAiServiceCache} from "./api/ai";
+
+const parseBooleanEnv = (value: string | undefined, defaultValue: boolean): boolean => {
+  if (value === undefined) {
+    return defaultValue;
+  }
+  return value === "true" || value === "1";
+};
+
+const parseExtraCatalogFromEnv = (): VertexModelEntry[] | undefined => {
+  const raw = process.env.VERTEX_EXTRA_MODEL_CATALOG_JSON;
+  if (!raw) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      return undefined;
+    }
+    return parsed as VertexModelEntry[];
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Example-app Vertex model registry setup.
+ * Downstream apps call {@link configureVertexModels} at startup with their own catalog/options.
+ */
+export const buildExampleVertexModelRegistryOptions = (): VertexModelRegistryOptions => {
+  const additionalCatalog = parseExtraCatalogFromEnv();
+
+  return {
+    additionalCatalog,
+    allowUnknownAnthropicModels: parseBooleanEnv(
+      process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_ANTHROPIC_MODELS,
+      false
+    ),
+    allowUnknownGeminiModels: parseBooleanEnv(
+      process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_GEMINI_MODELS,
+      true
+    ),
+    allowUnknownMaasModels: parseBooleanEnv(process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_MAAS_MODELS, false),
+    catalogMode: process.env.VERTEX_MODEL_CATALOG_MODE === "replace" ? "replace" : "extend",
+    defaultModelId: process.env.GOOGLE_VERTEX_DEFAULT_MODEL,
+    includeDefaultCatalog: process.env.VERTEX_INCLUDE_DEFAULT_CATALOG !== "false",
+    titleModelId: process.env.GOOGLE_VERTEX_TITLE_MODEL,
+  };
+};
+
+/** Configure process-wide Vertex models for the example backend (call before route registration). */
+export const configureExampleVertexModels = (): void => {
+  configureVertexModels(buildExampleVertexModelRegistryOptions());
+  resetAiServiceCache();
+};

--- a/example-backend/src/vertexModelConfig.ts
+++ b/example-backend/src/vertexModelConfig.ts
@@ -1,93 +1,108 @@
 import {resetAiServiceCache} from "./api/ai";
-import type {
-  VertexModelEntry,
-  VertexModelProviderKind,
-  VertexModelRegistryOptions,
-} from "./api/vertexModels";
+import type {VertexModelEntry, VertexModelRegistryOptions} from "./api/vertexModels";
 import {configureVertexModels} from "./api/vertexModels";
+import {AppConfiguration} from "./models/appConfiguration";
+import {
+  resetVertexAdminSettings,
+  setVertexAdminSettings,
+  type VertexAdminSettings,
+} from "./vertexAdminSettings";
 
-const isVertexProviderKind = (value: unknown): value is VertexModelProviderKind =>
+const isVertexProviderKind = (value: unknown): value is VertexModelEntry["provider"] =>
   value === "gemini" || value === "anthropic" || value === "maas";
 
-const isVertexModelEntry = (value: unknown): value is VertexModelEntry => {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const entry = value as Record<string, unknown>;
-  if (typeof entry.id !== "string" || typeof entry.label !== "string") {
-    return false;
-  }
-  if (!isVertexProviderKind(entry.provider)) {
-    return false;
-  }
-  if (
-    entry.requiresFeatureFlag !== undefined &&
-    entry.requiresFeatureFlag !== "anthropic" &&
-    entry.requiresFeatureFlag !== "maas"
-  ) {
-    return false;
-  }
-  return true;
-};
-
-const parseBooleanEnv = (value: string | undefined, defaultValue: boolean): boolean => {
-  if (value === undefined) {
-    return defaultValue;
-  }
-  return value === "true" || value === "1";
-};
-
-const parseExtraCatalogFromEnv = (): VertexModelEntry[] | undefined => {
-  const raw = process.env.VERTEX_EXTRA_MODEL_CATALOG_JSON;
-  if (!raw) {
-    return undefined;
+const normalizeCatalogEntries = (value: unknown): VertexModelEntry[] => {
+  if (!Array.isArray(value)) {
+    return [];
   }
 
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) {
-      return undefined;
+  const entries: VertexModelEntry[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") {
+      continue;
     }
-    const entries = parsed.filter(isVertexModelEntry);
-    if (entries.length === 0) {
-      return undefined;
+    const record = item as Record<string, unknown>;
+    if (typeof record.id !== "string" || typeof record.label !== "string") {
+      continue;
     }
-    return entries;
-  } catch {
-    return undefined;
+    if (!isVertexProviderKind(record.provider)) {
+      continue;
+    }
+    entries.push({
+      id: record.id,
+      label: record.label,
+      provider: record.provider,
+    });
   }
+  return entries;
 };
 
-/**
- * Example-app Vertex model registry setup.
- * Downstream apps call {@link configureVertexModels} at startup with their own catalog/options.
- */
-export const buildExampleVertexModelRegistryOptions = (): VertexModelRegistryOptions => {
-  const additionalCatalog = parseExtraCatalogFromEnv();
+export const buildVertexAdminSettingsFromAppConfig = (vertexAi: unknown): VertexAdminSettings => {
+  const config = (vertexAi ?? {}) as Record<string, unknown>;
 
   return {
-    additionalCatalog,
-    allowUnknownAnthropicModels: parseBooleanEnv(
-      process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_ANTHROPIC_MODELS,
-      false
-    ),
-    allowUnknownGeminiModels: parseBooleanEnv(
-      process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_GEMINI_MODELS,
-      true
-    ),
-    allowUnknownMaasModels: parseBooleanEnv(
-      process.env.GOOGLE_VERTEX_ALLOW_UNKNOWN_MAAS_MODELS,
-      false
-    ),
-    catalogMode: process.env.VERTEX_MODEL_CATALOG_MODE === "replace" ? "replace" : "extend",
-    defaultModelId: process.env.GOOGLE_VERTEX_DEFAULT_MODEL,
-    includeDefaultCatalog: process.env.VERTEX_INCLUDE_DEFAULT_CATALOG !== "false",
-    titleModelId: process.env.GOOGLE_VERTEX_TITLE_MODEL,
+    additionalCatalog: normalizeCatalogEntries(config.additionalCatalog),
+    allowUnknownAnthropicModels: config.allowUnknownAnthropicModels === true,
+    allowUnknownGeminiModels: config.allowUnknownGeminiModels !== false,
+    allowUnknownMaasModels: config.allowUnknownMaasModels === true,
+    anthropicLocation:
+      typeof config.anthropicLocation === "string" && config.anthropicLocation.length > 0
+        ? config.anthropicLocation
+        : "us-east5",
+    catalogMode: config.catalogMode === "replace" ? "replace" : "extend",
+    defaultModelId:
+      typeof config.defaultModelId === "string" && config.defaultModelId.length > 0
+        ? config.defaultModelId
+        : "gemini-3.5-flash",
+    enableAnthropicModels: config.enableAnthropicModels === true,
+    enabled: config.enabled === true,
+    enableMaasModels: config.enableMaasModels === true,
+    geminiApiKey: typeof config.geminiApiKey === "string" ? config.geminiApiKey : "",
+    includeDefaultCatalog: config.includeDefaultCatalog !== false,
+    location:
+      typeof config.location === "string" && config.location.length > 0
+        ? config.location
+        : "us-central1",
+    projectId: typeof config.projectId === "string" ? config.projectId : "",
+    titleModelId:
+      typeof config.titleModelId === "string" && config.titleModelId.length > 0
+        ? config.titleModelId
+        : "gemini-3.1-flash-lite",
   };
 };
 
-/** Configure process-wide Vertex models for the example backend (call before route registration). */
-export const configureExampleVertexModels = (): void => {
-  configureVertexModels(buildExampleVertexModelRegistryOptions());
+export const buildExampleVertexModelRegistryOptions = (
+  admin: VertexAdminSettings
+): VertexModelRegistryOptions => ({
+  additionalCatalog: admin.additionalCatalog,
+  allowUnknownAnthropicModels: admin.allowUnknownAnthropicModels,
+  allowUnknownGeminiModels: admin.allowUnknownGeminiModels,
+  allowUnknownMaasModels: admin.allowUnknownMaasModels,
+  catalogMode: admin.catalogMode,
+  defaultModelId: admin.defaultModelId,
+  includeDefaultCatalog: admin.includeDefaultCatalog,
+  isAnthropicEnabled: () => admin.enableAnthropicModels,
+  isMaasEnabled: () => admin.enableMaasModels,
+  titleModelId: admin.titleModelId,
+});
+
+export const loadVertexAdminSettingsFromAppConfiguration =
+  async (): Promise<VertexAdminSettings> => {
+    const vertexAi = await AppConfiguration.getConfig("vertexAi");
+    return buildVertexAdminSettingsFromAppConfig(vertexAi);
+  };
+
+/** Configure process-wide Vertex models from admin AppConfiguration (call after MongoDB connect). */
+export const configureExampleVertexModelsFromAdmin = async (): Promise<void> => {
+  const admin = await loadVertexAdminSettingsFromAppConfiguration();
+  setVertexAdminSettings(admin);
+  configureVertexModels(buildExampleVertexModelRegistryOptions(admin));
+  resetAiServiceCache();
+};
+
+/** Reset admin-driven Vertex configuration (mostly for tests). */
+export const resetExampleVertexModelsFromAdmin = (): void => {
+  resetVertexAdminSettings();
+  configureVertexModels({});
   resetAiServiceCache();
 };

--- a/example-frontend/app/(tabs)/ai.tsx
+++ b/example-frontend/app/(tabs)/ai.tsx
@@ -65,9 +65,20 @@ const readFileAsBase64DataUrl = async (uri: string, _mimeType: string): Promise<
 };
 
 const AVAILABLE_MODELS = [
+  {label: "Gemini 3.5 Flash", value: "gemini-3.5-flash"},
   {label: "Gemini 3.1 Flash Lite", value: "gemini-3.1-flash-lite"},
+  {label: "Gemini 3.1 Pro Preview", value: "gemini-3.1-pro-preview"},
   {label: "Gemini 2.5 Flash", value: "gemini-2.5-flash"},
   {label: "Gemini 2.5 Pro", value: "gemini-2.5-pro"},
+  ...(process.env.EXPO_PUBLIC_VERTEX_ANTHROPIC_MODELS === "true"
+    ? [
+        {label: "Claude Sonnet 4.6 (Vertex)", value: "claude-sonnet-4-6"},
+        {label: "Claude Opus 4.6 (Vertex)", value: "claude-opus-4-6"},
+      ]
+    : []),
+  ...(process.env.EXPO_PUBLIC_VERTEX_MAAS_MODELS === "true"
+    ? [{label: "GPT-OSS 20B (Vertex MaaS)", value: "openai/gpt-oss-20b-maas"}]
+    : []),
 ];
 
 const AiScreen: React.FC = () => {

--- a/example-frontend/app/(tabs)/ai.tsx
+++ b/example-frontend/app/(tabs)/ai.tsx
@@ -88,7 +88,7 @@ const AiScreen: React.FC = () => {
   const {data: modelsData} = useGetGptModelsQuery(undefined, {skip: !userId});
 
   const availableModels = useMemo(() => {
-    const fromApi = modelsData?.data?.models;
+    const fromApi = modelsData?.models;
     if (fromApi && fromApi.length > 0) {
       return fromApi;
     }
@@ -97,7 +97,7 @@ const AiScreen: React.FC = () => {
 
   // Keep selected model valid when the server registry changes
   useEffect(() => {
-    const defaultId = modelsData?.data?.defaultModelId;
+    const defaultId = modelsData?.defaultModelId;
     if (!defaultId) {
       return;
     }

--- a/example-frontend/app/(tabs)/ai.tsx
+++ b/example-frontend/app/(tabs)/ai.tsx
@@ -10,13 +10,14 @@ import {
   useStoredState,
 } from "@terreno/ui";
 import type React from "react";
-import {useCallback, useState} from "react";
+import {useCallback, useEffect, useMemo, useState} from "react";
 import {useDispatch} from "react-redux";
 import {
   type GptHistory,
   terrenoApi,
   useDeleteGptHistoriesByIdMutation,
   useGetGptHistoriesQuery,
+  useGetGptModelsQuery,
   usePatchGptHistoriesByIdMutation,
 } from "@/store";
 
@@ -64,21 +65,13 @@ const readFileAsBase64DataUrl = async (uri: string, _mimeType: string): Promise<
   });
 };
 
-const AVAILABLE_MODELS = [
+/** Used when the backend model list is unavailable (offline / demo). */
+const FALLBACK_VERTEX_MODELS = [
   {label: "Gemini 3.5 Flash", value: "gemini-3.5-flash"},
   {label: "Gemini 3.1 Flash Lite", value: "gemini-3.1-flash-lite"},
   {label: "Gemini 3.1 Pro Preview", value: "gemini-3.1-pro-preview"},
   {label: "Gemini 2.5 Flash", value: "gemini-2.5-flash"},
   {label: "Gemini 2.5 Pro", value: "gemini-2.5-pro"},
-  ...(process.env.EXPO_PUBLIC_VERTEX_ANTHROPIC_MODELS === "true"
-    ? [
-        {label: "Claude Sonnet 4.6 (Vertex)", value: "claude-sonnet-4-6"},
-        {label: "Claude Opus 4.6 (Vertex)", value: "claude-opus-4-6"},
-      ]
-    : []),
-  ...(process.env.EXPO_PUBLIC_VERTEX_MAAS_MODELS === "true"
-    ? [{label: "GPT-OSS 20B (Vertex MaaS)", value: "openai/gpt-oss-20b-maas"}]
-    : []),
 ];
 
 const AiScreen: React.FC = () => {
@@ -87,11 +80,32 @@ const AiScreen: React.FC = () => {
   const [isStreaming, setIsStreaming] = useState<boolean>(false);
   const [geminiApiKey, setGeminiApiKey] = useStoredState<string>("geminiApiKey", "");
   const [attachments, setAttachments] = useState<SelectedFile[]>([]);
-  const [selectedModel, setSelectedModel] = useState<string>(AVAILABLE_MODELS[0].value);
+  const [selectedModel, setSelectedModel] = useState<string>(FALLBACK_VERTEX_MODELS[0].value);
 
   const dispatch = useDispatch();
   const userId = useSelectCurrentUserId();
   const {data: historiesData, isLoading} = useGetGptHistoriesQuery(undefined, {skip: !userId});
+  const {data: modelsData} = useGetGptModelsQuery(undefined, {skip: !userId});
+
+  const availableModels = useMemo(() => {
+    const fromApi = modelsData?.data?.models;
+    if (fromApi && fromApi.length > 0) {
+      return fromApi;
+    }
+    return FALLBACK_VERTEX_MODELS;
+  }, [modelsData]);
+
+  // Keep selected model valid when the server registry changes
+  useEffect(() => {
+    const defaultId = modelsData?.data?.defaultModelId;
+    if (!defaultId) {
+      return;
+    }
+    const allowed = new Set(availableModels.map((model) => model.value));
+    if (!allowed.has(selectedModel)) {
+      setSelectedModel(defaultId);
+    }
+  }, [modelsData, availableModels, selectedModel]);
   const [deleteHistory] = useDeleteGptHistoriesByIdMutation();
   const [patchHistory] = usePatchGptHistoriesByIdMutation();
 
@@ -414,7 +428,7 @@ const AiScreen: React.FC = () => {
   return (
     <GPTChat
       attachments={attachments}
-      availableModels={AVAILABLE_MODELS}
+      availableModels={availableModels}
       currentHistoryId={currentHistoryId}
       currentMessages={currentMessages}
       geminiApiKey={geminiApiKey}

--- a/example-frontend/store/sdk.ts
+++ b/example-frontend/store/sdk.ts
@@ -112,18 +112,18 @@ export const terrenoApi = openapi
           url: "/aiRequestsExplorer",
         }),
       }),
+      getGptModels: builder.query<GptModelsResponse, void>({
+        query: () => ({
+          method: "GET",
+          url: "/gpt/models",
+        }),
+      }),
       // Get current user profile
       getMe: builder.query<ProfileResponse, void>({
         providesTags: ["profile"],
         query: () => ({
           method: "GET",
           url: "/auth/me",
-        }),
-      }),
-      getGptModels: builder.query<GptModelsResponse, void>({
-        query: () => ({
-          method: "GET",
-          url: "/gpt/models",
         }),
       }),
       // Update current user profile

--- a/example-frontend/store/sdk.ts
+++ b/example-frontend/store/sdk.ts
@@ -91,12 +91,11 @@ export interface GptModelOption {
   value: string;
 }
 
+/** emptyApi's base query already unwraps the `data` envelope from the API. */
 export interface GptModelsResponse {
-  data: {
-    defaultModelId: string;
-    models: GptModelOption[];
-    titleModelId: string;
-  };
+  defaultModelId: string;
+  models: GptModelOption[];
+  titleModelId: string;
 }
 
 export const terrenoApi = openapi

--- a/example-frontend/store/sdk.ts
+++ b/example-frontend/store/sdk.ts
@@ -86,6 +86,19 @@ export interface SetAdminUserPasswordRequest {
   password: string;
 }
 
+export interface GptModelOption {
+  label: string;
+  value: string;
+}
+
+export interface GptModelsResponse {
+  data: {
+    defaultModelId: string;
+    models: GptModelOption[];
+    titleModelId: string;
+  };
+}
+
 export const terrenoApi = openapi
   .injectEndpoints({
     endpoints: (builder) => ({
@@ -106,6 +119,12 @@ export const terrenoApi = openapi
         query: () => ({
           method: "GET",
           url: "/auth/me",
+        }),
+      }),
+      getGptModels: builder.query<GptModelsResponse, void>({
+        query: () => ({
+          method: "GET",
+          url: "/gpt/models",
         }),
       }),
       // Update current user profile
@@ -147,6 +166,7 @@ export const {
   useEmailSignUpMutation,
   useResetPasswordMutation,
   useGetMeQuery,
+  useGetGptModelsQuery,
   usePatchMeMutation,
   useGetAiRequestsExplorerQuery,
   useSetAdminUserPasswordMutation,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Vertex Enterprise model support with a configurable registry. **All Vertex model catalog, provider toggles, project/region, and Gemini API fallback are now admin-controlled** via App Configuration (`vertexAi` section)—not `process.env`.

## Admin configuration (`vertexAi`)

In the admin panel (App Configuration):

- **Connection**: `enabled`, `projectId`, `location`, `anthropicLocation`
- **Provider toggles**: `enableAnthropicModels`, `enableMaasModels`
- **Defaults**: `defaultModelId`, `titleModelId`
- **Catalog**: `catalogMode`, `includeDefaultCatalog`, `additionalCatalog[]`, allow-unknown flags per provider
- **Fallback**: `geminiApiKey` (secret) when Vertex is off

Changes apply on server startup and automatically when admin config is saved.

## API

- `GET /gpt/models` — picker list from active registry
- `configureVertexModels()` still available for downstream apps that build options in code

## Tests

- `vertexModelConfig.test.ts` — admin config → registry options
- `vertexModels.test.ts` — registry behavior via explicit toggles (no env)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cfd63c4-63d2-4a36-a3f7-92bdd1e4d75e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cfd63c4-63d2-4a36-a3f7-92bdd1e4d75e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

