### PR TITLE
Support user pickers for feature flag rule targeting

### DIFF
--- a/admin-frontend/src/AdminFieldRenderer.test.tsx
+++ b/admin-frontend/src/AdminFieldRenderer.test.tsx
@@ -5,6 +5,7 @@ import {renderWithTheme} from "@terreno/ui/src/test-utils";
 import React from "react";
 import type {ReactTestInstance} from "react-test-renderer";
 import {AdminFieldRenderer} from "./AdminFieldRenderer";
+import {AdminFieldRendererCore} from "./AdminFieldRendererCore";
 import type {AdminApi, AdminFieldConfig, RefFieldRendererProps} from "./types";
 
 const api = {} as unknown as AdminApi;
@@ -438,6 +439,55 @@ describe("AdminFieldRenderer (main)", () => {
       (CustomRenderer as unknown as {mock: {calls: unknown[][]}}).mock
         .calls[0][0] as RefFieldRendererProps
     ).toHaveProperty("routePath", "");
+  });
+
+  it("uses user ref renderers for multi-user feature flag rule values", () => {
+    const CustomRenderer = mock((_props: RefFieldRendererProps) => (
+      <></>
+    )) as unknown as React.FC<RefFieldRendererProps>;
+    renderWithTheme(
+      <AdminFieldRendererCore
+        {...base}
+        fieldConfig={{required: false, type: "mixed"}}
+        fieldKey="value"
+        modelConfigs={[{name: "User", routePath: "/admin/users"}]}
+        parentFormState={{field: "_id", operator: "in"}}
+        refRenderers={{User: CustomRenderer}}
+        value={["user-1", "user-2"]}
+      />
+    );
+    expect(CustomRenderer).toHaveBeenCalledTimes(2);
+    const firstProps = (CustomRenderer as unknown as {mock: {calls: unknown[][]}}).mock
+      .calls[0][0] as RefFieldRendererProps;
+    const secondProps = (CustomRenderer as unknown as {mock: {calls: unknown[][]}}).mock
+      .calls[1][0] as RefFieldRendererProps;
+    expect(firstProps.refModelName).toBe("User");
+    expect(firstProps.routePath).toBe("/admin/users");
+    expect(firstProps.value).toBe("user-1");
+    expect(secondProps.value).toBe("user-2");
+  });
+
+  it("uses user ref renderers for single-user feature flag rule values", () => {
+    const CustomRenderer = mock((_props: RefFieldRendererProps) => (
+      <></>
+    )) as unknown as React.FC<RefFieldRendererProps>;
+    renderWithTheme(
+      <AdminFieldRendererCore
+        {...base}
+        fieldConfig={{required: false, type: "mixed"}}
+        fieldKey="value"
+        modelConfigs={[{name: "User", routePath: "/admin/users"}]}
+        parentFormState={{field: "id", operator: "eq"}}
+        refRenderers={{User: CustomRenderer}}
+        value="user-1"
+      />
+    );
+    expect(CustomRenderer).toHaveBeenCalledTimes(1);
+    const props = (CustomRenderer as unknown as {mock: {calls: unknown[][]}}).mock
+      .calls[0][0] as RefFieldRendererProps;
+    expect(props.refModelName).toBe("User");
+    expect(props.routePath).toBe("/admin/users");
+    expect(props.value).toBe("user-1");
   });
 
   it("triggers onChange handlers for number, enum, array, object", () => {

--- a/admin-frontend/src/AdminFieldRenderer.test.tsx
+++ b/admin-frontend/src/AdminFieldRenderer.test.tsx
@@ -467,6 +467,39 @@ describe("AdminFieldRenderer (main)", () => {
     expect(secondProps.value).toBe("user-2");
   });
 
+  it("passes nested array item values into parentFormState for subfield renderers", () => {
+    const CustomRenderer = mock((_props: RefFieldRendererProps) => (
+      <></>
+    )) as unknown as React.FC<RefFieldRendererProps>;
+    renderWithTheme(
+      <AdminFieldRenderer
+        {...base}
+        fieldConfig={
+          {
+            items: {
+              field: {required: false, type: "string"},
+              operator: {required: false, type: "string"},
+              value: {required: false, type: "mixed"},
+            },
+            required: false,
+            type: "array",
+          } as unknown as AdminFieldConfig
+        }
+        fieldKey="rules"
+        modelConfigs={[{name: "User", routePath: "/admin/users"}]}
+        parentFormState={{key: "flag-key"}}
+        refRenderers={{User: CustomRenderer}}
+        value={[{field: "_id", operator: "in", value: ["user-1"]}]}
+      />
+    );
+    expect(CustomRenderer).toHaveBeenCalledTimes(1);
+    const props = (CustomRenderer as unknown as {mock: {calls: unknown[][]}}).mock
+      .calls[0][0] as RefFieldRendererProps;
+    expect(props.refModelName).toBe("User");
+    expect(props.routePath).toBe("/admin/users");
+    expect(props.value).toBe("user-1");
+  });
+
   it("uses user ref renderers for single-user feature flag rule values", () => {
     const CustomRenderer = mock((_props: RefFieldRendererProps) => (
       <></>

--- a/admin-frontend/src/AdminFieldRendererCore.tsx
+++ b/admin-frontend/src/AdminFieldRendererCore.tsx
@@ -13,6 +13,21 @@ import {CheckboxListEditor} from "./CheckboxListEditor";
 import {LocaleContentEditor} from "./LocaleContentEditor";
 import type {AdminFieldConfig, AdminFieldValue, AdminScreenProps, RefRendererMap} from "./types";
 
+const USER_REF_MODEL_NAME = "User";
+const USER_TARGET_FIELD_KEYS = new Set([
+  "_id",
+  "createdBy",
+  "id",
+  "ownerId",
+  "sub",
+  "updatedBy",
+  "user._id",
+  "user.id",
+  "userId",
+]);
+const MULTI_VALUE_USER_OPERATORS = new Set(["in", "nin", "$in", "$nin"]);
+const SINGLE_VALUE_USER_OPERATORS = new Set(["eq", "neq", "$eq", "$ne"]);
+
 // Attempts to parse a string as JSON, returning the parsed value or the raw string
 const parseJsonValue = (text: string): AdminFieldValue => {
   const trimmed = text.trim();
@@ -35,6 +50,24 @@ const serializeJsonValue = (val: AdminFieldValue): string => {
     return val;
   }
   return JSON.stringify(val, null, 2);
+};
+
+const isUserTargetingValueField = (
+  fieldKey: string,
+  parentFormState?: Record<string, AdminFieldValue>
+): boolean => {
+  if (fieldKey !== "value") {
+    return false;
+  }
+  const targetField = parentFormState?.field;
+  return typeof targetField === "string" && USER_TARGET_FIELD_KEYS.has(targetField);
+};
+
+const getRefModel = (
+  modelConfigs: Array<{name: string; routePath: string}> | undefined,
+  refModelName: string
+): {name: string; routePath: string} | undefined => {
+  return modelConfigs?.find((m) => m.name === refModelName);
 };
 
 export interface AdminFieldRendererCoreProps extends AdminScreenProps {
@@ -72,6 +105,67 @@ export const AdminFieldRendererCore: React.FC<AdminFieldRendererCoreProps> = ({
 }) => {
   const label = startCase(fieldKey);
   const helperText = fieldConfig.description;
+  const refModel = getRefModel(modelConfigs, USER_REF_MODEL_NAME);
+
+  if (isUserTargetingValueField(fieldKey, parentFormState)) {
+    const operator = parentFormState?.operator;
+    if (typeof operator === "string" && MULTI_VALUE_USER_OPERATORS.has(operator)) {
+      const arrayValue = Array.isArray(value)
+        ? value.filter((item): item is string => typeof item === "string")
+        : typeof value === "string" && value
+          ? [value]
+          : [];
+      return (
+        <AdminPrimitiveArrayField
+          api={api}
+          baseUrl={baseUrl}
+          errorText={errorText}
+          helperText={helperText ?? "Select users to target for this rule."}
+          itemRef={USER_REF_MODEL_NAME}
+          itemType="objectid"
+          modelConfigs={modelConfigs}
+          onChange={onChange}
+          refRenderers={refRenderers}
+          title={label}
+          value={arrayValue}
+        />
+      );
+    }
+    if (typeof operator === "string" && SINGLE_VALUE_USER_OPERATORS.has(operator)) {
+      const CustomRenderer = refRenderers?.[USER_REF_MODEL_NAME];
+      const stringValue = typeof value === "string" ? value : "";
+      if (CustomRenderer) {
+        return (
+          <CustomRenderer
+            api={api}
+            baseUrl={baseUrl}
+            errorText={errorText}
+            helperText={helperText ?? "Select the user to target for this rule."}
+            onChange={onChange}
+            refModelName={USER_REF_MODEL_NAME}
+            routePath={refModel?.routePath ?? ""}
+            title={label}
+            value={stringValue}
+          />
+        );
+      }
+      if (refModel) {
+        return (
+          <AdminRefField
+            api={api}
+            baseUrl={baseUrl}
+            errorText={errorText}
+            helperText={helperText ?? "Select the user to target for this rule."}
+            onChange={onChange}
+            refModelName={USER_REF_MODEL_NAME}
+            routePath={refModel.routePath}
+            title={label}
+            value={stringValue}
+          />
+        );
+      }
+    }
+  }
 
   // Dynamic enum: look for a sibling array field whose items have a `key` property.
   if (!fieldConfig.enum && parentFormState && fieldConfig.type === "string") {
@@ -100,7 +194,7 @@ export const AdminFieldRendererCore: React.FC<AdminFieldRendererCoreProps> = ({
   // ObjectId with ref -> reference field (skip arrays — those go to AdminPrimitiveArrayField)
   if (fieldConfig.ref && fieldConfig.type !== "array") {
     const CustomRenderer = refRenderers?.[fieldConfig.ref];
-    const refModel = modelConfigs?.find((m) => m.name === fieldConfig.ref);
+    const refModel = getRefModel(modelConfigs, fieldConfig.ref);
     if (CustomRenderer) {
       return (
         <CustomRenderer

--- a/admin-frontend/src/AdminNestedArrayField.tsx
+++ b/admin-frontend/src/AdminNestedArrayField.tsx
@@ -212,6 +212,10 @@ export const AdminNestedArrayField: React.FC<AdminNestedArrayFieldProps> = ({
       if (!itemData) {
         return <Box />;
       }
+      const subFieldParentFormState = {
+        ...(parentFormState ?? {}),
+        ...itemData,
+      };
 
       return (
         <Card padding={3}>
@@ -238,7 +242,7 @@ export const AdminNestedArrayField: React.FC<AdminNestedArrayFieldProps> = ({
                 index,
                 modelConfigs,
                 onSubFieldChange: handleSubFieldChange,
-                parentFormState,
+                parentFormState: subFieldParentFormState,
                 refRenderers,
               })
             )}

--- a/admin-frontend/src/AdminObjectPicker.tsx
+++ b/admin-frontend/src/AdminObjectPicker.tsx
@@ -246,9 +246,11 @@ export const AdminObjectPicker: React.FC<AdminObjectPickerProps> = ({
                   paddingY={2}
                   testID={`admin-picker-${refModelName}-result-${item._id}`}
                 >
-                  <Text size="sm">{getDisplayValue(item)}</Text>
+                  <Text size="sm" skipLinking>
+                    {getDisplayValue(item)}
+                  </Text>
                   {secondary && (
-                    <Text color="secondaryDark" size="sm">
+                    <Text color="secondaryDark" size="sm" skipLinking>
                       {secondary}
                     </Text>
                   )}

--- a/docs/implementationPlans/feature-flags.md
+++ b/docs/implementationPlans/feature-flags.md
@@ -242,6 +242,14 @@ None needed.
 
 No new dedicated screens. Feature flags are managed through the existing AdminApp generic form by registering the FeatureFlag model.
 
+For rule targeting values that reference users, the AdminApp form treats `_id`,
+`id`, `userId`, `ownerId`, and related user fields as User refs. Single-user
+operators (`eq`, `neq`, `$eq`, `$ne`) render a User picker, and multi-user
+operators (`in`, `nin`, `$in`, `$nin`) render an array of User pickers.
+Selected users should display through the configured User ref renderer or
+picker label, so admins see user names or emails rather than raw IDs when
+editing rules.
+
 ### Frontend Hook (`@terreno/rtk`)
 
 ```typescript


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Render feature flag rule values targeting user identifiers with the existing User reference picker/custom renderer path.
- Preserve multi-user targeting for `in`/`nin` rule operators and single-user targeting for equality operators.
- Pass nested array item state into subfield renderers so rule value rendering can react to sibling `field` and `operator` values.
- Disable auto-linking inside picker result labels so clicking email text selects the user instead of opening a mail client.
- Address bot review comments by documenting user picker targeting and adding nested array parent state regression coverage.

### UI verification
Tested in the example admin app at `http://localhost:8082/admin/FeatureFlag/create` using seeded admin credentials `superuser@example.com` / `testpassword123`.

[feature_flag_user_rule_picker_corrected.mp4](https://cursor.com/agents/bc-128178b7-7247-4ec9-9e46-ebb2c7286db8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeature_flag_user_rule_picker_corrected.mp4)

Verified a rule with Field `_id` and Operator `In` uses the user picker, supports selecting two users, and displays `Super User` / `Test User` chips instead of raw ObjectIds.

### Testing
- `bun install` (environment setup)
- `bun run ui:compile`
- `bun run api:compile && bun run feature-flags:compile && bun run admin-backend:compile && bun run rtk:compile`
- `bun run ai:compile && bun run api-health:compile && bun run backend:lint`
- `bun test src/AdminFieldRenderer.test.tsx` from `admin-frontend/`
- `bun run admin-frontend:compile && bun run admin-frontend:lint`
- `bun run admin-frontend:compile`
- `bun run admin-frontend:lint`
- Manual browser verification in example backend/frontend with local MongoDB and seeded users.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-128178b7-7247-4ec9-9e46-ebb2c7286db8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-128178b7-7247-4ec9-9e46-ebb2c7286db8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

