### PR TITLE
Fix publish-on-tag compile after workspace version replacement

### DIFF
--- a/.github/scripts/compile-workspace-deps.js
+++ b/.github/scripts/compile-workspace-deps.js
@@ -1,9 +1,9 @@
 /**
- * Recursively compiles all workspace:* dependencies for the current package.
+ * Recursively compiles @terreno/* monorepo dependencies for the current package.
  *
- * Reads package.json in the current directory, finds all @terreno/* workspace
- * dependencies, resolves their transitive workspace deps (depth-first), and
- * compiles each one exactly once via `bun tsc`.
+ * During tag publish, workspace:* refs are replaced with semver before install.
+ * Dependencies must still be compiled from sibling packages in this checkout
+ * (npm installs do not include TypeScript sources for compile).
  *
  * Usage (from a package directory):
  *   node ../.github/scripts/compile-workspace-deps.js
@@ -15,6 +15,18 @@ const {execSync} = require("child_process");
 const DEP_TYPES = ["dependencies", "devDependencies", "peerDependencies"];
 const compiled = new Set();
 
+const isTerrenoMonorepoDep = (name) => name.startsWith("@terreno/");
+
+const resolveMonorepoPackageDir = (fromDir, packageName) => {
+  const relative = path.join(fromDir, "..", packageName.replace("@terreno/", ""));
+  const resolved = path.resolve(relative);
+  const pkgPath = path.join(resolved, "package.json");
+  if (!fs.existsSync(pkgPath)) {
+    return null;
+  }
+  return resolved;
+};
+
 const compile = (dir) => {
   const resolved = path.resolve(dir);
   if (compiled.has(resolved)) {
@@ -25,11 +37,13 @@ const compile = (dir) => {
   const pkgPath = path.join(resolved, "package.json");
   const depPkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
 
-  // Compile transitive workspace deps first
   for (const t of DEP_TYPES) {
-    for (const [name, version] of Object.entries(depPkg[t] || {})) {
-      if (version === "workspace:*" && name.startsWith("@terreno/")) {
-        const depDir = path.join(resolved, "..", name.replace("@terreno/", ""));
+    for (const [name] of Object.entries(depPkg[t] || {})) {
+      if (!isTerrenoMonorepoDep(name)) {
+        continue;
+      }
+      const depDir = resolveMonorepoPackageDir(resolved, name);
+      if (depDir) {
         compile(depDir);
       }
     }
@@ -39,19 +53,21 @@ const compile = (dir) => {
   execSync("bun tsc", {cwd: resolved, stdio: "inherit"});
 };
 
-// Read the current package and compile its workspace deps
 const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
 for (const t of DEP_TYPES) {
-  for (const [name, version] of Object.entries(pkg[t] || {})) {
-    if (version === "workspace:*" && name.startsWith("@terreno/")) {
-      const depDir = path.join("..", name.replace("@terreno/", ""));
+  for (const [name] of Object.entries(pkg[t] || {})) {
+    if (!isTerrenoMonorepoDep(name)) {
+      continue;
+    }
+    const depDir = resolveMonorepoPackageDir(process.cwd(), name);
+    if (depDir) {
       compile(depDir);
     }
   }
 }
 
 if (compiled.size === 0) {
-  console.log("No workspace dependencies to compile");
+  console.log("No @terreno monorepo dependencies to compile");
 } else {
-  console.log(`Compiled ${compiled.size} workspace dependency(ies)`);
+  console.log(`Compiled ${compiled.size} @terreno monorepo dependency(ies)`);
 }

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -1011,6 +1011,7 @@ jobs:
             echo "No version changes to commit"
           else
             git commit -m "chore: bump package versions to ${VERSION}"
+            git pull --rebase origin master
             git push origin master
           fi
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tag publish jobs replace `workspace:*` `@terreno/*` dependencies with semver before `bun install`, but `compile-workspace-deps.js` only matched `workspace:*`. Dependent packages (admin-backend, feature-flags, ai, api-health) then skipped compiling sibling sources such as `api`, and `bun run compile` failed on the 0.16.0 release.

This change compiles any `@terreno/*` dependency that exists as a sibling package in the checkout, whether the version string is still `workspace:*` or already pinned. It also rebases onto `master` before pushing version bumps to reduce push rejections when `master` moves during a release.

## Human Testing Steps

- [ ] Merge this PR, then tag a new release (e.g. `0.16.1`) on `master`
- [ ] Confirm the Publish packages on tag workflow completes for all packages that failed on `0.16.0` (admin-backend, feature-flags, ai, api-health)
- [ ] Optionally re-run the failed jobs on the `0.16.0` workflow after merging (if you want to finish that tag without a new one)

## Changes

- Update `.github/scripts/compile-workspace-deps.js` to resolve and compile sibling `@terreno/*` packages regardless of semver vs `workspace:*`
- Add `git pull --rebase origin master` before pushing version bumps in `update-version-on-master`

## Automated Tests

- Locally simulated the feature-flags publish path: pin `@terreno/api` to `0.16.0`, run `compile-workspace-deps.js` (compiled `api`), then `bun run compile` — succeeded
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a718caa2-2d2e-4c5f-b503-db107e9fd391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a718caa2-2d2e-4c5f-b503-db107e9fd391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

