### PR TITLE
docs: surface top-level bootstrap command for dev setup

### DIFF
--- a/.cursor/rules/00-root.mdc
+++ b/.cursor/rules/00-root.mdc
@@ -25,12 +25,17 @@ A monorepo containing shared packages for building full-stack applications with 
 Uses [Bun](https://bun.sh/) as the package manager.
 
 ```bash
+bun run bootstrap        # Install dependencies + compile all packages (dev-ready setup)
+bun run bootstrap:update # Reinstall + recompile after pulling changes or switching branches
 bun install              # Install dependencies
 bun run compile          # Compile all packages
 bun run lint             # Lint all packages
 bun run lint:fix         # Fix lint issues
 bun run test             # Run tests in api and ui
 ```
+
+- **`bootstrap`**: Run when first cloning the repo or creating a new dev environment. Installs all dependencies and compiles every package so the workspace is ready for development.
+- **`bootstrap:update`**: Run when resuming work after pulling changes, switching branches, or when dependencies have changed.
 
 ### Package-specific commands
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,12 +20,17 @@ A monorepo containing shared packages for building full-stack applications with 
 Uses [Bun](https://bun.sh/) as the package manager.
 
 ```bash
+bun run bootstrap        # Install dependencies + compile all packages (dev-ready setup)
+bun run bootstrap:update # Reinstall + recompile after pulling changes or switching branches
 bun install              # Install dependencies
 bun run compile          # Compile all packages
 bun run lint             # Lint all packages
 bun run lint:fix         # Fix lint issues
 bun run test             # Run tests in api and ui
 ```
+
+- **`bootstrap`**: Run when first cloning the repo or creating a new dev environment. Installs all dependencies and compiles every package so the workspace is ready for development.
+- **`bootstrap:update`**: Run when resuming work after pulling changes, switching branches, or when dependencies have changed.
 
 ### Package-specific commands
 

--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -27,12 +27,17 @@ A monorepo containing shared packages for building full-stack applications with 
 Uses [Bun](https://bun.sh/) as the package manager.
 
 ```bash
+bun run bootstrap        # Install dependencies + compile all packages (dev-ready setup)
+bun run bootstrap:update # Reinstall + recompile after pulling changes or switching branches
 bun install              # Install dependencies
 bun run compile          # Compile all packages
 bun run lint             # Lint all packages
 bun run lint:fix         # Fix lint issues
 bun run test             # Run tests in api and ui
 ```
+
+- **`bootstrap`**: Run when first cloning the repo or creating a new dev environment. Installs all dependencies and compiles every package so the workspace is ready for development.
+- **`bootstrap:update`**: Run when resuming work after pulling changes, switching branches, or when dependencies have changed.
 
 ### Package-specific commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,17 @@ A monorepo containing shared packages for building full-stack applications with 
 Uses [Bun](https://bun.sh/) as the package manager.
 
 ```bash
+bun run bootstrap        # Install dependencies + compile all packages (dev-ready setup)
+bun run bootstrap:update # Reinstall + recompile after pulling changes or switching branches
 bun install              # Install dependencies
 bun run compile          # Compile all packages
 bun run lint             # Lint all packages
 bun run lint:fix         # Fix lint issues
 bun run test             # Run tests in api and ui
 ```
+
+- **`bootstrap`**: Run when first cloning the repo or creating a new dev environment. Installs all dependencies and compiles every package so the workspace is ready for development.
+- **`bootstrap:update`**: Run when resuming work after pulling changes, switching branches, or when dependencies have changed.
 
 ### Package-specific commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,12 +20,17 @@ A monorepo containing shared packages for building full-stack applications with 
 Uses [Bun](https://bun.sh/) as the package manager.
 
 ```bash
+bun run bootstrap        # Install dependencies + compile all packages (dev-ready setup)
+bun run bootstrap:update # Reinstall + recompile after pulling changes or switching branches
 bun install              # Install dependencies
 bun run compile          # Compile all packages
 bun run lint             # Lint all packages
 bun run lint:fix         # Fix lint issues
 bun run test             # Run tests in api and ui
 ```
+
+- **`bootstrap`**: Run when first cloning the repo or creating a new dev environment. Installs all dependencies and compiles every package so the workspace is ready for development.
+- **`bootstrap:update`**: Run when resuming work after pulling changes, switching branches, or when dependencies have changed.
 
 ### Package-specific commands
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ Terreno is designed to be the best framework for AI-assisted app development. Th
 
 This project uses [Bun](https://bun.sh/) as the package manager.
 
+### Bootstrap
+
+The fastest way to get a development-ready checkout is the top-level `bootstrap` command. It installs all dependencies and compiles every package so the workspace is ready for development:
+
+```bash
+bun run bootstrap         # Install dependencies + compile all packages
+bun run bootstrap:update  # Re-run after pulling changes or switching branches
+```
+
+- **`bootstrap`** — Run when first cloning the repo or creating a new dev environment. Installs all dependencies and compiles every package.
+- **`bootstrap:update`** — Run when resuming work after pulling changes, switching branches, or when dependencies have changed. Reinstalls dependencies and recompiles to pick up any changes.
+
+If you prefer to run the steps individually:
+
 ```bash
 # Install dependencies
 bun install


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ensures the repo has a discoverable top-level `bootstrap` command that sets up the app, runs `bun install`, and gets everything ready for development.

The script already existed in the root `package.json`:

```json
"bootstrap": "bun install && bun run compile",
"bootstrap:update": "bun install && bun run compile"
```

…but it was only documented in `CLAUDE.local.md`. It was missing from the main `README.md` Development section and from the generated AI rule files. This PR makes it discoverable everywhere.

## Changes

- Documented `bootstrap` / `bootstrap:update` in the `README.md` Development section (new **Bootstrap** subsection).
- Added the same docs to the rulesync root source (`.rulesync/rules/00-root.md`) and regenerated rules, so it now appears in `AGENTS.md`, `CLAUDE.md`, `.cursor/rules/00-root.mdc`, and `.github/copilot-instructions.md`.
- No change to the actual scripts — they already install deps and compile every package, which is what "ready for development" requires.

## Testing

- `bun run bootstrap` — verified end-to-end: `bun install` resolved 2074 installs, then all packages compiled with exit code 0.
- `bun run rules:check` — passes (generated rule files are in sync with source).

Notes: A pre-existing unrelated `bun.lock` version drift was reverted so this PR stays focused on documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-104840fe-e2eb-4a5e-9851-ff921ae09b4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-104840fe-e2eb-4a5e-9851-ff921ae09b4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

