### PR TITLE
fix(ui): Android select backdrop dismiss without forcing a selection

### DIFF
--- a/ui/src/PickerSelect.test.tsx
+++ b/ui/src/PickerSelect.test.tsx
@@ -336,14 +336,13 @@ describe("PickerSelect", () => {
     const PlatformModule = require("react-native").Platform;
     let savedOS: any;
 
-    it("renders android headless when useNativeAndroidPickerStyle is false", () => {
+    it("renders android modal picker by default (useNativeAndroidPickerStyle false)", () => {
       savedOS = PlatformModule.OS;
       try {
         PlatformModule.OS = "android";
-        const {getByTestId} = renderWithTheme(
-          <RNPickerSelect {...defaultProps} useNativeAndroidPickerStyle={false} value="1" />
-        );
+        const {getByTestId} = renderWithTheme(<RNPickerSelect {...defaultProps} value="1" />);
         expect(getByTestId("android_touchable_wrapper")).toBeTruthy();
+        expect(getByTestId("icon_container")).toBeTruthy();
       } finally {
         PlatformModule.OS = savedOS;
       }
@@ -382,23 +381,25 @@ describe("PickerSelect", () => {
       }
     });
 
-    it("renders native android picker style", () => {
+    it("renders native android picker style when useNativeAndroidPickerStyle is true", () => {
       savedOS = PlatformModule.OS;
       try {
         PlatformModule.OS = "android";
-        const {getByTestId} = renderWithTheme(<RNPickerSelect {...defaultProps} value="1" />);
+        const {getByTestId} = renderWithTheme(
+          <RNPickerSelect {...defaultProps} useNativeAndroidPickerStyle value="1" />
+        );
         expect(getByTestId("android_picker")).toBeTruthy();
       } finally {
         PlatformModule.OS = savedOS;
       }
     });
 
-    it("renders native android picker disabled", () => {
+    it("renders native android picker disabled when useNativeAndroidPickerStyle is true", () => {
       savedOS = PlatformModule.OS;
       try {
         PlatformModule.OS = "android";
         const {getByTestId} = renderWithTheme(
-          <RNPickerSelect {...defaultProps} disabled value="1" />
+          <RNPickerSelect {...defaultProps} disabled useNativeAndroidPickerStyle value="1" />
         );
         expect(getByTestId("android_picker")).toBeTruthy();
       } finally {
@@ -412,13 +413,69 @@ describe("PickerSelect", () => {
         PlatformModule.OS = "android";
         const mockOnValueChange = mock(() => {});
         const {getByTestId} = renderWithTheme(
-          <RNPickerSelect {...defaultProps} onValueChange={mockOnValueChange} value="1" />
+          <RNPickerSelect
+            {...defaultProps}
+            onValueChange={mockOnValueChange}
+            useNativeAndroidPickerStyle
+            value="1"
+          />
         );
         const picker = getByTestId("android_picker");
         await act(async () => {
           picker.props.onValueChange?.("2", 1);
         });
         expect(mockOnValueChange).toHaveBeenCalledWith("2", 1);
+      } finally {
+        PlatformModule.OS = savedOS;
+      }
+    });
+
+    it("fires onOpen when the android wrapper is pressed and onClose when Done is pressed", async () => {
+      savedOS = PlatformModule.OS;
+      try {
+        PlatformModule.OS = "android";
+        const onOpen = mock(() => {});
+        const onClose = mock(() => {});
+        const onDonePress = mock(() => {});
+        const {getByTestId} = renderWithTheme(
+          <RNPickerSelect
+            {...defaultProps}
+            onClose={onClose}
+            onDonePress={onDonePress}
+            onOpen={onOpen}
+          />
+        );
+
+        await act(async () => {
+          fireEvent.press(getByTestId("android_touchable_wrapper"));
+        });
+        expect(onOpen).toHaveBeenCalled();
+
+        await act(async () => {
+          fireEvent.press(getByTestId("done_button"));
+        });
+        expect(onClose).toHaveBeenCalled();
+        expect(onDonePress).toHaveBeenCalled();
+      } finally {
+        PlatformModule.OS = savedOS;
+      }
+    });
+
+    it("closes the android modal when the top overlay is pressed", async () => {
+      savedOS = PlatformModule.OS;
+      try {
+        PlatformModule.OS = "android";
+        const onClose = mock(() => {});
+        const {getByTestId} = renderWithTheme(
+          <RNPickerSelect {...defaultProps} onClose={onClose} />
+        );
+        await act(async () => {
+          fireEvent.press(getByTestId("android_touchable_wrapper"));
+        });
+        await act(async () => {
+          fireEvent.press(getByTestId("android_modal_top"));
+        });
+        expect(onClose).toHaveBeenCalled();
       } finally {
         PlatformModule.OS = savedOS;
       }

--- a/ui/src/PickerSelect.tsx
+++ b/ui/src/PickerSelect.tsx
@@ -93,20 +93,20 @@ export interface RNPickerSelectProps {
   useNativeAndroidPickerStyle?: boolean;
   fixAndroidTouchableBug?: boolean;
 
-  // Custom Modal props (iOS only)
+  // Custom Modal props (iOS and Android modal picker)
   doneText?: string;
   onDonePress?: () => void;
   onUpArrow?: () => void;
   onDownArrow?: () => void;
   onClose?: () => void;
 
-  // Modal props (iOS only)
+  // Modal props (iOS and Android modal picker)
   modalProps?: Partial<ModalProps>;
 
   // TextInput props
   textInputProps?: Partial<TextInputProps>;
 
-  // Touchable Done props (iOS only)
+  // Touchable Done props (iOS and Android modal picker)
   touchableDoneProps?: Partial<PressableProps>;
 
   // Touchable wrapper props
@@ -123,7 +123,7 @@ export const RNPickerSelect = ({
   disabled = false,
   itemKey,
   children,
-  useNativeAndroidPickerStyle = true,
+  useNativeAndroidPickerStyle = false,
   fixAndroidTouchableBug = false,
   doneText = "Done",
   onDonePress,
@@ -372,8 +372,12 @@ export const RNPickerSelect = ({
   };
 
   const renderIcon = () => {
-    // Icon only needed for iOS, web and android use default icons
-    if (Platform.OS !== "ios") {
+    // Show chevron for modal picker (iOS and Android modal style); web has its own icon.
+    if (Platform.OS === "web") {
+      return null;
+    }
+
+    if (Platform.OS === "android" && (useNativeAndroidPickerStyle || children)) {
       return null;
     }
 
@@ -425,7 +429,8 @@ export const RNPickerSelect = ({
     );
   };
 
-  const renderIOS = () => {
+  const renderModalPicker = () => {
+    const isIos = Platform.OS === "ios";
     return (
       <View
         style={[
@@ -450,7 +455,7 @@ export const RNPickerSelect = ({
             minHeight: 40,
             width: "95%",
           }}
-          testID="ios_touchable_wrapper"
+          testID={isIos ? "ios_touchable_wrapper" : "android_touchable_wrapper"}
           {...touchableWrapperProps}
         >
           {renderTextInputOrChildren()}
@@ -459,7 +464,7 @@ export const RNPickerSelect = ({
           animationType={animationType}
           onOrientationChange={onOrientationChange}
           supportedOrientations={["portrait", "landscape"]}
-          testID="ios_modal"
+          testID={isIos ? "ios_modal" : "android_modal"}
           transparent
           visible={showPicker}
           {...modalProps}
@@ -472,7 +477,7 @@ export const RNPickerSelect = ({
             style={{
               flex: 1,
             }}
-            testID="ios_modal_top"
+            testID={isIos ? "ios_modal_top" : "android_modal_top"}
           />
           {renderInputAccessoryView()}
           <View
@@ -487,7 +492,7 @@ export const RNPickerSelect = ({
             <Picker
               onValueChange={onValueChangeEvent}
               selectedValue={selectedItem?.value}
-              testID="ios_picker"
+              testID={isIos ? "ios_picker" : "android_picker"}
             >
               {renderPickerItems()}
             </Picker>
@@ -684,11 +689,23 @@ export const RNPickerSelect = ({
 
   const render = () => {
     if (Platform.OS === "ios") {
-      return renderIOS();
+      return renderModalPicker();
     }
 
     if (Platform.OS === "web") {
       return renderWeb();
+    }
+
+    if (Platform.OS === "android") {
+      if (useNativeAndroidPickerStyle && !children) {
+        return renderAndroidNativePickerStyle();
+      }
+
+      if (children) {
+        return renderAndroidHeadless();
+      }
+
+      return renderModalPicker();
     }
 
     if (children || !useNativeAndroidPickerStyle) {

--- a/ui/src/SelectBadge.android.test.tsx
+++ b/ui/src/SelectBadge.android.test.tsx
@@ -1,12 +1,11 @@
 import {afterAll, beforeAll, describe, expect, it, mock} from "bun:test";
-import {act} from "@testing-library/react-native";
-import {Platform} from "react-native";
+import {act, fireEvent} from "@testing-library/react-native";
+import {Platform, TouchableOpacity} from "react-native";
 
 import {SelectBadge} from "./SelectBadge";
 import {renderWithTheme} from "./test-utils";
 
-// Force Platform.OS to "android" for this file so SelectBadge takes the
-// renderPicker branch (native Picker overlay) instead of the iOS modal.
+// Force Platform.OS to "android" for this file so SelectBadge uses the modal picker.
 const originalOS = Platform.OS;
 beforeAll(() => {
   Object.defineProperty(Platform, "OS", {configurable: true, value: "android"});
@@ -22,40 +21,100 @@ describe("SelectBadge (android)", () => {
     {label: "Option C", value: "c"},
   ];
 
-  it("renders the Android-native Picker overlay", () => {
-    const {UNSAFE_getAllByProps, toJSON} = renderWithTheme(
+  it("renders the badge with the modal picker closed initially", () => {
+    const {toJSON, UNSAFE_getAllByProps} = renderWithTheme(
       <SelectBadge onChange={() => {}} options={options} value="a" />
     );
-    // The Android picker should be rendered (not the iOS modal or web dropdown)
     expect(toJSON()).toBeTruthy();
-    // Find the picker by its selectedValue prop (Android overlay renders a Picker directly)
-    const pickers = UNSAFE_getAllByProps({selectedValue: "a"});
-    expect(pickers.length).toBeGreaterThan(0);
+    const modals = UNSAFE_getAllByProps({visible: false});
+    expect(modals.length).toBeGreaterThan(0);
   });
 
-  it("invokes onChange when Android picker value changes", () => {
+  it("opens modal picker and invokes onChange when Save is pressed", async () => {
     const handleChange = mock((_val: string) => {});
-    const {UNSAFE_getAllByProps} = renderWithTheme(
+    const {UNSAFE_getAllByProps, UNSAFE_getAllByType} = renderWithTheme(
       <SelectBadge onChange={handleChange} options={options} value="a" />
     );
+
+    const openButtons = UNSAFE_getAllByType(TouchableOpacity).filter(
+      (t: {props?: {accessibilityLabel?: string}}) =>
+        t.props?.accessibilityLabel === "Open select badge options"
+    );
+    expect(openButtons.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      fireEvent.press(openButtons[0]);
+    });
+
     const pickers = UNSAFE_getAllByProps({selectedValue: "a"});
     const picker = pickers.find(
       (p: {props?: {onValueChange?: (v: string) => void}}) =>
         typeof p.props?.onValueChange === "function"
     );
     expect(picker).toBeDefined();
-    act(() => {
+
+    await act(async () => {
       if (picker) {
         picker.props.onValueChange("b");
       }
     });
+
+    const saveButtons = UNSAFE_getAllByType(TouchableOpacity).filter(
+      (t: {props?: {accessibilityLabel?: string}}) =>
+        t.props?.accessibilityLabel === "Save selected value"
+    );
+    expect(saveButtons.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      fireEvent.press(saveButtons[0]);
+    });
+
     expect(handleChange).toHaveBeenCalledWith("b");
   });
 
-  it("renders with disabled prop on Android", () => {
-    const {UNSAFE_getAllByProps} = renderWithTheme(
+  it("dismisses modal picker via backdrop without calling onChange", async () => {
+    const handleChange = mock((_val: string) => {});
+    const {UNSAFE_getAllByType} = renderWithTheme(
+      <SelectBadge onChange={handleChange} options={options} value="a" />
+    );
+
+    const openButtons = UNSAFE_getAllByType(TouchableOpacity).filter(
+      (t: {props?: {accessibilityLabel?: string}}) =>
+        t.props?.accessibilityLabel === "Open select badge options"
+    );
+
+    await act(async () => {
+      fireEvent.press(openButtons[0]);
+    });
+
+    const dismissButtons = UNSAFE_getAllByType(TouchableOpacity).filter(
+      (t: {props?: {accessibilityLabel?: string}}) =>
+        t.props?.accessibilityLabel === "Dismiss picker modal"
+    );
+    expect(dismissButtons.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      fireEvent.press(dismissButtons[0]);
+    });
+
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it("renders with disabled prop on Android", async () => {
+    const {UNSAFE_getAllByProps, UNSAFE_getAllByType} = renderWithTheme(
       <SelectBadge disabled onChange={() => {}} options={options} value="a" />
     );
+
+    const openButtons = UNSAFE_getAllByType(TouchableOpacity).filter(
+      (t: {props?: {accessibilityLabel?: string; disabled?: boolean}}) =>
+        t.props?.accessibilityLabel === "Open select badge options"
+    );
+    expect(openButtons[0]?.props?.disabled).toBe(true);
+
+    await act(async () => {
+      fireEvent.press(openButtons[0]);
+    });
+
     const pickers = UNSAFE_getAllByProps({enabled: false});
     expect(pickers.length).toBeGreaterThan(0);
   });

--- a/ui/src/SelectBadge.tsx
+++ b/ui/src/SelectBadge.tsx
@@ -21,9 +21,8 @@ export const SelectBadge = ({
 }: SelectBadgeProps): React.ReactElement => {
   const {theme} = useTheme();
   const [showPicker, setShowPicker] = useState(false);
-  // Temporary state to manage value changes for ios picker
-  // Assures the badge display value persists when user scrolls through options
-  const [iosDisplayValue, setIosDisplayValue] = useState<string | undefined>(value);
+  // Temporary state for modal picker (iOS/Android): keeps badge label stable while scrolling.
+  const [modalDisplayValue, setModalDisplayValue] = useState<string | undefined>(value);
 
   // Web-only: anchor the custom dropdown menu to the trigger element so that
   // Safari/Firefox/Chrome all render the same styled menu instead of the
@@ -103,14 +102,14 @@ export const SelectBadge = ({
     ));
   }, [options]);
 
-  const renderIosPicker = useCallback(() => {
-    const handleValueChangeIos = (itemValue: string) => {
-      setIosDisplayValue(itemValue);
+  const renderModalPicker = useCallback(() => {
+    const handleValueChangeModal = (itemValue: string) => {
+      setModalDisplayValue(itemValue);
     };
 
     const handleSave = () => {
-      if (iosDisplayValue && !disabled) {
-        handleOnChange(iosDisplayValue);
+      if (modalDisplayValue && !disabled) {
+        handleOnChange(modalDisplayValue);
       } else {
         setShowPicker(false);
       }
@@ -118,7 +117,7 @@ export const SelectBadge = ({
 
     const handleDismiss = () => {
       setShowPicker(false);
-      setIosDisplayValue(value);
+      setModalDisplayValue(value);
     };
 
     return (
@@ -181,8 +180,8 @@ export const SelectBadge = ({
             </View>
             <Picker
               enabled={!disabled}
-              onValueChange={handleValueChangeIos}
-              selectedValue={iosDisplayValue}
+              onValueChange={handleValueChangeModal}
+              selectedValue={modalDisplayValue}
             >
               {renderPickerItems()}
             </Picker>
@@ -190,7 +189,7 @@ export const SelectBadge = ({
         </View>
       </Modal>
     );
-  }, [showPicker, iosDisplayValue, disabled, theme, value, handleOnChange, renderPickerItems]);
+  }, [showPicker, modalDisplayValue, disabled, theme, value, handleOnChange, renderPickerItems]);
 
   const renderPicker = useCallback(() => {
     return (
@@ -265,6 +264,13 @@ export const SelectBadge = ({
             }
             return;
           }
+
+          if (Platform.OS === "ios" || Platform.OS === "android") {
+            setModalDisplayValue(value);
+            setShowPicker(true);
+            return;
+          }
+
           setShowPicker(!showPicker);
         }}
       >
@@ -332,8 +338,8 @@ export const SelectBadge = ({
           </View>
         </View>
       </TouchableOpacity>
-      {Platform.OS === "ios"
-        ? renderIosPicker()
+      {Platform.OS === "ios" || Platform.OS === "android"
+        ? renderModalPicker()
         : Platform.OS === "web"
           ? renderWebPicker()
           : renderPicker()}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On Android, `SelectField` and `SelectBadge` used the native system picker by default. Long lists scrolled fine, but tapping outside the picker did not dismiss it—users had to pick an option to close the modal.

## Solution

- **`RNPickerSelect`**: Default `useNativeAndroidPickerStyle` is now `false`, so Android uses the same modal picker as iOS (backdrop tap + Done dismiss without committing a selection).
- **`SelectBadge`**: Android now uses the shared modal picker flow (backdrop + Save) instead of an invisible native `Picker`.
- **Tests**: Updated Android tests for modal behavior; added backdrop-dismiss coverage for `PickerSelect`.

## Opt-out

Apps that prefer the old native Android dropdown can pass `useNativeAndroidPickerStyle={true}` to `RNPickerSelect` (and wire through `SelectField` if that prop is exposed).

## Testing

- `cd ui && bun test src/PickerSelect.test.tsx src/SelectBadge.android.test.tsx`
- `cd ui && bun run test:ci`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccf2c024-7a55-45d2-beae-45d7abff6070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccf2c024-7a55-45d2-beae-45d7abff6070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

