### PR TITLE
Add release skill for cutting and monitoring Terreno releases

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: release
+description: >-
+  Cut a Terreno release — organize commits since the last tag into useful
+  release notes, flag breaking changes, decide the semver version, create the
+  GitHub release, and monitor the publish-on-tag workflow until every package
+  deploys to npm. Trigger with /release.
+---
+# Release Terreno
+
+Cut a new Terreno release end-to-end: gather commits, write organized release notes, pick the version, create the GitHub release (which pushes the tag), and watch the npm publish workflow until all packages are live.
+
+## How releases work in this repo
+
+- Pushing a tag matching `X.Y.Z` (no `v` prefix, e.g. `0.18.0`) triggers `.github/workflows/publish-on-tag.yml`.
+- That workflow publishes **nine packages, all at the same version**: `@terreno/api`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
+- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. A `ui` or `api` failure cascades.
+- After successful publishes, the workflow commits `chore: bump package versions to X.Y.Z` back to master and sends a Zoom notification. Prerelease tags (`-beta`, `-alpha`) skip the master bump.
+
+## Step 1: Preflight
+
+1. Release from latest master with a clean tree:
+
+   ```bash
+   git checkout master && git pull origin master && git fetch --tags origin
+   git status --short  # must be empty
+   ```
+
+2. Verify `gh` auth (`gh api user -q .login`). If not logged in, export `GH_TOKEN` from the environment's GitHub token.
+3. Find the last release and confirm tag and GitHub release agree:
+
+   ```bash
+   git tag --sort=-v:refname | head -1
+   gh release list --limit 3
+   ```
+
+## Step 2: Collect the commits
+
+```bash
+git log <last-tag>..HEAD --oneline --no-merges
+```
+
+- If there are no commits, or the only commits are `chore: bump package versions ...` / lockfile-only changes, **stop — there is nothing to release**. Do not cut empty releases.
+- For any commit whose one-liner is unclear, pull PR context: `gh pr view <num> --json title,body,labels`.
+
+## Step 3: Decide the version
+
+- **Major**: pinned to the Expo SDK major. While the repo is on Expo 54/55 the major stays `0` (releases are `0.x.y`). Once the monorepo upgrades to Expo 56, releases become `56.x.y`, and each subsequent Expo SDK upgrade bumps the major to match.
+- **Minor**: standard semver — new features, new components/routes/exports, new `modelRouter` options, or any non-breaking API addition. While the major is `0`, breaking changes also bump the minor (semver 0.x convention) and must be called out in the notes.
+- **Patch**: standard semver — bug fixes, performance work, and releases containing only docs, CI/workflow, skills/rules, test-coverage (`[coverage]`, `[alignRules]`), or dependency-bump commits.
+- **Prerelease**: append `-beta.1` (etc.) to test the publish pipeline without moving `latest` or bumping versions on master.
+
+## Step 4: Identify breaking changes
+
+Scan the diff and PR bodies for anything a consumer must act on:
+
+- Removed or renamed exports — check the export surface directly:
+
+  ```bash
+  git diff <last-tag>..HEAD -- api/src/index.ts ui/src/index.tsx rtk/src/index.ts
+  ```
+
+- Changed function signatures or component prop types in published packages.
+- Removed/renamed `modelRouter` options, permissions, or auth behavior changes.
+- Mongoose schema changes that require a migration.
+- Peer dependency major bumps (expo, react-native, react, mongoose).
+- New required or renamed environment variables.
+
+Every breaking change gets its own bullet in the notes: what broke and how to migrate. If there are none, omit the section entirely — don't write "No breaking changes".
+
+## Step 5: Write the release notes
+
+Organize the commits — never ship the raw auto-generated list. Order sections by how much the reader needs them, and push mechanical commits to the bottom:
+
+```markdown
+## Breaking changes
+- `modelRouter`'s `foo` option was removed — pass `bar` instead. (#123)
+
+## Features
+- modelRouter actions: declare `instanceActions` / `collectionActions` for custom RPC-style endpoints. (#715)
+
+## Fixes
+- Fix consent signature layout and EAS dev builds. (#706)
+
+## Docs & tooling
+- Add design-blend skill with REST-first planning workflow. (#734)
+
+## Tests & housekeeping
+<details><summary>Coverage, rule-alignment, and chore commits</summary>
+
+- [coverage] Button.tsx, realtime.ts (#728)
+- Update workspace versions in bun lockfile (#735)
+</details>
+
+**Full Changelog**: https://github.com/FlourishHealth/terreno/compare/<last-tag>...<new-version>
+```
+
+Rules:
+
+- Lead with breaking changes, then features, then fixes. Omit empty sections.
+- `[coverage]`, `[alignRules]`, lockfile updates, dependabot bumps, and similar mechanical commits go in the collapsed **Tests & housekeeping** section, one line each.
+- Merge commits that belong to one feature (e.g. an IP/plan commit plus its implementation) into a single bullet.
+- Describe user-facing impact, not implementation detail. Keep `(#123)` PR references — GitHub autolinks them.
+
+## Step 6: Create the release
+
+Write the notes to a file, then create the release targeting master (this pushes the tag and starts the publish workflow):
+
+```bash
+gh release create "$VERSION" --target master --title "$VERSION" --notes-file /tmp/release-notes.md
+```
+
+## Step 7: Monitor the publish and verify npm
+
+1. Watch the workflow until it finishes:
+
+   ```bash
+   RUN_ID=$(gh run list --workflow=publish-on-tag.yml --branch "$VERSION" --limit 1 --json databaseId -q '.[0].databaseId')
+   gh run watch "$RUN_ID" --exit-status
+   ```
+
+2. Verify every package is live on npm (allow a couple of minutes of registry lag):
+
+   ```bash
+   for p in api ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
+     echo "@terreno/$p: $(npm view "@terreno/$p" version)"
+   done
+   ```
+
+   All nine must report `$VERSION`.
+
+3. Confirm the `chore: bump package versions to $VERSION` commit landed on master (`git fetch origin master && git log origin/master -1 --oneline`). Skipped for prereleases.
+
+## Step 8: If a publish job fails
+
+1. Inspect: `gh run view "$RUN_ID" --log-failed`.
+2. Transient failure (network, registry flake): `gh run rerun "$RUN_ID" --failed`.
+3. Real failure needing a code fix: fix it via a normal PR. npm versions are immutable, so if **any** package already published for this version, do not reuse the tag — merge the fix and release the next patch version. Only if nothing published may you delete the release and tag (`gh release delete "$VERSION" --cleanup-tag`) and re-create it from the fixed master.
+4. Report the final per-package publish status either way.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: release
+description: >-
+  Cut a Terreno release — organize commits since the last tag into useful
+  release notes, flag breaking changes, decide the semver version, create the
+  GitHub release, and monitor the publish-on-tag workflow until every package
+  deploys to npm. Trigger with /release.
+---
+# Release Terreno
+
+Cut a new Terreno release end-to-end: gather commits, write organized release notes, pick the version, create the GitHub release (which pushes the tag), and watch the npm publish workflow until all packages are live.
+
+## How releases work in this repo
+
+- Pushing a tag matching `X.Y.Z` (no `v` prefix, e.g. `0.18.0`) triggers `.github/workflows/publish-on-tag.yml`.
+- That workflow publishes **nine packages, all at the same version**: `@terreno/api`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
+- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. A `ui` or `api` failure cascades.
+- After successful publishes, the workflow commits `chore: bump package versions to X.Y.Z` back to master and sends a Zoom notification. Prerelease tags (`-beta`, `-alpha`) skip the master bump.
+
+## Step 1: Preflight
+
+1. Release from latest master with a clean tree:
+
+   ```bash
+   git checkout master && git pull origin master && git fetch --tags origin
+   git status --short  # must be empty
+   ```
+
+2. Verify `gh` auth (`gh api user -q .login`). If not logged in, export `GH_TOKEN` from the environment's GitHub token.
+3. Find the last release and confirm tag and GitHub release agree:
+
+   ```bash
+   git tag --sort=-v:refname | head -1
+   gh release list --limit 3
+   ```
+
+## Step 2: Collect the commits
+
+```bash
+git log <last-tag>..HEAD --oneline --no-merges
+```
+
+- If there are no commits, or the only commits are `chore: bump package versions ...` / lockfile-only changes, **stop — there is nothing to release**. Do not cut empty releases.
+- For any commit whose one-liner is unclear, pull PR context: `gh pr view <num> --json title,body,labels`.
+
+## Step 3: Decide the version
+
+- **Major**: pinned to the Expo SDK major. While the repo is on Expo 54/55 the major stays `0` (releases are `0.x.y`). Once the monorepo upgrades to Expo 56, releases become `56.x.y`, and each subsequent Expo SDK upgrade bumps the major to match.
+- **Minor**: standard semver — new features, new components/routes/exports, new `modelRouter` options, or any non-breaking API addition. While the major is `0`, breaking changes also bump the minor (semver 0.x convention) and must be called out in the notes.
+- **Patch**: standard semver — bug fixes, performance work, and releases containing only docs, CI/workflow, skills/rules, test-coverage (`[coverage]`, `[alignRules]`), or dependency-bump commits.
+- **Prerelease**: append `-beta.1` (etc.) to test the publish pipeline without moving `latest` or bumping versions on master.
+
+## Step 4: Identify breaking changes
+
+Scan the diff and PR bodies for anything a consumer must act on:
+
+- Removed or renamed exports — check the export surface directly:
+
+  ```bash
+  git diff <last-tag>..HEAD -- api/src/index.ts ui/src/index.tsx rtk/src/index.ts
+  ```
+
+- Changed function signatures or component prop types in published packages.
+- Removed/renamed `modelRouter` options, permissions, or auth behavior changes.
+- Mongoose schema changes that require a migration.
+- Peer dependency major bumps (expo, react-native, react, mongoose).
+- New required or renamed environment variables.
+
+Every breaking change gets its own bullet in the notes: what broke and how to migrate. If there are none, omit the section entirely — don't write "No breaking changes".
+
+## Step 5: Write the release notes
+
+Organize the commits — never ship the raw auto-generated list. Order sections by how much the reader needs them, and push mechanical commits to the bottom:
+
+```markdown
+## Breaking changes
+- `modelRouter`'s `foo` option was removed — pass `bar` instead. (#123)
+
+## Features
+- modelRouter actions: declare `instanceActions` / `collectionActions` for custom RPC-style endpoints. (#715)
+
+## Fixes
+- Fix consent signature layout and EAS dev builds. (#706)
+
+## Docs & tooling
+- Add design-blend skill with REST-first planning workflow. (#734)
+
+## Tests & housekeeping
+<details><summary>Coverage, rule-alignment, and chore commits</summary>
+
+- [coverage] Button.tsx, realtime.ts (#728)
+- Update workspace versions in bun lockfile (#735)
+</details>
+
+**Full Changelog**: https://github.com/FlourishHealth/terreno/compare/<last-tag>...<new-version>
+```
+
+Rules:
+
+- Lead with breaking changes, then features, then fixes. Omit empty sections.
+- `[coverage]`, `[alignRules]`, lockfile updates, dependabot bumps, and similar mechanical commits go in the collapsed **Tests & housekeeping** section, one line each.
+- Merge commits that belong to one feature (e.g. an IP/plan commit plus its implementation) into a single bullet.
+- Describe user-facing impact, not implementation detail. Keep `(#123)` PR references — GitHub autolinks them.
+
+## Step 6: Create the release
+
+Write the notes to a file, then create the release targeting master (this pushes the tag and starts the publish workflow):
+
+```bash
+gh release create "$VERSION" --target master --title "$VERSION" --notes-file /tmp/release-notes.md
+```
+
+## Step 7: Monitor the publish and verify npm
+
+1. Watch the workflow until it finishes:
+
+   ```bash
+   RUN_ID=$(gh run list --workflow=publish-on-tag.yml --branch "$VERSION" --limit 1 --json databaseId -q '.[0].databaseId')
+   gh run watch "$RUN_ID" --exit-status
+   ```
+
+2. Verify every package is live on npm (allow a couple of minutes of registry lag):
+
+   ```bash
+   for p in api ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
+     echo "@terreno/$p: $(npm view "@terreno/$p" version)"
+   done
+   ```
+
+   All nine must report `$VERSION`.
+
+3. Confirm the `chore: bump package versions to $VERSION` commit landed on master (`git fetch origin master && git log origin/master -1 --oneline`). Skipped for prereleases.
+
+## Step 8: If a publish job fails
+
+1. Inspect: `gh run view "$RUN_ID" --log-failed`.
+2. Transient failure (network, registry flake): `gh run rerun "$RUN_ID" --failed`.
+3. Real failure needing a code fix: fix it via a normal PR. npm versions are immutable, so if **any** package already published for this version, do not reuse the tag — merge the fix and release the next patch version. Only if nothing published may you delete the release and tag (`gh release delete "$VERSION" --cleanup-tag`) and re-create it from the fixed master.
+4. Report the final per-package publish status either way.

--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: release
+description: Cut a Terreno release — organize commits since the last tag into useful release notes, flag breaking changes, decide the semver version, create the GitHub release, and monitor the publish-on-tag workflow until every package deploys to npm. Trigger with /release.
+---
+# Release Terreno
+
+Cut a new Terreno release end-to-end: gather commits, write organized release notes, pick the version, create the GitHub release (which pushes the tag), and watch the npm publish workflow until all packages are live.
+
+## How releases work in this repo
+
+- Pushing a tag matching `X.Y.Z` (no `v` prefix, e.g. `0.18.0`) triggers `.github/workflows/publish-on-tag.yml`.
+- That workflow publishes **nine packages, all at the same version**: `@terreno/api`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
+- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. A `ui` or `api` failure cascades.
+- After successful publishes, the workflow commits `chore: bump package versions to X.Y.Z` back to master and sends a Zoom notification. Prerelease tags (`-beta`, `-alpha`) skip the master bump.
+
+## Step 1: Preflight
+
+1. Release from latest master with a clean tree:
+
+   ```bash
+   git checkout master && git pull origin master && git fetch --tags origin
+   git status --short  # must be empty
+   ```
+
+2. Verify `gh` auth (`gh api user -q .login`). If not logged in, export `GH_TOKEN` from the environment's GitHub token.
+3. Find the last release and confirm tag and GitHub release agree:
+
+   ```bash
+   git tag --sort=-v:refname | head -1
+   gh release list --limit 3
+   ```
+
+## Step 2: Collect the commits
+
+```bash
+git log <last-tag>..HEAD --oneline --no-merges
+```
+
+- If there are no commits, or the only commits are `chore: bump package versions ...` / lockfile-only changes, **stop — there is nothing to release**. Do not cut empty releases.
+- For any commit whose one-liner is unclear, pull PR context: `gh pr view <num> --json title,body,labels`.
+
+## Step 3: Decide the version
+
+- **Major**: pinned to the Expo SDK major. While the repo is on Expo 54/55 the major stays `0` (releases are `0.x.y`). Once the monorepo upgrades to Expo 56, releases become `56.x.y`, and each subsequent Expo SDK upgrade bumps the major to match.
+- **Minor**: standard semver — new features, new components/routes/exports, new `modelRouter` options, or any non-breaking API addition. While the major is `0`, breaking changes also bump the minor (semver 0.x convention) and must be called out in the notes.
+- **Patch**: standard semver — bug fixes, performance work, and releases containing only docs, CI/workflow, skills/rules, test-coverage (`[coverage]`, `[alignRules]`), or dependency-bump commits.
+- **Prerelease**: append `-beta.1` (etc.) to test the publish pipeline without moving `latest` or bumping versions on master.
+
+## Step 4: Identify breaking changes
+
+Scan the diff and PR bodies for anything a consumer must act on:
+
+- Removed or renamed exports — check the export surface directly:
+
+  ```bash
+  git diff <last-tag>..HEAD -- api/src/index.ts ui/src/index.tsx rtk/src/index.ts
+  ```
+
+- Changed function signatures or component prop types in published packages.
+- Removed/renamed `modelRouter` options, permissions, or auth behavior changes.
+- Mongoose schema changes that require a migration.
+- Peer dependency major bumps (expo, react-native, react, mongoose).
+- New required or renamed environment variables.
+
+Every breaking change gets its own bullet in the notes: what broke and how to migrate. If there are none, omit the section entirely — don't write "No breaking changes".
+
+## Step 5: Write the release notes
+
+Organize the commits — never ship the raw auto-generated list. Order sections by how much the reader needs them, and push mechanical commits to the bottom:
+
+```markdown
+## Breaking changes
+- `modelRouter`'s `foo` option was removed — pass `bar` instead. (#123)
+
+## Features
+- modelRouter actions: declare `instanceActions` / `collectionActions` for custom RPC-style endpoints. (#715)
+
+## Fixes
+- Fix consent signature layout and EAS dev builds. (#706)
+
+## Docs & tooling
+- Add design-blend skill with REST-first planning workflow. (#734)
+
+## Tests & housekeeping
+<details><summary>Coverage, rule-alignment, and chore commits</summary>
+
+- [coverage] Button.tsx, realtime.ts (#728)
+- Update workspace versions in bun lockfile (#735)
+</details>
+
+**Full Changelog**: https://github.com/FlourishHealth/terreno/compare/<last-tag>...<new-version>
+```
+
+Rules:
+
+- Lead with breaking changes, then features, then fixes. Omit empty sections.
+- `[coverage]`, `[alignRules]`, lockfile updates, dependabot bumps, and similar mechanical commits go in the collapsed **Tests & housekeeping** section, one line each.
+- Merge commits that belong to one feature (e.g. an IP/plan commit plus its implementation) into a single bullet.
+- Describe user-facing impact, not implementation detail. Keep `(#123)` PR references — GitHub autolinks them.
+
+## Step 6: Create the release
+
+Write the notes to a file, then create the release targeting master (this pushes the tag and starts the publish workflow):
+
+```bash
+gh release create "$VERSION" --target master --title "$VERSION" --notes-file /tmp/release-notes.md
+```
+
+## Step 7: Monitor the publish and verify npm
+
+1. Watch the workflow until it finishes:
+
+   ```bash
+   RUN_ID=$(gh run list --workflow=publish-on-tag.yml --branch "$VERSION" --limit 1 --json databaseId -q '.[0].databaseId')
+   gh run watch "$RUN_ID" --exit-status
+   ```
+
+2. Verify every package is live on npm (allow a couple of minutes of registry lag):
+
+   ```bash
+   for p in api ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
+     echo "@terreno/$p: $(npm view "@terreno/$p" version)"
+   done
+   ```
+
+   All nine must report `$VERSION`.
+
+3. Confirm the `chore: bump package versions to $VERSION` commit landed on master (`git fetch origin master && git log origin/master -1 --oneline`). Skipped for prereleases.
+
+## Step 8: If a publish job fails
+
+1. Inspect: `gh run view "$RUN_ID" --log-failed`.
+2. Transient failure (network, registry flake): `gh run rerun "$RUN_ID" --failed`.
+3. Real failure needing a code fix: fix it via a normal PR. npm versions are immutable, so if **any** package already published for this version, do not reuse the tag — merge the fix and release the next patch version. Only if nothing published may you delete the release and tag (`gh release delete "$VERSION" --cleanup-tag`) and re-create it from the fixed master.
+4. Report the final per-package publish status either way.

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: release
+description: >-
+  Cut a Terreno release — organize commits since the last tag into useful
+  release notes, flag breaking changes, decide the semver version, create the
+  GitHub release, and monitor the publish-on-tag workflow until every package
+  deploys to npm. Trigger with /release.
+---
+# Release Terreno
+
+Cut a new Terreno release end-to-end: gather commits, write organized release notes, pick the version, create the GitHub release (which pushes the tag), and watch the npm publish workflow until all packages are live.
+
+## How releases work in this repo
+
+- Pushing a tag matching `X.Y.Z` (no `v` prefix, e.g. `0.18.0`) triggers `.github/workflows/publish-on-tag.yml`.
+- That workflow publishes **nine packages, all at the same version**: `@terreno/api`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
+- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. A `ui` or `api` failure cascades.
+- After successful publishes, the workflow commits `chore: bump package versions to X.Y.Z` back to master and sends a Zoom notification. Prerelease tags (`-beta`, `-alpha`) skip the master bump.
+
+## Step 1: Preflight
+
+1. Release from latest master with a clean tree:
+
+   ```bash
+   git checkout master && git pull origin master && git fetch --tags origin
+   git status --short  # must be empty
+   ```
+
+2. Verify `gh` auth (`gh api user -q .login`). If not logged in, export `GH_TOKEN` from the environment's GitHub token.
+3. Find the last release and confirm tag and GitHub release agree:
+
+   ```bash
+   git tag --sort=-v:refname | head -1
+   gh release list --limit 3
+   ```
+
+## Step 2: Collect the commits
+
+```bash
+git log <last-tag>..HEAD --oneline --no-merges
+```
+
+- If there are no commits, or the only commits are `chore: bump package versions ...` / lockfile-only changes, **stop — there is nothing to release**. Do not cut empty releases.
+- For any commit whose one-liner is unclear, pull PR context: `gh pr view <num> --json title,body,labels`.
+
+## Step 3: Decide the version
+
+- **Major**: pinned to the Expo SDK major. While the repo is on Expo 54/55 the major stays `0` (releases are `0.x.y`). Once the monorepo upgrades to Expo 56, releases become `56.x.y`, and each subsequent Expo SDK upgrade bumps the major to match.
+- **Minor**: standard semver — new features, new components/routes/exports, new `modelRouter` options, or any non-breaking API addition. While the major is `0`, breaking changes also bump the minor (semver 0.x convention) and must be called out in the notes.
+- **Patch**: standard semver — bug fixes, performance work, and releases containing only docs, CI/workflow, skills/rules, test-coverage (`[coverage]`, `[alignRules]`), or dependency-bump commits.
+- **Prerelease**: append `-beta.1` (etc.) to test the publish pipeline without moving `latest` or bumping versions on master.
+
+## Step 4: Identify breaking changes
+
+Scan the diff and PR bodies for anything a consumer must act on:
+
+- Removed or renamed exports — check the export surface directly:
+
+  ```bash
+  git diff <last-tag>..HEAD -- api/src/index.ts ui/src/index.tsx rtk/src/index.ts
+  ```
+
+- Changed function signatures or component prop types in published packages.
+- Removed/renamed `modelRouter` options, permissions, or auth behavior changes.
+- Mongoose schema changes that require a migration.
+- Peer dependency major bumps (expo, react-native, react, mongoose).
+- New required or renamed environment variables.
+
+Every breaking change gets its own bullet in the notes: what broke and how to migrate. If there are none, omit the section entirely — don't write "No breaking changes".
+
+## Step 5: Write the release notes
+
+Organize the commits — never ship the raw auto-generated list. Order sections by how much the reader needs them, and push mechanical commits to the bottom:
+
+```markdown
+## Breaking changes
+- `modelRouter`'s `foo` option was removed — pass `bar` instead. (#123)
+
+## Features
+- modelRouter actions: declare `instanceActions` / `collectionActions` for custom RPC-style endpoints. (#715)
+
+## Fixes
+- Fix consent signature layout and EAS dev builds. (#706)
+
+## Docs & tooling
+- Add design-blend skill with REST-first planning workflow. (#734)
+
+## Tests & housekeeping
+<details><summary>Coverage, rule-alignment, and chore commits</summary>
+
+- [coverage] Button.tsx, realtime.ts (#728)
+- Update workspace versions in bun lockfile (#735)
+</details>
+
+**Full Changelog**: https://github.com/FlourishHealth/terreno/compare/<last-tag>...<new-version>
+```
+
+Rules:
+
+- Lead with breaking changes, then features, then fixes. Omit empty sections.
+- `[coverage]`, `[alignRules]`, lockfile updates, dependabot bumps, and similar mechanical commits go in the collapsed **Tests & housekeeping** section, one line each.
+- Merge commits that belong to one feature (e.g. an IP/plan commit plus its implementation) into a single bullet.
+- Describe user-facing impact, not implementation detail. Keep `(#123)` PR references — GitHub autolinks them.
+
+## Step 6: Create the release
+
+Write the notes to a file, then create the release targeting master (this pushes the tag and starts the publish workflow):
+
+```bash
+gh release create "$VERSION" --target master --title "$VERSION" --notes-file /tmp/release-notes.md
+```
+
+## Step 7: Monitor the publish and verify npm
+
+1. Watch the workflow until it finishes:
+
+   ```bash
+   RUN_ID=$(gh run list --workflow=publish-on-tag.yml --branch "$VERSION" --limit 1 --json databaseId -q '.[0].databaseId')
+   gh run watch "$RUN_ID" --exit-status
+   ```
+
+2. Verify every package is live on npm (allow a couple of minutes of registry lag):
+
+   ```bash
+   for p in api ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
+     echo "@terreno/$p: $(npm view "@terreno/$p" version)"
+   done
+   ```
+
+   All nine must report `$VERSION`.
+
+3. Confirm the `chore: bump package versions to $VERSION` commit landed on master (`git fetch origin master && git log origin/master -1 --oneline`). Skipped for prereleases.
+
+## Step 8: If a publish job fails
+
+1. Inspect: `gh run view "$RUN_ID" --log-failed`.
+2. Transient failure (network, registry flake): `gh run rerun "$RUN_ID" --failed`.
+3. Real failure needing a code fix: fix it via a normal PR. npm versions are immutable, so if **any** package already published for this version, do not reuse the tag — merge the fix and release the next patch version. Only if nothing published may you delete the release and tag (`gh release delete "$VERSION" --cleanup-tag`) and re-create it from the fixed master.
+4. Report the final per-package publish status either way.

--- a/.rulesync/skills/release/SKILL.md
+++ b/.rulesync/skills/release/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: release
+description: Cut a Terreno release — organize commits since the last tag into useful release notes, flag breaking changes, decide the semver version, create the GitHub release, and monitor the publish-on-tag workflow until every package deploys to npm. Trigger with /release.
+disable-model-invocation: true
+---
+
+# Release Terreno
+
+Cut a new Terreno release end-to-end: gather commits, write organized release notes, pick the version, create the GitHub release (which pushes the tag), and watch the npm publish workflow until all packages are live.
+
+## How releases work in this repo
+
+- Pushing a tag matching `X.Y.Z` (no `v` prefix, e.g. `0.18.0`) triggers `.github/workflows/publish-on-tag.yml`.
+- That workflow publishes **nine packages, all at the same version**: `@terreno/api`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
+- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. A `ui` or `api` failure cascades.
+- After successful publishes, the workflow commits `chore: bump package versions to X.Y.Z` back to master and sends a Zoom notification. Prerelease tags (`-beta`, `-alpha`) skip the master bump.
+
+## Step 1: Preflight
+
+1. Release from latest master with a clean tree:
+
+   ```bash
+   git checkout master && git pull origin master && git fetch --tags origin
+   git status --short  # must be empty
+   ```
+
+2. Verify `gh` auth (`gh api user -q .login`). If not logged in, export `GH_TOKEN` from the environment's GitHub token.
+3. Find the last release and confirm tag and GitHub release agree:
+
+   ```bash
+   git tag --sort=-v:refname | head -1
+   gh release list --limit 3
+   ```
+
+## Step 2: Collect the commits
+
+```bash
+git log <last-tag>..HEAD --oneline --no-merges
+```
+
+- If there are no commits, or the only commits are `chore: bump package versions ...` / lockfile-only changes, **stop — there is nothing to release**. Do not cut empty releases.
+- For any commit whose one-liner is unclear, pull PR context: `gh pr view <num> --json title,body,labels`.
+
+## Step 3: Decide the version
+
+- **Major**: pinned to the Expo SDK major. While the repo is on Expo 54/55 the major stays `0` (releases are `0.x.y`). Once the monorepo upgrades to Expo 56, releases become `56.x.y`, and each subsequent Expo SDK upgrade bumps the major to match.
+- **Minor**: standard semver — new features, new components/routes/exports, new `modelRouter` options, or any non-breaking API addition. While the major is `0`, breaking changes also bump the minor (semver 0.x convention) and must be called out in the notes.
+- **Patch**: standard semver — bug fixes, performance work, and releases containing only docs, CI/workflow, skills/rules, test-coverage (`[coverage]`, `[alignRules]`), or dependency-bump commits.
+- **Prerelease**: append `-beta.1` (etc.) to test the publish pipeline without moving `latest` or bumping versions on master.
+
+## Step 4: Identify breaking changes
+
+Scan the diff and PR bodies for anything a consumer must act on:
+
+- Removed or renamed exports — check the export surface directly:
+
+  ```bash
+  git diff <last-tag>..HEAD -- api/src/index.ts ui/src/index.tsx rtk/src/index.ts
+  ```
+
+- Changed function signatures or component prop types in published packages.
+- Removed/renamed `modelRouter` options, permissions, or auth behavior changes.
+- Mongoose schema changes that require a migration.
+- Peer dependency major bumps (expo, react-native, react, mongoose).
+- New required or renamed environment variables.
+
+Every breaking change gets its own bullet in the notes: what broke and how to migrate. If there are none, omit the section entirely — don't write "No breaking changes".
+
+## Step 5: Write the release notes
+
+Organize the commits — never ship the raw auto-generated list. Order sections by how much the reader needs them, and push mechanical commits to the bottom:
+
+```markdown
+## Breaking changes
+- `modelRouter`'s `foo` option was removed — pass `bar` instead. (#123)
+
+## Features
+- modelRouter actions: declare `instanceActions` / `collectionActions` for custom RPC-style endpoints. (#715)
+
+## Fixes
+- Fix consent signature layout and EAS dev builds. (#706)
+
+## Docs & tooling
+- Add design-blend skill with REST-first planning workflow. (#734)
+
+## Tests & housekeeping
+<details><summary>Coverage, rule-alignment, and chore commits</summary>
+
+- [coverage] Button.tsx, realtime.ts (#728)
+- Update workspace versions in bun lockfile (#735)
+</details>
+
+**Full Changelog**: https://github.com/FlourishHealth/terreno/compare/<last-tag>...<new-version>
+```
+
+Rules:
+
+- Lead with breaking changes, then features, then fixes. Omit empty sections.
+- `[coverage]`, `[alignRules]`, lockfile updates, dependabot bumps, and similar mechanical commits go in the collapsed **Tests & housekeeping** section, one line each.
+- Merge commits that belong to one feature (e.g. an IP/plan commit plus its implementation) into a single bullet.
+- Describe user-facing impact, not implementation detail. Keep `(#123)` PR references — GitHub autolinks them.
+
+## Step 6: Create the release
+
+Write the notes to a file, then create the release targeting master (this pushes the tag and starts the publish workflow):
+
+```bash
+gh release create "$VERSION" --target master --title "$VERSION" --notes-file /tmp/release-notes.md
+```
+
+## Step 7: Monitor the publish and verify npm
+
+1. Watch the workflow until it finishes:
+
+   ```bash
+   RUN_ID=$(gh run list --workflow=publish-on-tag.yml --branch "$VERSION" --limit 1 --json databaseId -q '.[0].databaseId')
+   gh run watch "$RUN_ID" --exit-status
+   ```
+
+2. Verify every package is live on npm (allow a couple of minutes of registry lag):
+
+   ```bash
+   for p in api ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
+     echo "@terreno/$p: $(npm view "@terreno/$p" version)"
+   done
+   ```
+
+   All nine must report `$VERSION`.
+
+3. Confirm the `chore: bump package versions to $VERSION` commit landed on master (`git fetch origin master && git log origin/master -1 --oneline`). Skipped for prereleases.
+
+## Step 8: If a publish job fails
+
+1. Inspect: `gh run view "$RUN_ID" --log-failed`.
+2. Transient failure (network, registry flake): `gh run rerun "$RUN_ID" --failed`.
+3. Real failure needing a code fix: fix it via a normal PR. npm versions are immutable, so if **any** package already published for this version, do not reuse the tag — merge the fix and release the next patch version. Only if nothing published may you delete the release and tag (`gh release delete "$VERSION" --cleanup-tag`) and re-create it from the fixed master.
+4. Report the final per-package publish status either way.

--- a/.windsurf/skills/release/SKILL.md
+++ b/.windsurf/skills/release/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: release
+description: >-
+  Cut a Terreno release — organize commits since the last tag into useful
+  release notes, flag breaking changes, decide the semver version, create the
+  GitHub release, and monitor the publish-on-tag workflow until every package
+  deploys to npm. Trigger with /release.
+---
+# Release Terreno
+
+Cut a new Terreno release end-to-end: gather commits, write organized release notes, pick the version, create the GitHub release (which pushes the tag), and watch the npm publish workflow until all packages are live.
+
+## How releases work in this repo
+
+- Pushing a tag matching `X.Y.Z` (no `v` prefix, e.g. `0.18.0`) triggers `.github/workflows/publish-on-tag.yml`.
+- That workflow publishes **nine packages, all at the same version**: `@terreno/api`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
+- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. A `ui` or `api` failure cascades.
+- After successful publishes, the workflow commits `chore: bump package versions to X.Y.Z` back to master and sends a Zoom notification. Prerelease tags (`-beta`, `-alpha`) skip the master bump.
+
+## Step 1: Preflight
+
+1. Release from latest master with a clean tree:
+
+   ```bash
+   git checkout master && git pull origin master && git fetch --tags origin
+   git status --short  # must be empty
+   ```
+
+2. Verify `gh` auth (`gh api user -q .login`). If not logged in, export `GH_TOKEN` from the environment's GitHub token.
+3. Find the last release and confirm tag and GitHub release agree:
+
+   ```bash
+   git tag --sort=-v:refname | head -1
+   gh release list --limit 3
+   ```
+
+## Step 2: Collect the commits
+
+```bash
+git log <last-tag>..HEAD --oneline --no-merges
+```
+
+- If there are no commits, or the only commits are `chore: bump package versions ...` / lockfile-only changes, **stop — there is nothing to release**. Do not cut empty releases.
+- For any commit whose one-liner is unclear, pull PR context: `gh pr view <num> --json title,body,labels`.
+
+## Step 3: Decide the version
+
+- **Major**: pinned to the Expo SDK major. While the repo is on Expo 54/55 the major stays `0` (releases are `0.x.y`). Once the monorepo upgrades to Expo 56, releases become `56.x.y`, and each subsequent Expo SDK upgrade bumps the major to match.
+- **Minor**: standard semver — new features, new components/routes/exports, new `modelRouter` options, or any non-breaking API addition. While the major is `0`, breaking changes also bump the minor (semver 0.x convention) and must be called out in the notes.
+- **Patch**: standard semver — bug fixes, performance work, and releases containing only docs, CI/workflow, skills/rules, test-coverage (`[coverage]`, `[alignRules]`), or dependency-bump commits.
+- **Prerelease**: append `-beta.1` (etc.) to test the publish pipeline without moving `latest` or bumping versions on master.
+
+## Step 4: Identify breaking changes
+
+Scan the diff and PR bodies for anything a consumer must act on:
+
+- Removed or renamed exports — check the export surface directly:
+
+  ```bash
+  git diff <last-tag>..HEAD -- api/src/index.ts ui/src/index.tsx rtk/src/index.ts
+  ```
+
+- Changed function signatures or component prop types in published packages.
+- Removed/renamed `modelRouter` options, permissions, or auth behavior changes.
+- Mongoose schema changes that require a migration.
+- Peer dependency major bumps (expo, react-native, react, mongoose).
+- New required or renamed environment variables.
+
+Every breaking change gets its own bullet in the notes: what broke and how to migrate. If there are none, omit the section entirely — don't write "No breaking changes".
+
+## Step 5: Write the release notes
+
+Organize the commits — never ship the raw auto-generated list. Order sections by how much the reader needs them, and push mechanical commits to the bottom:
+
+```markdown
+## Breaking changes
+- `modelRouter`'s `foo` option was removed — pass `bar` instead. (#123)
+
+## Features
+- modelRouter actions: declare `instanceActions` / `collectionActions` for custom RPC-style endpoints. (#715)
+
+## Fixes
+- Fix consent signature layout and EAS dev builds. (#706)
+
+## Docs & tooling
+- Add design-blend skill with REST-first planning workflow. (#734)
+
+## Tests & housekeeping
+<details><summary>Coverage, rule-alignment, and chore commits</summary>
+
+- [coverage] Button.tsx, realtime.ts (#728)
+- Update workspace versions in bun lockfile (#735)
+</details>
+
+**Full Changelog**: https://github.com/FlourishHealth/terreno/compare/<last-tag>...<new-version>
+```
+
+Rules:
+
+- Lead with breaking changes, then features, then fixes. Omit empty sections.
+- `[coverage]`, `[alignRules]`, lockfile updates, dependabot bumps, and similar mechanical commits go in the collapsed **Tests & housekeeping** section, one line each.
+- Merge commits that belong to one feature (e.g. an IP/plan commit plus its implementation) into a single bullet.
+- Describe user-facing impact, not implementation detail. Keep `(#123)` PR references — GitHub autolinks them.
+
+## Step 6: Create the release
+
+Write the notes to a file, then create the release targeting master (this pushes the tag and starts the publish workflow):
+
+```bash
+gh release create "$VERSION" --target master --title "$VERSION" --notes-file /tmp/release-notes.md
+```
+
+## Step 7: Monitor the publish and verify npm
+
+1. Watch the workflow until it finishes:
+
+   ```bash
+   RUN_ID=$(gh run list --workflow=publish-on-tag.yml --branch "$VERSION" --limit 1 --json databaseId -q '.[0].databaseId')
+   gh run watch "$RUN_ID" --exit-status
+   ```
+
+2. Verify every package is live on npm (allow a couple of minutes of registry lag):
+
+   ```bash
+   for p in api ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
+     echo "@terreno/$p: $(npm view "@terreno/$p" version)"
+   done
+   ```
+
+   All nine must report `$VERSION`.
+
+3. Confirm the `chore: bump package versions to $VERSION` commit landed on master (`git fetch origin master && git log origin/master -1 --oneline`). Skipped for prereleases.
+
+## Step 8: If a publish job fails
+
+1. Inspect: `gh run view "$RUN_ID" --log-failed`.
+2. Transient failure (network, registry flake): `gh run rerun "$RUN_ID" --failed`.
+3. Real failure needing a code fix: fix it via a normal PR. npm versions are immutable, so if **any** package already published for this version, do not reuse the tag — merge the fix and release the next patch version. Only if nothing published may you delete the release and tag (`gh release delete "$VERSION" --cleanup-tag`) and re-create it from the fixed master.
+4. Report the final per-package publish status either way.

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "admin-backend": {
       "name": "@terreno/admin-backend",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@google-cloud/storage": "^7.15.0",
         "@terreno/api": "workspace:*",
@@ -36,7 +36,7 @@
     },
     "admin-frontend": {
       "name": "@terreno/admin-frontend",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@terreno/ui": "workspace:*",
         "expo-router": "catalog:",
@@ -67,7 +67,7 @@
     },
     "admin-spa": {
       "name": "@terreno/admin-spa",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@expo/vector-icons": "catalog:",
         "@react-native-async-storage/async-storage": "catalog:",
@@ -118,7 +118,7 @@
     },
     "ai": {
       "name": "@terreno/ai",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@ai-sdk/mcp": "^1.0.21",
         "@google-cloud/storage": "^7.15.0",
@@ -153,7 +153,7 @@
     },
     "api": {
       "name": "@terreno/api",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@sentry/bun": "^10.25.0",
@@ -228,7 +228,7 @@
     },
     "api-health": {
       "name": "@terreno/api-health",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@terreno/api": "workspace:*",
         "express": "^5.2.1",
@@ -418,7 +418,7 @@
     },
     "feature-flags": {
       "name": "@terreno/feature-flags",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@terreno/api": "workspace:*",
         "express": "^5.2.1",
@@ -458,7 +458,7 @@
     },
     "rtk": {
       "name": "@terreno/rtk",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@better-auth/expo": "^1.2.8",
         "@react-native-async-storage/async-storage": "catalog:",
@@ -497,7 +497,7 @@
     },
     "ui": {
       "name": "@terreno/ui",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@expo-google-fonts/nunito": "^0.4.2",
         "@expo-google-fonts/titillium-web": "^0.4.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `/release` skill (`.rulesync/skills/release/SKILL.md`, generated to all targets via `bun run rules`) that documents the full Terreno release process:

- **How releases work**: `X.Y.Z` tag (no `v` prefix) triggers `publish-on-tag.yml`, which publishes all nine `@terreno/*` packages at the same version, then commits the version bump back to master. Documents the job dependency chain (ui/api failures cascade).
- **Versioning policy**: major is pinned to the Expo SDK major (stays `0.x.y` until the Expo 56 upgrade, then `56.x.y`); minor/patch follow standard semver, with breaking changes bumping the minor while on `0.x`. No empty releases.
- **Organized release notes**: Breaking changes → Features → Fixes → Docs & tooling, with `[coverage]`/`[alignRules]`/lockfile-style mechanical commits collapsed at the bottom in a Tests & housekeeping section — never the raw auto-generated list.
- **Breaking-change detection**: export-surface diff of `api`/`ui`/`rtk` index files, plus signature, schema, peer-dep, and env-var checks.
- **Monitoring**: `gh run watch` on the publish workflow, npm version verification for all nine packages, master bump confirmation, and a failure playbook (rerun transient failures; never reuse a tag once any package published).

Also updates `bun.lock` workspace versions to 0.18.0 (same mechanical follow-up as #735 after the 0.17.0 release).

## Applying the skill

The most recent commits were all released as 0.18.0 minutes before this work started (nothing unreleased remains except the automated bump commit), so the skill was exercised against that release instead of cutting an empty one:

- Rewrote the [0.18.0 release notes](https://github.com/FlourishHealth/terreno/releases/tag/0.18.0) into the organized format (Features / Fixes / Docs & tooling, coverage + chore commits collapsed at the bottom).
- Breaking changes: none in 0.17.0…0.18.0 — the only export-surface change is the additive `createSessionApi` in `@terreno/rtk`, which also validates 0.18.0 as a correct minor bump.
- Verified deployment: publish-on-tag run 27325113081 succeeded (all 12 jobs), all nine `@terreno/*` packages report 0.18.0 on npm, and the bump commit landed on master.

[Organized 0.18.0 release notes](https://cursor.com/agents/bc-5328f913-e074-4db9-bb9c-6c991a82983c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frelease_0_18_0_organized_notes.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5328f913-e074-4db9-bb9c-6c991a82983c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5328f913-e074-4db9-bb9c-6c991a82983c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

