### PR TITLE
Add Cursor plugin manifest at repository root

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "terreno",
+  "displayName": "Terreno",
+  "description": "Rules and agent skills for developing in the Terreno monorepo (React Native, Express, Mongoose, and shared packages).",
+  "version": "1.0.0",
+  "author": {
+    "name": "Terreno"
+  },
+  "keywords": [
+    "terreno",
+    "react-native",
+    "expo",
+    "express",
+    "mongoose",
+    "redux-toolkit",
+    "openapi"
+  ],
+  "rules": ".cursor/rules",
+  "skills": ".cursor/skills"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds [`.cursor-plugin/plugin.json`](https://cursor.com/docs/plugins) at the monorepo root so this repository can be used as a **Cursor plugin**. The manifest points at the existing [`.cursor/rules`](.cursor/rules) and [`.cursor/skills`](.cursor/skills) trees (generated/maintained via rulesync).

## Testing

- Validated `plugin.json` parses as JSON.
- No runtime or compile impact.

## Local use

Per Cursor docs: copy or symlink the repo (or plugin contents) under `~/.cursor/plugins/local/terreno` with `.cursor-plugin/plugin.json` at that folder root, then reload the window.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c46bf30-b19d-4594-b6cf-ce5155d6fa1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c46bf30-b19d-4594-b6cf-ce5155d6fa1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

