### PR TITLE
Fix @terreno/api Biome lint issues for CI

### DIFF
--- a/api/src/actions.openApi.test.ts
+++ b/api/src/actions.openApi.test.ts
@@ -7,7 +7,7 @@ import {addAuthRoutes, setupAuth} from "./auth";
 import {setupServer} from "./expressServer";
 import {Permissions} from "./permissions";
 import {TerrenoApp} from "./terrenoApp";
-import {authAsUser, FoodModel, setupDb, UserModel} from "./tests";
+import {FoodModel, setupDb, UserModel} from "./tests";
 import {z} from "./zodOpenApi";
 
 const foodActionPermissions = {

--- a/api/src/api.test.ts
+++ b/api/src/api.test.ts
@@ -2010,9 +2010,13 @@ describe("@terreno/api", () => {
     });
 
     it("returns 409 when precise conflict timestamp is older than doc.updated", async () => {
+      const ifUnmodifiedSince = DateTime.fromISO("2025-06-15T12:00:01.000Z").toHTTP();
+      if (ifUnmodifiedSince === null) {
+        throw new Error("expected HTTP If-Unmodified-Since value");
+      }
       await agent
         .patch(`/food/${spinach._id}`)
-        .set("If-Unmodified-Since", DateTime.fromISO("2025-06-15T12:00:01.000Z").toHTTP()!)
+        .set("If-Unmodified-Since", ifUnmodifiedSince)
         .set("X-Unmodified-Since-ISO", "2025-06-15T11:59:59.500Z")
         .send({name: "Precise Stale"})
         .expect(409);
@@ -2024,9 +2028,13 @@ describe("@terreno/api", () => {
         {$unset: {updated: ""}}
       );
 
+      const ifUnmodifiedSince = DateTime.fromISO("2025-06-15T11:59:59.999Z").toHTTP();
+      if (ifUnmodifiedSince === null) {
+        throw new Error("expected HTTP If-Unmodified-Since value");
+      }
       const res = await agent
         .patch(`/food/${spinach._id}`)
-        .set("If-Unmodified-Since", DateTime.fromISO("2025-06-15T11:59:59.999Z").toHTTP()!)
+        .set("If-Unmodified-Since", ifUnmodifiedSince)
         .send({name: "Created Fallback"})
         .expect(409);
 

--- a/api/src/expressServer.test.ts
+++ b/api/src/expressServer.test.ts
@@ -812,7 +812,6 @@ describe("expressServer", () => {
       // Mock app.listen on the Express prototype to avoid opening a real port
       const express = await import("express");
       const originalListen = express.default.application.listen;
-      // biome-ignore lint/suspicious/noExplicitAny: mocking Express internals requires type escape
       express.default.application.listen = mock(function (this: unknown, ...args: unknown[]) {
         const cb = args.find((a: unknown) => typeof a === "function") as (() => void) | undefined;
         if (cb) {

--- a/api/src/realtime/queryMatcher.ts
+++ b/api/src/realtime/queryMatcher.ts
@@ -6,7 +6,6 @@
  * Supports: equality, $eq, $ne, $gt, $gte, $lt, $lte, $in, $nin, $exists, $and, $or, $not.
  */
 
-// biome-ignore lint/suspicious/noExplicitAny: traversing arbitrary nested document fields by user-supplied dotted path
 const getNestedValue = (doc: any, path: string): any => {
   const parts = path.split(".");
   let current = doc;
@@ -19,7 +18,6 @@ const getNestedValue = (doc: any, path: string): any => {
   return current;
 };
 
-// biome-ignore lint/suspicious/noExplicitAny: value may be any document field type (string, number, ObjectId, etc.)
 const normalize = (value: any): any => {
   if (value === null || value === undefined) {
     return value;
@@ -36,7 +34,6 @@ const normalize = (value: any): any => {
   return value;
 };
 
-// biome-ignore lint/suspicious/noExplicitAny: rawValue is an arbitrary document field, condition is an arbitrary user query operand
 const matchesCondition = (rawValue: any, condition: any): boolean => {
   const value = normalize(rawValue);
 
@@ -91,7 +88,6 @@ const matchesCondition = (rawValue: any, condition: any): boolean => {
           return false;
         }
         const inValues = operand.map(normalize);
-        // biome-ignore lint/suspicious/noExplicitAny: normalized value of arbitrary document field
         if (!inValues.some((v: any) => v === value || String(v) === String(value))) {
           return false;
         }
@@ -102,7 +98,6 @@ const matchesCondition = (rawValue: any, condition: any): boolean => {
           return false;
         }
         const ninValues = operand.map(normalize);
-        // biome-ignore lint/suspicious/noExplicitAny: normalized value of arbitrary document field
         if (ninValues.some((v: any) => v === value || String(v) === String(value))) {
           return false;
         }
@@ -137,7 +132,6 @@ const matchesCondition = (rawValue: any, condition: any): boolean => {
  * @param query - MongoDB-style query object
  * @returns true if the document matches all query conditions
  */
-// biome-ignore lint/suspicious/noExplicitAny: doc is arbitrary; query values are arbitrary user-supplied JSON
 export const matchesQuery = (doc: any, query: Record<string, any>): boolean => {
   for (const [key, condition] of Object.entries(query)) {
     if (key === "$and") {

--- a/api/src/realtime/queryStore.ts
+++ b/api/src/realtime/queryStore.ts
@@ -9,7 +9,6 @@
 
 interface QuerySubscription {
   collection: string;
-  // biome-ignore lint/suspicious/noExplicitAny: MongoDB query filter values are arbitrary user-supplied JSON
   query: Record<string, any>;
   queryId: string;
 }
@@ -18,13 +17,8 @@ interface QuerySubscription {
  * Compute a deterministic queryId from collection and query on the server side.
  * This prevents clients from hijacking other subscriptions by providing a colliding queryId.
  */
-export const computeQueryId = (
-  collection: string,
-  // biome-ignore lint/suspicious/noExplicitAny: MongoDB query filter values are arbitrary user-supplied JSON
-  query: Record<string, any>
-): string => {
+export const computeQueryId = (collection: string, query: Record<string, any>): string => {
   const sortedKeys = Object.keys(query).sort();
-  // biome-ignore lint/suspicious/noExplicitAny: mirrors the input query value shape
   const normalized: Record<string, any> = {};
   for (const key of sortedKeys) {
     normalized[key] = query[key];
@@ -45,7 +39,6 @@ const socketQueries = new Map<string, Set<string>>();
 export const addQuerySubscription = (
   socketId: string,
   collection: string,
-  // biome-ignore lint/suspicious/noExplicitAny: MongoDB query filter values are arbitrary user-supplied JSON
   query: Record<string, any>,
   queryId: string
 ): void => {
@@ -109,9 +102,7 @@ export const removeAllSocketQueries = (socketId: string): void => {
  */
 export const getQuerySubscriptionsForCollection = (
   collection: string
-  // biome-ignore lint/suspicious/noExplicitAny: MongoDB query filter values are arbitrary user-supplied JSON
 ): {queryId: string; query: Record<string, any>}[] => {
-  // biome-ignore lint/suspicious/noExplicitAny: MongoDB query filter values are arbitrary user-supplied JSON
   const result: {queryId: string; query: Record<string, any>}[] = [];
 
   for (const [queryId, sub] of querySubscriptions) {

--- a/api/src/realtime/realtime.test.ts
+++ b/api/src/realtime/realtime.test.ts
@@ -1776,6 +1776,17 @@ describe("startChangeStreamWatcher", () => {
     };
   };
 
+  const invokeRegisteredChangeHandler = async (
+    mockStream: ReturnType<typeof createMockChangeStream>,
+    event: Record<string, unknown>
+  ): Promise<void> => {
+    const changeHandler = mockStream.listeners.get("change");
+    if (!changeHandler) {
+      throw new Error("expected change handler");
+    }
+    await changeHandler(event);
+  };
+
   const createMockIo = () => {
     const rooms = new Map<string, Set<string>>();
     const sockets = new Map<string, any>();
@@ -1864,9 +1875,7 @@ describe("startChangeStreamWatcher", () => {
     startChangeStreamWatcher(io, {}, true);
 
     // Trigger an insert change event
-    const changeHandler = mockStream.listeners.get("change");
-    expect(changeHandler).toBeDefined();
-    await changeHandler!({
+    await invokeRegisteredChangeHandler(mockStream, {
       documentKey: {_id: "doc-1"},
       fullDocument: {_id: "doc-1", name: "Test Todo"},
       ns: {coll: "todos"},
@@ -1886,9 +1895,8 @@ describe("startChangeStreamWatcher", () => {
 
     startChangeStreamWatcher(io, {}, true);
 
-    const changeHandler = mockStream.listeners.get("change");
     // Trigger for an unregistered collection — should not throw
-    await changeHandler!({
+    await invokeRegisteredChangeHandler(mockStream, {
       documentKey: {_id: "doc-1"},
       fullDocument: {_id: "doc-1"},
       ns: {coll: "unknown_collection"},
@@ -1927,9 +1935,8 @@ describe("startChangeStreamWatcher", () => {
 
     startChangeStreamWatcher(io, {}, true);
 
-    const changeHandler = mockStream.listeners.get("change");
     // Update event should be skipped because "update" not in methods
-    await changeHandler!({
+    await invokeRegisteredChangeHandler(mockStream, {
       documentKey: {_id: "doc-1"},
       fullDocument: {_id: "doc-1", name: "Updated"},
       ns: {coll: "todos"},
@@ -1969,9 +1976,8 @@ describe("startChangeStreamWatcher", () => {
 
     startChangeStreamWatcher(io, {}, true);
 
-    const changeHandler = mockStream.listeners.get("change");
     // Hard delete (no fullDocument)
-    await changeHandler!({
+    await invokeRegisteredChangeHandler(mockStream, {
       documentKey: {_id: "doc-1"},
       ns: {coll: "todos"},
       operationType: "delete",
@@ -2009,9 +2015,8 @@ describe("startChangeStreamWatcher", () => {
 
     startChangeStreamWatcher(io, {}, true);
 
-    const changeHandler = mockStream.listeners.get("change");
     // Hard delete for broadcast strategy
-    await changeHandler!({
+    await invokeRegisteredChangeHandler(mockStream, {
       documentKey: {_id: "doc-1"},
       ns: {coll: "broadcasts"},
       operationType: "delete",
@@ -2049,8 +2054,7 @@ describe("startChangeStreamWatcher", () => {
 
     startChangeStreamWatcher(io, {}, true);
 
-    const changeHandler = mockStream.listeners.get("change");
-    await changeHandler!({
+    await invokeRegisteredChangeHandler(mockStream, {
       documentKey: {_id: "doc-1"},
       fullDocument: {_id: "doc-1", name: "Updated", status: "done"},
       ns: {coll: "todos"},
@@ -2110,9 +2114,8 @@ describe("startChangeStreamWatcher", () => {
 
     startChangeStreamWatcher(io, {ignoredOperations: ["insert"]}, true);
 
-    const changeHandler = mockStream.listeners.get("change");
     // This insert should be skipped because "insert" is ignored
-    await changeHandler!({
+    await invokeRegisteredChangeHandler(mockStream, {
       documentKey: {_id: "doc-1"},
       fullDocument: {_id: "doc-1"},
       ns: {coll: "todos"},
@@ -2132,15 +2135,14 @@ describe("startChangeStreamWatcher", () => {
 
     startChangeStreamWatcher(io, {}, true);
 
-    const changeHandler = mockStream.listeners.get("change");
     // Missing ns.coll
-    await changeHandler!({
+    await invokeRegisteredChangeHandler(mockStream, {
       documentKey: {_id: "doc-1"},
       ns: {},
       operationType: "insert",
     });
     // Missing documentKey
-    await changeHandler!({
+    await invokeRegisteredChangeHandler(mockStream, {
       documentKey: {},
       ns: {coll: "todos"},
       operationType: "insert",
@@ -2159,9 +2161,8 @@ describe("startChangeStreamWatcher", () => {
 
     startChangeStreamWatcher(io, {}, true);
 
-    const changeHandler = mockStream.listeners.get("change");
     // "drop" is not in our pipeline filter, should be skipped
-    await changeHandler!({
+    await invokeRegisteredChangeHandler(mockStream, {
       operationType: "drop",
     });
   });
@@ -2257,9 +2258,8 @@ describe("startChangeStreamWatcher", () => {
 
     startChangeStreamWatcher(io, {}, true);
 
-    const changeHandler = mockStream.listeners.get("change");
     // Should not throw even though permission check throws
-    await changeHandler!({
+    await invokeRegisteredChangeHandler(mockStream, {
       documentKey: {_id: "doc-1"},
       fullDocument: {_id: "doc-1", name: "Test"},
       ns: {coll: "todos"},
@@ -2317,7 +2317,7 @@ describe("RealtimeApp.onServerCreated", () => {
   });
 
   const makeServer = (): import("http").Server => {
-    const http = require("http");
+    const http = require("node:http");
     const server = http.createServer();
     servers.push(server);
     return server;
@@ -2366,7 +2366,7 @@ describe("RealtimeApp.setupAdapter (private, via onServerCreated config)", () =>
   });
 
   const makeServer = (): import("http").Server => {
-    const http = require("http");
+    const http = require("node:http");
     const server = http.createServer();
     servers.push(server);
     return server;

--- a/api/src/realtime/realtimeApp.ts
+++ b/api/src/realtime/realtimeApp.ts
@@ -60,7 +60,6 @@ export interface RealtimeSocketLike extends SocketWithDecodedToken {
   join: (room: string) => Promise<void> | void;
   leave: (room: string) => Promise<void> | void;
   emit: (event: string, payload: unknown) => void;
-  // biome-ignore lint/suspicious/noExplicitAny: Socket.io event handlers accept arbitrary argument shapes per event name
   on: (event: string, handler: (...args: any[]) => any) => void;
 }
 

--- a/api/src/realtime/registry.ts
+++ b/api/src/realtime/registry.ts
@@ -17,7 +17,6 @@ export interface RealtimeRegistryEntry {
   /**
    * Full modelRouter options (for responseHandler, permissions, etc.).
    */
-  // biome-ignore lint/suspicious/noExplicitAny: registry stores heterogeneous models — narrowing the generic is not useful at the registry level
   options: ModelRouterOptions<any>;
 }
 

--- a/api/src/realtime/types.ts
+++ b/api/src/realtime/types.ts
@@ -19,10 +19,8 @@ export interface RealtimeConfig {
     | "owner"
     | "model"
     | "broadcast"
-    // biome-ignore lint/suspicious/noExplicitAny: doc is an arbitrary Mongoose document; consumers cast to their model type
     | ((doc: any, method: string, req: express.Request) => string[]);
   /** Custom serializer for real-time events. Falls back to the modelRouter responseHandler. */
-  // biome-ignore lint/suspicious/noExplicitAny: doc shape and return value are consumer-defined per model
   realtimeResponseHandler?: (doc: any, method: string) => any;
 }
 
@@ -39,7 +37,6 @@ export interface RealtimeEvent {
   /** Document ID */
   id: string;
   /** Serialized document data (omitted for hard deletes) */
-  // biome-ignore lint/suspicious/noExplicitAny: emitted document shape varies by model and serializer
   data?: any;
   /** Fields that were updated (for update events from change streams) */
   updatedFields?: string[];
@@ -105,7 +102,6 @@ export interface QuerySubscription {
   /** Collection tag (e.g. "todos") */
   collection: string;
   /** MongoDB-style query filter (e.g. {completed: false}) */
-  // biome-ignore lint/suspicious/noExplicitAny: MongoDB query filter values are arbitrary user-supplied JSON
   query: Record<string, any>;
   /** Client-provided queryId (ignored — server computes a canonical ID) */
   queryId?: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This branch cleans up **Biome** diagnostics in `@terreno/api` so `bun run lint` in API CI passes without errors.

## Changes

- Removed **redundant** `biome-ignore lint/suspicious/noExplicitAny` comments where the file already uses `biome-ignore-all` for the same rule (realtime modules, `expressServer.test.ts`). Those duplicates triggered `suppressions/unused` diagnostics.
- Replaced **non-null assertions** in `api.test.ts` (Luxon `toHTTP()!`) with explicit null checks.
- Routed change-stream tests through **`invokeRegisteredChangeHandler`** instead of `changeHandler!` to satisfy `noNonNullAssertion`.
- Updated **`require("http")`** to **`require("node:http")`** per `useNodejsImportProtocol`.
- Removed unused **`authAsUser`** import from `actions.openApi.test.ts`.
- Applied Biome **formatter** expectation for `computeQueryId` in `queryStore.ts`.

## Verification

- `cd api && bunx biome check ./src` exits 0 locally.
- Full `bun run test:ci` in this environment requires MongoDB; API CI still runs tests with the workflow’s MongoDB service.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78a0e460-722c-4aa5-8184-8bc34498c20c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78a0e460-722c-4aa5-8184-8bc34498c20c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

