### PR TITLE
Resolve Biome warnings in @terreno/api for strict lint CI

### DIFF
--- a/api/src/api.test.ts
+++ b/api/src/api.test.ts
@@ -2010,9 +2010,13 @@ describe("@terreno/api", () => {
     });
 
     it("returns 409 when precise conflict timestamp is older than doc.updated", async () => {
+      const ifUnmodifiedSince = DateTime.fromISO("2025-06-15T12:00:01.000Z").toHTTP();
+      if (!ifUnmodifiedSince) {
+        throw new Error("expected If-Unmodified-Since header value");
+      }
       await agent
         .patch(`/food/${spinach._id}`)
-        .set("If-Unmodified-Since", DateTime.fromISO("2025-06-15T12:00:01.000Z").toHTTP()!)
+        .set("If-Unmodified-Since", ifUnmodifiedSince)
         .set("X-Unmodified-Since-ISO", "2025-06-15T11:59:59.500Z")
         .send({name: "Precise Stale"})
         .expect(409);
@@ -2024,9 +2028,13 @@ describe("@terreno/api", () => {
         {$unset: {updated: ""}}
       );
 
+      const ifUnmodifiedSince = DateTime.fromISO("2025-06-15T11:59:59.999Z").toHTTP();
+      if (!ifUnmodifiedSince) {
+        throw new Error("expected If-Unmodified-Since header value");
+      }
       const res = await agent
         .patch(`/food/${spinach._id}`)
-        .set("If-Unmodified-Since", DateTime.fromISO("2025-06-15T11:59:59.999Z").toHTTP()!)
+        .set("If-Unmodified-Since", ifUnmodifiedSince)
         .send({name: "Created Fallback"})
         .expect(409);
 

--- a/api/src/expressServer.test.ts
+++ b/api/src/expressServer.test.ts
@@ -812,7 +812,6 @@ describe("expressServer", () => {
       // Mock app.listen on the Express prototype to avoid opening a real port
       const express = await import("express");
       const originalListen = express.default.application.listen;
-      // biome-ignore lint/suspicious/noExplicitAny: mocking Express internals requires type escape
       express.default.application.listen = mock(function (this: unknown, ...args: unknown[]) {
         const cb = args.find((a: unknown) => typeof a === "function") as (() => void) | undefined;
         if (cb) {

--- a/api/src/realtime/queryMatcher.ts
+++ b/api/src/realtime/queryMatcher.ts
@@ -6,7 +6,6 @@
  * Supports: equality, $eq, $ne, $gt, $gte, $lt, $lte, $in, $nin, $exists, $and, $or, $not.
  */
 
-// biome-ignore lint/suspicious/noExplicitAny: traversing arbitrary nested document fields by user-supplied dotted path
 const getNestedValue = (doc: any, path: string): any => {
   const parts = path.split(".");
   let current = doc;
@@ -19,7 +18,6 @@ const getNestedValue = (doc: any, path: string): any => {
   return current;
 };
 
-// biome-ignore lint/suspicious/noExplicitAny: value may be any document field type (string, number, ObjectId, etc.)
 const normalize = (value: any): any => {
   if (value === null || value === undefined) {
     return value;
@@ -36,7 +34,6 @@ const normalize = (value: any): any => {
   return value;
 };
 
-// biome-ignore lint/suspicious/noExplicitAny: rawValue is an arbitrary document field, condition is an arbitrary user query operand
 const matchesCondition = (rawValue: any, condition: any): boolean => {
   const value = normalize(rawValue);
 
@@ -91,7 +88,6 @@ const matchesCondition = (rawValue: any, condition: any): boolean => {
           return false;
         }
         const inValues = operand.map(normalize);
-        // biome-ignore lint/suspicious/noExplicitAny: normalized value of arbitrary document field
         if (!inValues.some((v: any) => v === value || String(v) === String(value))) {
           return false;
         }
@@ -102,7 +98,6 @@ const matchesCondition = (rawValue: any, condition: any): boolean => {
           return false;
         }
         const ninValues = operand.map(normalize);
-        // biome-ignore lint/suspicious/noExplicitAny: normalized value of arbitrary document field
         if (ninValues.some((v: any) => v === value || String(v) === String(value))) {
           return false;
         }
@@ -137,7 +132,6 @@ const matchesCondition = (rawValue: any, condition: any): boolean => {
  * @param query - MongoDB-style query object
  * @returns true if the document matches all query conditions
  */
-// biome-ignore lint/suspicious/noExplicitAny: doc is arbitrary; query values are arbitrary user-supplied JSON
 export const matchesQuery = (doc: any, query: Record<string, any>): boolean => {
   for (const [key, condition] of Object.entries(query)) {
     if (key === "$and") {

--- a/api/src/realtime/queryStore.ts
+++ b/api/src/realtime/queryStore.ts
@@ -9,7 +9,6 @@
 
 interface QuerySubscription {
   collection: string;
-  // biome-ignore lint/suspicious/noExplicitAny: MongoDB query filter values are arbitrary user-supplied JSON
   query: Record<string, any>;
   queryId: string;
 }
@@ -18,13 +17,8 @@ interface QuerySubscription {
  * Compute a deterministic queryId from collection and query on the server side.
  * This prevents clients from hijacking other subscriptions by providing a colliding queryId.
  */
-export const computeQueryId = (
-  collection: string,
-  // biome-ignore lint/suspicious/noExplicitAny: MongoDB query filter values are arbitrary user-supplied JSON
-  query: Record<string, any>
-): string => {
+export const computeQueryId = (collection: string, query: Record<string, any>): string => {
   const sortedKeys = Object.keys(query).sort();
-  // biome-ignore lint/suspicious/noExplicitAny: mirrors the input query value shape
   const normalized: Record<string, any> = {};
   for (const key of sortedKeys) {
     normalized[key] = query[key];
@@ -45,7 +39,6 @@ const socketQueries = new Map<string, Set<string>>();
 export const addQuerySubscription = (
   socketId: string,
   collection: string,
-  // biome-ignore lint/suspicious/noExplicitAny: MongoDB query filter values are arbitrary user-supplied JSON
   query: Record<string, any>,
   queryId: string
 ): void => {
@@ -109,9 +102,7 @@ export const removeAllSocketQueries = (socketId: string): void => {
  */
 export const getQuerySubscriptionsForCollection = (
   collection: string
-  // biome-ignore lint/suspicious/noExplicitAny: MongoDB query filter values are arbitrary user-supplied JSON
 ): {queryId: string; query: Record<string, any>}[] => {
-  // biome-ignore lint/suspicious/noExplicitAny: MongoDB query filter values are arbitrary user-supplied JSON
   const result: {queryId: string; query: Record<string, any>}[] = [];
 
   for (const [queryId, sub] of querySubscriptions) {

--- a/api/src/realtime/realtime.test.ts
+++ b/api/src/realtime/realtime.test.ts
@@ -1866,7 +1866,10 @@ describe("startChangeStreamWatcher", () => {
     // Trigger an insert change event
     const changeHandler = mockStream.listeners.get("change");
     expect(changeHandler).toBeDefined();
-    await changeHandler!({
+    if (!changeHandler) {
+      return;
+    }
+    await changeHandler({
       documentKey: {_id: "doc-1"},
       fullDocument: {_id: "doc-1", name: "Test Todo"},
       ns: {coll: "todos"},
@@ -1887,8 +1890,12 @@ describe("startChangeStreamWatcher", () => {
     startChangeStreamWatcher(io, {}, true);
 
     const changeHandler = mockStream.listeners.get("change");
+    expect(changeHandler).toBeDefined();
+    if (!changeHandler) {
+      return;
+    }
     // Trigger for an unregistered collection — should not throw
-    await changeHandler!({
+    await changeHandler({
       documentKey: {_id: "doc-1"},
       fullDocument: {_id: "doc-1"},
       ns: {coll: "unknown_collection"},
@@ -1928,8 +1935,12 @@ describe("startChangeStreamWatcher", () => {
     startChangeStreamWatcher(io, {}, true);
 
     const changeHandler = mockStream.listeners.get("change");
+    expect(changeHandler).toBeDefined();
+    if (!changeHandler) {
+      return;
+    }
     // Update event should be skipped because "update" not in methods
-    await changeHandler!({
+    await changeHandler({
       documentKey: {_id: "doc-1"},
       fullDocument: {_id: "doc-1", name: "Updated"},
       ns: {coll: "todos"},
@@ -1970,8 +1981,12 @@ describe("startChangeStreamWatcher", () => {
     startChangeStreamWatcher(io, {}, true);
 
     const changeHandler = mockStream.listeners.get("change");
+    expect(changeHandler).toBeDefined();
+    if (!changeHandler) {
+      return;
+    }
     // Hard delete (no fullDocument)
-    await changeHandler!({
+    await changeHandler({
       documentKey: {_id: "doc-1"},
       ns: {coll: "todos"},
       operationType: "delete",
@@ -2010,8 +2025,12 @@ describe("startChangeStreamWatcher", () => {
     startChangeStreamWatcher(io, {}, true);
 
     const changeHandler = mockStream.listeners.get("change");
+    expect(changeHandler).toBeDefined();
+    if (!changeHandler) {
+      return;
+    }
     // Hard delete for broadcast strategy
-    await changeHandler!({
+    await changeHandler({
       documentKey: {_id: "doc-1"},
       ns: {coll: "broadcasts"},
       operationType: "delete",
@@ -2050,7 +2069,11 @@ describe("startChangeStreamWatcher", () => {
     startChangeStreamWatcher(io, {}, true);
 
     const changeHandler = mockStream.listeners.get("change");
-    await changeHandler!({
+    expect(changeHandler).toBeDefined();
+    if (!changeHandler) {
+      return;
+    }
+    await changeHandler({
       documentKey: {_id: "doc-1"},
       fullDocument: {_id: "doc-1", name: "Updated", status: "done"},
       ns: {coll: "todos"},
@@ -2111,8 +2134,12 @@ describe("startChangeStreamWatcher", () => {
     startChangeStreamWatcher(io, {ignoredOperations: ["insert"]}, true);
 
     const changeHandler = mockStream.listeners.get("change");
+    expect(changeHandler).toBeDefined();
+    if (!changeHandler) {
+      return;
+    }
     // This insert should be skipped because "insert" is ignored
-    await changeHandler!({
+    await changeHandler({
       documentKey: {_id: "doc-1"},
       fullDocument: {_id: "doc-1"},
       ns: {coll: "todos"},
@@ -2133,14 +2160,18 @@ describe("startChangeStreamWatcher", () => {
     startChangeStreamWatcher(io, {}, true);
 
     const changeHandler = mockStream.listeners.get("change");
+    expect(changeHandler).toBeDefined();
+    if (!changeHandler) {
+      return;
+    }
     // Missing ns.coll
-    await changeHandler!({
+    await changeHandler({
       documentKey: {_id: "doc-1"},
       ns: {},
       operationType: "insert",
     });
     // Missing documentKey
-    await changeHandler!({
+    await changeHandler({
       documentKey: {},
       ns: {coll: "todos"},
       operationType: "insert",
@@ -2160,8 +2191,12 @@ describe("startChangeStreamWatcher", () => {
     startChangeStreamWatcher(io, {}, true);
 
     const changeHandler = mockStream.listeners.get("change");
+    expect(changeHandler).toBeDefined();
+    if (!changeHandler) {
+      return;
+    }
     // "drop" is not in our pipeline filter, should be skipped
-    await changeHandler!({
+    await changeHandler({
       operationType: "drop",
     });
   });
@@ -2258,8 +2293,12 @@ describe("startChangeStreamWatcher", () => {
     startChangeStreamWatcher(io, {}, true);
 
     const changeHandler = mockStream.listeners.get("change");
+    expect(changeHandler).toBeDefined();
+    if (!changeHandler) {
+      return;
+    }
     // Should not throw even though permission check throws
-    await changeHandler!({
+    await changeHandler({
       documentKey: {_id: "doc-1"},
       fullDocument: {_id: "doc-1", name: "Test"},
       ns: {coll: "todos"},
@@ -2317,7 +2356,7 @@ describe("RealtimeApp.onServerCreated", () => {
   });
 
   const makeServer = (): import("http").Server => {
-    const http = require("http");
+    const http = require("node:http");
     const server = http.createServer();
     servers.push(server);
     return server;
@@ -2366,7 +2405,7 @@ describe("RealtimeApp.setupAdapter (private, via onServerCreated config)", () =>
   });
 
   const makeServer = (): import("http").Server => {
-    const http = require("http");
+    const http = require("node:http");
     const server = http.createServer();
     servers.push(server);
     return server;

--- a/api/src/realtime/realtimeApp.ts
+++ b/api/src/realtime/realtimeApp.ts
@@ -60,7 +60,6 @@ export interface RealtimeSocketLike extends SocketWithDecodedToken {
   join: (room: string) => Promise<void> | void;
   leave: (room: string) => Promise<void> | void;
   emit: (event: string, payload: unknown) => void;
-  // biome-ignore lint/suspicious/noExplicitAny: Socket.io event handlers accept arbitrary argument shapes per event name
   on: (event: string, handler: (...args: any[]) => any) => void;
 }
 

--- a/api/src/realtime/registry.ts
+++ b/api/src/realtime/registry.ts
@@ -17,7 +17,6 @@ export interface RealtimeRegistryEntry {
   /**
    * Full modelRouter options (for responseHandler, permissions, etc.).
    */
-  // biome-ignore lint/suspicious/noExplicitAny: registry stores heterogeneous models — narrowing the generic is not useful at the registry level
   options: ModelRouterOptions<any>;
 }
 

--- a/api/src/realtime/types.ts
+++ b/api/src/realtime/types.ts
@@ -19,10 +19,8 @@ export interface RealtimeConfig {
     | "owner"
     | "model"
     | "broadcast"
-    // biome-ignore lint/suspicious/noExplicitAny: doc is an arbitrary Mongoose document; consumers cast to their model type
     | ((doc: any, method: string, req: express.Request) => string[]);
   /** Custom serializer for real-time events. Falls back to the modelRouter responseHandler. */
-  // biome-ignore lint/suspicious/noExplicitAny: doc shape and return value are consumer-defined per model
   realtimeResponseHandler?: (doc: any, method: string) => any;
 }
 
@@ -39,7 +37,6 @@ export interface RealtimeEvent {
   /** Document ID */
   id: string;
   /** Serialized document data (omitted for hard deletes) */
-  // biome-ignore lint/suspicious/noExplicitAny: emitted document shape varies by model and serializer
   data?: any;
   /** Fields that were updated (for update events from change streams) */
   updatedFields?: string[];
@@ -105,7 +102,6 @@ export interface QuerySubscription {
   /** Collection tag (e.g. "todos") */
   collection: string;
   /** MongoDB-style query filter (e.g. {completed: false}) */
-  // biome-ignore lint/suspicious/noExplicitAny: MongoDB query filter values are arbitrary user-supplied JSON
   query: Record<string, any>;
   /** Client-provided queryId (ignored — server computes a canonical ID) */
   queryId?: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

API CI runs Biome on `api/src`. With `--error-on-warnings` (and similar strict settings), redundant suppression comments and `noNonNullAssertion` issues fail the check. This change removes duplicate `biome-ignore` lines that were shadowed by file-level `biome-ignore-all`, replaces test non-null assertions with explicit guards, and uses the `node:` protocol for `http` in test helpers.

## Human Testing Steps

- [ ] From `api/`, run `bunx biome check ./src --error-on-warnings` and confirm exit code 0.
- [ ] With MongoDB available, run `bun run test:ci` in `api/` and confirm tests pass.

## Changes

- Drop redundant `noExplicitAny` suppression comments in realtime modules and `expressServer.test.ts` where `biome-ignore-all` already applies.
- In `api.test.ts`, avoid `toHTTP()!` by validating the header string before use.
- In `realtime.test.ts`, narrow `changeHandler` after `get()` and use `require("node:http")` for the import-protocol rule.
- Let Biome collapse `computeQueryId` signature formatting in `queryStore.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77d543dc-5be3-404d-955c-620f795437d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77d543dc-5be3-404d-955c-620f795437d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

