### PR TITLE
AIService helpers for structured JSON (Vercel AI SDK Output)

### DIFF
--- a/.agents/skills/ai-prompt-governance/SKILL.md
+++ b/.agents/skills/ai-prompt-governance/SKILL.md
@@ -38,7 +38,7 @@ Pick the lowest temperature that still produces good results. Don't override the
 
 Every `AIService` method already logs to the `AIRequest` model via the internal `logRequest()` call. Do not bypass `AIService` and call the Vercel SDK directly from routes — you lose request logging, error capture, and the `requestType` taxonomy.
 
-Current `AIRequest.requestType` values: `"general" | "remix" | "summarization" | "translation"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
+Current `AIRequest.requestType` values include `"general"`, `"remix"`, `"summarization"`, `"translation"`, `"json_value"`, `"json_object"`, and `"json_array"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
 
 Logging failures must never break the main flow — the existing pattern catches and logs internally. Preserve that behavior.
 

--- a/.claude/rules/ai/00-ai.md
+++ b/.claude/rules/ai/00-ai.md
@@ -63,11 +63,18 @@ const aiService = new AIService({
 | Method | Description |
 |--------|-------------|
 | `generateText(options)` | Generate text (non-streaming) |
+| `generateJsonValue(options)` | Parse any JSON value via AI SDK `Output.json()` (logged as `json_value`) |
+| `generateJsonObject(options)` | Typed object from `jsonSchema` / Zod / `FlexibleSchema` via `Output.object()` (`json_object`) |
+| `generateJsonArray(options)` | Typed array via `Output.array()`; model emits `{"elements":[...]}` (`json_array`) |
 | `generateTextStream(options)` | Stream text chunks (AsyncGenerator) |
 | `generateRemix({text, userId?})` | Reword text naturally |
 | `generateSummary({text, userId?})` | Summarize text |
 | `translateText({text, targetLanguage, sourceLanguage?, userId?})` | Translate text |
 | `generateChatStream({messages, systemPrompt?, userId?})` | Stream chat response |
+
+Structured helpers default to `TemperaturePresets.DETERMINISTIC` and use `JSON_VALUE_SYSTEM_PROMPT` when `systemPrompt` is omitted. They run `doGenerate` text through `normalizeLlmJsonTextForStructuredOutput` (see `parseAiJson`: fences, preamble, first balanced `{`/`[` slice, trailing commas, smart-quote fallback) before Vercel `Output.*` parsing. On failure, `logger.error` records prompt, system, raw model text, and error details; `AIRequest` rows store `response` (raw text or a sentinel), `error`, and `metadata` (`system`, `finishReason`, `errorStack`, `rawModelTextCaptured`).
+
+Re-exported from `@terreno/ai`: `parseAiJson`, `normalizeLlmJsonTextForStructuredOutput`, `ParseResult` types, plus `Output`, `jsonSchema`, and types `JSONValue`, `FlexibleSchema` (from the `ai` package) for building schemas in app code.
 
 All methods automatically log requests to the AIRequest model.
 
@@ -94,7 +101,7 @@ Logs all AI requests with metrics for monitoring and debugging.
 // Fields
 aiModel: string          // Model identifier (e.g., "gemini-2.5-flash")
 prompt: string           // Input prompt
-requestType: "general" | "remix" | "summarization" | "translation"
+requestType: string       // e.g. "general" | "remix" | "summarization" | "translation" | "json_value" | "json_object" | "json_array"
 response?: string        // AI response text
 responseTime?: number    // Response time in ms
 tokensUsed?: number      // Total tokens consumed

--- a/.claude/skills/ai-prompt-governance/SKILL.md
+++ b/.claude/skills/ai-prompt-governance/SKILL.md
@@ -38,7 +38,7 @@ Pick the lowest temperature that still produces good results. Don't override the
 
 Every `AIService` method already logs to the `AIRequest` model via the internal `logRequest()` call. Do not bypass `AIService` and call the Vercel SDK directly from routes — you lose request logging, error capture, and the `requestType` taxonomy.
 
-Current `AIRequest.requestType` values: `"general" | "remix" | "summarization" | "translation"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
+Current `AIRequest.requestType` values include `"general"`, `"remix"`, `"summarization"`, `"translation"`, `"json_value"`, `"json_object"`, and `"json_array"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
 
 Logging failures must never break the main flow — the existing pattern catches and logs internally. Preserve that behavior.
 

--- a/.cursor/rules/ai/00-ai.mdc
+++ b/.cursor/rules/ai/00-ai.mdc
@@ -73,7 +73,9 @@ const aiService = new AIService({
 | `translateText({text, targetLanguage, sourceLanguage?, userId?})` | Translate text |
 | `generateChatStream({messages, systemPrompt?, userId?})` | Stream chat response |
 
-Structured helpers default to `TemperaturePresets.DETERMINISTIC` and use `JSON_VALUE_SYSTEM_PROMPT` when `systemPrompt` is omitted. Re-exported from `@terreno/ai`: `Output`, `jsonSchema`, and types `JSONValue`, `FlexibleSchema` (from the `ai` package) for building schemas in app code.
+Structured helpers default to `TemperaturePresets.DETERMINISTIC` and use `JSON_VALUE_SYSTEM_PROMPT` when `systemPrompt` is omitted. They run against a thin model wrapper that strips common markdown ``` / ```json fences (including ```lang:`) from `doGenerate` text before parsing. On failure, `logger.error` records prompt, system, raw model text, and error details; `AIRequest` rows store `response` (raw text or a sentinel), `error`, and `metadata` (`system`, `finishReason`, `errorStack`, `rawModelTextCaptured`).
+
+Re-exported from `@terreno/ai`: `Output`, `jsonSchema`, and types `JSONValue`, `FlexibleSchema` (from the `ai` package) for building schemas in app code.
 
 All methods automatically log requests to the AIRequest model.
 

--- a/.cursor/rules/ai/00-ai.mdc
+++ b/.cursor/rules/ai/00-ai.mdc
@@ -64,11 +64,16 @@ const aiService = new AIService({
 | Method | Description |
 |--------|-------------|
 | `generateText(options)` | Generate text (non-streaming) |
+| `generateJsonValue(options)` | Parse any JSON value via AI SDK `Output.json()` (logged as `json_value`) |
+| `generateJsonObject(options)` | Typed object from `jsonSchema` / Zod / `FlexibleSchema` via `Output.object()` (`json_object`) |
+| `generateJsonArray(options)` | Typed array via `Output.array()`; model emits `{"elements":[...]}` (`json_array`) |
 | `generateTextStream(options)` | Stream text chunks (AsyncGenerator) |
 | `generateRemix({text, userId?})` | Reword text naturally |
 | `generateSummary({text, userId?})` | Summarize text |
 | `translateText({text, targetLanguage, sourceLanguage?, userId?})` | Translate text |
 | `generateChatStream({messages, systemPrompt?, userId?})` | Stream chat response |
+
+Structured helpers default to `TemperaturePresets.DETERMINISTIC` and use `JSON_VALUE_SYSTEM_PROMPT` when `systemPrompt` is omitted. Re-exported from `@terreno/ai`: `Output`, `jsonSchema`, and types `JSONValue`, `FlexibleSchema` (from the `ai` package) for building schemas in app code.
 
 All methods automatically log requests to the AIRequest model.
 
@@ -95,7 +100,7 @@ Logs all AI requests with metrics for monitoring and debugging.
 // Fields
 aiModel: string          // Model identifier (e.g., "gemini-2.5-flash")
 prompt: string           // Input prompt
-requestType: "general" | "remix" | "summarization" | "translation"
+requestType: string       // e.g. "general" | "remix" | "summarization" | "translation" | "json_value" | "json_object" | "json_array"
 response?: string        // AI response text
 responseTime?: number    // Response time in ms
 tokensUsed?: number      // Total tokens consumed

--- a/.cursor/rules/ai/00-ai.mdc
+++ b/.cursor/rules/ai/00-ai.mdc
@@ -73,9 +73,9 @@ const aiService = new AIService({
 | `translateText({text, targetLanguage, sourceLanguage?, userId?})` | Translate text |
 | `generateChatStream({messages, systemPrompt?, userId?})` | Stream chat response |
 
-Structured helpers default to `TemperaturePresets.DETERMINISTIC` and use `JSON_VALUE_SYSTEM_PROMPT` when `systemPrompt` is omitted. They run against a thin model wrapper that strips common markdown ``` / ```json fences (including ```lang:`) from `doGenerate` text before parsing. On failure, `logger.error` records prompt, system, raw model text, and error details; `AIRequest` rows store `response` (raw text or a sentinel), `error`, and `metadata` (`system`, `finishReason`, `errorStack`, `rawModelTextCaptured`).
+Structured helpers default to `TemperaturePresets.DETERMINISTIC` and use `JSON_VALUE_SYSTEM_PROMPT` when `systemPrompt` is omitted. They run `doGenerate` text through `normalizeLlmJsonTextForStructuredOutput` (see `parseAiJson`: fences, preamble, first balanced `{`/`[` slice, trailing commas, smart-quote fallback) before Vercel `Output.*` parsing. On failure, `logger.error` records prompt, system, raw model text, and error details; `AIRequest` rows store `response` (raw text or a sentinel), `error`, and `metadata` (`system`, `finishReason`, `errorStack`, `rawModelTextCaptured`).
 
-Re-exported from `@terreno/ai`: `Output`, `jsonSchema`, and types `JSONValue`, `FlexibleSchema` (from the `ai` package) for building schemas in app code.
+Re-exported from `@terreno/ai`: `parseAiJson`, `normalizeLlmJsonTextForStructuredOutput`, `ParseResult` types, plus `Output`, `jsonSchema`, and types `JSONValue`, `FlexibleSchema` (from the `ai` package) for building schemas in app code.
 
 All methods automatically log requests to the AIRequest model.
 

--- a/.cursor/skills/ai-prompt-governance/SKILL.md
+++ b/.cursor/skills/ai-prompt-governance/SKILL.md
@@ -34,7 +34,7 @@ Pick the lowest temperature that still produces good results. Don't override the
 
 Every `AIService` method already logs to the `AIRequest` model via the internal `logRequest()` call. Do not bypass `AIService` and call the Vercel SDK directly from routes — you lose request logging, error capture, and the `requestType` taxonomy.
 
-Current `AIRequest.requestType` values: `"general" | "remix" | "summarization" | "translation"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
+Current `AIRequest.requestType` values include `"general"`, `"remix"`, `"summarization"`, `"translation"`, `"json_value"`, `"json_object"`, and `"json_array"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
 
 Logging failures must never break the main flow — the existing pattern catches and logs internally. Preserve that behavior.
 

--- a/.github/instructions/ai/00-ai.instructions.md
+++ b/.github/instructions/ai/00-ai.instructions.md
@@ -63,11 +63,18 @@ const aiService = new AIService({
 | Method | Description |
 |--------|-------------|
 | `generateText(options)` | Generate text (non-streaming) |
+| `generateJsonValue(options)` | Parse any JSON value via AI SDK `Output.json()` (logged as `json_value`) |
+| `generateJsonObject(options)` | Typed object from `jsonSchema` / Zod / `FlexibleSchema` via `Output.object()` (`json_object`) |
+| `generateJsonArray(options)` | Typed array via `Output.array()`; model emits `{"elements":[...]}` (`json_array`) |
 | `generateTextStream(options)` | Stream text chunks (AsyncGenerator) |
 | `generateRemix({text, userId?})` | Reword text naturally |
 | `generateSummary({text, userId?})` | Summarize text |
 | `translateText({text, targetLanguage, sourceLanguage?, userId?})` | Translate text |
 | `generateChatStream({messages, systemPrompt?, userId?})` | Stream chat response |
+
+Structured helpers default to `TemperaturePresets.DETERMINISTIC` and use `JSON_VALUE_SYSTEM_PROMPT` when `systemPrompt` is omitted. They run `doGenerate` text through `normalizeLlmJsonTextForStructuredOutput` (see `parseAiJson`: fences, preamble, first balanced `{`/`[` slice, trailing commas, smart-quote fallback) before Vercel `Output.*` parsing. On failure, `logger.error` records prompt, system, raw model text, and error details; `AIRequest` rows store `response` (raw text or a sentinel), `error`, and `metadata` (`system`, `finishReason`, `errorStack`, `rawModelTextCaptured`).
+
+Re-exported from `@terreno/ai`: `parseAiJson`, `normalizeLlmJsonTextForStructuredOutput`, `ParseResult` types, plus `Output`, `jsonSchema`, and types `JSONValue`, `FlexibleSchema` (from the `ai` package) for building schemas in app code.
 
 All methods automatically log requests to the AIRequest model.
 
@@ -94,7 +101,7 @@ Logs all AI requests with metrics for monitoring and debugging.
 // Fields
 aiModel: string          // Model identifier (e.g., "gemini-2.5-flash")
 prompt: string           // Input prompt
-requestType: "general" | "remix" | "summarization" | "translation"
+requestType: string       // e.g. "general" | "remix" | "summarization" | "translation" | "json_value" | "json_object" | "json_array"
 response?: string        // AI response text
 responseTime?: number    // Response time in ms
 tokensUsed?: number      // Total tokens consumed

--- a/.github/skills/ai-prompt-governance/SKILL.md
+++ b/.github/skills/ai-prompt-governance/SKILL.md
@@ -38,7 +38,7 @@ Pick the lowest temperature that still produces good results. Don't override the
 
 Every `AIService` method already logs to the `AIRequest` model via the internal `logRequest()` call. Do not bypass `AIService` and call the Vercel SDK directly from routes — you lose request logging, error capture, and the `requestType` taxonomy.
 
-Current `AIRequest.requestType` values: `"general" | "remix" | "summarization" | "translation"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
+Current `AIRequest.requestType` values include `"general"`, `"remix"`, `"summarization"`, `"translation"`, `"json_value"`, `"json_object"`, and `"json_array"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
 
 Logging failures must never break the main flow — the existing pattern catches and logs internally. Preserve that behavior.
 

--- a/.rulesync/rules/ai/00-ai.md
+++ b/.rulesync/rules/ai/00-ai.md
@@ -65,11 +65,18 @@ const aiService = new AIService({
 | Method | Description |
 |--------|-------------|
 | `generateText(options)` | Generate text (non-streaming) |
+| `generateJsonValue(options)` | Parse any JSON value via AI SDK `Output.json()` (logged as `json_value`) |
+| `generateJsonObject(options)` | Typed object from `jsonSchema` / Zod / `FlexibleSchema` via `Output.object()` (`json_object`) |
+| `generateJsonArray(options)` | Typed array via `Output.array()`; model emits `{"elements":[...]}` (`json_array`) |
 | `generateTextStream(options)` | Stream text chunks (AsyncGenerator) |
 | `generateRemix({text, userId?})` | Reword text naturally |
 | `generateSummary({text, userId?})` | Summarize text |
 | `translateText({text, targetLanguage, sourceLanguage?, userId?})` | Translate text |
 | `generateChatStream({messages, systemPrompt?, userId?})` | Stream chat response |
+
+Structured helpers default to `TemperaturePresets.DETERMINISTIC` and use `JSON_VALUE_SYSTEM_PROMPT` when `systemPrompt` is omitted. They run `doGenerate` text through `normalizeLlmJsonTextForStructuredOutput` (see `parseAiJson`: fences, preamble, first balanced `{`/`[` slice, trailing commas, smart-quote fallback) before Vercel `Output.*` parsing. On failure, `logger.error` records prompt, system, raw model text, and error details; `AIRequest` rows store `response` (raw text or a sentinel), `error`, and `metadata` (`system`, `finishReason`, `errorStack`, `rawModelTextCaptured`).
+
+Re-exported from `@terreno/ai`: `parseAiJson`, `normalizeLlmJsonTextForStructuredOutput`, `ParseResult` types, plus `Output`, `jsonSchema`, and types `JSONValue`, `FlexibleSchema` (from the `ai` package) for building schemas in app code.
 
 All methods automatically log requests to the AIRequest model.
 
@@ -96,7 +103,7 @@ Logs all AI requests with metrics for monitoring and debugging.
 // Fields
 aiModel: string          // Model identifier (e.g., "gemini-2.5-flash")
 prompt: string           // Input prompt
-requestType: "general" | "remix" | "summarization" | "translation"
+requestType: string       // e.g. "general" | "remix" | "summarization" | "translation" | "json_value" | "json_object" | "json_array"
 response?: string        // AI response text
 responseTime?: number    // Response time in ms
 tokensUsed?: number      // Total tokens consumed

--- a/.rulesync/skills/ai-prompt-governance/SKILL.md
+++ b/.rulesync/skills/ai-prompt-governance/SKILL.md
@@ -38,7 +38,7 @@ Pick the lowest temperature that still produces good results. Don't override the
 
 Every `AIService` method already logs to the `AIRequest` model via the internal `logRequest()` call. Do not bypass `AIService` and call the Vercel SDK directly from routes — you lose request logging, error capture, and the `requestType` taxonomy.
 
-Current `AIRequest.requestType` values: `"general" | "remix" | "summarization" | "translation"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
+Current `AIRequest.requestType` values include `"general"`, `"remix"`, `"summarization"`, `"translation"`, `"json_value"`, `"json_object"`, and `"json_array"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
 
 Logging failures must never break the main flow — the existing pattern catches and logs internally. Preserve that behavior.
 

--- a/.windsurf/rules/ai/00-ai.md
+++ b/.windsurf/rules/ai/00-ai.md
@@ -63,11 +63,18 @@ const aiService = new AIService({
 | Method | Description |
 |--------|-------------|
 | `generateText(options)` | Generate text (non-streaming) |
+| `generateJsonValue(options)` | Parse any JSON value via AI SDK `Output.json()` (logged as `json_value`) |
+| `generateJsonObject(options)` | Typed object from `jsonSchema` / Zod / `FlexibleSchema` via `Output.object()` (`json_object`) |
+| `generateJsonArray(options)` | Typed array via `Output.array()`; model emits `{"elements":[...]}` (`json_array`) |
 | `generateTextStream(options)` | Stream text chunks (AsyncGenerator) |
 | `generateRemix({text, userId?})` | Reword text naturally |
 | `generateSummary({text, userId?})` | Summarize text |
 | `translateText({text, targetLanguage, sourceLanguage?, userId?})` | Translate text |
 | `generateChatStream({messages, systemPrompt?, userId?})` | Stream chat response |
+
+Structured helpers default to `TemperaturePresets.DETERMINISTIC` and use `JSON_VALUE_SYSTEM_PROMPT` when `systemPrompt` is omitted. They run `doGenerate` text through `normalizeLlmJsonTextForStructuredOutput` (see `parseAiJson`: fences, preamble, first balanced `{`/`[` slice, trailing commas, smart-quote fallback) before Vercel `Output.*` parsing. On failure, `logger.error` records prompt, system, raw model text, and error details; `AIRequest` rows store `response` (raw text or a sentinel), `error`, and `metadata` (`system`, `finishReason`, `errorStack`, `rawModelTextCaptured`).
+
+Re-exported from `@terreno/ai`: `parseAiJson`, `normalizeLlmJsonTextForStructuredOutput`, `ParseResult` types, plus `Output`, `jsonSchema`, and types `JSONValue`, `FlexibleSchema` (from the `ai` package) for building schemas in app code.
 
 All methods automatically log requests to the AIRequest model.
 
@@ -94,7 +101,7 @@ Logs all AI requests with metrics for monitoring and debugging.
 // Fields
 aiModel: string          // Model identifier (e.g., "gemini-2.5-flash")
 prompt: string           // Input prompt
-requestType: "general" | "remix" | "summarization" | "translation"
+requestType: string       // e.g. "general" | "remix" | "summarization" | "translation" | "json_value" | "json_object" | "json_array"
 response?: string        // AI response text
 responseTime?: number    // Response time in ms
 tokensUsed?: number      // Total tokens consumed

--- a/.windsurf/skills/ai-prompt-governance/SKILL.md
+++ b/.windsurf/skills/ai-prompt-governance/SKILL.md
@@ -38,7 +38,7 @@ Pick the lowest temperature that still produces good results. Don't override the
 
 Every `AIService` method already logs to the `AIRequest` model via the internal `logRequest()` call. Do not bypass `AIService` and call the Vercel SDK directly from routes — you lose request logging, error capture, and the `requestType` taxonomy.
 
-Current `AIRequest.requestType` values: `"general" | "remix" | "summarization" | "translation"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
+Current `AIRequest.requestType` values include `"general"`, `"remix"`, `"summarization"`, `"translation"`, `"json_value"`, `"json_object"`, and `"json_array"`. If you add a new category, extend the type union in `ai/src/types/index.ts` and update the admin explorer filters in `ai/src/routes/aiRequestsExplorer.ts`.
 
 Logging failures must never break the main flow — the existing pattern catches and logs internally. Preserve that behavior.
 

--- a/ai/src/service/aiService.test.ts
+++ b/ai/src/service/aiService.test.ts
@@ -118,6 +118,28 @@ describe("AIService", () => {
       expect(JSON.parse(logs[0].response ?? "{}")).toEqual({n: 3, ok: true});
     });
 
+    it("parses JSON wrapped in markdown fences (including ```json:)", async () => {
+      const model = createMockModel('```json:\n{"colon":true}\n```');
+      const service = new AIService({model: model as unknown as LanguageModel});
+
+      const result = await service.generateJsonValue({
+        prompt: "Return JSON",
+      });
+
+      expect(result).toEqual({colon: true});
+    });
+
+    it("parses JSON wrapped in a generic ```lang fence", async () => {
+      const model = createMockModel("```typescript\n[1,2]\n```");
+      const service = new AIService({model: model as unknown as LanguageModel});
+
+      const result = await service.generateJsonValue({
+        prompt: "Return JSON",
+      });
+
+      expect(result).toEqual([1, 2]);
+    });
+
     it("logs errors when JSON output cannot be produced", async () => {
       const model = createMockModel("not-json");
       const service = new AIService({model: model as unknown as LanguageModel});
@@ -128,6 +150,8 @@ describe("AIService", () => {
       expect(logs.length).toBe(1);
       expect(logs[0].error).toBeTruthy();
       expect(logs[0].requestType).toBe("json_value");
+      expect(logs[0].response).toBe("not-json");
+      expect(logs[0].metadata?.rawModelTextCaptured).toBe(true);
     });
   });
 
@@ -158,6 +182,28 @@ describe("AIService", () => {
       const logs = await AIRequest.find({userId});
       expect(logs[0].requestType).toBe("json_object");
     });
+
+    it("parses object output wrapped in markdown fences", async () => {
+      const model = createMockModel('```json\n{"id":"fenced","count":9}\n```');
+      const service = new AIService({model: model as unknown as LanguageModel});
+
+      const schema = jsonSchema<{count: number; id: string}>({
+        additionalProperties: false,
+        properties: {
+          count: {type: "number"},
+          id: {type: "string"},
+        },
+        required: ["id", "count"],
+        type: "object",
+      });
+
+      const result = await service.generateJsonObject({
+        prompt: "Extract fields",
+        schema,
+      });
+
+      expect(result).toEqual({count: 9, id: "fenced"});
+    });
   });
 
   describe("generateJsonArray", () => {
@@ -178,6 +224,19 @@ describe("AIService", () => {
 
       const logs = await AIRequest.find({userId});
       expect(logs[0].requestType).toBe("json_array");
+    });
+
+    it("parses array payload when model wraps elements in markdown fences", async () => {
+      const model = createMockModel('```json\n{"elements":[1,2]}\n```');
+      const service = new AIService({model: model as unknown as LanguageModel});
+      const element = jsonSchema<number>({type: "number"});
+
+      const result = await service.generateJsonArray({
+        element,
+        prompt: "List numbers",
+      });
+
+      expect(result).toEqual([1, 2]);
     });
   });
 

--- a/ai/src/service/aiService.test.ts
+++ b/ai/src/service/aiService.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, beforeEach, describe, expect, it, mock} from "bun:test";
-import type {LanguageModel} from "ai";
+import {jsonSchema, type LanguageModel} from "ai";
 import mongoose from "mongoose";
 
 import {AIRequest} from "../models/aiRequest";
@@ -96,6 +96,88 @@ describe("AIService", () => {
       const logs = await AIRequest.find({});
       expect(logs.length).toBe(1);
       expect(logs[0].error).toBe("API error");
+    });
+  });
+
+  describe("generateJsonValue", () => {
+    it("parses JSON, returns the value, and logs json_value", async () => {
+      const model = createMockModel('{"ok":true,"n":3}');
+      const service = new AIService({model: model as unknown as LanguageModel});
+      const userId = new mongoose.Types.ObjectId();
+
+      const result = await service.generateJsonValue({
+        prompt: "Return a small object",
+        userId,
+      });
+
+      expect(result).toEqual({n: 3, ok: true});
+
+      const logs = await AIRequest.find({userId});
+      expect(logs.length).toBe(1);
+      expect(logs[0].requestType).toBe("json_value");
+      expect(JSON.parse(logs[0].response ?? "{}")).toEqual({n: 3, ok: true});
+    });
+
+    it("logs errors when JSON output cannot be produced", async () => {
+      const model = createMockModel("not-json");
+      const service = new AIService({model: model as unknown as LanguageModel});
+
+      await expect(service.generateJsonValue({prompt: "bad"})).rejects.toThrow();
+
+      const logs = await AIRequest.find({prompt: "bad"});
+      expect(logs.length).toBe(1);
+      expect(logs[0].error).toBeTruthy();
+      expect(logs[0].requestType).toBe("json_value");
+    });
+  });
+
+  describe("generateJsonObject", () => {
+    it("parses against a schema and logs json_object", async () => {
+      const model = createMockModel('{"id":"item-1","count":2}');
+      const service = new AIService({model: model as unknown as LanguageModel});
+      const userId = new mongoose.Types.ObjectId();
+
+      const schema = jsonSchema<{count: number; id: string}>({
+        additionalProperties: false,
+        properties: {
+          count: {type: "number"},
+          id: {type: "string"},
+        },
+        required: ["id", "count"],
+        type: "object",
+      });
+
+      const result = await service.generateJsonObject({
+        prompt: "Extract fields",
+        schema,
+        userId,
+      });
+
+      expect(result).toEqual({count: 2, id: "item-1"});
+
+      const logs = await AIRequest.find({userId});
+      expect(logs[0].requestType).toBe("json_object");
+    });
+  });
+
+  describe("generateJsonArray", () => {
+    it("parses an array against an element schema and logs json_array", async () => {
+      const model = createMockModel('{"elements":[10,20,30]}');
+      const service = new AIService({model: model as unknown as LanguageModel});
+      const userId = new mongoose.Types.ObjectId();
+
+      const element = jsonSchema<number>({type: "number"});
+
+      const result = await service.generateJsonArray({
+        element,
+        prompt: "List numbers",
+        userId,
+      });
+
+      expect(result).toEqual([10, 20, 30]);
+
+      const logs = await AIRequest.find({userId});
+      expect(logs[0].requestType).toBe("json_array");
     });
   });
 

--- a/ai/src/service/aiService.ts
+++ b/ai/src/service/aiService.ts
@@ -1,6 +1,6 @@
 import {logger} from "@terreno/api";
-import type {DataContent, LanguageModel, ModelMessage} from "ai";
-import {generateText as aiGenerateText, stepCountIs, streamText} from "ai";
+import type {DataContent, JSONValue, LanguageModel, ModelMessage} from "ai";
+import {generateText as aiGenerateText, Output, stepCountIs, streamText} from "ai";
 import type mongoose from "mongoose";
 
 import {AIRequest} from "../models/aiRequest";
@@ -8,6 +8,9 @@ import type {
   AIRequestType,
   AIServiceOptions,
   GenerateChatStreamOptions,
+  GenerateJsonArrayOptions,
+  GenerateJsonObjectOptions,
+  GenerateJsonValueOptions,
   GenerateStreamOptions,
   GenerateTextOptions,
   GptHistoryPrompt,
@@ -18,6 +21,7 @@ import type {
 import {
   CONTENT_SUMMARY_PROMPT,
   DEFAULT_GPT_MEMORY,
+  JSON_VALUE_SYSTEM_PROMPT,
   REMIX_PROMPT,
   TRANSLATION_PROMPT,
 } from "./prompts";
@@ -101,6 +105,174 @@ export class AIService {
         error: error instanceof Error ? error.message : String(error),
         prompt,
         requestType: "general",
+        responseTime,
+        userId,
+      });
+      throw error;
+    }
+  }
+
+  /** Any JSON value (object, array, primitive, or null) via the AI SDK `Output.json()` parser. */
+  async generateJsonValue(options: GenerateJsonValueOptions): Promise<JSONValue> {
+    const {
+      maxOutputTokens,
+      outputDescription,
+      outputName,
+      prompt,
+      systemPrompt,
+      temperature,
+      userId,
+    } = options;
+    const startTime = Date.now();
+    const system = systemPrompt ?? JSON_VALUE_SYSTEM_PROMPT;
+
+    try {
+      const result = await aiGenerateText({
+        experimental_telemetry: {functionId: "generate-json-value", isEnabled: true},
+        maxOutputTokens,
+        model: this.model,
+        output: Output.json({description: outputDescription, name: outputName}),
+        prompt,
+        system,
+        temperature: temperature ?? TemperaturePresets.DETERMINISTIC,
+      });
+
+      const responseTime = Date.now() - startTime;
+      await this.logRequest({
+        aiModel: getModelId(this.model),
+        prompt,
+        requestType: "json_value",
+        response: JSON.stringify(result.output),
+        responseTime,
+        tokensUsed: result.usage?.totalTokens,
+        userId,
+      });
+
+      return result.output;
+    } catch (error) {
+      const responseTime = Date.now() - startTime;
+      await this.logRequest({
+        aiModel: getModelId(this.model),
+        error: error instanceof Error ? error.message : String(error),
+        prompt,
+        requestType: "json_value",
+        responseTime,
+        userId,
+      });
+      throw error;
+    }
+  }
+
+  /** Typed object from a Zod schema, `jsonSchema(...)`, or other `FlexibleSchema` (`Output.object()`). */
+  async generateJsonObject<OBJECT>(options: GenerateJsonObjectOptions<OBJECT>): Promise<OBJECT> {
+    const {
+      maxOutputTokens,
+      prompt,
+      schema,
+      schemaDescription,
+      schemaName,
+      systemPrompt,
+      temperature,
+      userId,
+    } = options;
+    const startTime = Date.now();
+    const system = systemPrompt ?? JSON_VALUE_SYSTEM_PROMPT;
+
+    try {
+      const result = await aiGenerateText({
+        experimental_telemetry: {functionId: "generate-json-object", isEnabled: true},
+        maxOutputTokens,
+        model: this.model,
+        output: Output.object({
+          description: schemaDescription,
+          name: schemaName,
+          schema,
+        }),
+        prompt,
+        system,
+        temperature: temperature ?? TemperaturePresets.DETERMINISTIC,
+      });
+
+      const responseTime = Date.now() - startTime;
+      await this.logRequest({
+        aiModel: getModelId(this.model),
+        prompt,
+        requestType: "json_object",
+        response: JSON.stringify(result.output),
+        responseTime,
+        tokensUsed: result.usage?.totalTokens,
+        userId,
+      });
+
+      return result.output;
+    } catch (error) {
+      const responseTime = Date.now() - startTime;
+      await this.logRequest({
+        aiModel: getModelId(this.model),
+        error: error instanceof Error ? error.message : String(error),
+        prompt,
+        requestType: "json_object",
+        responseTime,
+        userId,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Typed array: the model is steered to emit `{"elements":[...]}`; the SDK validates each entry
+   * and this method returns the plain array (`Output.array()`).
+   */
+  async generateJsonArray<ELEMENT>(
+    options: GenerateJsonArrayOptions<ELEMENT>
+  ): Promise<Array<ELEMENT>> {
+    const {
+      element,
+      maxOutputTokens,
+      outputDescription,
+      outputName,
+      prompt,
+      systemPrompt,
+      temperature,
+      userId,
+    } = options;
+    const startTime = Date.now();
+    const system = systemPrompt ?? JSON_VALUE_SYSTEM_PROMPT;
+
+    try {
+      const result = await aiGenerateText({
+        experimental_telemetry: {functionId: "generate-json-array", isEnabled: true},
+        maxOutputTokens,
+        model: this.model,
+        output: Output.array({
+          description: outputDescription,
+          element,
+          name: outputName,
+        }),
+        prompt,
+        system,
+        temperature: temperature ?? TemperaturePresets.DETERMINISTIC,
+      });
+
+      const responseTime = Date.now() - startTime;
+      await this.logRequest({
+        aiModel: getModelId(this.model),
+        prompt,
+        requestType: "json_array",
+        response: JSON.stringify(result.output),
+        responseTime,
+        tokensUsed: result.usage?.totalTokens,
+        userId,
+      });
+
+      return result.output;
+    } catch (error) {
+      const responseTime = Date.now() - startTime;
+      await this.logRequest({
+        aiModel: getModelId(this.model),
+        error: error instanceof Error ? error.message : String(error),
+        prompt,
+        requestType: "json_array",
         responseTime,
         userId,
       });

--- a/ai/src/service/aiService.ts
+++ b/ai/src/service/aiService.ts
@@ -1,6 +1,12 @@
 import {logger} from "@terreno/api";
 import type {DataContent, JSONValue, LanguageModel, ModelMessage} from "ai";
-import {generateText as aiGenerateText, Output, stepCountIs, streamText} from "ai";
+import {
+  generateText as aiGenerateText,
+  NoObjectGeneratedError,
+  Output,
+  stepCountIs,
+  streamText,
+} from "ai";
 import type mongoose from "mongoose";
 
 import {AIRequest} from "../models/aiRequest";
@@ -35,6 +41,66 @@ export const TemperaturePresets = {
   MAXIMUM: 2.0,
 } as const;
 
+/**
+ * Strips leading/trailing markdown fences (including ```json, ```json:, and other ```lang
+ * prefixes) so structured JSON parsing succeeds when models wrap the payload.
+ */
+const stripJsonMarkdownFenceText = (text: string): string => {
+  let t = text.trim();
+  t = t.replace(/^```[a-zA-Z0-9_-]*\s*:?\s*\n?/, "");
+  t = t.replace(/\n?```\s*$/m, "").trim();
+  return t;
+};
+
+/**
+ * Wraps a language model so non-streaming `doGenerate` text parts are passed through
+ * {@link stripJsonMarkdownFenceText} before structured-output parsing (models often wrap JSON in ``` fences).
+ */
+const withStrippedJsonFencesModel = (model: LanguageModel): LanguageModel => {
+  if (typeof model === "string") {
+    return model;
+  }
+
+  return new Proxy(model, {
+    get(target, prop, receiver) {
+      if (prop === "doGenerate") {
+        const original = Reflect.get(target, prop, receiver);
+        if (typeof original !== "function") {
+          return original;
+        }
+
+        const boundGenerate = original as (options: unknown) => PromiseLike<{
+          content: Array<{text?: string; type: string; [key: string]: unknown}>;
+          [key: string]: unknown;
+        }>;
+
+        return async (options: unknown) => {
+          const result = await Promise.resolve(boundGenerate.call(target, options));
+          if (!result?.content || !Array.isArray(result.content)) {
+            return result;
+          }
+
+          return {
+            ...result,
+            content: result.content.map((part) => {
+              if (part.type !== "text" || typeof part.text !== "string") {
+                return part;
+              }
+
+              return {
+                ...part,
+                text: stripJsonMarkdownFenceText(part.text),
+              };
+            }),
+          };
+        };
+      }
+
+      return Reflect.get(target, prop, receiver);
+    },
+  }) as LanguageModel;
+};
+
 const getModelId = (model: LanguageModel): string => {
   if (typeof model === "string") {
     return model;
@@ -45,6 +111,7 @@ const getModelId = (model: LanguageModel): string => {
 export class AIService {
   readonly model: LanguageModel;
   readonly defaultTemperature: number;
+  private structuredJsonModel?: LanguageModel;
 
   constructor({model, defaultTemperature = TemperaturePresets.DEFAULT}: AIServiceOptions) {
     this.model = model;
@@ -55,9 +122,97 @@ export class AIService {
     return getModelId(this.model);
   }
 
+  private getModelForStructuredJson(): LanguageModel {
+    if (!this.structuredJsonModel) {
+      this.structuredJsonModel = withStrippedJsonFencesModel(this.model);
+    }
+    return this.structuredJsonModel;
+  }
+
+  private describeStructuredGenerationError(error: unknown): string {
+    if (error instanceof Error) {
+      const base = `${error.name}: ${error.message}`;
+      if (error.cause instanceof Error) {
+        return `${base} | cause: ${error.cause.name}: ${error.cause.message}`;
+      }
+      return base;
+    }
+    return String(error);
+  }
+
+  private extractRawModelTextFromStructuredError(error: unknown): string | undefined {
+    if (NoObjectGeneratedError.isInstance(error) && typeof error.text === "string") {
+      return error.text;
+    }
+    if (error instanceof Error && "text" in error) {
+      const t = (error as {text?: unknown}).text;
+      if (typeof t === "string") {
+        return t;
+      }
+    }
+    return undefined;
+  }
+
+  private extractFinishReasonFromStructuredError(error: unknown): string | undefined {
+    if (NoObjectGeneratedError.isInstance(error) && error.finishReason) {
+      return error.finishReason;
+    }
+    return undefined;
+  }
+
+  private async logStructuredJsonFailure(params: {
+    error: unknown;
+    prompt: string;
+    requestType: AIRequestType;
+    responseTime: number;
+    system: string;
+    userId?: mongoose.Types.ObjectId;
+  }): Promise<void> {
+    const rawText = this.extractRawModelTextFromStructuredError(params.error);
+    const responseForLog =
+      rawText !== undefined && rawText.length > 0
+        ? rawText
+        : "(no raw model text captured on this error)";
+    const errorDescription = this.describeStructuredGenerationError(params.error);
+    const finishReason = this.extractFinishReasonFromStructuredError(params.error);
+    const errorStack =
+      params.error instanceof Error && typeof params.error.stack === "string"
+        ? params.error.stack.length > 8000
+          ? `${params.error.stack.slice(0, 8000)}…`
+          : params.error.stack
+        : undefined;
+
+    logger.error("AIService structured JSON generation failed", {
+      aiModel: getModelId(this.model),
+      error: errorDescription,
+      finishReason,
+      prompt: params.prompt,
+      requestType: params.requestType,
+      response: rawText ?? "",
+      system: params.system,
+    });
+
+    await this.logRequest({
+      aiModel: getModelId(this.model),
+      error: errorDescription,
+      metadata: {
+        errorStack,
+        finishReason,
+        rawModelTextCaptured: Boolean(rawText && rawText.length > 0),
+        system: params.system,
+      },
+      prompt: params.prompt,
+      requestType: params.requestType,
+      response: responseForLog,
+      responseTime: params.responseTime,
+      userId: params.userId,
+    });
+  }
+
   private async logRequest(params: {
     aiModel: string;
     error?: string;
+    metadata?: Record<string, unknown>;
     prompt: string;
     requestType: AIRequestType;
     response?: string;
@@ -130,7 +285,7 @@ export class AIService {
       const result = await aiGenerateText({
         experimental_telemetry: {functionId: "generate-json-value", isEnabled: true},
         maxOutputTokens,
-        model: this.model,
+        model: this.getModelForStructuredJson(),
         output: Output.json({description: outputDescription, name: outputName}),
         prompt,
         system,
@@ -151,12 +306,12 @@ export class AIService {
       return result.output;
     } catch (error) {
       const responseTime = Date.now() - startTime;
-      await this.logRequest({
-        aiModel: getModelId(this.model),
-        error: error instanceof Error ? error.message : String(error),
+      await this.logStructuredJsonFailure({
+        error,
         prompt,
         requestType: "json_value",
         responseTime,
+        system,
         userId,
       });
       throw error;
@@ -182,7 +337,7 @@ export class AIService {
       const result = await aiGenerateText({
         experimental_telemetry: {functionId: "generate-json-object", isEnabled: true},
         maxOutputTokens,
-        model: this.model,
+        model: this.getModelForStructuredJson(),
         output: Output.object({
           description: schemaDescription,
           name: schemaName,
@@ -207,12 +362,12 @@ export class AIService {
       return result.output;
     } catch (error) {
       const responseTime = Date.now() - startTime;
-      await this.logRequest({
-        aiModel: getModelId(this.model),
-        error: error instanceof Error ? error.message : String(error),
+      await this.logStructuredJsonFailure({
+        error,
         prompt,
         requestType: "json_object",
         responseTime,
+        system,
         userId,
       });
       throw error;
@@ -243,7 +398,7 @@ export class AIService {
       const result = await aiGenerateText({
         experimental_telemetry: {functionId: "generate-json-array", isEnabled: true},
         maxOutputTokens,
-        model: this.model,
+        model: this.getModelForStructuredJson(),
         output: Output.array({
           description: outputDescription,
           element,
@@ -268,12 +423,12 @@ export class AIService {
       return result.output;
     } catch (error) {
       const responseTime = Date.now() - startTime;
-      await this.logRequest({
-        aiModel: getModelId(this.model),
-        error: error instanceof Error ? error.message : String(error),
+      await this.logStructuredJsonFailure({
+        error,
         prompt,
         requestType: "json_array",
         responseTime,
+        system,
         userId,
       });
       throw error;

--- a/ai/src/service/aiService.ts
+++ b/ai/src/service/aiService.ts
@@ -24,6 +24,7 @@ import type {
   SummaryOptions,
   TranslateOptions,
 } from "../types";
+import {normalizeLlmJsonTextForStructuredOutput} from "./parseAiJson";
 import {
   CONTENT_SUMMARY_PROMPT,
   DEFAULT_GPT_MEMORY,
@@ -42,19 +43,9 @@ export const TemperaturePresets = {
 } as const;
 
 /**
- * Strips leading/trailing markdown fences (including ```json, ```json:, and other ```lang
- * prefixes) so structured JSON parsing succeeds when models wrap the payload.
- */
-const stripJsonMarkdownFenceText = (text: string): string => {
-  let t = text.trim();
-  t = t.replace(/^```[a-zA-Z0-9_-]*\s*:?\s*\n?/, "");
-  t = t.replace(/\n?```\s*$/m, "").trim();
-  return t;
-};
-
-/**
- * Wraps a language model so non-streaming `doGenerate` text parts are passed through
- * {@link stripJsonMarkdownFenceText} before structured-output parsing (models often wrap JSON in ``` fences).
+ * Wraps a language model so non-streaming `doGenerate` text parts are normalized via
+ * {@link normalizeLlmJsonTextForStructuredOutput} (fences, preamble, balanced slice, light repairs)
+ * before Vercel `Output.*` parsing.
  */
 const withStrippedJsonFencesModel = (model: LanguageModel): LanguageModel => {
   if (typeof model === "string") {
@@ -89,7 +80,7 @@ const withStrippedJsonFencesModel = (model: LanguageModel): LanguageModel => {
 
               return {
                 ...part,
-                text: stripJsonMarkdownFenceText(part.text),
+                text: normalizeLlmJsonTextForStructuredOutput(part.text),
               };
             }),
           };

--- a/ai/src/service/index.ts
+++ b/ai/src/service/index.ts
@@ -1,3 +1,5 @@
+export type {FlexibleSchema, JSONValue} from "ai";
+export {jsonSchema, Output} from "ai";
 export {AIService, TemperaturePresets} from "./aiService";
 export {FileStorageService} from "./fileStorage";
 export type {ListGeminiApiModelsOptions} from "./gemini";
@@ -6,6 +8,7 @@ export {MCPService} from "./mcpService";
 export {
   CONTENT_SUMMARY_PROMPT,
   DEFAULT_GPT_MEMORY,
+  JSON_VALUE_SYSTEM_PROMPT,
   REMIX_PROMPT,
   TITLE_GENERATION_PROMPT,
   TRANSLATION_PROMPT,

--- a/ai/src/service/index.ts
+++ b/ai/src/service/index.ts
@@ -5,6 +5,8 @@ export {FileStorageService} from "./fileStorage";
 export type {ListGeminiApiModelsOptions} from "./gemini";
 export {GEMINI_API_BASE_URL, listGeminiApiModels, normalizeGeminiModelId} from "./gemini";
 export {MCPService} from "./mcpService";
+export type {ParseFailure, ParseResult, ParseSuccess} from "./parseAiJson";
+export {normalizeLlmJsonTextForStructuredOutput, parseAiJson} from "./parseAiJson";
 export {
   CONTENT_SUMMARY_PROMPT,
   DEFAULT_GPT_MEMORY,

--- a/ai/src/service/parseAiJson.test.ts
+++ b/ai/src/service/parseAiJson.test.ts
@@ -1,0 +1,76 @@
+import {describe, expect, it} from "bun:test";
+
+import {normalizeLlmJsonTextForStructuredOutput, parseAiJson} from "./parseAiJson";
+
+describe("parseAiJson", () => {
+  it("parses clean JSON without repair", () => {
+    const r = parseAiJson<{a: number}>(`{"a":1}`);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.repaired).toBe(false);
+      expect(r.data).toEqual({a: 1});
+    }
+  });
+
+  it("strips a fully wrapped ```json fence", () => {
+    const r = parseAiJson(`\`\`\`json\n{"b":2}\n\`\`\``);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data).toEqual({b: 2});
+    }
+  });
+
+  it("extracts JSON from preamble and trailing prose", () => {
+    const r = parseAiJson(`Sure! Here is the result: {"ok":true} — hope this helps.`);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.repaired).toBe(true);
+      expect(r.data).toEqual({ok: true});
+    }
+  });
+
+  it("handles nested objects and arrays in balanced extraction", () => {
+    const r = parseAiJson(`noise {"x":[1,{"y":2}]} tail`);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data).toEqual({x: [1, {y: 2}]});
+    }
+  });
+
+  it("repairs trailing commas outside strings", () => {
+    const r = parseAiJson(`{"a":1,}`);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.repaired).toBe(true);
+      expect(r.data).toEqual({a: 1});
+    }
+  });
+
+  it("repairs smart quotes on property names via aggressive normalization", () => {
+    const r = parseAiJson(`{“smart”: true}`);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.repaired).toBe(true);
+      expect(r.data).toEqual({smart: true});
+    }
+  });
+
+  it("returns failure for non-JSON", () => {
+    const r = parseAiJson("not json at all");
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.length).toBeGreaterThan(0);
+      expect(r.raw).toBe("not json at all");
+    }
+  });
+});
+
+describe("normalizeLlmJsonTextForStructuredOutput", () => {
+  it("returns JSON.stringify output on success", () => {
+    expect(normalizeLlmJsonTextForStructuredOutput(`Yep: [1,2]`)).toBe("[1,2]");
+  });
+
+  it("returns fence-stripped text when parse fails", () => {
+    expect(normalizeLlmJsonTextForStructuredOutput("```json\nbroken\n```")).toBe("broken");
+  });
+});

--- a/ai/src/service/parseAiJson.ts
+++ b/ai/src/service/parseAiJson.ts
@@ -1,0 +1,214 @@
+/**
+ * Bulletproof-ish extraction of JSON from LLM output.
+ *
+ * Handles common "return only JSON" violations:
+ * - markdown code fences (full ```json … ``` wrappers or partial ``` lines)
+ * - preamble / trailing prose around a JSON value
+ * - JSON buried mid-string (first balanced `{`/`[` … `}`/`]` slice)
+ * - trailing commas before `}` or `]`
+ * - smart quotes outside string literals (conservative repair)
+ *
+ * Strategy: try the cheapest parse first, escalate only when it fails.
+ */
+
+export interface ParseSuccess<T> {
+  data: T;
+  repaired: boolean;
+  success: true;
+}
+
+export interface ParseFailure {
+  error: string;
+  raw: string;
+  success: false;
+}
+
+export type ParseResult<T> = ParseFailure | ParseSuccess<T>;
+
+/**
+ * Strip leading/trailing markdown code fences when the whole payload is fenced,
+ * otherwise strip a common opening ```lang line and trailing ``` block.
+ */
+const stripFences = (input: string): string => {
+  const trimmed = input.trim();
+  const fullyFenced = /^```(?:json|javascript|js|typescript|ts)?\s*\n?([\s\S]*?)\n?```$/i.exec(
+    trimmed
+  );
+  if (fullyFenced) {
+    return fullyFenced[1].trim();
+  }
+
+  let t = trimmed;
+  t = t.replace(/^```[a-zA-Z0-9_-]*\s*:?\s*\n?/, "");
+  t = t.replace(/\n?```\s*$/m, "").trim();
+  return t;
+};
+
+/**
+ * Returns the first balanced JSON object or array substring, respecting string literals
+ * and escapes. Uses a bracket stack so nested `{}` / `[]` mix correctly.
+ */
+const extractBalancedJson = (input: string): string | null => {
+  const start = input.search(/[{[]/);
+  if (start === -1) {
+    return null;
+  }
+
+  const stack: string[] = [];
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < input.length; i++) {
+    const char = input[i];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) {
+      continue;
+    }
+
+    if (char === "{") {
+      stack.push("}");
+      continue;
+    }
+    if (char === "[") {
+      stack.push("]");
+      continue;
+    }
+    if (char === "}" || char === "]") {
+      const expected = stack.pop();
+      if (expected !== char) {
+        return null;
+      }
+      if (stack.length === 0) {
+        return input.slice(start, i + 1);
+      }
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Light-touch repairs for common malformations. Only changes characters outside
+ * string literals so legitimate string content is preserved.
+ */
+const repairJsonishOutsideStrings = (input: string): string => {
+  let result = "";
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+
+    if (escaped) {
+      result += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      result += char;
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      inString = !inString;
+      result += char;
+      continue;
+    }
+
+    if (!inString) {
+      if (char === "\u201C" || char === "\u201D") {
+        result += '"';
+        continue;
+      }
+      if (char === ",") {
+        const rest = input.slice(i + 1);
+        const next = rest.match(/^\s*([}\]])/);
+        if (next) {
+          continue;
+        }
+      }
+    }
+
+    result += char;
+  }
+
+  return result;
+};
+
+const tryParse = <T>(candidate: string): T | undefined => {
+  try {
+    return JSON.parse(candidate) as T;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Extract and parse JSON from arbitrary LLM output.
+ */
+export const parseAiJson = <T = unknown>(input: string): ParseResult<T> => {
+  if (typeof input !== "string" || input.trim().length === 0) {
+    return {error: "Empty or non-string input", raw: input, success: false};
+  }
+
+  const cleaned = stripFences(input);
+
+  const direct = tryParse<T>(cleaned);
+  if (direct !== undefined) {
+    return {data: direct, repaired: false, success: true};
+  }
+
+  const balanced = extractBalancedJson(cleaned);
+  if (balanced !== null) {
+    const extracted = tryParse<T>(balanced);
+    if (extracted !== undefined) {
+      return {data: extracted, repaired: true, success: true};
+    }
+
+    const repairedSlice = tryParse<T>(repairJsonishOutsideStrings(balanced));
+    if (repairedSlice !== undefined) {
+      return {data: repairedSlice, repaired: true, success: true};
+    }
+  }
+
+  const repairedWhole = tryParse<T>(repairJsonishOutsideStrings(cleaned));
+  if (repairedWhole !== undefined) {
+    return {data: repairedWhole, repaired: true, success: true};
+  }
+
+  const aggressiveQuotes = tryParse<T>(cleaned.replace(/[\u201C\u201D]/g, '"'));
+  if (aggressiveQuotes !== undefined) {
+    return {data: aggressiveQuotes, repaired: true, success: true};
+  }
+
+  return {
+    error: "No valid JSON could be extracted",
+    raw: input,
+    success: false,
+  };
+};
+
+/**
+ * Normalizes raw LLM text into a single JSON text payload for Vercel `Output.*` parsers.
+ * On success returns `JSON.stringify` of the parsed value; on failure returns `cleaned`
+ * (fence-stripped) text so the SDK can still attempt its own error path.
+ */
+export const normalizeLlmJsonTextForStructuredOutput = (raw: string): string => {
+  const parsed = parseAiJson<unknown>(raw);
+  if (parsed.success) {
+    return JSON.stringify(parsed.data);
+  }
+  return stripFences(raw);
+};

--- a/ai/src/service/prompts.ts
+++ b/ai/src/service/prompts.ts
@@ -20,3 +20,8 @@ export const TRANSLATION_PROMPT =
 export const TITLE_GENERATION_PROMPT =
   "Generate a short title (3-6 words) that summarizes this conversation for a sidebar label. " +
   "Return only the title text with no quotes, punctuation, or additional commentary.";
+
+/** When callers omit systemPrompt for JSON helpers, steer the model away from prose and markdown fences. */
+export const JSON_VALUE_SYSTEM_PROMPT =
+  "You respond with a single JSON value (object, array, string, number, boolean, or null) only. " +
+  "No markdown code fences, no commentary before or after the JSON.";

--- a/ai/src/types/index.ts
+++ b/ai/src/types/index.ts
@@ -8,6 +8,9 @@ import type mongoose from "mongoose";
 
 export const DEFAULT_AI_REQUEST_TYPES = [
   "general",
+  "json_array",
+  "json_object",
+  "json_value",
   "remix",
   "summarization",
   "translation",
@@ -202,6 +205,44 @@ export interface TranslateOptions {
   sourceLanguage?: string;
   targetLanguage: string;
   text: string;
+  userId?: mongoose.Types.ObjectId;
+}
+
+export interface GenerateJsonValueOptions {
+  maxOutputTokens?: number;
+  /** Optional name passed to the provider for structured-output guidance. */
+  outputName?: string;
+  /** Optional description passed to the provider for structured-output guidance. */
+  outputDescription?: string;
+  prompt: string;
+  systemPrompt?: string;
+  temperature?: number;
+  userId?: mongoose.Types.ObjectId;
+}
+
+export interface GenerateJsonObjectOptions<OBJECT> {
+  maxOutputTokens?: number;
+  prompt: string;
+  /** Zod schema, `jsonSchema(...)`, or other `FlexibleSchema` accepted by the AI SDK. */
+  schema: import("ai").FlexibleSchema<OBJECT>;
+  schemaDescription?: string;
+  schemaName?: string;
+  systemPrompt?: string;
+  temperature?: number;
+  userId?: mongoose.Types.ObjectId;
+}
+
+export interface GenerateJsonArrayOptions<ELEMENT> {
+  /** Schema for each array element. */
+  element: import("ai").FlexibleSchema<ELEMENT>;
+  /** Optional description for the array output (provider guidance). */
+  outputDescription?: string;
+  /** Optional name for the array output (provider guidance). */
+  outputName?: string;
+  maxOutputTokens?: number;
+  prompt: string;
+  systemPrompt?: string;
+  temperature?: number;
   userId?: mongoose.Types.ObjectId;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds first-class `AIService` methods for structured model output using the Vercel AI SDK `generateText` + `Output.json()`, `Output.object()`, and `Output.array()`, so consuming apps do not need local wrappers around the SDK for parsing, telemetry, and request logging.

Also exports `Output`, `jsonSchema`, `JSONValue`, and `FlexibleSchema` from `@terreno/ai` alongside `JSON_VALUE_SYSTEM_PROMPT` for a sensible default when callers omit a system prompt on JSON flows.

New `AIRequest.requestType` values: `json_value`, `json_object`, `json_array` (included in `DEFAULT_AI_REQUEST_TYPES`).

We could not read `flourishhealth/flourish` branch `appointment-ai2` from this environment (GitHub API 404); the implementation follows AI SDK 6 structured output (`Output.*`) as documented in the installed `ai` package.

## Human Testing Steps

- [ ] In an app using `@terreno/ai`, call `generateJsonObject` with `jsonSchema(...)` or a Zod schema and confirm the returned object matches expectations.
- [ ] Confirm `AIRequest` rows show the new `requestType` values and serialized `response` for structured calls.

## Changes

- `AIService`: `generateJsonValue`, `generateJsonObject`, `generateJsonArray` with logging and deterministic default temperature.
- `prompts.ts`: `JSON_VALUE_SYSTEM_PROMPT` for default JSON-only guidance.
- `@terreno/ai` service exports: `Output`, `jsonSchema`, types `JSONValue`, `FlexibleSchema`.
- Types: options interfaces and default request type list; docs in `.cursor/rules/ai/00-ai.mdc` and ai-prompt-governance skill.

## Automated Tests

- `bun test --preload ./ai/src/tests/bunSetup.ts ./ai/src/service/aiService.test.ts` (requires MongoDB on `127.0.0.1:27017`; started local `mongod` in the agent VM to verify).
- `bun run compile` from repo root (all packages).
- `bun run ai:lint`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4e736d6-1f38-4fb7-9000-4a08b4a5e4a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4e736d6-1f38-4fb7-9000-4a08b4a5e4a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

