### PR TITLE
Prefix terreno-planning Cursor plugin skills with terreno-

### DIFF
--- a/plugins/terreno-planning/.cursor-plugin/plugin.json
+++ b/plugins/terreno-planning/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "terreno-planning",
   "displayName": "Terreno Planning",
   "description": "Plugins for planning and executing plans for the whole SDLC",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Flourish Health",
     "email": "josh@flourish.health"

--- a/plugins/terreno-planning/skills/terreno-blend/SKILL.md
+++ b/plugins/terreno-planning/skills/terreno-blend/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: blend
+name: terreno-blend
 description: Use ONLY when a concrete spec/Linear ticket/feature request must be converted into an Implementation Plan document. Do NOT use for code implementation, PR submission, or post-PR review handling.
 disable-model-invocation: true
 ---
@@ -34,8 +34,8 @@ If a project is not in the registry, resolve it with `gh repo view <input>`.
 
 ### Step 1: Ingest PRD/spec
 
-- `$PRD` is required for `/blend` when invoked as plan-from-text/file.
-- If `$PRD` is missing, stop immediately and return: `Error: /blend requires a PRD as the first argument (either a file path or inline PRD text). Please re-run as /blend <path-or-text>.`
+- `$PRD` is required for `/terreno-blend` when invoked as plan-from-text/file.
+- If `$PRD` is missing, stop immediately and return: `Error: /terreno-blend requires a PRD as the first argument (either a file path or inline PRD text). Please re-run as /terreno-blend <path-or-text>.`
 - Accept file path or inline text.
 - Summarize problem, business impact, stakeholders, constraints.
 - Ask for confirmation before research.

--- a/plugins/terreno-planning/skills/terreno-cupping/SKILL.md
+++ b/plugins/terreno-planning/skills/terreno-cupping/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: cupping
+name: terreno-cupping
 description: Use ONLY when implementation already exists and you need an independent verification pass against the IP/spec. Do NOT use for writing new feature code, planning the IP, or running the PR submission/review loop.
 ---
 

--- a/plugins/terreno-planning/skills/terreno-dialin/SKILL.md
+++ b/plugins/terreno-planning/skills/terreno-dialin/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dialin
+name: terreno-dialin
 description: Use ONLY when a PR is already open and the task is to run the reactive review loop (CI + bot/human comments) until mergeable or timeout. Do NOT use for initial planning, feature implementation from scratch, or opening the PR itself.
 disable-model-invocation: true
 ---
@@ -10,7 +10,7 @@ Own all post-review-open reactive work: CI watching/fixing, comment triage/fixes
 
 ## Ownership Boundary
 
-Dialin starts after `pour` opens/updates the PR and triggers CI.
+Dialin starts after `terreno-pour` opens/updates the PR and triggers CI.
 Dialin exclusively owns all work after that handoff.
 
 ## Timer Loop Contract
@@ -33,7 +33,7 @@ Each cycle:
    - Clarifications / out-of-scope items
 4. Apply code fixes for actionable items.
 5. Run targeted checks.
-6. Commit + push fixes (same commit hygiene rules as `pour`; no AI attribution).
+6. Commit + push fixes (same commit hygiene rules as `terreno-pour`; no AI attribution).
 7. Re-check CI and continue loop.
 8. Reply to addressed comments and resolve threads when fully fixed.
 

--- a/plugins/terreno-planning/skills/terreno-pour/SKILL.md
+++ b/plugins/terreno-planning/skills/terreno-pour/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: pour
+name: terreno-pour
 description: Use ONLY when code is ready to enter review and the task is to perform commit/push/PR setup plus immediate handoff. Do NOT use for implementation work, independent verification, or waiting on CI/comments after the PR is open.
 disable-model-invocation: true
 ---
 
 # Pour
 
-Get work into review, then immediately hand ownership to `dialin`.
+Get work into review, then immediately hand ownership to `terreno-dialin`.
 
 ## Scope Boundary
 
@@ -17,7 +17,7 @@ Pour owns only pre-review-open and review-open actions:
 3. Create/update draft PR.
 4. Resolve merge conflicts required to get PR updated.
 5. Ensure CI is triggered on the first push.
-6. Immediately invoke `dialin`.
+6. Immediately invoke `terreno-dialin`.
 
 Pour must never block on CI completion or review comments.
 
@@ -60,8 +60,8 @@ If push/rebase/merge conflicts block PR update:
 
 As soon as PR is open/updated and CI has been triggered on first push:
 
-- Invoke `dialin` immediately.
-- Exit `pour` without waiting.
+- Invoke `terreno-dialin` immediately.
+- Exit `terreno-pour` without waiting.
 
 ## Branch/Repo Conventions
 

--- a/plugins/terreno-planning/skills/terreno-roast/SKILL.md
+++ b/plugins/terreno-planning/skills/terreno-roast/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: roast
+name: terreno-roast
 description: Use ONLY when an approved IP exists and the work now needs to be executed in code through a strict TDD cycle. Do NOT use for creating IPs, opening PRs, or monitoring CI/review comments after a PR is open.
 ---
 
@@ -116,4 +116,4 @@ For every commit:
 - All planned implementation tasks for the scoped slice are complete.
 - Tests are credible under anti-mocking rules.
 - No unresolved review findings remain from independent sub-agents.
-- Work is ready for `pour`.
+- Work is ready for `terreno-pour`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The five skills shipped with the `terreno-planning` Cursor plugin used short directory and YAML `name` values (`blend`, `cupping`, `dialin`, `pour`, `roast`). They are now consistently prefixed with `terreno-` so installed skill identifiers are clearly namespaced.

## Changes

- Renamed skill folders under `plugins/terreno-planning/skills/` to `terreno-blend`, `terreno-cupping`, `terreno-dialin`, `terreno-pour`, and `terreno-roast`.
- Updated each `SKILL.md` frontmatter `name` and adjusted in-doc slash commands and cross-references (`/terreno-blend`, `terreno-pour` / `terreno-dialin` handoffs).
- Bumped `.cursor-plugin/plugin.json` version to **1.0.1** (path/name change is breaking for anyone hard-coding old skill paths).

## Notes

Anyone who bookmarked or scripted `/blend` (etc.) should switch to `/terreno-blend` and the matching names for the other four skills after updating the plugin.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edbbff11-09f3-4e5f-bd4b-cfffe9f555d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edbbff11-09f3-4e5f-bd4b-cfffe9f555d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

