### PR TITLE
feat(api): configuration & secret upgrades (no-persist secrets, $set updates, soft-delete singleton, pluggable ConfigurationApp)

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.20.0
+
+### Changed (breaking)
+
+- **`ConfigurationApp` `POST {basePath}/list-secrets` no longer persists secret values.** Previously it resolved secrets from the provider and wrote the resolved plaintext values into the configuration document. It is now a **read-only validation/status** endpoint: it reports, per secret field, only non-sensitive metadata (`path`, `secretName`, `version`, and a boolean `resolvable`/`isConfigured`) and never writes to the document or returns secret values. A `POST {basePath}/validate-secrets` alias with the same behavior is also registered.
+- **`ConfigurationApp` `PATCH {basePath}` strips `secret: true` fields** from the incoming body, so a secret value can never be written through the update path. Secret fields are read-only via this surface.
+- **`configurationPlugin` no longer adds the `_singleton` unique index by default.** It is now opt-in via `enforceSingletonIndex: true` so it does not double-enforce or conflict with consumers that already guarantee a single non-deleted document via the pre-save guard or their own soft-delete plugin/indexes.
+- **`configurationPlugin` singleton semantics are now soft-delete aware.** `getConfig`, `updateConfig`, and the pre-save guard operate on `{deleted: false}` when the schema has a `deleted` path (e.g. via `isDeletedPlugin`). A soft-deleted document no longer blocks creating a new singleton; hard deletes (`deleteOne`/`deleteMany`/`findOneAndDelete`) remain blocked.
+- **`configurationPlugin.updateConfig` now applies updates via `findOneAndUpdate({$set})` with dotted paths** instead of `Object.assign` + `doc.save()`. This preserves sibling fields inside nested subdocuments on partial patches and tolerates legacy/out-of-schema fields already persisted under `strict: "throw"`.
+
+### Added
+
+- **`SecretProvider.getSecret(secretName, version?)`** — optional `version` parameter. `GcpSecretProvider` resolves `projects/{projectId}/secrets/{name}/versions/{version}` (default `latest`, full resource paths still honored); `EnvSecretProvider` ignores it. Secret fields can declare a `secretVersion` schema option, surfaced on `SecretFieldMeta.version` and passed through `resolveSecrets`.
+- **`CompositeSecretProvider`** — composes an ordered list of providers and returns the first non-null result; a failing provider is warn-logged (secret name only) and resolution falls through to the next.
+- **`CachingSecretProvider`** — wraps any provider with an in-memory TTL cache keyed by `secretName@version`, with `clear()` / `clearKey()` for rotation and tests. Caches `null` results. Never logs values.
+- **`ConfigurationApp` pluggable permissions** — `permissions: {read?, update?, meta?, listSecrets?}` accepts terreno permission functions (e.g. `[IsStaff]`), AND-combined like `modelRouter`. Defaults to admin-only for every route.
+- **`ConfigurationApp` lifecycle hooks** — `preUpdate(body, req)` (validate/normalize) and `postUpdate(config, prevValue, req)` (audit logging). Both payloads have secret values redacted.
+- **`flattenToDotPaths`** — exported helper used by `updateConfig`.
+
+### Migration
+
+- If you relied on `list-secrets` to populate secret values into the configuration document, stop. Resolve secrets on-demand at runtime via `Model.resolveSecrets(provider)` (returns an in-memory `Map`) and read them from memory; never persist them.
+- If you depended on the `_singleton` unique index, pass `configurationPlugin(schema, {enforceSingletonIndex: true})`.
+- For GCP-with-env-fallback and caching, compose `new CachingSecretProvider(new CompositeSecretProvider([gcp, env]), {ttlMs})`.
+
 ## 0.16.0
 
 ### Added

--- a/api/package.json
+++ b/api/package.json
@@ -109,5 +109,5 @@
     "updateSnapshot": "bun test --update-snapshots"
   },
   "types": "dist/index.d.ts",
-  "version": "0.19.0"
+  "version": "0.20.0"
 }

--- a/api/src/configuration.test.ts
+++ b/api/src/configuration.test.ts
@@ -523,6 +523,27 @@ describe("ConfigurationApp with update hooks", () => {
     expect(preUpdateCalls).toHaveLength(1);
   });
 
+  it("does not persist secret values even if preUpdate re-introduces them", async () => {
+    // Build an app whose preUpdate maliciously/accidentally re-adds a secret path.
+    const leakyApp = buildApp(TestConfig, {
+      preUpdate: (body) => ({
+        ...body,
+        integrations: {...(body.integrations as Record<string, unknown>), apiKey: "leaked-secret"},
+      }),
+    });
+    const agent = await authAsUser(leakyApp, "admin");
+
+    const res = await agent
+      .patch("/configuration")
+      .send({general: {appName: "Safe"}})
+      .expect(200);
+    expect(res.body.data.general.appName).toBe("Safe");
+    expect(res.body.data.integrations.apiKey).toBe("");
+
+    const stored = await (TestConfig as any).getConfig();
+    expect(stored.integrations.apiKey).toBe("");
+  });
+
   it("runs postUpdate with redacted config and previous value", async () => {
     // Seed a secret so we can confirm it is redacted in hook payloads.
     await (TestConfig as any).updateConfig({integrations: {apiKey: "should-not-leak"}});

--- a/api/src/configuration.test.ts
+++ b/api/src/configuration.test.ts
@@ -93,16 +93,15 @@ const ScalarConfig = (mongoose.models.ScalarConfig ||
 
 const buildApp = (
   configModel: mongoose.Model<any>,
-  options?: {basePath?: string; fieldOverrides?: Record<string, {widget?: string}>}
+  options?: Partial<Omit<ConstructorParameters<typeof ConfigurationApp>[0], "model">>
 ): express.Application => {
   const app = getBaseServer();
   setupAuth(app, UserModel as any);
   addAuthRoutes(app, UserModel as any);
 
   const configApp = new ConfigurationApp({
-    basePath: options?.basePath,
-    fieldOverrides: options?.fieldOverrides,
     model: configModel,
+    ...options,
   });
   configApp.register(app);
 
@@ -167,6 +166,31 @@ describe("configurationPlugin", () => {
       });
       expect(updated.general.appName).toBe("Changed");
       expect(updated.general.maintenanceMode).toBe(true);
+    });
+
+    it("preserves sibling subdoc fields on a partial nested patch", async () => {
+      await TestConfig.updateConfig({general: {appName: "Initial", maintenanceMode: true}});
+      // Patch only one field within the nested subdoc.
+      const updated = await TestConfig.updateConfig({general: {appName: "Renamed"}});
+      expect(updated.general.appName).toBe("Renamed");
+      // Sibling must be preserved (not clobbered back to the default).
+      expect(updated.general.maintenanceMode).toBe(true);
+    });
+
+    it("tolerates legacy/out-of-schema fields already persisted", async () => {
+      // Insert a document containing a field that is not in the (strict: throw) schema.
+      await TestConfig.getConfig();
+      await mongoose.connection.db
+        ?.collection("testconfigs")
+        .updateOne({}, {$set: {legacyField: "stale"}});
+
+      // A full doc.save() would throw under strict: "throw"; $set must not.
+      const updated = await TestConfig.updateConfig({general: {appName: "Survives"}});
+      expect(updated.general.appName).toBe("Survives");
+
+      // The legacy field is left untouched on the document.
+      const raw = await mongoose.connection.db?.collection("testconfigs").findOne({});
+      expect(raw?.legacyField).toBe("stale");
     });
   });
 
@@ -327,12 +351,18 @@ describe("ConfigurationApp routes", () => {
       expect(res.body.data.general.appName).toBe("New Name");
     });
 
-    it("redacts secrets in the response", async () => {
+    it("never persists secret field values supplied in the body", async () => {
       const res = await adminAgent
         .patch("/configuration")
-        .send({integrations: {apiKey: "new-secret"}})
+        .send({integrations: {apiKey: "new-secret", webhookUrl: "https://changed.example.com"}})
         .expect(200);
-      expect(res.body.data.integrations.apiKey).toBe("********");
+      // Secret stays empty (stripped); non-secret sibling is updated.
+      expect(res.body.data.integrations.apiKey).toBe("");
+      expect(res.body.data.integrations.webhookUrl).toBe("https://changed.example.com");
+
+      // Confirm the raw stored document holds no secret value.
+      const stored = await (TestConfig as any).getConfig();
+      expect(stored.integrations.apiKey).toBe("");
     });
 
     it("returns 403 for non-admin", async () => {
@@ -344,11 +374,29 @@ describe("ConfigurationApp routes", () => {
   });
 
   describe("POST /configuration/list-secrets", () => {
-    it("returns discovered secret fields", async () => {
+    it("returns discovered secret fields with resolvable status", async () => {
       const res = await adminAgent.post("/configuration/list-secrets").expect(200);
       expect(res.body.secretFields).toHaveLength(1);
       expect(res.body.secretFields[0].path).toBe("integrations.apiKey");
       expect(res.body.secretFields[0].secretName).toBe("external-api-key");
+      // No provider configured -> not resolvable, and no value is ever returned.
+      expect(res.body.secretFields[0].resolvable).toBe(false);
+      expect(res.body.secretFields[0].isConfigured).toBe(false);
+      expect(JSON.stringify(res.body)).not.toContain("super-secret");
+    });
+
+    it("does not mutate the stored config document's secret fields", async () => {
+      await (TestConfig as any).getConfig();
+      await adminAgent.post("/configuration/list-secrets").expect(200);
+      const stored = await (TestConfig as any).getConfig();
+      // list-secrets must never write resolved values into the document.
+      expect(stored.integrations.apiKey).toBe("");
+    });
+
+    it("is also exposed as validate-secrets", async () => {
+      const res = await adminAgent.post("/configuration/validate-secrets").expect(200);
+      expect(res.body.secretFields).toHaveLength(1);
+      expect(res.body.secretFields[0].path).toBe("integrations.apiKey");
     });
 
     it("returns 403 for non-admin", async () => {
@@ -395,5 +443,100 @@ describe("ConfigurationApp with field overrides", () => {
     const res = await adminAgent.get("/configuration/meta").expect(200);
     const intSection = res.body.sections.find((s: any) => s.name === "integrations");
     expect(intSection.fields.webhookUrl.widget).toBe("url");
+  });
+});
+
+describe("ConfigurationApp with custom permissions", () => {
+  let app: express.Application;
+  let adminAgent: TestAgent;
+  let notAdminAgent: TestAgent;
+
+  // Terreno-style permission: any authenticated user (not just admins).
+  const isAuthenticated = (_method: any, user?: any): boolean => Boolean(user?.id);
+
+  beforeEach(async () => {
+    await setupDb();
+    await mongoose.connection.db?.collection("testconfigs").deleteMany({});
+    app = buildApp(TestConfig, {
+      permissions: {
+        read: [isAuthenticated],
+        // update intentionally left default (admin-only)
+      },
+    });
+    adminAgent = await authAsUser(app, "admin");
+    notAdminAgent = await authAsUser(app, "notAdmin");
+  });
+
+  it("allows non-admin reads when a custom read permission is supplied", async () => {
+    const res = await notAdminAgent.get("/configuration").expect(200);
+    expect(res.body.data.general.appName).toBe("Test App");
+  });
+
+  it("still rejects unauthenticated reads", async () => {
+    await supertest(app).get("/configuration").expect(401);
+  });
+
+  it("keeps update admin-only by default", async () => {
+    await notAdminAgent
+      .patch("/configuration")
+      .send({general: {appName: "Nope"}})
+      .expect(403);
+    await adminAgent
+      .patch("/configuration")
+      .send({general: {appName: "Yes"}})
+      .expect(200);
+  });
+});
+
+describe("ConfigurationApp with update hooks", () => {
+  let app: express.Application;
+  let adminAgent: TestAgent;
+  let preUpdateCalls: Array<Record<string, unknown>>;
+  let postUpdateCalls: Array<{config: Record<string, unknown>; prev: Record<string, unknown>}>;
+
+  beforeEach(async () => {
+    await setupDb();
+    await mongoose.connection.db?.collection("testconfigs").deleteMany({});
+    preUpdateCalls = [];
+    postUpdateCalls = [];
+    app = buildApp(TestConfig, {
+      postUpdate: async (config, prevValue) => {
+        postUpdateCalls.push({config, prev: prevValue});
+      },
+      preUpdate: async (body) => {
+        preUpdateCalls.push(body);
+        // Normalize: force maintenanceMode on.
+        const general = (body.general as Record<string, unknown>) ?? {};
+        return {...body, general: {...general, maintenanceMode: true}};
+      },
+    });
+    adminAgent = await authAsUser(app, "admin");
+  });
+
+  it("runs preUpdate to transform the body before applying", async () => {
+    const res = await adminAgent
+      .patch("/configuration")
+      .send({general: {appName: "Hooked"}})
+      .expect(200);
+    expect(res.body.data.general.appName).toBe("Hooked");
+    expect(res.body.data.general.maintenanceMode).toBe(true);
+    expect(preUpdateCalls).toHaveLength(1);
+  });
+
+  it("runs postUpdate with redacted config and previous value", async () => {
+    // Seed a secret so we can confirm it is redacted in hook payloads.
+    await (TestConfig as any).updateConfig({integrations: {apiKey: "should-not-leak"}});
+    await adminAgent
+      .patch("/configuration")
+      .send({general: {appName: "Audited"}})
+      .expect(200);
+
+    expect(postUpdateCalls).toHaveLength(1);
+    const {config, prev} = postUpdateCalls[0];
+    expect((config.general as any).appName).toBe("Audited");
+    // Secret values must be redacted in both payloads.
+    expect((config.integrations as any).apiKey).toBe("********");
+    expect((prev.integrations as any).apiKey).toBe("********");
+    expect(JSON.stringify(postUpdateCalls)).not.toContain("should-not-leak");
   });
 });

--- a/api/src/configurationApp.ts
+++ b/api/src/configurationApp.ts
@@ -1,16 +1,18 @@
 import type express from "express";
 import type {Model, Schema} from "mongoose";
 
-import {asyncHandler} from "./api";
+import {asyncHandler, type RESTMethod} from "./api";
 import {authenticateMiddleware} from "./auth";
 import type {SecretFieldMeta} from "./configurationPlugin";
 import {APIError} from "./errors";
 import {logger} from "./logger";
+import {checkPermissions, type PermissionMethod} from "./permissions";
 import {getOpenApiSpecForModel} from "./populate";
 import type {TerrenoPlugin} from "./terrenoPlugin";
 
 /**
- * Middleware that requires the user to be an admin.
+ * Middleware that requires the user to be an admin. Used as the default guard
+ * for every configuration route when no custom `permissions` are supplied.
  */
 const requireAdmin = (
   req: express.Request,
@@ -23,6 +25,29 @@ const requireAdmin = (
   }
   next();
 };
+
+/**
+ * Builds an Express middleware that AND-combines terreno permission functions
+ * (the same {@link PermissionMethod} contract used by `modelRouter`). The
+ * configuration singleton has no per-object ownership, so the loaded config
+ * document is passed as the permission object.
+ */
+const buildPermissionMiddleware = (
+  perms: PermissionMethod<unknown>[],
+  method: RESTMethod,
+  loadObj?: () => Promise<unknown>
+): express.RequestHandler =>
+  asyncHandler(async (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    const obj = loadObj ? await loadObj() : undefined;
+    const allowed = await checkPermissions(method, perms, req.user, obj);
+    if (!allowed) {
+      throw new APIError({
+        status: 403,
+        title: "Access to configuration denied",
+      });
+    }
+    next();
+  });
 
 /**
  * Metadata for a single configuration field, sent to the frontend.
@@ -55,6 +80,54 @@ export interface ConfigurationMetaResponse {
 }
 
 /**
+ * Per-route permission overrides for ConfigurationApp. Each value is an array of
+ * terreno permission functions ({@link PermissionMethod}), AND-combined like
+ * `modelRouter` permissions. When a route is omitted, the default admin-only
+ * guard applies.
+ *
+ * @example
+ * ```typescript
+ * permissions: {
+ *   read: [IsStaff],
+ *   update: [IsSuperUser],
+ * }
+ * ```
+ */
+export interface ConfigurationPermissions {
+  /** Guards `GET {basePath}` (current values). */
+  read?: PermissionMethod<unknown>[];
+  /** Guards `PATCH {basePath}` (update values). */
+  update?: PermissionMethod<unknown>[];
+  /** Guards `GET {basePath}/meta` (schema metadata). */
+  meta?: PermissionMethod<unknown>[];
+  /** Guards `POST {basePath}/list-secrets` and `/validate-secrets`. */
+  listSecrets?: PermissionMethod<unknown>[];
+}
+
+/**
+ * Hook invoked before a configuration update is applied. Receives the incoming
+ * (already system-field- and secret-field-stripped) body and the request, and
+ * returns the body to apply. Use it to validate or normalize input. Throw an
+ * {@link APIError} to reject the update.
+ */
+export type ConfigurationPreUpdateHook = (
+  body: Record<string, unknown>,
+  req: express.Request
+) => Record<string, unknown> | Promise<Record<string, unknown>>;
+
+/**
+ * Hook invoked after a configuration update is applied. Receives the updated
+ * configuration and the previous value (both with secret values redacted) plus
+ * the request, enabling audit logging of who changed what. Secret values are
+ * never included.
+ */
+export type ConfigurationPostUpdateHook = (
+  config: Record<string, unknown>,
+  prevValue: Record<string, unknown>,
+  req: express.Request
+) => void | Promise<void>;
+
+/**
  * Options for ConfigurationApp.
  */
 export interface ConfigurationAppOptions {
@@ -65,6 +138,16 @@ export interface ConfigurationAppOptions {
   basePath?: string;
   /** Per-field widget overrides (e.g., {"ai.systemPrompt": "markdown"}). */
   fieldOverrides?: Record<string, {widget?: string}>;
+  /**
+   * Per-route permission overrides. Defaults to admin-only for every route when
+   * omitted. Supply terreno permission functions (e.g. `[IsStaff]`) to expose
+   * configuration to a consumer's own permission system.
+   */
+  permissions?: ConfigurationPermissions;
+  /** Hook run before an update is applied (validation/normalization). */
+  preUpdate?: ConfigurationPreUpdateHook;
+  /** Hook run after an update is applied (audit logging). */
+  postUpdate?: ConfigurationPostUpdateHook;
 }
 
 /**
@@ -153,6 +236,41 @@ const redactSecrets = (
 };
 
 /**
+ * Removes secret field values from an incoming update body so a secret value can
+ * never be written to the configuration document through the update path.
+ * Copies nodes along each secret path to avoid mutating the caller's object.
+ */
+const stripSecretFields = (
+  obj: Record<string, unknown>,
+  secretFields: SecretFieldMeta[]
+): Record<string, unknown> => {
+  const stripped: Record<string, unknown> = {...obj};
+  for (const field of secretFields) {
+    const parts = field.path.split(".");
+    let current: Record<string, unknown> | null = stripped;
+    for (let i = 0; i < parts.length - 1; i++) {
+      if (!current) {
+        break;
+      }
+      const part = parts[i];
+      const nested = current[part];
+      if (nested != null && typeof nested === "object") {
+        const copy = {...(nested as Record<string, unknown>)};
+        current[part] = copy;
+        current = copy;
+      } else {
+        current = null;
+        break;
+      }
+    }
+    if (current != null) {
+      delete current[parts[parts.length - 1]];
+    }
+  }
+  return stripped;
+};
+
+/**
  * Converts a camelCase or PascalCase string into a display-friendly title.
  */
 const toDisplayName = (name: string): string => {
@@ -167,11 +285,21 @@ const toDisplayName = (name: string): string => {
  *
  * Inspects the Mongoose configuration model to auto-generate:
  * - `GET {basePath}/meta` — Schema metadata (sections, fields, types, descriptions)
- * - `GET {basePath}` — Current configuration values
- * - `PATCH {basePath}` — Update configuration values
- * - `POST {basePath}/refresh-secrets` — Trigger secret refresh (if provider configured)
+ * - `GET {basePath}` — Current configuration values (secret values redacted)
+ * - `PATCH {basePath}` — Update configuration values (secret fields stripped; never written)
+ * - `POST {basePath}/list-secrets` (alias `POST {basePath}/validate-secrets`) —
+ *   Read-only status of each secret field (whether the provider can resolve it).
+ *   This endpoint never resolves values into the document and returns no secret values.
  *
- * All endpoints require `Permissions.IsAdmin`.
+ * By default all endpoints require `Permissions.IsAdmin`. Supply `permissions`
+ * to gate routes with a consumer's own permission functions, and `preUpdate`/
+ * `postUpdate` hooks to validate and audit-log changes. This makes
+ * `ConfigurationApp` suitable as a single, consumer-owned configuration surface
+ * that can replace a bespoke config router.
+ *
+ * Secret values never touch the database, logs, audit payloads, or API
+ * responses: secret fields are stripped from incoming updates and redacted on
+ * every read.
  *
  * Nested subschemas in the model become separate sections in the metadata,
  * making them renderable as cards/accordions in the admin UI.
@@ -193,7 +321,10 @@ const toDisplayName = (name: string): string => {
  * const AppConfig = mongoose.model("AppConfig", configSchema);
  *
  * new TerrenoApp({ userModel: User })
- *   .configure(AppConfig)
+ *   .configure(AppConfig, {
+ *     permissions: {read: [IsStaff], update: [IsSuperUser]},
+ *     postUpdate: (config, prevValue, req) => auditLog(req.user, prevValue, config),
+ *   })
  *   .start();
  * ```
  */
@@ -202,6 +333,21 @@ export class ConfigurationApp implements TerrenoPlugin {
 
   constructor(options: ConfigurationAppOptions) {
     this.options = options;
+  }
+
+  /**
+   * Resolves the guard middleware for a route: the consumer's terreno permission
+   * functions when supplied, otherwise the default admin-only guard.
+   */
+  private guardFor(
+    route: keyof ConfigurationPermissions,
+    method: RESTMethod
+  ): express.RequestHandler {
+    const perms = this.options.permissions?.[route];
+    if (perms && perms.length > 0) {
+      return buildPermissionMiddleware(perms, method);
+    }
+    return requireAdmin;
   }
 
   register(app: express.Application): void {
@@ -216,7 +362,7 @@ export class ConfigurationApp implements TerrenoPlugin {
     app.get(
       `${basePath}/meta`,
       authenticateMiddleware(),
-      requireAdmin,
+      this.guardFor("meta", "read"),
       (_req: express.Request, res: express.Response) => {
         return res.json(meta);
       }
@@ -239,7 +385,7 @@ export class ConfigurationApp implements TerrenoPlugin {
     app.get(
       `${basePath}`,
       authenticateMiddleware(),
-      requireAdmin,
+      this.guardFor("read", "read"),
       asyncHandler(async (_req: express.Request, res: express.Response) => {
         const config = await ConfigStatics.getConfig();
         const data = redactSecrets(config.toJSON(), secretFields);
@@ -247,44 +393,78 @@ export class ConfigurationApp implements TerrenoPlugin {
       })
     );
 
-    // PATCH /configuration — update values (secrets redacted in response)
+    // PATCH /configuration — update values (secret fields stripped; secrets redacted in response)
     app.patch(
       `${basePath}`,
       authenticateMiddleware(),
-      requireAdmin,
+      this.guardFor("update", "update"),
       asyncHandler(async (req: express.Request, res: express.Response) => {
-        // Strip internal system fields that should never be updated via the API
-        const {_singleton: _s, _id: _i, __v: _v, ...safeBody} = req.body;
+        // Strip internal system fields that should never be updated via the API.
+        const {_singleton: _s, _id: _i, __v: _v, ...rest} = req.body;
+        // Strip secret fields so a secret value can never be persisted via update.
+        let safeBody = stripSecretFields(rest, secretFields);
+
+        // Allow consumers to validate/normalize before applying.
+        if (this.options.preUpdate) {
+          safeBody = await this.options.preUpdate(safeBody, req);
+        }
+
+        // Capture the previous (redacted) value for audit hooks.
+        let prevValue: Record<string, unknown> = {};
+        if (this.options.postUpdate) {
+          const before = await ConfigStatics.getConfig();
+          prevValue = redactSecrets(before.toJSON(), secretFields);
+        }
+
         const config = await ConfigStatics.updateConfig(safeBody);
         logger.info(`Configuration updated by ${req.user?.email ?? "unknown"}`);
         const data = redactSecrets(config.toJSON(), secretFields);
+
+        if (this.options.postUpdate) {
+          await this.options.postUpdate(data, prevValue, req);
+        }
+
         return res.json({data});
       })
     );
 
-    // POST /configuration/list-secrets — list secret fields and optionally resolve from provider
+    // POST /configuration/list-secrets — read-only status of each secret field.
+    // Never resolves values into the document and never returns secret values.
+    const validateSecretsHandler = asyncHandler(
+      async (_req: express.Request, res: express.Response) => {
+        // In-memory resolution only — used to report whether each secret is
+        // configured/resolvable. Values are never persisted or returned.
+        const resolved: Map<string, string> = await ConfigStatics.resolveSecrets();
+        const fields = secretFields.map((s) => ({
+          isConfigured: resolved.has(s.path),
+          path: s.path,
+          resolvable: resolved.has(s.path),
+          secretName: s.secretName,
+          version: s.version,
+        }));
+        logger.info(`Validated ${resolved.size}/${secretFields.length} secrets (read-only)`);
+
+        return res.json({
+          message: `${resolved.size}/${secretFields.length} secrets resolvable.`,
+          resolved: resolved.size,
+          secretFields: fields,
+          total: secretFields.length,
+        });
+      }
+    );
+
     app.post(
       `${basePath}/list-secrets`,
       authenticateMiddleware(),
-      requireAdmin,
-      asyncHandler(async (_req: express.Request, res: express.Response) => {
-        const resolved: Map<string, string> = await ConfigStatics.resolveSecrets();
-        if (resolved.size > 0) {
-          const updates: Record<string, unknown> = {};
-          for (const [path, value] of resolved) {
-            updates[path] = value;
-          }
-          await ConfigStatics.updateConfig(updates);
-          logger.info(`Refreshed ${resolved.size}/${secretFields.length} secrets`);
-        }
-
-        return res.json({
-          message: `Resolved ${resolved.size}/${secretFields.length} secrets.`,
-          resolved: resolved.size,
-          secretFields: secretFields.map((s) => ({path: s.path, secretName: s.secretName})),
-          total: secretFields.length,
-        });
-      })
+      this.guardFor("listSecrets", "read"),
+      validateSecretsHandler
+    );
+    // Accurate alias for the read-only validation semantics.
+    app.post(
+      `${basePath}/validate-secrets`,
+      authenticateMiddleware(),
+      this.guardFor("listSecrets", "read"),
+      validateSecretsHandler
     );
 
     logger.info(`Configuration routes mounted at ${basePath}`);

--- a/api/src/configurationApp.ts
+++ b/api/src/configurationApp.ts
@@ -407,6 +407,9 @@ export class ConfigurationApp implements TerrenoPlugin {
         // Allow consumers to validate/normalize before applying.
         if (this.options.preUpdate) {
           safeBody = await this.options.preUpdate(safeBody, req);
+          // Re-strip after the hook: preUpdate receives the raw request and could
+          // otherwise (re)introduce secret paths. Secrets must never persist here.
+          safeBody = stripSecretFields(safeBody, secretFields);
         }
 
         // Capture the previous (redacted) value for audit hooks.

--- a/api/src/configurationPlugin.test.ts
+++ b/api/src/configurationPlugin.test.ts
@@ -83,6 +83,19 @@ softDeleteSchema.plugin(configurationPlugin);
 softDeleteSchema.plugin(isDeletedPlugin);
 const SoftDeleteConfigModel = model("SoftDeleteConfiguration", softDeleteSchema) as any;
 
+// --- Schema with a validated field (enum) for runValidators coverage ---
+
+const validatedSchema = new Schema({
+  level: {
+    default: "low",
+    description: "Severity level",
+    enum: ["low", "medium", "high"],
+    type: String,
+  },
+});
+validatedSchema.plugin(configurationPlugin);
+const ValidatedConfigModel = model("ValidatedConfiguration", validatedSchema) as any;
+
 describe("configurationPlugin", () => {
   describe("schema setup", () => {
     it("does not add a _singleton index by default", () => {
@@ -327,6 +340,22 @@ describe("configurationPlugin", () => {
       }
       const config = await SimpleConfigModel.updateConfig({value: "custom"});
       expect(config.value).toBe("custom");
+    });
+
+    it("runs schema validators on updateConfig (rejects invalid enum)", async () => {
+      if (!dbConnected) {
+        return;
+      }
+      try {
+        await ValidatedConfigModel.collection.drop();
+      } catch {
+        // Collection may not exist yet
+      }
+      await ValidatedConfigModel.getConfig();
+      await expect(ValidatedConfigModel.updateConfig({level: "bogus"})).rejects.toThrow();
+      // A valid value still applies.
+      const ok = await ValidatedConfigModel.updateConfig({level: "high"});
+      expect(ok.level).toBe("high");
     });
 
     it("prevents deleteOne", async () => {

--- a/api/src/configurationPlugin.test.ts
+++ b/api/src/configurationPlugin.test.ts
@@ -2,7 +2,8 @@
 import {afterAll, beforeAll, beforeEach, describe, expect, it} from "bun:test";
 import mongoose, {model, Schema} from "mongoose";
 import type {SecretProvider} from "./configurationPlugin";
-import {configurationPlugin} from "./configurationPlugin";
+import {configurationPlugin, flattenToDotPaths} from "./configurationPlugin";
+import {isDeletedPlugin} from "./plugins";
 
 // --- Test schema with secret fields ---
 
@@ -65,10 +66,36 @@ const simpleSchema = new Schema({
 simpleSchema.plugin(configurationPlugin);
 const SimpleConfigModel = model("SimpleConfiguration", simpleSchema) as any;
 
+// --- Schema opting into the _singleton unique index ---
+
+const indexedSchema = new Schema({
+  value: {default: "default", description: "A value", type: String},
+});
+indexedSchema.plugin(configurationPlugin, {enforceSingletonIndex: true});
+const IndexedConfigModel = model("IndexedConfiguration", indexedSchema) as any;
+
+// --- Soft-delete-aware schema ---
+
+const softDeleteSchema = new Schema({
+  value: {default: "default", description: "A value", type: String},
+});
+softDeleteSchema.plugin(configurationPlugin);
+softDeleteSchema.plugin(isDeletedPlugin);
+const SoftDeleteConfigModel = model("SoftDeleteConfiguration", softDeleteSchema) as any;
+
 describe("configurationPlugin", () => {
   describe("schema setup", () => {
-    it("adds a _singleton field with unique index", () => {
+    it("does not add a _singleton index by default", () => {
       const indexes = SimpleConfigModel.schema.indexes();
+      const singletonIndex = indexes.find(
+        ([fields]: [Record<string, any>]) => fields._singleton !== undefined
+      );
+      expect(singletonIndex).toBeUndefined();
+      expect(SimpleConfigModel.schema.path("_singleton")).toBeUndefined();
+    });
+
+    it("adds a _singleton field with unique index when enforceSingletonIndex is true", () => {
+      const indexes = IndexedConfigModel.schema.indexes();
       const singletonIndex = indexes.find(
         ([fields]: [Record<string, any>]) => fields._singleton !== undefined
       );
@@ -167,6 +194,50 @@ describe("configurationPlugin", () => {
       const resolved = await TestConfigModel.resolveSecrets(provider);
       expect(resolved.size).toBe(1);
       expect(resolved.get("apiKey")).toBe("resolved-key");
+    });
+
+    it("passes the discovered secret version to the provider", async () => {
+      const versionedSchema = new Schema({
+        token: {
+          default: "",
+          description: "Pinned secret",
+          secret: true,
+          secretName: "pinned-token",
+          secretVersion: "5",
+          type: String,
+        },
+      });
+      versionedSchema.plugin(configurationPlugin);
+      const VersionedModel = model("VersionedConfiguration", versionedSchema) as any;
+
+      const received: Array<{name: string; version?: string}> = [];
+      const provider: SecretProvider = {
+        getSecret: async (name: string, version?: string) => {
+          received.push({name, version});
+          return "value";
+        },
+        name: "versioned-provider",
+      };
+
+      await VersionedModel.resolveSecrets(provider);
+      expect(received).toEqual([{name: "pinned-token", version: "5"}]);
+    });
+  });
+
+  describe("flattenToDotPaths", () => {
+    it("flattens nested plain objects into dotted paths", () => {
+      expect(flattenToDotPaths({a: {b: 1}})).toEqual([["a.b", 1]]);
+    });
+
+    it("treats arrays as leaves", () => {
+      expect(flattenToDotPaths({a: [1, 2]})).toEqual([["a", [1, 2]]]);
+    });
+
+    it("treats null as a leaf and keeps top-level keys", () => {
+      expect(flattenToDotPaths({a: null, b: "x"})).toEqual([
+        ["a", null],
+        ["b", "x"],
+      ]);
     });
   });
 
@@ -295,6 +366,78 @@ describe("configurationPlugin", () => {
       } catch (err: any) {
         expect(err.title).toMatch(/Cannot hard-delete the configuration document/);
       }
+    });
+  });
+
+  describe("soft-delete-aware singleton (requires MongoDB)", () => {
+    let dbConnected = false;
+
+    beforeAll(async () => {
+      try {
+        if (mongoose.connection.readyState === 1) {
+          dbConnected = true;
+        } else {
+          await mongoose.connect("mongodb://127.0.0.1/terreno-config-test", {
+            connectTimeoutMS: 3000,
+            serverSelectionTimeoutMS: 3000,
+          });
+          dbConnected = true;
+        }
+      } catch {
+        dbConnected = false;
+      }
+    });
+
+    beforeEach(async () => {
+      if (!dbConnected) {
+        return;
+      }
+      try {
+        await SoftDeleteConfigModel.collection.drop();
+      } catch {
+        // Collection may not exist yet
+      }
+    });
+
+    it("operates on the non-deleted singleton", async () => {
+      if (!dbConnected) {
+        return;
+      }
+      const config = await SoftDeleteConfigModel.getConfig();
+      expect(config.value).toBe("default");
+      const updated = await SoftDeleteConfigModel.updateConfig({value: "live"});
+      expect(updated.value).toBe("live");
+      expect(updated.deleted).toBe(false);
+    });
+
+    it("allows a new singleton after the existing one is soft-deleted", async () => {
+      if (!dbConnected) {
+        return;
+      }
+      const first = await SoftDeleteConfigModel.getConfig();
+      // Soft delete by setting deleted: true (allowed)
+      first.deleted = true;
+      await first.save();
+
+      // A new non-deleted singleton can now be created
+      const second = await SoftDeleteConfigModel.getConfig();
+      expect(second.deleted).toBe(false);
+      expect(second._id.toString()).not.toBe(first._id.toString());
+    });
+
+    it("does not let updateConfig touch a soft-deleted document", async () => {
+      if (!dbConnected) {
+        return;
+      }
+      const first = await SoftDeleteConfigModel.getConfig();
+      first.deleted = true;
+      await first.save();
+
+      // updateConfig creates and targets a fresh non-deleted singleton
+      const updated = await SoftDeleteConfigModel.updateConfig({value: "fresh"});
+      expect(updated.deleted).toBe(false);
+      expect(updated.value).toBe("fresh");
+      expect(updated._id.toString()).not.toBe(first._id.toString());
     });
   });
 });

--- a/api/src/configurationPlugin.ts
+++ b/api/src/configurationPlugin.ts
@@ -337,7 +337,15 @@ export const configurationPlugin = (schema: Schema, options?: ConfigurationPlugi
       return (this as unknown as ConfigurationModel<Record<string, unknown>>).getConfig();
     }
 
-    const updated = await this.findOneAndUpdate(singletonFilter, {$set: setFields}, {new: true});
+    // runValidators keeps schema validation (enum/min/custom validators) on the
+    // patched paths, matching the prior doc.save() behavior. Legacy/out-of-schema
+    // fields already on the document are untouched (not in $set), so they are not
+    // re-validated.
+    const updated = await this.findOneAndUpdate(
+      singletonFilter,
+      {$set: setFields},
+      {new: true, runValidators: true}
+    );
     if (updated) {
       return updated;
     }
@@ -345,7 +353,11 @@ export const configurationPlugin = (schema: Schema, options?: ConfigurationPlugi
     // No singleton yet — create one (with subdocument defaults applied), then
     // apply the patch.
     await (this as unknown as ConfigurationModel<Record<string, unknown>>).getConfig();
-    return this.findOneAndUpdate(singletonFilter, {$set: setFields}, {new: true}).orFail();
+    return this.findOneAndUpdate(
+      singletonFilter,
+      {$set: setFields},
+      {new: true, runValidators: true}
+    ).orFail();
   };
 
   // Static: discover secret fields from schema options

--- a/api/src/configurationPlugin.ts
+++ b/api/src/configurationPlugin.ts
@@ -11,6 +11,12 @@ export interface SecretFieldMeta {
   path: string;
   secretProvider?: string;
   secretName: string;
+  /**
+   * Optional secret version to pin resolution to. When omitted the provider
+   * resolves the latest version. Discovered from the `secretVersion` schema
+   * path option.
+   */
+  version?: string;
 }
 
 /**
@@ -18,7 +24,15 @@ export interface SecretFieldMeta {
  */
 export interface SecretProvider {
   name: string;
-  getSecret(secretName: string): Promise<string | null>;
+  /**
+   * Resolve a secret value by name. Returns `null` when the secret is not found.
+   *
+   * @param secretName - The secret identifier (short name or provider-specific path).
+   * @param version - Optional version to pin resolution to. Providers that do not
+   *   support versioning (e.g. environment variables) ignore this parameter. When
+   *   omitted, the latest version is resolved.
+   */
+  getSecret(secretName: string, version?: string): Promise<string | null>;
 }
 
 /**
@@ -30,6 +44,18 @@ export interface ConfigurationPluginOptions {
    * Typically set during app startup so the model can resolve secrets on demand.
    */
   secretProvider?: SecretProvider;
+  /**
+   * When `true`, adds a `_singleton` sentinel field with a unique index to
+   * enforce the singleton constraint at the database level.
+   *
+   * Defaults to `false`. Leave this off when the consuming app already enforces
+   * a single non-deleted document via the pre-save guard (the default behavior)
+   * or via its own indexes/soft-delete plugin, to avoid double-enforcement and
+   * conflicting indexes.
+   *
+   * @defaultValue false
+   */
+  enforceSingletonIndex?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -75,14 +101,26 @@ export interface ConfigurationStatics<T extends object> {
   getConfig(): Promise<T & Document>;
   /** Get a specific value by dot-notation key. */
   getConfig<P extends Paths<T>>(key: P): Promise<PathValue<T, P>>;
-  /** Update the singleton configuration document (deep merge). */
+  /**
+   * Update the singleton configuration document.
+   *
+   * The patch is flattened into MongoDB dotted paths and applied with
+   * `findOneAndUpdate({$set})`. This preserves sibling fields inside nested
+   * subdocuments when a partial nested patch is supplied, and tolerates legacy /
+   * out-of-schema fields already persisted on the document (unlike a full
+   * `doc.save()`, which throws under `strict: "throw"`).
+   */
   updateConfig(updates: DeepPartial<T>): Promise<T & Document>;
   /** Get secret field metadata discovered from the schema. */
   getSecretFields(): SecretFieldMeta[];
   /**
    * Resolve all secret field values from a provider.
    * Uses the provider passed here, or falls back to the one configured in the plugin options.
-   * Returns a map of path -> value.
+   * Returns an **in-memory** map of path -> value for programmatic use (startup
+   * self-checks, request-time resolution).
+   *
+   * This method never persists resolved values. Secret material must never be
+   * written to the configuration document.
    */
   resolveSecrets(provider?: SecretProvider): Promise<Map<string, string>>;
 }
@@ -104,6 +142,47 @@ export interface ConfigurationStatics<T extends object> {
 export interface ConfigurationModel<T extends object> extends Model<T>, ConfigurationStatics<T> {}
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Flattens a nested patch into MongoDB-style dotted paths, recursing into plain
+ * objects only; arrays and other values are treated as leaves.
+ *
+ * @example
+ * flattenToDotPaths({a: {b: 1}}) // => [["a.b", 1]]
+ */
+export const flattenToDotPaths = (
+  obj: Record<string, unknown>,
+  prefix = ""
+): Array<[string, unknown]> => {
+  const out: Array<[string, unknown]> = [];
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    const isPlainObject =
+      value !== null &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      Object.getPrototypeOf(value) === Object.prototype;
+    if (isPlainObject) {
+      out.push(...flattenToDotPaths(value as Record<string, unknown>, path));
+    } else {
+      out.push([path, value]);
+    }
+  }
+  return out;
+};
+
+/**
+ * Builds the filter used to locate the singleton document. When the schema is
+ * soft-delete aware (has a `deleted` path, e.g. via `isDeletedPlugin`), the
+ * singleton is "the one non-deleted document"; otherwise any document matches.
+ */
+const buildSingletonFilter = (schema: Schema): Record<string, unknown> => {
+  return schema.path("deleted") ? {deleted: false} : {};
+};
+
+// ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
 
@@ -111,13 +190,23 @@ export interface ConfigurationModel<T extends object> extends Model<T>, Configur
  * Mongoose schema plugin that adds singleton configuration behavior.
  *
  * Adds:
- * - Pre-save hook enforcing exactly one document
+ * - Pre-save hook enforcing exactly one non-deleted document (soft-delete aware
+ *   when the schema has a `deleted` path, e.g. via `isDeletedPlugin`)
  * - `getConfig()` static: fetches or creates the singleton (full doc or keyed value)
- * - `updateConfig(updates)` static: patches the singleton
+ * - `updateConfig(updates)` static: patches the singleton via `findOneAndUpdate({$set})`
+ *   with dotted paths (preserves sibling subdoc fields; tolerates legacy fields)
  * - `getSecretFields()` static: returns metadata for fields with `secret: true`
- * - `resolveSecrets(provider?)` static: fetches secret values, using the plugin provider by default
+ * - `resolveSecrets(provider?)` static: resolves secret values into an in-memory map,
+ *   using the plugin provider by default (never persists values)
+ * - Hard-delete blockers (`deleteOne`/`deleteMany`/`findOneAndDelete`); soft deletes
+ *   (setting `deleted: true`) are allowed
  *
- * Mark fields as secrets using schema path options:
+ * Soft deletes are allowed and a soft-deleted document does not block creating a
+ * new singleton. The `_singleton` unique index is opt-in via
+ * `enforceSingletonIndex` (default off).
+ *
+ * Mark fields as secrets using schema path options. Pin a version with the
+ * optional `secretVersion` option:
  * ```typescript
  * const configSchema = new Schema({
  *   apiKey: {
@@ -125,6 +214,7 @@ export interface ConfigurationModel<T extends object> extends Model<T>, Configur
  *     description: "Third-party API key",
  *     secret: true,
  *     secretName: "my-api-key",
+ *     secretVersion: "3", // optional — resolves "latest" when omitted
  *   },
  * });
  * configSchema.plugin(configurationPlugin, {secretProvider: new EnvSecretProvider()});
@@ -136,24 +226,31 @@ export const configurationPlugin = (schema: Schema, options?: ConfigurationPlugi
   // Apply findOneOrNone so the singleton lookup avoids bare Model.findOne (idempotent).
   findOneOrNone(schema);
 
-  // Add a sentinel field with a unique index to enforce singleton at the DB level.
-  // All config documents get _singleton: "config", and the unique index prevents duplicates.
-  schema.add({
-    _singleton: {
-      default: "config",
-      description: "Sentinel field enforcing singleton constraint",
-      immutable: true,
-      select: false,
-      type: String,
-    },
-  });
-  schema.index({_singleton: 1}, {unique: true});
+  // Optionally add a sentinel field with a unique index to enforce the singleton
+  // at the database level. This is opt-in (default off) so it does not conflict
+  // with consumers that already enforce a single non-deleted document via the
+  // pre-save guard below or via their own soft-delete plugin/indexes.
+  if (pluginOptions.enforceSingletonIndex) {
+    schema.add({
+      _singleton: {
+        default: "config",
+        description: "Sentinel field enforcing singleton constraint",
+        immutable: true,
+        select: false,
+        type: String,
+      },
+    });
+    schema.index({_singleton: 1}, {unique: true});
+  }
 
-  // Enforce singleton: only one document allowed (application-level guard)
+  // Enforce singleton: only one non-deleted document allowed (application-level
+  // guard). Soft-delete-aware: a soft-deleted document does not block creating a
+  // new singleton.
   schema.pre("save", async function () {
     if (this.isNew) {
+      const filter = buildSingletonFilter(schema);
       // Cheap existence check — no document needs to be returned.
-      const existing = await (this.constructor as Model<unknown>).exists({});
+      const existing = await (this.constructor as Model<unknown>).exists(filter);
       if (existing) {
         throw new APIError({
           status: 409,
@@ -183,9 +280,10 @@ export const configurationPlugin = (schema: Schema, options?: ConfigurationPlugi
 
   // Static: get the singleton configuration document or a value at a path (race-safe via upsert)
   schema.statics.getConfig = async function (key?: string): Promise<unknown> {
+    const singletonFilter = buildSingletonFilter(this.schema);
     const findSingleton = (): Promise<Document | null> =>
       (this as unknown as FindOneOrNonePlugin<unknown>).findOneOrNone(
-        {}
+        singletonFilter
       ) as Promise<Document | null>;
     let config: Document | null = await findSingleton();
     if (!config) {
@@ -222,14 +320,32 @@ export const configurationPlugin = (schema: Schema, options?: ConfigurationPlugi
     return value;
   };
 
-  // Static: update the singleton configuration document (race-safe)
+  // Static: update the singleton configuration document via $set dotted paths.
+  // Flattening to dotted paths preserves sibling subdoc fields and tolerates
+  // legacy/out-of-schema fields already persisted on the document.
   schema.statics.updateConfig = async function (
     updates: Record<string, unknown>
   ): Promise<unknown> {
-    const config = await (this as ConfigurationModel<Record<string, unknown>>).getConfig();
-    Object.assign(config, updates);
-    await (config as Document).save();
-    return config;
+    const singletonFilter = buildSingletonFilter(this.schema);
+    const setFields: Record<string, unknown> = {};
+    for (const [path, value] of flattenToDotPaths(updates)) {
+      setFields[path] = value;
+    }
+
+    // Nothing to set — return the current singleton (creating it if missing).
+    if (Object.keys(setFields).length === 0) {
+      return (this as unknown as ConfigurationModel<Record<string, unknown>>).getConfig();
+    }
+
+    const updated = await this.findOneAndUpdate(singletonFilter, {$set: setFields}, {new: true});
+    if (updated) {
+      return updated;
+    }
+
+    // No singleton yet — create one (with subdocument defaults applied), then
+    // apply the patch.
+    await (this as unknown as ConfigurationModel<Record<string, unknown>>).getConfig();
+    return this.findOneAndUpdate(singletonFilter, {$set: setFields}, {new: true}).orFail();
   };
 
   // Static: discover secret fields from schema options
@@ -243,6 +359,7 @@ export const configurationPlugin = (schema: Schema, options?: ConfigurationPlugi
             path: prefix ? `${prefix}.${pathName}` : pathName,
             secretName: (opts.secretName as string) ?? pathName,
             secretProvider: opts.secretProvider as string | undefined,
+            version: opts.secretVersion as string | undefined,
           });
         }
         // Recurse into subschemas
@@ -275,7 +392,7 @@ export const configurationPlugin = (schema: Schema, options?: ConfigurationPlugi
 
     const results = await Promise.allSettled(
       secrets.map(async (meta: SecretFieldMeta) => {
-        const value = await resolvedProvider.getSecret(meta.secretName);
+        const value = await resolvedProvider.getSecret(meta.secretName, meta.version);
         if (value !== null) {
           resolved.set(meta.path, value);
         }

--- a/api/src/secretProviders.test.ts
+++ b/api/src/secretProviders.test.ts
@@ -1,0 +1,186 @@
+import {beforeEach, describe, expect, it} from "bun:test";
+
+import type {SecretProvider} from "./configurationPlugin";
+import {CachingSecretProvider, CompositeSecretProvider, EnvSecretProvider} from "./secretProviders";
+
+describe("EnvSecretProvider", () => {
+  beforeEach(() => {
+    delete process.env.MY_SECRET_KEY;
+  });
+
+  it("resolves from a SCREAMING_SNAKE_CASE env var", async () => {
+    process.env.MY_SECRET_KEY = "from-env";
+    const provider = new EnvSecretProvider();
+    expect(await provider.getSecret("my-secret-key")).toBe("from-env");
+  });
+
+  it("returns null when the env var is missing", async () => {
+    const provider = new EnvSecretProvider();
+    expect(await provider.getSecret("my-secret-key")).toBeNull();
+  });
+
+  it("ignores the version parameter", async () => {
+    process.env.MY_SECRET_KEY = "value";
+    const provider = new EnvSecretProvider();
+    expect(await provider.getSecret("my-secret-key", "5")).toBe("value");
+  });
+});
+
+describe("CompositeSecretProvider", () => {
+  it("throws when constructed with no providers", () => {
+    expect(() => new CompositeSecretProvider([])).toThrow();
+  });
+
+  it("returns the first non-null result", async () => {
+    const a: SecretProvider = {getSecret: async () => null, name: "a"};
+    const b: SecretProvider = {getSecret: async () => "from-b", name: "b"};
+    const c: SecretProvider = {getSecret: async () => "from-c", name: "c"};
+    const provider = new CompositeSecretProvider([a, b, c]);
+    expect(await provider.getSecret("x")).toBe("from-b");
+  });
+
+  it("falls through to the next provider when one throws", async () => {
+    const failing: SecretProvider = {
+      getSecret: async () => {
+        throw new Error("provider down");
+      },
+      name: "failing",
+    };
+    const fallback: SecretProvider = {getSecret: async () => "from-fallback", name: "fallback"};
+    const provider = new CompositeSecretProvider([failing, fallback]);
+    expect(await provider.getSecret("x")).toBe("from-fallback");
+  });
+
+  it("returns null when every provider yields null", async () => {
+    const a: SecretProvider = {getSecret: async () => null, name: "a"};
+    const b: SecretProvider = {getSecret: async () => null, name: "b"};
+    const provider = new CompositeSecretProvider([a, b]);
+    expect(await provider.getSecret("x")).toBeNull();
+  });
+
+  it("forwards the version parameter to each provider", async () => {
+    const seen: Array<string | undefined> = [];
+    const a: SecretProvider = {
+      getSecret: async (_name, version) => {
+        seen.push(version);
+        return null;
+      },
+      name: "a",
+    };
+    const b: SecretProvider = {
+      getSecret: async (_name, version) => {
+        seen.push(version);
+        return "value";
+      },
+      name: "b",
+    };
+    const provider = new CompositeSecretProvider([a, b]);
+    await provider.getSecret("x", "7");
+    expect(seen).toEqual(["7", "7"]);
+  });
+
+  it("builds a composite name from the underlying providers", () => {
+    const provider = new CompositeSecretProvider([
+      {getSecret: async () => null, name: "gcp"},
+      {getSecret: async () => null, name: "env"},
+    ]);
+    expect(provider.name).toBe("composite(gcp,env)");
+  });
+});
+
+describe("CachingSecretProvider", () => {
+  it("memoizes a value within the TTL (single underlying call)", async () => {
+    let calls = 0;
+    const underlying: SecretProvider = {
+      getSecret: async () => {
+        calls++;
+        return "value";
+      },
+      name: "underlying",
+    };
+    const provider = new CachingSecretProvider(underlying, {ttlMs: 10_000});
+    expect(await provider.getSecret("x")).toBe("value");
+    expect(await provider.getSecret("x")).toBe("value");
+    expect(calls).toBe(1);
+  });
+
+  it("re-fetches after clear()", async () => {
+    let calls = 0;
+    const underlying: SecretProvider = {
+      getSecret: async () => {
+        calls++;
+        return `value-${calls}`;
+      },
+      name: "underlying",
+    };
+    const provider = new CachingSecretProvider(underlying, {ttlMs: 10_000});
+    expect(await provider.getSecret("x")).toBe("value-1");
+    provider.clear();
+    expect(await provider.getSecret("x")).toBe("value-2");
+    expect(calls).toBe(2);
+  });
+
+  it("re-fetches after the TTL expires", async () => {
+    let calls = 0;
+    const underlying: SecretProvider = {
+      getSecret: async () => {
+        calls++;
+        return `value-${calls}`;
+      },
+      name: "underlying",
+    };
+    const provider = new CachingSecretProvider(underlying, {ttlMs: 1});
+    expect(await provider.getSecret("x")).toBe("value-1");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(await provider.getSecret("x")).toBe("value-2");
+    expect(calls).toBe(2);
+  });
+
+  it("caches different versions independently", async () => {
+    const seen: Array<string | undefined> = [];
+    const underlying: SecretProvider = {
+      getSecret: async (_name, version) => {
+        seen.push(version);
+        return `v-${version ?? "latest"}`;
+      },
+      name: "underlying",
+    };
+    const provider = new CachingSecretProvider(underlying, {ttlMs: 10_000});
+    expect(await provider.getSecret("x", "1")).toBe("v-1");
+    expect(await provider.getSecret("x", "2")).toBe("v-2");
+    // Cached hits, no additional underlying calls.
+    expect(await provider.getSecret("x", "1")).toBe("v-1");
+    expect(seen).toEqual(["1", "2"]);
+  });
+
+  it("clearKey invalidates a single secret", async () => {
+    let calls = 0;
+    const underlying: SecretProvider = {
+      getSecret: async () => {
+        calls++;
+        return `value-${calls}`;
+      },
+      name: "underlying",
+    };
+    const provider = new CachingSecretProvider(underlying, {ttlMs: 10_000});
+    await provider.getSecret("x");
+    provider.clearKey("x");
+    await provider.getSecret("x");
+    expect(calls).toBe(2);
+  });
+
+  it("caches null results", async () => {
+    let calls = 0;
+    const underlying: SecretProvider = {
+      getSecret: async () => {
+        calls++;
+        return null;
+      },
+      name: "underlying",
+    };
+    const provider = new CachingSecretProvider(underlying, {ttlMs: 10_000});
+    expect(await provider.getSecret("missing")).toBeNull();
+    expect(await provider.getSecret("missing")).toBeNull();
+    expect(calls).toBe(1);
+  });
+});

--- a/api/src/secretProviders.ts
+++ b/api/src/secretProviders.ts
@@ -28,7 +28,11 @@ interface SecretManagerModule {
 export class EnvSecretProvider implements SecretProvider {
   name = "env";
 
-  async getSecret(secretName: string): Promise<string | null> {
+  /**
+   * Resolve a secret from an environment variable. Environment variables have no
+   * versions, so the optional `version` parameter is ignored.
+   */
+  async getSecret(secretName: string, _version?: string): Promise<string | null> {
     // Convert secret name to env var format: "openai-api-key" → "OPENAI_API_KEY"
     const envKey = secretName.replace(/[-.]/g, "_").toUpperCase();
     const value = process.env[envKey] ?? null;
@@ -96,16 +100,28 @@ export class GcpSecretProvider implements SecretProvider {
     return this.client;
   }
 
-  async getSecret(secretName: string): Promise<string | null> {
+  /**
+   * Resolve a secret from Google Cloud Secret Manager.
+   *
+   * @param secretName - A short secret id (e.g. "openai-api-key") or a full
+   *   resource path (e.g. "projects/p/secrets/s" or
+   *   "projects/p/secrets/s/versions/3").
+   * @param version - Optional version to resolve when `secretName` is a short id
+   *   (e.g. "3"). Defaults to "latest". Ignored when `secretName` already
+   *   contains an explicit `/versions/...` suffix.
+   */
+  async getSecret(secretName: string, version?: string): Promise<string | null> {
     const client = await this.getClient();
 
+    const resolvedVersion = version ?? "latest";
     let resourceName: string;
     if (secretName.startsWith("projects/")) {
-      resourceName = secretName.endsWith("/versions/latest")
+      // Honor a full resource path. Only append a version when one is not present.
+      resourceName = secretName.includes("/versions/")
         ? secretName
-        : `${secretName}/versions/latest`;
+        : `${secretName}/versions/${resolvedVersion}`;
     } else {
-      resourceName = `projects/${this.projectId}/secrets/${secretName}/versions/latest`;
+      resourceName = `projects/${this.projectId}/secrets/${secretName}/versions/${resolvedVersion}`;
     }
 
     try {
@@ -124,5 +140,129 @@ export class GcpSecretProvider implements SecretProvider {
       }
       throw error;
     }
+  }
+}
+
+/**
+ * Secret provider that delegates to an ordered list of providers, returning the
+ * first non-null result.
+ *
+ * A provider that throws is warn-logged (secret name only — never the value) and
+ * resolution falls through to the next provider. This makes it easy to compose a
+ * primary provider with a fallback, e.g. GCP with an environment-variable
+ * fallback:
+ *
+ * @example
+ * ```typescript
+ * const provider = new CompositeSecretProvider([
+ *   new GcpSecretProvider({projectId: "my-project"}),
+ *   new EnvSecretProvider(),
+ * ]);
+ * const key = await provider.getSecret("openai-api-key");
+ * ```
+ */
+export class CompositeSecretProvider implements SecretProvider {
+  name: string;
+  private providers: SecretProvider[];
+
+  constructor(providers: SecretProvider[]) {
+    if (!providers || providers.length === 0) {
+      throw new APIError({
+        status: 500,
+        title: "CompositeSecretProvider requires at least one provider",
+      });
+    }
+    this.providers = providers;
+    this.name = `composite(${providers.map((p) => p.name).join(",")})`;
+  }
+
+  async getSecret(secretName: string, version?: string): Promise<string | null> {
+    for (const provider of this.providers) {
+      try {
+        const value = await provider.getSecret(secretName, version);
+        if (value !== null) {
+          return value;
+        }
+      } catch (error: unknown) {
+        // Never log the secret value — only the name and which provider failed.
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn(
+          `CompositeSecretProvider: provider ${provider.name} failed for secret ${secretName}: ${message}`
+        );
+      }
+    }
+    return null;
+  }
+}
+
+/**
+ * Options for CachingSecretProvider.
+ */
+export interface CachingSecretProviderOptions {
+  /** Time-to-live for cached values, in milliseconds. Defaults to 60_000 (1 minute). */
+  ttlMs?: number;
+}
+
+interface CacheEntry {
+  value: string | null;
+  expiresAt: number;
+}
+
+/**
+ * Secret provider that wraps any provider with an in-memory TTL cache.
+ *
+ * Cache entries are keyed by `secretName@version` so that pinned versions are
+ * cached independently. `null` results (secret not found) are cached too, to
+ * avoid hammering the underlying provider for missing secrets. Secret values are
+ * never logged.
+ *
+ * Use `clear()` to drop the entire cache (e.g. on rotation) or `clearKey()` to
+ * invalidate a single secret.
+ *
+ * @example
+ * ```typescript
+ * const provider = new CachingSecretProvider(
+ *   new CompositeSecretProvider([gcp, env]),
+ *   {ttlMs: 30_000}
+ * );
+ * ```
+ */
+export class CachingSecretProvider implements SecretProvider {
+  name: string;
+  private provider: SecretProvider;
+  private ttlMs: number;
+  private cache = new Map<string, CacheEntry>();
+
+  constructor(provider: SecretProvider, options?: CachingSecretProviderOptions) {
+    this.provider = provider;
+    this.ttlMs = options?.ttlMs ?? 60_000;
+    this.name = `caching(${provider.name})`;
+  }
+
+  private cacheKey(secretName: string, version?: string): string {
+    return `${secretName}@${version ?? "latest"}`;
+  }
+
+  async getSecret(secretName: string, version?: string): Promise<string | null> {
+    const key = this.cacheKey(secretName, version);
+    const now = Date.now();
+    const cached = this.cache.get(key);
+    if (cached && cached.expiresAt > now) {
+      return cached.value;
+    }
+
+    const value = await this.provider.getSecret(secretName, version);
+    this.cache.set(key, {expiresAt: now + this.ttlMs, value});
+    return value;
+  }
+
+  /** Clears the entire cache. Useful on secret rotation and in tests. */
+  clear(): void {
+    this.cache.clear();
+  }
+
+  /** Invalidates a single cached secret by name (and optional version). */
+  clearKey(secretName: string, version?: string): void {
+    this.cache.delete(this.cacheKey(secretName, version));
   }
 }

--- a/example-backend/src/models/appConfiguration.ts
+++ b/example-backend/src/models/appConfiguration.ts
@@ -1,12 +1,28 @@
-import {type ConfigurationModel, configurationPlugin, createdUpdatedPlugin} from "@terreno/api";
+import {
+  CachingSecretProvider,
+  CompositeSecretProvider,
+  type ConfigurationModel,
+  configurationPlugin,
+  createdUpdatedPlugin,
+  EnvSecretProvider,
+} from "@terreno/api";
 import mongoose, {Schema} from "mongoose";
 
 /**
  * Example configuration model demonstrating the Terreno configuration system.
  *
  * Each top-level subschema becomes a section in the admin configuration UI.
- * Fields marked with `secret: true` can be resolved from a SecretProvider.
+ * Fields marked with `secret: true` are resolved on-demand from a
+ * SecretProvider (never persisted to the document).
+ *
+ * The provider below composes sources (here just env vars, but production apps
+ * typically prepend a `GcpSecretProvider`) and wraps them in a short-TTL cache:
+ *   new CachingSecretProvider(new CompositeSecretProvider([gcp, env]), {ttlMs})
  */
+const secretProvider = new CachingSecretProvider(
+  new CompositeSecretProvider([new EnvSecretProvider()]),
+  {ttlMs: 60_000}
+);
 
 const generalSchema = new Schema(
   {
@@ -131,7 +147,7 @@ const appConfigSchema = new Schema<AppConfigDocument>(
   {strict: "throw", toJSON: {virtuals: true}, toObject: {virtuals: true}}
 );
 
-appConfigSchema.plugin(configurationPlugin);
+appConfigSchema.plugin(configurationPlugin, {secretProvider});
 appConfigSchema.plugin(createdUpdatedPlugin);
 
 export const AppConfiguration = mongoose.model<AppConfigDocument>(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Evolves `@terreno/api`'s configuration/secret handling so a HIPAA-regulated consumer can route all config and secret access through the framework without secret **values** ever landing in MongoDB. Implements Tasks 1–6 from the spec with tests and a changelog entry. Behavior changes are documented and the version is bumped to `0.20.0`.

## Changes

### Task 1 — Stop persisting secret values (`configurationApp.ts`)
- `POST {basePath}/list-secrets` is now a **read-only validation/status** endpoint. It no longer resolves secrets into the document or returns values — it returns only `path`, `secretName`, `version`, and `resolvable`/`isConfigured` per secret field. A `POST {basePath}/validate-secrets` alias with identical behavior is registered.
- `PATCH {basePath}` **strips `secret: true` fields** from the incoming body, so secret values can never be written through the update path.
- `resolveSecrets()` remains in-memory only; audited all framework call sites — nothing writes resolved values back to the model.

### Task 2 — `updateConfig` via `$set` dotted paths (`configurationPlugin.ts`)
- Reimplemented `updateConfig` to flatten patches into dotted paths and apply via `findOneAndUpdate({$set}, {new:true})`. Preserves sibling subdoc fields on partial nested patches and tolerates legacy/out-of-schema fields already persisted under `strict: "throw"`.

### Task 3 — Soft-delete-aware singleton (`configurationPlugin.ts`)
- `getConfig`, `updateConfig`, and the pre-save guard operate on `{deleted: false}` when the schema has a `deleted` path. A soft-deleted doc no longer blocks creating a new singleton; hard deletes remain blocked.
- The `_singleton` unique index is now **opt-in** via `enforceSingletonIndex` (default `false`).

### Task 4 — Optional `version` on secret resolution
- `SecretProvider.getSecret(secretName, version?)`. `GcpSecretProvider` builds `.../versions/{version}` (default `latest`, full paths still honored); `EnvSecretProvider` ignores it. Fields may declare `secretVersion`, surfaced on `SecretFieldMeta.version` and passed through `resolveSecrets`.

### Task 5 — Composite + caching providers (`secretProviders.ts`)
- `CompositeSecretProvider` (first non-null; warn-logs name only and falls through on error).
- `CachingSecretProvider` (TTL cache keyed by `secretName@version`, with `clear()`/`clearKey()`). Never logs values.

### Task 6 — Pluggable permissions + update hooks (`configurationApp.ts`)
- `permissions: {read?, update?, meta?, listSecrets?}` accepts terreno permission functions (e.g. `[IsStaff]`), AND-combined like `modelRouter`; defaults to admin-only.
- `preUpdate(body, req)` and `postUpdate(config, prevValue, req)` hooks for validation and audit logging; both payloads are secret-redacted.

## Cross-cutting
- Secret values never touch MongoDB documents, logs, audit payloads, API responses, or error messages.
- Back-compat preserved except the intentional, documented `list-secrets` change.
- Updated exported types, JSDoc, and `example-backend` to demonstrate `CachingSecretProvider(CompositeSecretProvider([...]))`.

## Testing
- New `secretProviders.test.ts`; extended `configurationPlugin.test.ts` and `configuration.test.ts`.
- Full `@terreno/api` suite: **1137 pass / 0 fail**. `bun run lint` and `bun tsc` clean. Full workspace `compile` passes (incl. `example-backend`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e099dac-766e-4f78-b10d-b181de4ef94a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e099dac-766e-4f78-b10d-b181de4ef94a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

