### PR TITLE
feat(ai): export ./parseAiJson subpath from @terreno/ai

### DIFF
--- a/ai/package.json
+++ b/ai/package.json
@@ -49,6 +49,12 @@
       "import": "./dist/langfuseApp.js",
       "require": "./dist/langfuseApp.js",
       "default": "./dist/langfuseApp.js"
+    },
+    "./parseAiJson": {
+      "types": "./dist/service/parseAiJson.d.ts",
+      "import": "./dist/service/parseAiJson.js",
+      "require": "./dist/service/parseAiJson.js",
+      "default": "./dist/service/parseAiJson.js"
     }
   },
   "homepage": "https://github.com/FlourishHealth/terreno#readme",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `./parseAiJson` subpath export to `@terreno/ai` so downstream consumers can import the JSON-parsing helpers directly without patching `node_modules/@terreno/ai/package.json`.

Previously, downstream apps had to apply a `patch-package` diff to add this export. This change upstreams that patch.

## Change

```jsonc
"./parseAiJson": {
  "types": "./dist/service/parseAiJson.d.ts",
  "import": "./dist/service/parseAiJson.js",
  "require": "./dist/service/parseAiJson.js",
  "default": "./dist/service/parseAiJson.js"
}
```

The export points to the already-compiled `src/service/parseAiJson.ts`, which exposes `parseAiJson` and `normalizeLlmJsonTextForStructuredOutput`. These remain re-exported from the package root (`@terreno/ai`) as well — this just adds a dedicated subpath.

## Verification

- `bun run bootstrap` — full workspace compiles cleanly, including `@terreno/ai`.
- Confirmed dist artifacts exist at the declared paths (`dist/service/parseAiJson.{js,d.ts}`).
- `require.resolve("@terreno/ai/parseAiJson")` resolves to `dist/service/parseAiJson.js` and exposes `parseAiJson` + `normalizeLlmJsonTextForStructuredOutput`.
- `biome check ./src` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6e7173b-c181-410a-9f28-772fe5af86da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6e7173b-c181-410a-9f28-772fe5af86da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

