### PR TITLE
Planning: terreno-blend question gate before IP

### DIFF
--- a/plugins/terreno-planning/skills/terreno-blend/SKILL.md
+++ b/plugins/terreno-planning/skills/terreno-blend/SKILL.md
@@ -13,6 +13,7 @@ Turn a raw request into an Implementation Plan (IP) using the existing `/ip` str
 - Output is the IP document (plus optional acceptance criteria and optional E2E test scaffolding when requested).
 - Keep scope bounded and explicit.
 - Preserve existing project conventions, tool usage, and repository patterns.
+- **Question-first:** do not write the IP (or any section that commits product or architecture decisions) until blocking questions are asked and the user has answered. Present options as questions or labeled alternatives (A/B/C), not as a finalized plan.
 
 ## Project Registry
 
@@ -42,16 +43,29 @@ If a project is not in the registry, resolve it with `gh repo view <input>`.
 
 ### Step 2: Research context
 
-Produce a complete research artifact before shaping:
+Produce a complete research artifact before any committed plan shape:
 
 1. Scope statement and what will be investigated.
 2. Deep codebase read (models/routes/screens/components/tests/docs/rules).
 3. External research for APIs/libraries/best practices.
-4. Findings document with summary, options, recommendation, open questions, references.
-5. Iterate with user feedback.
+4. Findings document with summary, **candidate options with tradeoffs** (do not pick a single “chosen” architecture as fact), **open questions**, references. Avoid a narrative that reads like a finished implementation decision.
+5. Save draft research; **stop** for user input on factual gaps or repo-specific ambiguities if needed.
 6. Save final research as `research.md`.
 
-### Step 3: Shape and question
+### Step 3: Clarification pass (mandatory — blocks Steps 4–6)
+
+**Stop here before writing the IP or task list with decided outcomes.**
+
+1. Emit a numbered **Blocking questions** list: product scope, data ownership, API/auth patterns, UX/navigation, rollout/feature flags, migrations, and anything not inferable with high confidence from the PRD + repo.
+2. For each item where multiple approaches exist, present **options** (e.g. A/B/C) and the tradeoffs — **do not state one option as the plan** until the user chooses.
+3. Optionally add a short **Non-blocking / nice-to-have** questions section (can default if user defers).
+4. **End this step with an explicit pause:** ask the user to answer the blocking questions (or explicitly approve named assumptions). **Do not proceed** to Step 4, Step 5, or Step 6 until you have those answers in the conversation.
+
+If the user has not yet answered blocking questions, you may refine research or re-read code, but you must **not** write `docs/implementationPlans/` IP content or `docs/tasks/` as if decisions were final.
+
+### Step 4: Shape (after answers)
+
+Only after Step 3 answers (or explicit assumption approvals):
 
 #### Phase 1: Models + APIs first
 
@@ -70,9 +84,11 @@ Define:
 - Risks and mitigations.
 - Explicit not-included scope.
 
-### Step 4: Plan sections (optional deep pass)
+Ground every decision in the user’s answers; call out any residual ambiguity as a follow-up question before generating the IP.
 
-Deepen any section as needed:
+### Step 5: Plan sections (optional deep pass)
+
+Deepen any section as needed (same section list as before). Skip or shorten if the user wants a lighter IP.
 
 1. Models
 2. APIs
@@ -83,7 +99,7 @@ Deepen any section as needed:
 7. Activity log and user updates
 8. Not included / future work
 
-### Step 5: Generate IP output
+### Step 6: Generate IP output
 
 Write the final IP with the same structure used by legacy `/ip`:
 
@@ -102,20 +118,20 @@ Persist planning artifacts in the standard repo paths:
 - Save the final IP document under `docs/implementationPlans/`.
 - Save the executable task breakdown under `docs/tasks/`.
 
-### Step 6: Acceptance criteria (optional)
+### Step 7: Acceptance criteria (optional)
 
 - Parse the IP into testable outcomes.
 - Add criteria covering happy path, edge/error paths, auth/permissions, data integrity, and regressions.
 - Ensure testIDs required by criteria are explicitly called out.
 
-### Step 7: E2E test planning/generation (optional)
+### Step 8: E2E test planning/generation (optional)
 
 - Read IP + acceptance criteria.
 - Identify files to create.
 - Identify missing `testID`s that must be added first.
 - Generate Playwright plan/tests where requested.
 
-### Step 8: Dual-model review (optional)
+### Step 9: Dual-model review (optional)
 
 Run independent review passes (parallel) and merge findings:
 
@@ -124,7 +140,7 @@ Run independent review passes (parallel) and merge findings:
 - Verify critical claims.
 - Update IP with review log.
 
-### Step 9: Attack and adjust (optional)
+### Step 10: Attack and adjust (optional)
 
 Stress-test assumptions, then tighten scope/plan before implementation.
 
@@ -205,4 +221,4 @@ Close a single IP and keep files/index consistent.
 
 - Keep inline annotations (`%%`) behavior for user-provided instructions in plan/task artifacts.
 - Preserve MCP/Linear/tool references already present in existing workflows.
-- Keep recommendations opinionated and evidence-based.
+- Keep recommendations opinionated and evidence-based **after** the clarification pass; during research and Step 3, frame strong takes as options to choose from, not as the committed plan.

--- a/plugins/terreno-planning/skills/terreno-blend/SKILL.md
+++ b/plugins/terreno-planning/skills/terreno-blend/SKILL.md
@@ -14,6 +14,7 @@ Turn a raw request into an Implementation Plan (IP) using the existing `/ip` str
 - Keep scope bounded and explicit.
 - Preserve existing project conventions, tool usage, and repository patterns.
 - **Question-first:** do not write the IP (or any section that commits product or architecture decisions) until blocking questions are asked and the user has answered. Present options as questions or labeled alternatives (A/B/C), not as a finalized plan.
+- **Post-attack questions:** when the Attack and adjust phase (Step 10) runs, always follow with a dedicated question pass (Step 11) and user answers before treating the plan as implementation-ready.
 
 ## Project Registry
 
@@ -144,6 +145,18 @@ Run independent review passes (parallel) and merge findings:
 
 Stress-test assumptions, then tighten scope/plan before implementation.
 
+Document what changed during attack (scope cuts, new risks, deferred work). **If Step 10 runs, you must continue to Step 11** before finalizing the IP for handoff.
+
+### Step 11: Post-attack clarification (mandatory when Step 10 ran)
+
+Run this step whenever Step 10 (Attack and adjust) was executed. If Step 10 was skipped, Step 11 is optional (skip or ask a single catch-all: any remaining ambiguities?).
+
+1. Summarize attack outcomes: what was challenged, tightened, deferred, or newly exposed.
+2. Emit numbered **blocking follow-up questions** raised by the attack pass (risk acceptance, sequencing, owner/product sign-off, cut-line for “not included,” technical bets).
+3. Present options where tradeoffs remain — **do not** bake unresolved attack findings into the IP as silent decisions.
+4. **Pause** for explicit user answers or named-assumption approval.
+5. Only then update `docs/implementationPlans/` and `docs/tasks/` to match; if no file edits are needed, still confirm alignment in the thread before calling the plan final.
+
 ## Lifecycle Operations
 
 Support the existing lifecycle commands from legacy `/ip`:
@@ -221,4 +234,4 @@ Close a single IP and keep files/index consistent.
 
 - Keep inline annotations (`%%`) behavior for user-provided instructions in plan/task artifacts.
 - Preserve MCP/Linear/tool references already present in existing workflows.
-- Keep recommendations opinionated and evidence-based **after** the clarification pass; during research and Step 3, frame strong takes as options to choose from, not as the committed plan.
+- Keep recommendations opinionated and evidence-based **after** the clarification pass; during research and Step 3, frame strong takes as options to choose from, not as the committed plan. The same applies after Step 10 until Step 11 is complete: attack may surface new choices — ask, do not assume.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the `terreno-blend` skill (`plugins/terreno-planning/skills/terreno-blend/SKILL.md`) so the workflow **pauses on blocking questions** instead of drafting the implementation plan with decisions already baked in.

## Changes

- **Overview:** question-first rule — no IP (or decision-committing sections) until blocking questions are answered; options framed as questions or A/B/C, not a finalized plan.
- **Step 2 (Research):** findings emphasize candidate options and tradeoffs; avoid a narrative that reads like a finished architecture; optional stop for factual gaps before saving `research.md`.
- **New Step 3 (Clarification pass):** mandatory numbered blocking questions, explicit pause, no progression to shape / optional deep pass / IP or `docs/tasks/` writes until the user answers or explicitly approves named assumptions.
- **Former shape/plan/IP steps** renumbered to Steps 4–6; optional steps 7–10 renumbered accordingly.
- **Conventions:** strong recommendations belong after clarification; during research and Step 3, present takes as options, not committed plan.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3463668-4713-41b7-9cbe-2cc3efadb040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3463668-4713-41b7-9cbe-2cc3efadb040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

