### PR TITLE
Planning: pour handoff loads dialin skill by file path (Cursor)

### DIFF
--- a/plugins/terreno-planning/skills/terreno-dialin/SKILL.md
+++ b/plugins/terreno-planning/skills/terreno-dialin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: terreno-dialin
-description: Run the reactive PR review loop — watch and fix CI plus bot/human comments until the PR is mergeable or times out. Use ONLY when a PR is already open — not for initial planning, feature implementation from scratch, or opening the PR itself.
+description: Run the reactive PR review loop — watch and fix CI plus bot/human comments until the PR is mergeable or times out. Use ONLY when a PR is already open — not for initial planning, feature implementation from scratch, or opening the PR itself. Typically entered after `terreno-pour`; load that workflow from plugins/terreno-planning/skills/terreno-pour/SKILL.md when needed (Cursor may not resolve plugin skill names alone).
 disable-model-invocation: true
 ---
 
@@ -10,7 +10,7 @@ Own all post-review-open reactive work: CI watching/fixing, comment triage/fixes
 
 ## Ownership Boundary
 
-Dialin starts after `terreno-pour` opens/updates the PR and triggers CI.
+Dialin starts after **Pour** opens/updates the PR and triggers CI. Pour’s procedure lives at `plugins/terreno-planning/skills/terreno-pour/SKILL.md` — read that file if you need pour scope or commit rules; do not assume `terreno-pour` is invocable by name alone in Cursor.
 Dialin exclusively owns all work after that handoff.
 
 ## Timer Loop Contract
@@ -33,7 +33,7 @@ Each cycle:
    - Clarifications / out-of-scope items
 4. Apply code fixes for actionable items.
 5. Run targeted checks.
-6. Commit + push fixes (same commit hygiene rules as `terreno-pour`; no AI attribution).
+6. Commit + push fixes (same commit hygiene rules as Pour — see `plugins/terreno-planning/skills/terreno-pour/SKILL.md`; no AI attribution).
 7. Re-check CI and continue loop.
 8. Reply to addressed comments and resolve threads when fully fixed.
 

--- a/plugins/terreno-planning/skills/terreno-pour/SKILL.md
+++ b/plugins/terreno-planning/skills/terreno-pour/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: terreno-pour
-description: Commit, push, and set up the PR, then hand off to terreno-dialin. Use ONLY when code is ready to enter review — not for implementation work, independent verification, or waiting on CI/comments after the PR is open.
+description: Commit, push, and set up the PR, then hand off by loading plugins/terreno-planning/skills/terreno-dialin/SKILL.md (Cursor does not reliably invoke sibling plugin skills by name alone). Use ONLY when code is ready to enter review — not for implementation work, independent verification, or waiting on CI/comments after the PR is open.
 disable-model-invocation: true
 ---
 
 # Pour
 
-Get work into review, then immediately hand ownership to `terreno-dialin`.
+Get work into review, then immediately hand ownership to **Dial In** by loading the dialin skill from disk (see Handoff).
 
 ## Scope Boundary
 
@@ -17,7 +17,7 @@ Pour owns only pre-review-open and review-open actions:
 3. Create/update draft PR.
 4. Resolve merge conflicts required to get PR updated.
 5. Ensure CI is triggered on the first push.
-6. Immediately invoke `terreno-dialin`.
+6. Immediately hand off to Dial In using the path in Handoff (do not rely on skill-name-only invocation).
 
 Pour must never block on CI completion or review comments.
 
@@ -60,8 +60,13 @@ If push/rebase/merge conflicts block PR update:
 
 As soon as PR is open/updated and CI has been triggered on first push:
 
-- Invoke `terreno-dialin` immediately.
-- Exit `terreno-pour` without waiting.
+**Cursor / plugin caveat:** Skills inside `plugins/terreno-planning/skills/` are not always registered as separately invocable skills. Treat the markdown file as the source of truth.
+
+1. Read `plugins/terreno-planning/skills/terreno-dialin/SKILL.md` from the repository root (same path on disk as this pour skill).
+2. Execute the **Dial In** procedure from that file immediately — same turn if possible — without waiting for CI to finish.
+3. Exit pour’s scope without blocking; Dial In owns the reactive loop from here.
+
+Optional: if your Cursor/plugin setup exposes a `/terreno-dialin` slash command and it successfully loads that skill, you may use it **instead of** step 1–2 only when you have confirmed it resolves to the same `terreno-dialin/SKILL.md` content.
 
 ## Branch/Repo Conventions
 

--- a/plugins/terreno-planning/skills/terreno-roast/SKILL.md
+++ b/plugins/terreno-planning/skills/terreno-roast/SKILL.md
@@ -116,4 +116,4 @@ For every commit:
 - All planned implementation tasks for the scoped slice are complete.
 - Tests are credible under anti-mocking rules.
 - No unresolved review findings remain from independent sub-agents.
-- Work is ready for `terreno-pour`.
+- Work is ready for **Pour** (`plugins/terreno-planning/skills/terreno-pour/SKILL.md`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cursor often does not register sibling skills under `plugins/terreno-planning/skills/` as separately invocable by name, so “invoke `terreno-dialin`” from **Pour** could fail. This change makes the handoff **path-based**: read `plugins/terreno-planning/skills/terreno-dialin/SKILL.md` and run that procedure.

## Changes

- **terreno-pour:** Handoff section documents the Cursor/plugin caveat, requires reading the dialin `SKILL.md` from the repo root, optional `/terreno-dialin` only when it maps to the same file. YAML description updated.
- **terreno-dialin:** Points to pour at `plugins/terreno-planning/skills/terreno-pour/SKILL.md` for scope/commit rules; description notes typical entry after pour.
- **terreno-roast:** Done criteria link pour via the same path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3463668-4713-41b7-9cbe-2cc3efadb040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3463668-4713-41b7-9cbe-2cc3efadb040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

