### PR TITLE
chore: sync bun.lock workspace package versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "admin-backend": {
       "name": "@terreno/admin-backend",
-      "version": "0.20.0",
+      "version": "0.20.2",
       "dependencies": {
         "@google-cloud/storage": "^7.15.0",
         "@terreno/api": "workspace:*",
@@ -36,7 +36,7 @@
     },
     "admin-frontend": {
       "name": "@terreno/admin-frontend",
-      "version": "0.20.0",
+      "version": "0.20.2",
       "dependencies": {
         "@terreno/ui": "workspace:*",
         "expo-router": "catalog:",
@@ -67,7 +67,7 @@
     },
     "admin-spa": {
       "name": "@terreno/admin-spa",
-      "version": "0.20.0",
+      "version": "0.20.2",
       "dependencies": {
         "@expo/vector-icons": "catalog:",
         "@react-native-async-storage/async-storage": "catalog:",
@@ -118,7 +118,7 @@
     },
     "ai": {
       "name": "@terreno/ai",
-      "version": "0.20.0",
+      "version": "0.20.2",
       "dependencies": {
         "@ai-sdk/mcp": "^1.0.21",
         "@google-cloud/storage": "^7.15.0",
@@ -153,7 +153,7 @@
     },
     "api": {
       "name": "@terreno/api",
-      "version": "0.20.0",
+      "version": "0.20.2",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@sentry/bun": "^10.25.0",
@@ -228,7 +228,7 @@
     },
     "api-health": {
       "name": "@terreno/api-health",
-      "version": "0.20.0",
+      "version": "0.20.2",
       "dependencies": {
         "@terreno/api": "workspace:*",
         "express": "^5.2.1",
@@ -431,7 +431,7 @@
     },
     "feature-flags": {
       "name": "@terreno/feature-flags",
-      "version": "0.20.0",
+      "version": "0.20.2",
       "dependencies": {
         "@openfeature/server-sdk": "catalog:",
         "@terreno/api": "workspace:*",
@@ -472,7 +472,7 @@
     },
     "rtk": {
       "name": "@terreno/rtk",
-      "version": "0.20.0",
+      "version": "0.20.2",
       "dependencies": {
         "@better-auth/expo": "^1.2.8",
         "@openfeature/core": "catalog:",
@@ -516,7 +516,7 @@
     },
     "ui": {
       "name": "@terreno/ui",
-      "version": "0.20.0",
+      "version": "0.20.2",
       "dependencies": {
         "@expo-google-fonts/nunito": "^0.4.2",
         "@expo-google-fonts/titillium-web": "^0.4.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The workspace `package.json` files list **0.20.2**, but `bun.lock` still recorded **0.20.0** for several workspace packages. This commit updates the lockfile so it matches the declared package versions after `bun install`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71697ce3-c5b3-4352-ada6-7034a63595e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71697ce3-c5b3-4352-ada6-7034a63595e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

