### PR TITLE
feat(example): showcase admin UI v2 in example-backend and example-frontend

### DIFF
--- a/admin-frontend/src/AdminHome.tsx
+++ b/admin-frontend/src/AdminHome.tsx
@@ -1,13 +1,4 @@
-import {
-  Box,
-  Button,
-  Card,
-  Heading,
-  Page,
-  printDateAndTime,
-  Spinner,
-  Text,
-} from "@terreno/ui";
+import {Box, Button, Card, Heading, Page, printDateAndTime, Spinner, Text} from "@terreno/ui";
 import type {Href} from "expo-router";
 import {router} from "expo-router";
 import React, {useCallback, useMemo} from "react";
@@ -55,6 +46,11 @@ interface AdminHomeProps {
   apiBase?: string;
   routeBase?: string;
   api: AdminApi;
+  /**
+   * When true, omits the outer {@link Page} wrapper so the dashboard can sit under a parent
+   * screen (for example, the Expo admin index together with tools and model cards).
+   */
+  embedded?: boolean;
 }
 
 const ModelStatRow: React.FC<{
@@ -257,9 +253,7 @@ const RecentActivityWidget: React.FC<{
             const label = String(row.recordLabel ?? row.recordId ?? "");
             const created = row.createdAt ?? row.created;
             const when =
-              typeof created === "string"
-                ? printDateAndTime(created, {defaultValue: created})
-                : "";
+              typeof created === "string" ? printDateAndTime(created, {defaultValue: created}) : "";
             return (
               <Box border="default" key={id || `${verb}-${label}`} padding={2} rounding="sm">
                 <Text size="sm">
@@ -320,9 +314,7 @@ const renderWidget = (params: {
     case "feature-flags-overrides":
       return <FeatureFlagsOverridesWidget model={featureFlagModel} routeBase={routeBase} />;
     case "versionConfig":
-      return (
-        <AdminVersionConfig api={api} apiBase={apiBase} embedded routeBase={routeBase} />
-      );
+      return <AdminVersionConfig api={api} apiBase={apiBase} embedded routeBase={routeBase} />;
     case "scriptRunner":
       return <ScriptRunnerWidget routeBase={routeBase} />;
     case "recentActivity":
@@ -336,7 +328,13 @@ const renderWidget = (params: {
  * Config-driven admin home dashboard: renders `home.slots` from `/admin/config` with built-in
  * widgets (stats, model grid, scripts, version config, audit recent activity).
  */
-export const AdminHome: React.FC<AdminHomeProps> = ({baseUrl, apiBase, routeBase, api}) => {
+export const AdminHome: React.FC<AdminHomeProps> = ({
+  baseUrl,
+  apiBase,
+  routeBase,
+  api,
+  embedded = false,
+}) => {
   const {apiBase: resolvedApiBase, routeBase: resolvedRouteBase} = resolveAdminBases({
     apiBase,
     baseUrl,
@@ -361,21 +359,33 @@ export const AdminHome: React.FC<AdminHomeProps> = ({baseUrl, apiBase, routeBase
   const sidebar = normalizeSidebarWidgets(slots?.sidebar);
 
   if (isLoading) {
+    const loadingBody = (
+      <Box alignItems="center" justifyContent="center" padding={6} testID="admin-home-loading">
+        <Spinner />
+      </Box>
+    );
+    if (embedded) {
+      return loadingBody;
+    }
     return (
       <Page maxWidth="100%" title={config?.home?.title ?? "Admin"}>
-        <Box alignItems="center" justifyContent="center" padding={6} testID="admin-home-loading">
-          <Spinner />
-        </Box>
+        {loadingBody}
       </Page>
     );
   }
 
   if (error || !config) {
+    const errorBody = (
+      <Box padding={4} testID="admin-home-error">
+        <Text color="error">Failed to load admin configuration.</Text>
+      </Box>
+    );
+    if (embedded) {
+      return errorBody;
+    }
     return (
       <Page maxWidth="100%" title="Admin">
-        <Box padding={4} testID="admin-home-error">
-          <Text color="error">Failed to load admin configuration.</Text>
-        </Box>
+        {errorBody}
       </Page>
     );
   }
@@ -391,49 +401,58 @@ export const AdminHome: React.FC<AdminHomeProps> = ({baseUrl, apiBase, routeBase
     routeBase: resolvedRouteBase,
   };
 
+  const dashboardBody = (
+    <Box gap={4} padding={embedded ? 0 : 4}>
+      {!embedded ? <Heading size="md">{title}</Heading> : null}
+
+      {navGlobal.length > 0 ? (
+        <Box direction="row" gap={3} testID="admin-home-slot-navGlobal" wrap>
+          {navGlobal.map((id) => (
+            <Box key={`ng-${id}`}>{renderWidget({...widgetParams, widgetId: id})}</Box>
+          ))}
+        </Box>
+      ) : null}
+
+      {contentTop.length > 0 ? (
+        <Box direction="column" gap={3} testID="admin-home-slot-contentTop">
+          {contentTop.map((id) => (
+            <Box key={`ct-${id}`}>{renderWidget({...widgetParams, widgetId: id})}</Box>
+          ))}
+        </Box>
+      ) : null}
+
+      <Box direction="row" gap={4} wrap>
+        {main.length > 0 ? (
+          <Box flex="grow" gap={3} minWidth={280} testID="admin-home-slot-main">
+            {main.map((id) => (
+              <Box key={`mn-${id}`}>{renderWidget({...widgetParams, widgetId: id})}</Box>
+            ))}
+          </Box>
+        ) : null}
+        {sidebar.length > 0 ? (
+          <Box
+            direction="column"
+            gap={3}
+            minWidth={280}
+            testID="admin-home-slot-sidebar"
+            width={320}
+          >
+            {sidebar.map((id) => (
+              <Box key={`sb-${id}`}>{renderWidget({...widgetParams, widgetId: id})}</Box>
+            ))}
+          </Box>
+        ) : null}
+      </Box>
+    </Box>
+  );
+
+  if (embedded) {
+    return dashboardBody;
+  }
+
   return (
     <Page maxWidth="100%" scroll title={title}>
-      <Box gap={4} padding={4}>
-        <Heading size="md">{title}</Heading>
-
-        {navGlobal.length > 0 ? (
-          <Box
-            direction="row"
-            gap={3}
-            testID="admin-home-slot-navGlobal"
-            wrap
-          >
-            {navGlobal.map((id) => (
-              <Box key={`ng-${id}`}>{renderWidget({...widgetParams, widgetId: id})}</Box>
-            ))}
-          </Box>
-        ) : null}
-
-        {contentTop.length > 0 ? (
-          <Box direction="column" gap={3} testID="admin-home-slot-contentTop">
-            {contentTop.map((id) => (
-              <Box key={`ct-${id}`}>{renderWidget({...widgetParams, widgetId: id})}</Box>
-            ))}
-          </Box>
-        ) : null}
-
-        <Box direction="row" gap={4} wrap>
-          {main.length > 0 ? (
-            <Box flex="grow" gap={3} minWidth={280} testID="admin-home-slot-main">
-              {main.map((id) => (
-                <Box key={`mn-${id}`}>{renderWidget({...widgetParams, widgetId: id})}</Box>
-              ))}
-            </Box>
-          ) : null}
-          {sidebar.length > 0 ? (
-            <Box direction="column" gap={3} minWidth={280} testID="admin-home-slot-sidebar" width={320}>
-              {sidebar.map((id) => (
-                <Box key={`sb-${id}`}>{renderWidget({...widgetParams, widgetId: id})}</Box>
-              ))}
-            </Box>
-          ) : null}
-        </Box>
-      </Box>
+      {dashboardBody}
     </Page>
   );
 };

--- a/admin-frontend/src/AdminModelList.tsx
+++ b/admin-frontend/src/AdminModelList.tsx
@@ -22,6 +22,10 @@ interface AdminModelListProps {
   configurationPath?: string;
   /** Additional custom screens to display as cards. Merged with any custom screens from the backend config. */
   customScreens?: AdminCustomScreen[];
+  /** When true, omits the outer {@link Page} wrapper for composition under a parent screen. */
+  embedded?: boolean;
+  /** When true, hides the model grid (for example when models are shown in {@link AdminHome}). */
+  hideModelsSection?: boolean;
 }
 
 const ScriptsCard: React.FC<{count: number; onPress: () => void}> = ({count, onPress}) => (
@@ -133,6 +137,8 @@ export const AdminModelList: React.FC<AdminModelListProps> = ({
   api,
   configurationPath,
   customScreens: propCustomScreens,
+  embedded = false,
+  hideModelsSection = false,
 }) => {
   const {apiBase: resolvedApiBase, routeBase: resolvedRouteBase} = resolveAdminBases({
     apiBase,
@@ -149,21 +155,33 @@ export const AdminModelList: React.FC<AdminModelListProps> = ({
   );
 
   if (isLoading) {
+    const loadingBody = (
+      <Box alignItems="center" justifyContent="center" padding={6}>
+        <Spinner />
+      </Box>
+    );
+    if (embedded) {
+      return loadingBody;
+    }
     return (
       <Page maxWidth="100%" title="Admin">
-        <Box alignItems="center" justifyContent="center" padding={6}>
-          <Spinner />
-        </Box>
+        {loadingBody}
       </Page>
     );
   }
 
   if (error || !config) {
+    const errorBody = (
+      <Box padding={4}>
+        <Text color="error">Failed to load admin configuration.</Text>
+      </Box>
+    );
+    if (embedded) {
+      return errorBody;
+    }
     return (
       <Page maxWidth="100%" title="Admin">
-        <Box padding={4}>
-          <Text color="error">Failed to load admin configuration.</Text>
-        </Box>
+        {errorBody}
       </Page>
     );
   }
@@ -173,29 +191,29 @@ export const AdminModelList: React.FC<AdminModelListProps> = ({
   const scripts = config.scripts ?? [];
   const hasToolCards = allCustomScreens.length > 0 || scripts.length > 0 || !!configurationPath;
 
-  return (
-    <Page maxWidth="100%" scroll title="Admin">
-      <Box gap={4} padding={4}>
-        {hasToolCards && (
-          <Box gap={2}>
-            <Heading size="sm">Tools</Heading>
-            <Box direction="row" gap={4} wrap>
-              {allCustomScreens.map((screen) => (
-                <CustomScreenCard
-                  key={screen.name}
-                  onPress={() => handlePress(screen.name)}
-                  screen={screen}
-                />
-              ))}
-              {scripts.length > 0 && (
-                <ScriptsCard count={scripts.length} onPress={() => handlePress("__scripts")} />
-              )}
-              {configurationPath && (
-                <ConfigurationCard onPress={() => router.push(configurationPath as Href)} />
-              )}
-            </Box>
+  const listBody = (
+    <Box gap={4} padding={embedded ? 0 : 4}>
+      {hasToolCards ? (
+        <Box gap={2}>
+          <Heading size="sm">Tools</Heading>
+          <Box direction="row" gap={4} wrap>
+            {allCustomScreens.map((screen) => (
+              <CustomScreenCard
+                key={screen.name}
+                onPress={() => handlePress(screen.name)}
+                screen={screen}
+              />
+            ))}
+            {scripts.length > 0 ? (
+              <ScriptsCard count={scripts.length} onPress={() => handlePress("__scripts")} />
+            ) : null}
+            {configurationPath ? (
+              <ConfigurationCard onPress={() => router.push(configurationPath as Href)} />
+            ) : null}
           </Box>
-        )}
+        </Box>
+      ) : null}
+      {!hideModelsSection ? (
         <Box gap={2}>
           <Heading size="sm">Models</Heading>
           <Box direction="row" gap={4} wrap>
@@ -204,7 +222,17 @@ export const AdminModelList: React.FC<AdminModelListProps> = ({
             ))}
           </Box>
         </Box>
-      </Box>
+      ) : null}
+    </Box>
+  );
+
+  if (embedded) {
+    return listBody;
+  }
+
+  return (
+    <Page maxWidth="100%" scroll title="Admin">
+      {listBody}
     </Page>
   );
 };

--- a/example-backend/README.md
+++ b/example-backend/README.md
@@ -50,6 +50,10 @@ Start the development server with hot reload:
 bun run dev
 ```
 
+## Admin (`AdminApp`)
+
+`src/server.ts` registers `@terreno/admin-backend` with a **full admin UI v2** surface for the example app: home dashboard slots (stats, model grid, feature-flag shortcut, scripts, version config, recent audit), per-model filters, fieldsets, list display and row links, read-only fields, bulk row actions, `onAdminAudit` → `AdminAuditLog`, maintenance scripts, and a `customScreens` entry for the Expo “Admin UI v2 map” route. Pair with `example-frontend` Profile → Admin to explore the UI.
+
 ## Scripts
 
 - `bun run dev` - Start development server with hot reload

--- a/example-backend/src/server.ts
+++ b/example-backend/src/server.ts
@@ -241,9 +241,17 @@ export async function start(skipListen = false): Promise<express.Application> {
       )
       .register(
         new AdminApp({
+          customScreens: [
+            {
+              description: "How this example wires Terreno admin UI v2",
+              displayName: "Admin UI v2 map",
+              name: "showcase",
+            },
+          ],
           home: {
             slots: {
-              main: ["modelsGrid"],
+              contentTop: ["feature-flags-overrides"],
+              main: ["modelStats", "modelsGrid"],
               navGlobal: ["scriptRunner"],
               sidebar: ["versionConfig", "recentActivity"],
             },
@@ -280,8 +288,21 @@ export async function start(skipListen = false): Promise<express.Application> {
               sortableFields: ["key", "name", "type", "enabled", "archived", "created"],
             },
             {
+              actions: [
+                {
+                  confirm: "Mark selected todos as completed?",
+                  id: "markComplete",
+                  label: "Mark completed",
+                  patchKeys: ["completed"],
+                },
+              ],
+              bulkPatchAllowlist: ["completed", "priority", "tags"],
               defaultSort: "-created",
               displayName: "Todos",
+              fieldsets: [
+                {fields: ["title", "tags", "priority", "completed"], title: "Task"},
+                {fields: ["ownerId"], title: "Ownership"},
+              ],
               filters: [
                 {field: "completed", kind: "boolean", label: "Completed"},
                 {
@@ -294,25 +315,37 @@ export async function start(skipListen = false): Promise<express.Application> {
                   kind: "choice",
                   label: "Priority",
                 },
+                {field: "created", kind: "dateRange", label: "Created"},
+                {field: "ownerId", kind: "ref", label: "Owner", refModel: "User"},
               ],
               group: "Examples",
+              listDisplay: ["title", "completed", "priority", "ownerId", "created", "tags"],
+              listDisplayLinks: ["title"],
               listFields: ["title", "completed", "ownerId", "created", "priority", "tags"],
               model: Todo,
               pageSize: 25,
               permissions: {delete: false},
+              readonlyFields: ["ownerId"],
+              realtime: true,
               routePath: "/todos",
               searchFields: ["title", "tags"],
               sortableFields: ["title", "completed", "created", "priority"],
             },
             {
               displayName: "Users",
+              fieldsets: [
+                {fields: ["email", "name"], title: "Profile"},
+                {fields: ["admin", "oauthProvider"], title: "Access"},
+              ],
               filters: [{field: "admin", kind: "boolean", label: "Admin user"}],
               group: "Users",
               hiddenFields: ["hash", "salt"],
+              listDisplayLinks: ["email"],
               listFields: ["email", "name", "admin", "created"],
               // biome-ignore lint/suspicious/noExplicitAny: User model type mismatch
               model: User as any,
               pageSize: 50,
+              readonlyFields: ["email"],
               routePath: "/users",
               searchFields: ["email", "name"],
               sortableFields: ["email", "name", "admin", "created"],
@@ -341,6 +374,25 @@ export async function start(skipListen = false): Promise<express.Application> {
                 content: {widget: "locale-content"},
                 defaultLocale: {widget: "locale-default"},
               },
+              fieldsets: [
+                {
+                  fields: ["title", "slug", "type", "version", "order", "active", "required"],
+                  title: "Basics",
+                },
+                {
+                  fields: ["content", "defaultLocale", "requireScrollToBottom", "checkboxes"],
+                  title: "Content",
+                },
+                {
+                  fields: [
+                    "captureSignature",
+                    "agreeButtonText",
+                    "allowDecline",
+                    "declineButtonText",
+                  ],
+                  title: "Actions",
+                },
+              ],
               filters: [
                 {field: "active", kind: "boolean", label: "Active"},
                 {
@@ -358,6 +410,7 @@ export async function start(skipListen = false): Promise<express.Application> {
                 },
               ],
               group: "Compliance",
+              listDisplay: ["title", "type", "version", "active", "order"],
               listFields: ["title", "type", "version", "active", "order"],
               model: ConsentForm,
               routePath: "/consent-forms",

--- a/example-frontend/README.md
+++ b/example-frontend/README.md
@@ -11,6 +11,7 @@ Example Expo app demonstrating full-stack Terreno usage with @terreno/api backen
 - **Profile Management**: User profile viewing and editing
 - **Tab Navigation**: Expo Router with file-based routing
 - **Cross-platform**: Runs on web, iOS, and Android
+- **Admin UI v2**: Profile → Admin uses `@terreno/admin-frontend` with `AdminHome` (config-driven dashboard from `/admin/config`) plus tools, models, configuration, scripts, and a static “Admin UI v2 map” screen — backed by the rich `AdminApp` setup in `example-backend`
 
 ## Prerequisites
 

--- a/example-frontend/app/admin/_layout.tsx
+++ b/example-frontend/app/admin/_layout.tsx
@@ -5,6 +5,7 @@ const AdminLayout: React.FC = () => {
   return (
     <Stack>
       <Stack.Screen name="index" options={{title: "Admin"}} />
+      <Stack.Screen name="showcase" options={{title: "Admin UI v2 map"}} />
       <Stack.Screen name="configuration" options={{title: "Configuration"}} />
       <Stack.Screen name="[model]" options={{headerShown: false}} />
     </Stack>

--- a/example-frontend/app/admin/index.tsx
+++ b/example-frontend/app/admin/index.tsx
@@ -1,4 +1,5 @@
-import {type AdminCustomScreen, AdminModelList} from "@terreno/admin-frontend";
+import {type AdminCustomScreen, AdminHome, AdminModelList} from "@terreno/admin-frontend";
+import {Box, Page} from "@terreno/ui";
 import React from "react";
 import {terrenoApi} from "@/store/sdk";
 
@@ -10,14 +11,23 @@ const CUSTOM_SCREENS: AdminCustomScreen[] = [
   },
 ];
 
+const ADMIN_ROUTE = "/admin";
+
 const AdminListScreen: React.FC = () => {
   return (
-    <AdminModelList
-      api={terrenoApi}
-      baseUrl="/admin"
-      configurationPath="/admin/configuration"
-      customScreens={CUSTOM_SCREENS}
-    />
+    <Page maxWidth="100%" scroll title="Admin">
+      <Box gap={4} padding={4}>
+        <AdminHome api={terrenoApi} baseUrl={ADMIN_ROUTE} embedded />
+        <AdminModelList
+          api={terrenoApi}
+          baseUrl={ADMIN_ROUTE}
+          configurationPath="/admin/configuration"
+          customScreens={CUSTOM_SCREENS}
+          embedded
+          hideModelsSection
+        />
+      </Box>
+    </Page>
   );
 };
 

--- a/example-frontend/app/admin/showcase.tsx
+++ b/example-frontend/app/admin/showcase.tsx
@@ -1,0 +1,56 @@
+import {Box, Heading, Link, Text} from "@terreno/ui";
+import React from "react";
+
+const DOC_LINK =
+  "https://github.com/FlourishHealth/terreno/blob/master/docs/implementationPlans/admin-ui-v2-django-parity.md";
+
+/**
+ * Static map of admin UI v2 features demonstrated by example-backend AdminApp and this admin
+ * shell.
+ */
+const AdminUiV2ShowcaseScreen: React.FC = () => {
+  return (
+    <Box direction="column" gap={3} padding={4} testID="admin-showcase-root">
+      <Heading size="lg">Admin UI v2 in this example</Heading>
+      <Text color="secondaryDark" size="sm">
+        The example backend registers AdminApp with models, scripts, audit logging, and a home
+        dashboard. Use this page as a checklist while you click through the admin.
+      </Text>
+      <Heading size="md">Home dashboard</Heading>
+      <Text size="sm">
+        From Profile → Admin: per-model counts, model grid, feature-flag quick access, scripts,
+        version config, and recent audit activity — wired via home.slots in
+        example-backend/src/server.ts.
+      </Text>
+      <Heading size="md">Models and changelist</Heading>
+      <Box direction="column" gap={2}>
+        <Text size="sm">
+          • Feature Flags — boolean and choice filters, extended columns, text search, grouping.
+        </Text>
+        <Text size="sm">
+          • Todos — form fieldsets, read-only ownerId, title as row link, boolean/choice/date-range
+          and ref filters, bulk “Mark completed” row action, realtime hint, bulk-patch allowlist,
+          deletes disabled.
+        </Text>
+        <Text size="sm">
+          • Users — profile/access fieldsets, email read-only on edit, admin filter.
+        </Text>
+        <Text size="sm">
+          • Consent forms — locale and checkbox-list widgets, fieldsets, list display, filters.
+        </Text>
+        <Text size="sm">• Consent responses — filters; delete disabled in admin config.</Text>
+        <Text size="sm">
+          • Audit log — read-only model populated by onAdminAudit after mutations.
+        </Text>
+      </Box>
+      <Heading size="md">Also try</Heading>
+      <Text size="sm">
+        Maintenance scripts (dry and wet runs), application configuration, document storage on the
+        Files tab, and the AI Admin custom screen.
+      </Text>
+      <Link href={DOC_LINK} size="sm" text="Django-parity implementation plan (repo doc)" />
+    </Box>
+  );
+};
+
+export default AdminUiV2ShowcaseScreen;

--- a/example-frontend/e2e/admin.spec.ts
+++ b/example-frontend/e2e/admin.spec.ts
@@ -10,26 +10,39 @@ test.describe("Admin Panel", () => {
   });
 
   test("admin panel renders model list", async ({page}) => {
-    await page.getByTestId("admin-model-card-User").waitFor({state: "visible"});
-    await expect(page.getByTestId("admin-model-card-User")).toBeVisible();
-    await expect(page.getByTestId("admin-model-card-Todo")).toBeVisible();
+    const userEntry = page
+      .getByTestId("admin-model-card-User")
+      .or(page.getByTestId("admin-home-models-grid-User"));
+    const todoEntry = page
+      .getByTestId("admin-model-card-Todo")
+      .or(page.getByTestId("admin-home-models-grid-Todo"));
+    await userEntry.first().waitFor({state: "visible"});
+    await expect(userEntry.first()).toBeVisible();
+    await expect(todoEntry.first()).toBeVisible();
   });
 
   test("admin panel shows custom screens", async ({page}) => {
     await page.getByTestId("admin-custom-screen-card-ai-admin").waitFor({state: "visible"});
     await expect(page.getByTestId("admin-custom-screen-card-ai-admin")).toBeVisible();
+    await expect(page.getByTestId("admin-custom-screen-card-showcase")).toBeVisible();
   });
 
   test("can navigate to model table", async ({page}) => {
-    await page.getByTestId("admin-model-card-Todo").waitFor({state: "visible"});
-    await page.getByTestId("admin-model-card-Todo").click();
+    const todoEntry = page
+      .getByTestId("admin-model-card-Todo")
+      .or(page.getByTestId("admin-home-models-grid-Todo"));
+    await todoEntry.first().waitFor({state: "visible"});
+    await todoEntry.first().click();
     await page.getByTestId("admin-create-button").waitFor({state: "visible"});
     await expect(page.getByTestId("admin-create-button")).toBeVisible();
   });
 
   test("can navigate to create form", async ({page}) => {
-    await page.getByTestId("admin-model-card-Todo").waitFor({state: "visible"});
-    await page.getByTestId("admin-model-card-Todo").click();
+    const todoEntry = page
+      .getByTestId("admin-model-card-Todo")
+      .or(page.getByTestId("admin-home-models-grid-Todo"));
+    await todoEntry.first().waitFor({state: "visible"});
+    await todoEntry.first().click();
     await page.getByTestId("admin-create-button").waitFor({state: "visible"});
     await page.getByTestId("admin-create-button").click();
     await page.getByTestId("admin-save-button").waitFor({state: "visible"});
@@ -57,8 +70,11 @@ test.describe("Admin Panel", () => {
     expect(createRes.ok()).toBeTruthy();
 
     // Navigate to the Todos admin table
-    await page.getByTestId("admin-model-card-Todo").waitFor({state: "visible"});
-    await page.getByTestId("admin-model-card-Todo").click();
+    const todoEntry = page
+      .getByTestId("admin-model-card-Todo")
+      .or(page.getByTestId("admin-home-models-grid-Todo"));
+    await todoEntry.first().waitFor({state: "visible"});
+    await todoEntry.first().click();
     await page.waitForLoadState("networkidle");
 
     // Verify the todo appears in the admin table. Other screens (e.g. the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Demonstrates Terreno admin UI v2 end-to-end in the example stack: richer `AdminApp` configuration in `example-backend`, a composed admin entry screen in `example-frontend`, and small library hooks so `AdminHome` and `AdminModelList` can share one scrollable page.

## Backend (`example-backend`)

- **Home** — `contentTop: feature-flags-overrides`, `main: modelStats + modelsGrid`, existing nav/sidebar widgets.
- **Todos** — fieldsets, `readonlyFields` on `ownerId`, `listDisplay` / `listDisplayLinks`, `dateRange` + `ref` filters, bulk “Mark completed” action, `realtime`, explicit `bulkPatchAllowlist`.
- **Users** — fieldsets, `readonlyFields: ["email"]`, `listDisplayLinks: ["email"]`.
- **Consent forms** — fieldsets + `listDisplay`.
- **Custom screen** — `showcase` card (opens static map in the Expo app).

## Frontend (`example-frontend`)

- Admin **index** — `Page` wrapping embedded `AdminHome` + embedded `AdminModelList` (`hideModelsSection` so the grid is not duplicated).
- New **`/admin/showcase`** — short checklist linking to the Django-parity plan doc.
- **E2E** — locators accept either model cards or home grid tiles.

## Library (`admin-frontend`)

- **`embedded`** on `AdminHome` — omit outer `Page` for composition.
- **`embedded`** + **`hideModelsSection`** on `AdminModelList` — same.

## Docs

- README bullets in `example-backend` and `example-frontend` pointing admins at the setup.

## Test plan

- [x] `bun test src/openapi.test.ts` (example-backend)
- [x] `bun test src/AdminModelList.test.tsx` (admin-frontend)
- [x] `bun run lint:fix` (example-frontend touched files)
- [x] `bunx biome check --write` on modified `AdminHome` / `AdminModelList`

**Note:** This branch currently includes the admin UI v2 backend/frontend stack (same tip as `cursor/admin-ui-v2-backend-a736`) plus the example commits above. If that PR merges first, rebase this branch onto `master` for a smaller diff.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7337d84-7e21-4a2d-bd9d-39d31757a736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7337d84-7e21-4a2d-bd9d-39d31757a736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

