### PR TITLE
chore: fix Biome lint on master (ui, demo, website, admin-spa)

### DIFF
--- a/admin-spa/src/serve.ts
+++ b/admin-spa/src/serve.ts
@@ -78,8 +78,6 @@ export class AdminSpaServeApp implements TerrenoPlugin {
         res.set("Cache-Control", NO_STORE).json(appConfig);
       });
       // Lazy require so production deploys without the dev dependency don't break.
-      // biome-ignore lint/suspicious/noExplicitAny: dynamic require of optional dev dependency
-      // noExplicitAny: module types are not available at runtime for optional dev-only dependency.
       const {createProxyMiddleware} = require("http-proxy-middleware") as {
         createProxyMiddleware: (options: {
           changeOrigin: boolean;

--- a/demo/stories/SelectBadge.stories.tsx
+++ b/demo/stories/SelectBadge.stories.tsx
@@ -94,12 +94,7 @@ export const BadgeSelectBadgeComparison = () => {
         <Badge status="info" value="Text" />
         <Badge iconName="check" status="success" value="" variant="iconOnly" />
         <Badge maxValue={99} status="error" value="5" variant="numberOnly" />
-        <SelectBadge
-          onChange={() => {}}
-          options={statusOptions}
-          status="info"
-          value="active"
-        />
+        <SelectBadge onChange={() => {}} options={statusOptions} status="info" value="active" />
       </Box>
     </StorybookContainer>
   );

--- a/ui/src/PickerSelect.tsx
+++ b/ui/src/PickerSelect.tsx
@@ -407,9 +407,7 @@ export const RNPickerSelect = ({
           multiline
           {...textInputProps}
           style={
-            textInputProps?.style
-              ? [baseTextInputStyle, textInputProps.style]
-              : baseTextInputStyle
+            textInputProps?.style ? [baseTextInputStyle, textInputProps.style] : baseTextInputStyle
           }
           testID={textInputProps?.testID ?? "text_input"}
           value={selectedLabel}

--- a/website/scripts/generate-api-reference.ts
+++ b/website/scripts/generate-api-reference.ts
@@ -1,5 +1,5 @@
 import {spawnSync} from "node:child_process";
-import {existsSync, mkdirSync, readFileSync, rmSync, writeFileSync} from "node:fs";
+import {existsSync, mkdirSync, rmSync, writeFileSync} from "node:fs";
 import {dirname, join, resolve} from "node:path";
 import {fileURLToPath} from "node:url";
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves current **Biome** failures on `master` so `bun run lint` passes in CI.

## Changes

- **`ui`**: `PickerSelect` — apply Biome formatter output for the `TextInput` `style` prop.
- **`demo`**: `SelectBadge.stories` — single-line `SelectBadge` JSX per formatter.
- **`website`**: `generate-api-reference.ts` — remove unused `readFileSync` import.
- **`admin-spa`**: `serve.ts` — remove ineffective `biome-ignore` (Biome reported `suppressions/unused`).

## Verification

- [x] `bun run lint`
- [x] `bun run compile`
- [x] `bun run api:test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7337d84-7e21-4a2d-bd9d-39d31757a736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7337d84-7e21-4a2d-bd9d-39d31757a736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

