### PR TITLE
fix(ci): install workspace deps before Trigger EAS Workflow dispatch

### DIFF
--- a/.github/workflows/eas-dev-build.yml
+++ b/.github/workflows/eas-dev-build.yml
@@ -27,7 +27,7 @@ jobs:
   dispatch:
     name: Dispatch EAS workflow
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -45,12 +45,28 @@ jobs:
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
+      - name: Cache bun + node_modules
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Setup EAS CLI
         uses: expo/expo-github-action@v8
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
+
+      # eas workflow:run evaluates app.config.ts locally; workspace deps (expo, config-plugins) must be installed.
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Dispatch to EAS Cloud
         env:

--- a/scripts/eas-workflows.test.ts
+++ b/scripts/eas-workflows.test.ts
@@ -37,7 +37,6 @@ describe("EAS PR workflows", () => {
       const workflow = readRepoFile(workflowPath);
 
       assert.match(workflow, /type:\s*build/);
-      assert.match(workflow, /type:\s*get-build/);
       assert.doesNotMatch(workflow, /eas-cli@latest update/);
       assert.doesNotMatch(workflow, /--branch "pr-/);
       assert.doesNotMatch(workflow, /inputs\.pr_number/);
@@ -49,6 +48,7 @@ describe("EAS PR workflows", () => {
     const manualDispatch = readRepoFile(".github/workflows/eas-dev-build.yml");
 
     assert.match(manualDispatch, /eas workflow:run "\.eas\/workflows\/\$file"/);
+    assert.match(manualDispatch, /bun install --frozen-lockfile/);
     assert.doesNotMatch(manualDispatch, /pr_number/);
     assert.doesNotMatch(manualDispatch, /pr_title/);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **Trigger EAS Workflow** manual action runs `eas workflow:run` from each app directory. EAS evaluates `app.config.ts` on the runner, which imports `expo/config` and `expo/config-plugins`. Without a prior `bun install`, `expo` was not in `node_modules`, causing the failure seen on `demo` (and the same risk for `example-frontend`).

## Changes

- **`.github/workflows/eas-dev-build.yml`**: Pin Bun `1.3.10` (same as `eas-pr.yml`), add `actions/cache` for `~/.bun/install/cache` and root `node_modules`, run `bun install --frozen-lockfile` before dispatch, increase job timeout from 5 to 10 minutes.
- **`scripts/eas-workflows.test.ts`**: Assert the manual workflow includes frozen lockfile install; remove the obsolete `type: get-build` assertion because the EAS cloud workflow YAMLs are build-only (three `type: build` jobs).

## Testing

- `bun test scripts/eas-workflows.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98466dbd-32d2-4b80-8df7-f591ef54781b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98466dbd-32d2-4b80-8df7-f591ef54781b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

