### PR TITLE
Capture per-story snapshots in Card Appium test

### DIFF
--- a/.github/workflows/demo-appium-ci.yml
+++ b/.github/workflows/demo-appium-ci.yml
@@ -122,6 +122,15 @@ jobs:
           NODE_ENV: production
           NODE_OPTIONS: --openssl-legacy-provider
 
+      - name: Upload Appium story snapshots
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: demo-appium-android-screenshots
+          path: demo/appium/screenshots/
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: Upload Appium logs
         if: failure()
         uses: actions/upload-artifact@v7.0.1
@@ -256,6 +265,15 @@ jobs:
           else
             echo "Skipping full iOS diagnostics in smoke mode" >> demo/logs/diag-env.txt
           fi
+
+      - name: Upload Appium story snapshots
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: demo-appium-ios-screenshots
+          path: demo/appium/screenshots/
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload Appium logs
         if: failure()

--- a/demo/appium/helpers/snapshots.ts
+++ b/demo/appium/helpers/snapshots.ts
@@ -1,0 +1,42 @@
+import {mkdir} from "node:fs/promises";
+import {dirname, join} from "node:path";
+import {fileURLToPath} from "node:url";
+
+// Story snapshots live alongside the specs (not in the gitignored logs/ folder)
+// so they can be committed and diffed: a changed PNG in a pull request is the
+// signal that a component's rendering changed. Baselines are device-specific, so
+// regenerate them on the same platform/emulator before comparing.
+const helpersDir = dirname(fileURLToPath(import.meta.url));
+const snapshotsDir = join(helpersDir, "..", "screenshots");
+
+const toPlatformLabel = (): string => (driver.isAndroid ? "android" : "ios");
+
+interface CaptureStorySnapshotOptions {
+  // The element to capture. Capturing the story root rather than the full screen
+  // keeps the volatile status bar (clock, battery) out of the image.
+  element: ChainablePromiseElement;
+  // Stable, human-readable file name without extension, e.g. "Card-Plain".
+  name: string;
+}
+
+// Saves a PNG snapshot of the given element to
+// appium/screenshots/<platform>/<name>.png and returns the written path.
+export const captureStorySnapshot = async ({
+  element,
+  name,
+}: CaptureStorySnapshotOptions): Promise<string> => {
+  const snapshotPath = join(snapshotsDir, toPlatformLabel(), `${name}.png`);
+  await mkdir(dirname(snapshotPath), {recursive: true});
+
+  try {
+    await element.saveScreenshot(snapshotPath);
+  } catch (error) {
+    // Element screenshots can fail when the node is larger than the viewport;
+    // fall back to a full-screen capture so a snapshot is always produced.
+    console.warn(`Element snapshot failed for "${name}"; capturing full screen instead`, error);
+    await driver.saveScreenshot(snapshotPath);
+  }
+
+  console.info(`Saved story snapshot: ${snapshotPath}`);
+  return snapshotPath;
+};

--- a/demo/appium/specs/card-stories.spec.ts
+++ b/demo/appium/specs/card-stories.spec.ts
@@ -1,6 +1,7 @@
 import {$} from "@wdio/globals";
 
 import {byTestId, type DevStoryTarget, openDevStory} from "../helpers/navigation";
+import {captureStorySnapshot} from "../helpers/snapshots";
 
 const CARD_COMPONENT = "Card";
 
@@ -23,6 +24,10 @@ describe("Card dev stories render correctly", () => {
 
       const storyRoot = await $(byTestId(testId));
       await expect(storyRoot).toBeDisplayed();
+
+      // Capture a per-platform snapshot of the rendered story so visual changes
+      // surface as an image diff under appium/screenshots/<platform>.
+      await captureStorySnapshot({element: storyRoot, name: `${CARD_COMPONENT}-${story}`});
     });
   }
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Card Appium test (`demo/appium/specs/card-stories.spec.ts`) previously only asserted that each Card dev story mounted. This adds a screenshot snapshot of each story so we can tell when one has changed.

## Changes

- **New helper `demo/appium/helpers/snapshots.ts`** — `captureStorySnapshot({element, name})` saves a PNG of the given element to `demo/appium/screenshots/<platform>/<name>.png`.
  - Captures the **story root element** (not the full screen) to keep the volatile status bar (clock, battery) out of the image.
  - Falls back to a full-screen capture if an element screenshot fails (e.g. when the node is larger than the viewport).
  - Writes under `appium/screenshots/` (not the gitignored `logs/`) so baselines can be committed and diffed — a changed PNG in a PR is the signal that a component's rendering changed.
- **`card-stories.spec.ts`** — after asserting the story is displayed, captures a snapshot named `Card-<Story>` (e.g. `Card-Plain.png`) for each of the 6 stories.
- **`.github/workflows/demo-appium-ci.yml`** — both the Android and iOS jobs upload `demo/appium/screenshots/` as an artifact (`if: always()`) so captures are retrievable per run for comparison.

## Notes

- Snapshots are device/platform specific (resolution, font rendering), so regenerate baselines on the same emulator/simulator config before comparing.
- `bun run appium:compile` (tsc) passes. The `appium/` directory is excluded from biome, so no lint changes apply there.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e3afa11-0dd7-4454-81a1-85cedc6a0348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e3afa11-0dd7-4454-81a1-85cedc6a0348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

