### PR TITLE
Add withOperationId() to OpenApiMiddlewareBuilder

### DIFF
--- a/api/src/__snapshots__/openApiBuilder.test.ts.snap
+++ b/api/src/__snapshots__/openApiBuilder.test.ts.snap
@@ -910,6 +910,7 @@ exports[`OpenApiMiddlewareBuilder snapshot tests matches OpenAPI spec snapshot 1
     "/food/stats": {
       "get": {
         "description": "Returns aggregated statistics about food items",
+        "operationId": "getFoodStats",
         "parameters": [
           {
             "description": "Filter by food category",

--- a/api/src/openApiBuilder.test.ts
+++ b/api/src/openApiBuilder.test.ts
@@ -16,6 +16,7 @@ function addRoutesWithBuilder(router: Router, options?: Partial<ModelRouterOptio
   const statsMiddleware = createOpenApiBuilder(options ?? {})
     .withTags(["Stats"])
     .withSummary("Get food statistics")
+    .withOperationId("getFoodStats")
     .withDescription("Returns aggregated statistics about food items")
     .withQueryParameter(
       "category",
@@ -193,6 +194,14 @@ describe("OpenApiMiddlewareBuilder", () => {
       expect(categoryParam.schema.type).toBe("string");
       expect(categoryParam.description).toBe("Filter by food category");
       expect(categoryParam.required).toBe(false);
+    });
+
+    it("includes the explicit operationId in OpenAPI spec", async () => {
+      server = supertest(app);
+      const res = await server.get("/openapi.json").expect(200);
+
+      const statsPath = res.body.paths["/food/stats"];
+      expect(statsPath.get.operationId).toBe("getFoodStats");
     });
 
     it("includes request body schema in OpenAPI spec", async () => {

--- a/api/src/openApiBuilder.ts
+++ b/api/src/openApiBuilder.ts
@@ -213,6 +213,8 @@ interface OpenApiConfig {
   summary?: string;
   /** Detailed description of the operation */
   description?: string;
+  /** Explicit operationId for the operation */
+  operationId?: string;
   /** Operation parameters (query, path, header) */
   parameters?: OpenApiParameter[];
   /** Request body configuration */
@@ -356,6 +358,28 @@ export class OpenApiMiddlewareBuilder {
    */
   withSummary(summary: string): this {
     this.config.summary = summary;
+    return this;
+  }
+
+  /**
+   * Sets an explicit `operationId` for the OpenAPI operation.
+   *
+   * The `operationId` is a unique string used to identify an operation. Client and SDK
+   * generators (e.g. RTK Query codegen) derive generated function and hook names from it,
+   * so setting it keeps generated names stable and readable for routes whose URL path would
+   * otherwise produce unwieldy names (e.g. deeply nested routes). It must be unique across
+   * the whole OpenAPI document.
+   *
+   * @param operationId - Unique operation identifier (e.g. "getUserStats")
+   * @returns The builder instance for chaining
+   *
+   * @example
+   * ```typescript
+   * builder.withOperationId("getUserStats");
+   * ```
+   */
+  withOperationId(operationId: string): this {
+    this.config.operationId = operationId;
     return this;
   }
 


### PR DESCRIPTION
## Summary
- Add `withOperationId()` to the OpenAPI middleware builder so custom routes can pin an explicit OpenAPI `operationId`.
- SDK/codegen tools (e.g. RTK Query) derive generated function and hook names from `operationId`. Without it, deeply nested routes produce unwieldy generated names, which forces consumers to hand-roll endpoints. This builder method lets a backend keep generated names stable and readable.

## Changes
- `api/src/openApiBuilder.ts`: new `withOperationId(operationId)` chainable method + `operationId` on the internal `OpenApiConfig` (flows through `build()` into the emitted operation).
- `api/src/openApiBuilder.test.ts`: sets an operationId on the `/food/stats` fixture and asserts it appears in the generated spec.
- Updated the OpenAPI spec snapshot for the added `operationId`.

## Motivation
Downstream (flourish) has task-mounted routes like `/tasks/appointmentAI/scheduleItems/{id}/aiSuggestions` whose path-derived codegen names are unusable, so the endpoints were hand-rolled in the RTK SDK. With `withOperationId()`, those routes can be annotated with stable ids (`getScheduleItemAiSuggestions`, etc.) and generated normally.

## Test plan
- [x] `bun test api/src/openApiBuilder.test.ts` (33 pass)
- [x] `biome check` clean on changed files

Made with [Cursor](https://cursor.com)