### PR TITLE
Button: add ghost variant, sm size, fix outline height

### DIFF
--- a/demo/stories/Button.stories.tsx
+++ b/demo/stories/Button.stories.tsx
@@ -37,6 +37,7 @@ const BUTTON_VARIANT_EXAMPLES: ButtonVariantExample[] = [
   {iconName: "border-all", text: "Outline", variant: "outline"},
   {iconName: "leaf", text: "Muted", variant: "muted"},
   {iconName: "trash", text: "Destructive", variant: "destructive"},
+  {iconName: "ghost", text: "Ghost", variant: "ghost"},
 ];
 
 const handleDemoClick = (): void => {
@@ -77,6 +78,9 @@ export const ButtonVariants: React.FC<Partial<ButtonProps>> = (props = {}) => {
           <Button onClick={handleDemoClick} text="Muted" variant="muted" {...props} />
         </Box>
         <Box padding={1}>
+          <Button onClick={handleDemoClick} text="Ghost" variant="ghost" {...props} />
+        </Box>
+        <Box padding={1}>
           <Button disabled onClick={handleDemoClick} text="Disabled" {...props} />
         </Box>
       </Box>
@@ -110,6 +114,9 @@ export const ButtonVariants: React.FC<Partial<ButtonProps>> = (props = {}) => {
         </Box>
         <Box padding={1}>
           <Button disabled onClick={handleDemoClick} text="Muted" variant="muted" {...props} />
+        </Box>
+        <Box padding={1}>
+          <Button disabled onClick={handleDemoClick} text="Ghost" variant="ghost" {...props} />
         </Box>
       </Box>
     </>
@@ -249,6 +256,42 @@ export const ButtonPressAnimations: React.FC = () => (
         </Box>
       </Box>
     ))}
+  </Box>
+);
+
+export const ButtonSizes: React.FC = () => (
+  <Box gap={4}>
+    <Box gap={1}>
+      <Heading>Default size</Heading>
+      <Box direction="row" wrap>
+        {BUTTON_VARIANT_EXAMPLES.map((button) => (
+          <Box key={`default-${button.text}`} padding={1}>
+            <Button
+              iconName={button.iconName}
+              onClick={handleDemoClick}
+              text={button.text}
+              variant={button.variant}
+            />
+          </Box>
+        ))}
+      </Box>
+    </Box>
+    <Box gap={1}>
+      <Heading>Small (sm)</Heading>
+      <Box direction="row" wrap>
+        {BUTTON_VARIANT_EXAMPLES.map((button) => (
+          <Box key={`sm-${button.text}`} padding={1}>
+            <Button
+              iconName={button.iconName}
+              onClick={handleDemoClick}
+              size="sm"
+              text={button.text}
+              variant={button.variant}
+            />
+          </Box>
+        ))}
+      </Box>
+    </Box>
   </Box>
 );
 

--- a/demo/story-config/Button.config.tsx
+++ b/demo/story-config/Button.config.tsx
@@ -1,9 +1,10 @@
-import {DemoConfiguration} from "@config";
+import type {DemoConfiguration} from "@config";
 import {
   ButtonDemo,
   ButtonIconPosition,
   ButtonLoading,
   ButtonPressAnimations,
+  ButtonSizes,
   ButtonVariants,
   ConfirmationButton,
   FullWidthButtons,
@@ -60,6 +61,8 @@ export const ButtonConfiguration: DemoConfiguration = {
           {label: "Secondary", value: "secondary"},
           {label: "Outline", value: "outline"},
           {label: "Muted", value: "muted"},
+          {label: "Destructive", value: "destructive"},
+          {label: "Ghost", value: "ghost"},
         ],
       },
       iconName: {
@@ -98,10 +101,19 @@ export const ButtonConfiguration: DemoConfiguration = {
         type: "boolean",
         defaultValue: false,
       },
+      size: {
+        type: "select",
+        defaultValue: "default",
+        options: [
+          {label: "Default", value: "default"},
+          {label: "Small", value: "sm"},
+        ],
+      },
     },
   },
   stories: {
     Variants: {render: () => <ButtonVariants />},
+    Sizes: {render: () => <ButtonSizes />},
     IconPosition: {render: () => <ButtonIconPosition />},
     Loading: {render: () => <ButtonLoading />},
     Confirmation: {render: () => <ConfirmationButton />},

--- a/ui/src/Button.tsx
+++ b/ui/src/Button.tsx
@@ -45,6 +45,7 @@ const ButtonComponent: React.FC<ButtonProps> = ({
   modalTitle = "Confirm",
   modalSubTitle,
   pressAnimation = DEFAULT_BUTTON_PRESS_ANIMATION,
+  size = "default",
   testID,
   text,
   variant = "primary",
@@ -79,6 +80,9 @@ const ButtonComponent: React.FC<ButtonProps> = ({
       textColor = theme.text.secondaryDark;
     } else if (variant === "destructive") {
       bgColor = theme.surface.error;
+    } else if (variant === "ghost") {
+      bgColor = theme.surface.base;
+      textColor = theme.surface.secondaryDark;
     }
 
     return {
@@ -143,8 +147,8 @@ const ButtonComponent: React.FC<ButtonProps> = ({
         borderWidth,
         flexDirection: "column",
         justifyContent: "center",
-        paddingHorizontal: 20,
-        paddingVertical: 8,
+        paddingHorizontal: size === "sm" ? 16 : 20,
+        paddingVertical: 8 - (borderWidth ?? 0),
         width: fullWidth ? "100%" : "auto",
       }}
       testID={testID}
@@ -166,7 +170,7 @@ const ButtonComponent: React.FC<ButtonProps> = ({
               )}
             </View>
           )}
-          <Text style={{color, fontSize: 16, fontWeight: "700"}}>{text}</Text>
+          <Text style={{color, fontSize: size === "sm" ? 14 : 16, fontWeight: "700"}}>{text}</Text>
         </View>
         {Boolean(loading) && (
           <Box marginLeft={2}>

--- a/ui/src/Common.ts
+++ b/ui/src/Common.ts
@@ -1667,10 +1667,15 @@ export interface ButtonProps {
    */
   tooltipText?: string;
   /**
+   * The size of the button.
+   * @default "default"
+   */
+  size?: "default" | "sm";
+  /**
    * The type of the button, which determines its style.
    * @default "primary"
    */
-  variant?: "primary" | "secondary" | "muted" | "outline" | "destructive";
+  variant?: "primary" | "secondary" | "muted" | "outline" | "destructive" | "ghost";
   /**
    * If true, a confirmation modal will be shown before the onClick action.
    */

--- a/ui/src/__snapshots__/Button.test.tsx.snap
+++ b/ui/src/__snapshots__/Button.test.tsx.snap
@@ -346,7 +346,7 @@ exports[`Button renders outline variant 1`] = `
       "flexDirection": "column",
       "justifyContent": "center",
       "paddingHorizontal": 20,
-      "paddingVertical": 8,
+      "paddingVertical": 6,
       "width": "auto",
     },
     "testID": undefined,


### PR DESCRIPTION
## Summary
Adds `variant="ghost"` and `size="sm"` to the `Button` component per the Terreno Design System spec, and fixes a bug where the `outline` variant rendered 4px taller than all other variants due to its border being additive.

Linear: https://linear.app/flourish-health/issue/FH-797/update-button-component-to-include-ghost-style-small-size-and-correct

<img width="167" height="180" alt="Screenshot 2026-06-23 at 1 04 19 PM" src="https://github.com/user-attachments/assets/2a72b91a-792c-441d-9682-ba980df07a72" />

<img width="565" height="1068" alt="Screenshot 2026-06-23 at 1 17 55 PM" src="https://github.com/user-attachments/assets/698086e4-745a-46c8-a3e8-f52df4bdf9f0" />

<img width="400" height="756" alt="Screenshot 2026-06-17 at 3 50 59 PM" src="https://github.com/user-attachments/assets/3e3134e6-2caf-47b6-82ff-99b623a0af61" />


## Human Testing Steps
- [ ] Open demo app (`bun run demo:start`) → Button → Variants: all variants should be the same height, including Outline
- [ ] Button → Sizes story: Default and Small rows should show all variants at correct proportions
- [ ] Interactive demo: toggle `variant=ghost` and `size=sm` controls and verify styles

## Changes
- `ui/src/Common.ts`: added `size?: "default" | "sm"` prop and `"ghost"` to variant union on `ButtonProps`
- `ui/src/Button.tsx`: ghost styling (white bg, `theme.surface.secondaryDark` text); sm sizing (16px h-padding, 14px font); outline height fix (`paddingVertical: 8 - (borderWidth ?? 0)`)
- `demo/stories/Button.stories.tsx`: ghost added to `BUTTON_VARIANT_EXAMPLES` and `ButtonVariants`; new `ButtonSizes` story
- `demo/story-config/Button.config.tsx`: registered `Sizes` story; added `size` select control to interactive demo

## Automated Tests
- `bun run ui:test`: 1712 pass, 0 fail — snapshot updated for outline variant's corrected `paddingVertical: 6`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI component and demo changes; outline padding tweak affects all bordered buttons consistently with no auth or data paths.
> 
> **Overview**
> Extends **`Button`** with **`variant="ghost"`** (base surface background, secondary-dark label) and **`size="sm"`** (tighter horizontal padding and 14px label), aligned with Terreno Design System.
> 
> **Outline** buttons no longer sit taller than other variants: vertical padding is reduced by the border width (`paddingVertical: 8 - (borderWidth ?? 0)`), with a snapshot update for outline.
> 
> The demo adds **Ghost** to variant examples and a **Sizes** story plus interactive **`size`** / **`ghost`** controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7971ffb8a90e79aa25c89de8b56a1d221446f075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->