### PR TITLE
ci: publish @terreno/test on release tags

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -13,8 +13,8 @@ Cut a new Terreno release end-to-end: gather commits, write organized release no
 ## How releases work in this repo
 
 - Pushing a tag matching `X.Y.Z` (no `v` prefix, e.g. `0.18.0`) triggers `.github/workflows/publish-on-tag.yml`.
-- That workflow publishes **nine packages, all at the same version**: `@terreno/api`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
-- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. A `ui` or `api` failure cascades.
+- That workflow publishes **ten packages, all at the same version**: `@terreno/api`, `@terreno/test`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
+- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. `api`, `test`, and `ui` publish independently (no upstream `needs`). A `ui` or `api` failure cascades.
 - After successful publishes, the workflow commits `chore: bump package versions to X.Y.Z` back to master and sends a Zoom notification. Prerelease tags (`-beta`, `-alpha`) skip the master bump.
 
 ## Step 1: Preflight
@@ -122,12 +122,12 @@ gh release create "$VERSION" --target master --title "$VERSION" --notes-file /tm
 2. Verify every package is live on npm (allow a couple of minutes of registry lag):
 
    ```bash
-   for p in api ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
+   for p in api test ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
      echo "@terreno/$p: $(npm view "@terreno/$p" version)"
    done
    ```
 
-   All nine must report `$VERSION`.
+   All ten must report `$VERSION`.
 
 3. Confirm the `chore: bump package versions to $VERSION` commit landed on master (`git fetch origin master && git log origin/master -1 --oneline`). Skipped for prereleases.
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -13,8 +13,8 @@ Cut a new Terreno release end-to-end: gather commits, write organized release no
 ## How releases work in this repo
 
 - Pushing a tag matching `X.Y.Z` (no `v` prefix, e.g. `0.18.0`) triggers `.github/workflows/publish-on-tag.yml`.
-- That workflow publishes **nine packages, all at the same version**: `@terreno/api`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
-- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. A `ui` or `api` failure cascades.
+- That workflow publishes **ten packages, all at the same version**: `@terreno/api`, `@terreno/test`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
+- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. `api`, `test`, and `ui` publish independently (no upstream `needs`). A `ui` or `api` failure cascades.
 - After successful publishes, the workflow commits `chore: bump package versions to X.Y.Z` back to master and sends a Zoom notification. Prerelease tags (`-beta`, `-alpha`) skip the master bump.
 
 ## Step 1: Preflight
@@ -122,12 +122,12 @@ gh release create "$VERSION" --target master --title "$VERSION" --notes-file /tm
 2. Verify every package is live on npm (allow a couple of minutes of registry lag):
 
    ```bash
-   for p in api ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
+   for p in api test ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
      echo "@terreno/$p: $(npm view "@terreno/$p" version)"
    done
    ```
 
-   All nine must report `$VERSION`.
+   All ten must report `$VERSION`.
 
 3. Confirm the `chore: bump package versions to $VERSION` commit landed on master (`git fetch origin master && git log origin/master -1 --oneline`). Skipped for prereleases.
 

--- a/.cursor/skills/release/SKILL.md
+++ b/.cursor/skills/release/SKILL.md
@@ -9,8 +9,8 @@ Cut a new Terreno release end-to-end: gather commits, write organized release no
 ## How releases work in this repo
 
 - Pushing a tag matching `X.Y.Z` (no `v` prefix, e.g. `0.18.0`) triggers `.github/workflows/publish-on-tag.yml`.
-- That workflow publishes **nine packages, all at the same version**: `@terreno/api`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
-- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. A `ui` or `api` failure cascades.
+- That workflow publishes **ten packages, all at the same version**: `@terreno/api`, `@terreno/test`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
+- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. `api`, `test`, and `ui` publish independently (no upstream `needs`). A `ui` or `api` failure cascades.
 - After successful publishes, the workflow commits `chore: bump package versions to X.Y.Z` back to master and sends a Zoom notification. Prerelease tags (`-beta`, `-alpha`) skip the master bump.
 
 ## Step 1: Preflight
@@ -118,12 +118,12 @@ gh release create "$VERSION" --target master --title "$VERSION" --notes-file /tm
 2. Verify every package is live on npm (allow a couple of minutes of registry lag):
 
    ```bash
-   for p in api ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
+   for p in api test ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
      echo "@terreno/$p: $(npm view "@terreno/$p" version)"
    done
    ```
 
-   All nine must report `$VERSION`.
+   All ten must report `$VERSION`.
 
 3. Confirm the `chore: bump package versions to $VERSION` commit landed on master (`git fetch origin master && git log origin/master -1 --oneline`). Skipped for prereleases.
 

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -13,8 +13,8 @@ Cut a new Terreno release end-to-end: gather commits, write organized release no
 ## How releases work in this repo
 
 - Pushing a tag matching `X.Y.Z` (no `v` prefix, e.g. `0.18.0`) triggers `.github/workflows/publish-on-tag.yml`.
-- That workflow publishes **nine packages, all at the same version**: `@terreno/api`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
-- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. A `ui` or `api` failure cascades.
+- That workflow publishes **ten packages, all at the same version**: `@terreno/api`, `@terreno/test`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
+- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. `api`, `test`, and `ui` publish independently (no upstream `needs`). A `ui` or `api` failure cascades.
 - After successful publishes, the workflow commits `chore: bump package versions to X.Y.Z` back to master and sends a Zoom notification. Prerelease tags (`-beta`, `-alpha`) skip the master bump.
 
 ## Step 1: Preflight
@@ -122,12 +122,12 @@ gh release create "$VERSION" --target master --title "$VERSION" --notes-file /tm
 2. Verify every package is live on npm (allow a couple of minutes of registry lag):
 
    ```bash
-   for p in api ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
+   for p in api test ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
      echo "@terreno/$p: $(npm view "@terreno/$p" version)"
    done
    ```
 
-   All nine must report `$VERSION`.
+   All ten must report `$VERSION`.
 
 3. Confirm the `chore: bump package versions to $VERSION` commit landed on master (`git fetch origin master && git log origin/master -1 --oneline`). Skipped for prereleases.
 

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -146,6 +146,85 @@ jobs:
       - name: Summary
         run: echo "Published @terreno/api@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
 
+  publish-test:
+    needs: check-changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: test
+    steps:
+      - uses: actions/checkout@v6.0.3
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Validate required secrets
+        run: |
+          missing=()
+          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then missing+=("NPM_TOKEN"); fi
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('bun.lock', 'package.json') }}
+          restore-keys: |
+            bun-${{ runner.os }}-${{ github.ref }}-
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Update version
+        run: |
+          VERSION="${{ needs.check-changes.outputs.version }}"
+          node -e "const fs = require('fs'); const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')); pkg.version = '$VERSION'; fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');"
+
+      - name: Replace catalog references
+        run: |
+          node -e "
+          const fs = require('fs');
+          const rootPkg = JSON.parse(fs.readFileSync('../package.json', 'utf8'));
+          const catalog = rootPkg.catalog || {};
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          for (const depType of ['dependencies', 'devDependencies', 'peerDependencies']) {
+            if (!pkg[depType]) continue;
+            for (const [key, value] of Object.entries(pkg[depType])) {
+              if (value === 'catalog:') {
+                if (!catalog[key]) throw new Error(\`Catalog entry not found for \${key}\`);
+                pkg[depType][key] = catalog[key];
+              }
+            }
+          }
+          fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+      - name: Compile
+        run: bun run compile
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        run: echo "Published @terreno/test@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+
   publish-ui:
     needs: check-changes
     runs-on: ubuntu-latest
@@ -1151,13 +1230,13 @@ jobs:
         run: echo "Published @terreno/mcp@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
 
   update-version-on-master:
-    needs: [check-changes, publish-api, publish-ui, publish-rtk, publish-admin-backend, publish-admin-frontend, publish-admin-spa, publish-ai, publish-api-health, publish-feature-flags, publish-mcp]
+    needs: [check-changes, publish-api, publish-test, publish-ui, publish-rtk, publish-admin-backend, publish-admin-frontend, publish-admin-spa, publish-ai, publish-api-health, publish-feature-flags, publish-mcp]
     # Run if any package was published and this is not a prerelease (beta/alpha) tag
     if: |
       always() &&
       !contains(needs.check-changes.outputs.version, '-beta') &&
       !contains(needs.check-changes.outputs.version, '-alpha') &&
-      (needs.publish-api.result == 'success' || needs.publish-ui.result == 'success' || needs.publish-rtk.result == 'success' || needs.publish-admin-backend.result == 'success' || needs.publish-admin-frontend.result == 'success' || needs.publish-admin-spa.result == 'success' || needs.publish-ai.result == 'success' || needs.publish-api-health.result == 'success' || needs.publish-feature-flags.result == 'success' || needs.publish-mcp.result == 'success')
+      (needs.publish-api.result == 'success' || needs.publish-test.result == 'success' || needs.publish-ui.result == 'success' || needs.publish-rtk.result == 'success' || needs.publish-admin-backend.result == 'success' || needs.publish-admin-frontend.result == 'success' || needs.publish-admin-spa.result == 'success' || needs.publish-ai.result == 'success' || needs.publish-api-health.result == 'success' || needs.publish-feature-flags.result == 'success' || needs.publish-mcp.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1196,6 +1275,7 @@ jobs:
           }
 
           update_version api "${{ needs.publish-api.result }}"
+          update_version test "${{ needs.publish-test.result }}"
           update_version ui "${{ needs.publish-ui.result }}"
           update_version rtk "${{ needs.publish-rtk.result }}"
           update_version admin-backend "${{ needs.publish-admin-backend.result }}"
@@ -1286,7 +1366,7 @@ jobs:
           fi
 
   notify:
-    needs: [check-changes, publish-api, publish-ui, publish-rtk, publish-admin-backend, publish-admin-frontend, publish-admin-spa, publish-ai, publish-api-health, publish-feature-flags, publish-mcp]
+    needs: [check-changes, publish-api, publish-test, publish-ui, publish-rtk, publish-admin-backend, publish-admin-frontend, publish-admin-spa, publish-ai, publish-api-health, publish-feature-flags, publish-mcp]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -1309,6 +1389,7 @@ jobs:
           }
 
           add_status "@terreno/api" "${{ needs.publish-api.result }}"
+          add_status "@terreno/test" "${{ needs.publish-test.result }}"
           add_status "@terreno/ui" "${{ needs.publish-ui.result }}"
           add_status "@terreno/rtk" "${{ needs.publish-rtk.result }}"
           add_status "@terreno/admin-backend" "${{ needs.publish-admin-backend.result }}"

--- a/.rulesync/skills/release/SKILL.md
+++ b/.rulesync/skills/release/SKILL.md
@@ -11,8 +11,8 @@ Cut a new Terreno release end-to-end: gather commits, write organized release no
 ## How releases work in this repo
 
 - Pushing a tag matching `X.Y.Z` (no `v` prefix, e.g. `0.18.0`) triggers `.github/workflows/publish-on-tag.yml`.
-- That workflow publishes **nine packages, all at the same version**: `@terreno/api`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
-- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. A `ui` or `api` failure cascades.
+- That workflow publishes **ten packages, all at the same version**: `@terreno/api`, `@terreno/test`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
+- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. `api`, `test`, and `ui` publish independently (no upstream `needs`). A `ui` or `api` failure cascades.
 - After successful publishes, the workflow commits `chore: bump package versions to X.Y.Z` back to master and sends a Zoom notification. Prerelease tags (`-beta`, `-alpha`) skip the master bump.
 
 ## Step 1: Preflight
@@ -120,12 +120,12 @@ gh release create "$VERSION" --target master --title "$VERSION" --notes-file /tm
 2. Verify every package is live on npm (allow a couple of minutes of registry lag):
 
    ```bash
-   for p in api ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
+   for p in api test ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
      echo "@terreno/$p: $(npm view "@terreno/$p" version)"
    done
    ```
 
-   All nine must report `$VERSION`.
+   All ten must report `$VERSION`.
 
 3. Confirm the `chore: bump package versions to $VERSION` commit landed on master (`git fetch origin master && git log origin/master -1 --oneline`). Skipped for prereleases.
 

--- a/.windsurf/skills/release/SKILL.md
+++ b/.windsurf/skills/release/SKILL.md
@@ -13,8 +13,8 @@ Cut a new Terreno release end-to-end: gather commits, write organized release no
 ## How releases work in this repo
 
 - Pushing a tag matching `X.Y.Z` (no `v` prefix, e.g. `0.18.0`) triggers `.github/workflows/publish-on-tag.yml`.
-- That workflow publishes **nine packages, all at the same version**: `@terreno/api`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
-- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. A `ui` or `api` failure cascades.
+- That workflow publishes **ten packages, all at the same version**: `@terreno/api`, `@terreno/test`, `@terreno/ui`, `@terreno/rtk`, `@terreno/admin-backend`, `@terreno/admin-frontend`, `@terreno/admin-spa`, `@terreno/ai`, `@terreno/api-health`, `@terreno/feature-flags`. (`mcp-server`, `demo`, and the example apps are not published.)
+- Publish jobs are chained: `rtk`, `admin-frontend`, and `admin-spa` depend on `publish-ui`; `admin-backend`, `ai`, `api-health`, and `feature-flags` depend on `publish-api`. `api`, `test`, and `ui` publish independently (no upstream `needs`). A `ui` or `api` failure cascades.
 - After successful publishes, the workflow commits `chore: bump package versions to X.Y.Z` back to master and sends a Zoom notification. Prerelease tags (`-beta`, `-alpha`) skip the master bump.
 
 ## Step 1: Preflight
@@ -122,12 +122,12 @@ gh release create "$VERSION" --target master --title "$VERSION" --notes-file /tm
 2. Verify every package is live on npm (allow a couple of minutes of registry lag):
 
    ```bash
-   for p in api ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
+   for p in api test ui rtk admin-backend admin-frontend admin-spa ai api-health feature-flags; do
      echo "@terreno/$p: $(npm view "@terreno/$p" version)"
    done
    ```
 
-   All nine must report `$VERSION`.
+   All ten must report `$VERSION`.
 
 3. Confirm the `chore: bump package versions to $VERSION` commit landed on master (`git fetch origin master && git log origin/master -1 --oneline`). Skipped for prereleases.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`@terreno/test` (the shared Bun test-helper / MongoDB preload package) is set up to be published — it has `publishConfig.access: public`, a `main`/`types`/`exports` surface, and compiles to `dist/` — but it was **missing from `.github/workflows/publish-on-tag.yml`**. As a result it is **not published on npm** (`npm view @terreno/test` returns 404), even though `@terreno/api`, `@terreno/ai`, `@terreno/admin-backend`, `@terreno/feature-flags`, and `@terreno/example-backend` all depend on it via `workspace:*`.

## Change

- Add a `publish-test` job to the publish-on-tag workflow (no upstream `needs`, runs in parallel with `publish-api`/`publish-ui`). It mirrors the `publish-api` setup: install, bump version from tag, replace `catalog:` references, compile, then `npm publish`. Like `api`/`ai`, the package has no `files` field but `npm publish` runs from its own directory so `dist/` and `src/` are included correctly.
- Wire `publish-test` into the `update-version-on-master` job (so the post-publish version bump on master covers `test/package.json`) and into the `notify` job (so the Zoom release notification reports its status).
- Update the `release` skill doc to reflect ten published packages and include `test` in the npm verification loop.

## Notes

- This workflow fix must land on `master` **before** the next release tag is cut, since `publish-on-tag.yml` runs from the tagged commit. Tags pushed before this merges will not publish `@terreno/test`.
- No version bump is needed in `test/package.json`; it already sits at `0.21.0` alongside the other packages, and the workflow sets the version from the tag at publish time.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-625ed447-d8ac-42bd-b94e-def5e3eda236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-625ed447-d8ac-42bd-b94e-def5e3eda236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

