### PR TITLE
fix(test): pin qs to ^6.14.1 instead of missing catalog entry

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -529,7 +529,7 @@
       "dependencies": {
         "express": "^5.2.1",
         "lodash": "catalog:",
-        "qs": "catalog:",
+        "qs": "^6.14.1",
         "winston": "^3.18.3",
       },
       "devDependencies": {

--- a/test/package.json
+++ b/test/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "express": "^5.2.1",
     "lodash": "catalog:",
-    "qs": "catalog:",
+    "qs": "^6.14.1",
     "winston": "^3.18.3"
   },
   "description": "Shared Bun test helpers, MongoDB preload utilities, and HTTP fixtures for Terreno packages",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `0.22.0` release exposed a latent bug in `@terreno/test`'s `package.json`: it declared `"qs": "catalog:"`, but the root `package.json` `catalog` has **no `qs` entry** (`qs` is only pinned via `overrides`). Local installs survive on the existing lockfile, but the `publish-on-tag` workflow's strict "Replace catalog references" step throws `Catalog entry not found for qs`, so `publish-test` failed.

Because `@terreno/ai`, `@terreno/admin-backend`, and `@terreno/feature-flags` depend on `@terreno/test` via `workspace:*` (rewritten to the release version, then reinstalled), the failed `@terreno/test` publish **cascaded**: those three jobs failed trying to resolve `@terreno/test@0.22.0` from npm.

> Result for `0.22.0`: `api`, `ui`, `rtk`, `admin-frontend`, `api-health`, `mcp`, and `admin-spa` published; `test`, `ai`, `admin-backend`, and `feature-flags` failed. Since npm versions are immutable, `0.22.0` cannot be reused — the fix will ship as `0.22.1`.

## Change

- Pin `qs` in `test/package.json` to `^6.14.1`, matching `@terreno/api` and `@terreno/rtk` and the root `overrides` entry. This is the only `catalog:` reference in `@terreno/test` that lacks a catalog entry (`lodash`, `@biomejs/biome`, `mongoose`, `typescript` all resolve).
- Update `bun.lock` accordingly (single-line change).

## Verification

- Simulated the workflow's catalog-replacement script against `test/package.json` — it now resolves all `catalog:` refs and succeeds.
- `@terreno/test` compiles cleanly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-625ed447-d8ac-42bd-b94e-def5e3eda236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-625ed447-d8ac-42bd-b94e-def5e3eda236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

