### PR TITLE
fix(api): declare @terreno/test as a runtime dependency

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -76,61 +76,30 @@ jobs:
           VERSION="${{ needs.check-changes.outputs.version }}"
           node -e "const fs = require('fs'); const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')); pkg.version = '$VERSION'; fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');"
 
-      - name: Replace catalog references
+      - name: Replace catalog and workspace references
         run: |
+          VERSION="${{ needs.check-changes.outputs.version }}"
           node -e "
           const fs = require('fs');
-          const path = require('path');
-          
-          // Read root catalog
           const rootPkg = JSON.parse(fs.readFileSync('../package.json', 'utf8'));
           const catalog = rootPkg.catalog || {};
-          
-          // Read current package.json
           const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-          
-          // Replace catalog: in dependencies
-          if (pkg.dependencies) {
-            for (const [key, value] of Object.entries(pkg.dependencies)) {
+          const version = process.env.VERSION;
+          for (const depType of ['dependencies', 'devDependencies', 'peerDependencies']) {
+            if (!pkg[depType]) continue;
+            for (const [key, value] of Object.entries(pkg[depType])) {
               if (value === 'catalog:') {
-                if (catalog[key]) {
-                  pkg.dependencies[key] = catalog[key];
-                } else {
-                  throw new Error(\`Catalog entry not found for \${key}\`);
-                }
+                if (!catalog[key]) throw new Error(\`Catalog entry not found for \${key}\`);
+                pkg[depType][key] = catalog[key];
+              } else if (value === 'workspace:*' && key.startsWith('@terreno/')) {
+                pkg[depType][key] = version;
               }
             }
           }
-          
-          // Replace catalog: in devDependencies
-          if (pkg.devDependencies) {
-            for (const [key, value] of Object.entries(pkg.devDependencies)) {
-              if (value === 'catalog:') {
-                if (catalog[key]) {
-                  pkg.devDependencies[key] = catalog[key];
-                } else {
-                  throw new Error(\`Catalog entry not found for \${key}\`);
-                }
-              }
-            }
-          }
-          
-          // Replace catalog: in peerDependencies
-          if (pkg.peerDependencies) {
-            for (const [key, value] of Object.entries(pkg.peerDependencies)) {
-              if (value === 'catalog:') {
-                if (catalog[key]) {
-                  pkg.peerDependencies[key] = catalog[key];
-                } else {
-                  throw new Error(\`Catalog entry not found for \${key}\`);
-                }
-              }
-            }
-          }
-          
-          // Write updated package.json
           fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
+        env:
+          VERSION: ${{ needs.check-changes.outputs.version }}
 
       - name: Compile
         run: bun run compile
@@ -539,7 +508,7 @@ jobs:
         run: echo "Published @terreno/rtk@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
 
   publish-admin-backend:
-    needs: [check-changes, publish-api]
+    needs: [check-changes, publish-api, publish-test]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -842,7 +811,7 @@ jobs:
         run: echo "Published @terreno/admin-spa@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
 
   publish-ai:
-    needs: [check-changes, publish-api]
+    needs: [check-changes, publish-api, publish-test]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -942,7 +911,7 @@ jobs:
         run: echo "Published @terreno/ai@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
 
   publish-api-health:
-    needs: [check-changes, publish-api]
+    needs: [check-changes, publish-api, publish-test]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1036,7 +1005,7 @@ jobs:
         run: echo "Published @terreno/api-health@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
 
   publish-feature-flags:
-    needs: [check-changes, publish-api]
+    needs: [check-changes, publish-api, publish-test]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1136,7 +1105,7 @@ jobs:
         run: echo "Published @terreno/feature-flags@${{ needs.check-changes.outputs.version }}" >> $GITHUB_STEP_SUMMARY
 
   publish-mcp:
-    needs: [check-changes, publish-api]
+    needs: [check-changes, publish-api, publish-test]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/api/package.json
+++ b/api/package.json
@@ -7,6 +7,7 @@
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@sentry/bun": "^10.25.0",
     "@sentry/profiling-node": "^10.25.0",
+    "@terreno/test": "workspace:*",
     "@types/qs": "^6.14.0",
     "ajv": "8.18.0",
     "ajv-formats": "^3.0.1",
@@ -46,7 +47,6 @@
   "description": "Styled after the Django & Django REST Framework, a batteries-include framework for building REST APIs with Node/Express/Mongoose.",
   "devDependencies": {
     "@biomejs/biome": "^2.3.6",
-    "@terreno/test": "workspace:*",
     "@types/bcrypt": "^6.0.0",
     "@types/bun": "^1.2.4",
     "@types/cors": "^2.8.17",

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "admin-backend": {
       "name": "@terreno/admin-backend",
-      "version": "0.21.0",
+      "version": "0.22.1",
       "dependencies": {
         "@google-cloud/storage": "^7.15.0",
         "@terreno/api": "workspace:*",
@@ -37,7 +37,7 @@
     },
     "admin-frontend": {
       "name": "@terreno/admin-frontend",
-      "version": "0.21.0",
+      "version": "0.22.1",
       "dependencies": {
         "@terreno/ui": "workspace:*",
         "expo-router": "catalog:",
@@ -68,7 +68,7 @@
     },
     "admin-spa": {
       "name": "@terreno/admin-spa",
-      "version": "0.21.0",
+      "version": "0.22.1",
       "dependencies": {
         "@expo/vector-icons": "catalog:",
         "@react-native-async-storage/async-storage": "catalog:",
@@ -119,7 +119,7 @@
     },
     "ai": {
       "name": "@terreno/ai",
-      "version": "0.21.0",
+      "version": "0.22.1",
       "dependencies": {
         "@ai-sdk/mcp": "^1.0.21",
         "@google-cloud/storage": "^7.15.0",
@@ -155,11 +155,12 @@
     },
     "api": {
       "name": "@terreno/api",
-      "version": "0.21.0",
+      "version": "0.22.1",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@sentry/bun": "^10.25.0",
         "@sentry/profiling-node": "^10.25.0",
+        "@terreno/test": "workspace:*",
         "@thream/socketio-jwt": "^3.1.4",
         "@types/qs": "^6.14.0",
         "ajv": "8.18.0",
@@ -198,7 +199,6 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.6",
-        "@terreno/test": "workspace:*",
         "@types/bcrypt": "^6.0.0",
         "@types/bun": "^1.2.4",
         "@types/cors": "^2.8.17",
@@ -231,7 +231,7 @@
     },
     "api-health": {
       "name": "@terreno/api-health",
-      "version": "0.21.0",
+      "version": "0.22.1",
       "dependencies": {
         "@terreno/api": "workspace:*",
         "express": "^5.2.1",
@@ -460,7 +460,7 @@
     },
     "mcp-server": {
       "name": "@terreno/mcp",
-      "version": "0.21.0",
+      "version": "0.22.1",
       "bin": {
         "terreno-mcp": "./dist/index.js",
         "terreno-mcp-local": "./dist/local/index.js",
@@ -481,7 +481,7 @@
     },
     "rtk": {
       "name": "@terreno/rtk",
-      "version": "0.21.0",
+      "version": "0.22.1",
       "dependencies": {
         "@better-auth/expo": "^1.2.8",
         "@openfeature/core": "catalog:",
@@ -525,7 +525,7 @@
     },
     "test": {
       "name": "@terreno/test",
-      "version": "0.21.0",
+      "version": "0.22.1",
       "dependencies": {
         "express": "^5.2.1",
         "lodash": "catalog:",
@@ -550,7 +550,7 @@
     },
     "ui": {
       "name": "@terreno/ui",
-      "version": "0.21.0",
+      "version": "0.22.1",
       "dependencies": {
         "@expo-google-fonts/nunito": "^0.4.2",
         "@expo-google-fonts/titillium-web": "^0.4.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `0.22.1` release published every package **except `@terreno/feature-flags`**, which failed its test run with:

```
error: Cannot find module '@terreno/test' from '.../@terreno/api@0.22.1/.../dist/tests.js'
```

`@terreno/api` exposes a public `./testing` entry (`dist/tests.js`) — the shared test helpers `getBaseServer`, `authAsUser`, `setupDb`, `UserModel`, etc. That file `require`s `@terreno/test`, but `@terreno/test` was only a **devDependency** of `@terreno/api`. Under bun's isolated installs (and for any external consumer of `@terreno/api/testing`), the api package can't resolve `@terreno/test`, so the import fails.

- `feature-flags` and `admin-backend` import `@terreno/api/testing`. `feature-flags` runs tests in its publish job → failed. `admin-backend`'s publish job only compiles (no test run), so it didn't surface the error.
- `ai` imports `@terreno/test` directly (never loads api's `./testing`), which is why its publish job passed.

This is a real bug for external consumers too: anyone importing `@terreno/api/testing` cannot resolve `@terreno/test`.

## Change

- Move `@terreno/test` from `devDependencies` to `dependencies` in `api/package.json`, since `@terreno/api` ships code that imports it at runtime. Its heavy tooling (`mongodb-memory-server`, etc.) remains a devDependency of `@terreno/test`, so consumers don't pull that in — only the light runtime deps (`express`, `lodash`, `qs`, `winston`) that api already depends on.
- Make the `publish-api` job's "Replace … references" step **workspace-aware** (convert `workspace:*` `@terreno/*` deps to the release version, in addition to `catalog:`), so the published `@terreno/api` references a concrete `@terreno/test` version rather than `workspace:*`.
- Gate the api-dependent publish jobs (`admin-backend`, `ai`, `api-health`, `feature-flags`, `mcp`) on `publish-test`, since they install `@terreno/api` from npm and now transitively need `@terreno/test` to be published first.
- Sync `bun.lock` (dep move + corrects pre-existing workspace version drift to `0.22.1`).

## Release status

`0.22.0` and `0.22.1` are both immutable on npm now. Once this merges, the fix ships as **`0.22.2`**, which republishes all packages at `0.22.2` (including `feature-flags`, which is still at `0.21.0`).

## Verification

- `@terreno/api` compiles cleanly (its `compile` script already compiles `@terreno/test` via `compile-workspace-deps`).
- Workflow YAML validated; job dependency graph confirmed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-625ed447-d8ac-42bd-b94e-def5e3eda236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-625ed447-d8ac-42bd-b94e-def5e3eda236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

