### PR TITLE
feat: expose admin scripts as a CLI with flexible argument handling

### DIFF
--- a/.github/workflows/example-backend-script-runner.yml
+++ b/.github/workflows/example-backend-script-runner.yml
@@ -1,0 +1,110 @@
+name: Example Backend Script Runner
+
+# Exercises the admin script runner CLI (`bun run script`) end-to-end against the
+# example backend with a real MongoDB. This guards the CLI surface that lets AI
+# assistants run admin scripts directly from the project.
+
+on:
+  push:
+    paths:
+      - "api/**"
+      - "ai/**"
+      - "api-health/**"
+      - "admin-backend/**"
+      - "admin-frontend/**"
+      - "admin-spa/**"
+      - "feature-flags/**"
+      - "rtk/**"
+      - "ui/**"
+      - "example-backend/**"
+      - ".github/workflows/example-backend-script-runner.yml"
+
+jobs:
+  run-script-cli:
+    name: Run admin script CLI
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mongodb-version: ["6.0"]
+    steps:
+      - uses: actions/checkout@v6.0.3
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        id: cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('bun.lock', 'package.json') }}
+          restore-keys: |
+            bun-${{ runner.os }}-${{ github.ref }}-
+            bun-${{ runner.os }}-
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.12.1
+        with:
+          mongodb-version: ${{ matrix.mongodb-version }}
+          mongodb-image: mirror.gcr.io/library/mongo
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # example-backend imports the compiled output of these workspace packages.
+      - name: Build dependencies
+        run: |
+          for pkg in api ai api-health admin-backend feature-flags ui rtk admin-frontend admin-spa; do
+            echo "::group::compile $pkg"
+            (cd "$pkg" && bun run compile)
+            echo "::endgroup::"
+          done
+
+      - name: Build example backend
+        run: bun run compile
+        working-directory: example-backend
+
+      - name: List available scripts (no database needed)
+        run: |
+          set -euo pipefail
+          output="$(bun run script --list)"
+          echo "$output"
+          echo "$output" | grep -q "countRecords"
+          echo "$output" | grep -q "seedFeatureFlags"
+        working-directory: example-backend
+
+      - name: Run countRecords as a dry run with an argument
+        run: |
+          set -euo pipefail
+          output="$(bun run script countRecords --json --model todos)"
+          echo "$output"
+          echo "$output" | grep -q '"success":true'
+          echo "$output" | grep -q '"wetRun":false'
+        working-directory: example-backend
+        env:
+          CI: true
+
+      - name: Run seedFeatureFlags as a wet run (mutating script)
+        run: |
+          set -euo pipefail
+          output="$(bun run script seedFeatureFlags --wet --json)"
+          echo "$output"
+          echo "$output" | grep -q '"success":true'
+          echo "$output" | grep -q '"wetRun":true'
+        working-directory: example-backend
+        env:
+          CI: true
+
+      - name: Reject an unknown script with a non-zero exit
+        run: |
+          set -euo pipefail
+          if bun run script does-not-exist; then
+            echo "Expected the CLI to fail for an unknown script"
+            exit 1
+          fi
+        working-directory: example-backend
+        env:
+          CI: true

--- a/admin-backend/src/adminApp.test.ts
+++ b/admin-backend/src/adminApp.test.ts
@@ -171,6 +171,84 @@ describe("AdminApp script routes", () => {
     });
   });
 
+  describe("POST /admin/scripts/:name/run with arguments", () => {
+    const createArgScript = () => ({
+      args: [
+        {default: "all", description: "Which model", name: "model", type: "string" as const},
+        {description: "Limit", name: "limit", required: true, type: "number" as const},
+      ],
+      description: "Echoes its arguments",
+      name: "argScript",
+      runner: async (
+        _wetRun: boolean,
+        ctx?: {
+          args: {
+            getString: (n: string, f?: string) => string | undefined;
+            getNumber: (n: string) => number | undefined;
+          };
+        }
+      ) => ({
+        results: [`model=${ctx?.args.getString("model")}`, `limit=${ctx?.args.getNumber("limit")}`],
+        success: true,
+      }),
+    });
+
+    beforeEach(async () => {
+      await setupDb();
+      app = buildApp([createArgScript()]);
+      adminAgent = await authAsUser(app, "admin");
+    });
+
+    it("passes JSON body args to the runner", async () => {
+      const res = await adminAgent
+        .post("/admin/scripts/argScript/run")
+        .send({args: {limit: 5, model: "todos"}})
+        .expect(201);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const task = await BackgroundTask.findById(res.body.taskId);
+      expect(task?.status).toBe("completed");
+      expect(task?.result).toContain("model=todos");
+      expect(task?.result).toContain("limit=5");
+    });
+
+    it("passes query params as args", async () => {
+      const res = await adminAgent
+        .post("/admin/scripts/argScript/run?model=users&limit=9")
+        .expect(201);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const task = await BackgroundTask.findById(res.body.taskId);
+      expect(task?.result).toContain("model=users");
+      expect(task?.result).toContain("limit=9");
+    });
+
+    it("applies declared defaults when an arg is omitted", async () => {
+      const res = await adminAgent
+        .post("/admin/scripts/argScript/run")
+        .send({args: {limit: 1}})
+        .expect(201);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const task = await BackgroundTask.findById(res.body.taskId);
+      expect(task?.result).toContain("model=all");
+    });
+
+    it("returns 400 when a required arg is missing", async () => {
+      const res = await adminAgent.post("/admin/scripts/argScript/run").expect(400);
+      expect(res.body.title).toInclude("Invalid arguments for script: argScript");
+      expect(res.body.detail).toInclude("Missing required argument: --limit");
+    });
+
+    it("returns 400 when an arg fails type coercion", async () => {
+      const res = await adminAgent
+        .post("/admin/scripts/argScript/run")
+        .send({args: {limit: "not-a-number"}})
+        .expect(400);
+      expect(res.body.detail).toInclude("expected a number");
+    });
+  });
+
   describe("GET /admin/scripts/tasks/:id", () => {
     let taskId: string;
 
@@ -402,6 +480,23 @@ describe("AdminApp script routes", () => {
       expect(res.body.scripts[0].description).toBe("Migrate old data");
       expect(res.body.scripts[1].name).toBe("cleanup");
       expect(res.body.scripts[1].description).toBe("Clean up orphans");
+      expect(res.body.scripts[0].args).toEqual([]);
+    });
+
+    it("exposes declared script args in the config response", async () => {
+      app = buildApp([
+        {
+          args: [{description: "Which model", name: "model", type: "string"}],
+          description: "Echoes args",
+          name: "argScript",
+          runner: async () => ({results: [], success: true}),
+        },
+      ]);
+      const freshAdmin = await authAsUser(app, "admin");
+      const res = await freshAdmin.get("/admin/config").expect(200);
+
+      expect(res.body.scripts[0].args).toHaveLength(1);
+      expect(res.body.scripts[0].args[0].name).toBe("model");
     });
 
     it("returns empty scripts array when no scripts configured", async () => {

--- a/admin-backend/src/adminApp.test.ts
+++ b/admin-backend/src/adminApp.test.ts
@@ -247,6 +247,30 @@ describe("AdminApp script routes", () => {
         .expect(400);
       expect(res.body.detail).toInclude("expected a number");
     });
+
+    it("strips reserved runner flags from ctx.args over HTTP", async () => {
+      const echoScript = {
+        description: "Echoes arg keys",
+        name: "echoArgs",
+        runner: async (_wetRun: boolean, ctx?: {args: {raw: Record<string, unknown>}}) => ({
+          results: [
+            Object.keys(ctx?.args.raw ?? {})
+              .sort()
+              .join(","),
+          ],
+          success: true,
+        }),
+      };
+      app = buildApp([echoScript]);
+      const agent = await authAsUser(app, "admin");
+      const res = await agent
+        .post("/admin/scripts/echoArgs/run?wetRun=true&json=true&keep=yes")
+        .expect(201);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const task = await BackgroundTask.findById(res.body.taskId);
+      expect(task?.result?.[0]).toBe("keep");
+    });
   });
 
   describe("GET /admin/scripts/tasks/:id", () => {

--- a/admin-backend/src/adminApp.ts
+++ b/admin-backend/src/adminApp.ts
@@ -6,6 +6,7 @@ import {
   type BackgroundTaskDocument,
   checkPermissions,
   createOpenApiBuilder,
+  createScriptArgs,
   getOpenApiSpecForModel,
   type JSONValue,
   logger,
@@ -13,6 +14,8 @@ import {
   modelRouter,
   type OpenApiMiddleware,
   Permissions,
+  type ScriptArgDef,
+  type ScriptArgValue,
   type ScriptContext,
   type ScriptResult,
   type ScriptRunner,
@@ -117,6 +120,12 @@ export interface AdminScriptConfig {
   name: string;
   /** Human-readable description shown in the admin UI */
   description: string;
+  /**
+   * Optional declarations for the arguments this script accepts. Drives CLI help,
+   * type coercion, defaults, and validation. Scripts may still read undeclared
+   * arguments via `ctx.args`.
+   */
+  args?: ScriptArgDef[];
   /** The function that executes the script. Must return string[] results. */
   runner: ScriptRunner;
 }
@@ -213,6 +222,7 @@ interface AdminModelMeta {
 interface AdminScriptMeta {
   name: string;
   description: string;
+  args: ScriptArgDef[];
 }
 
 interface AdminConfigResponse {
@@ -568,6 +578,7 @@ export class AdminApp {
     // Build script metadata for config response
     const scriptConfigs = this.options.scripts ?? [];
     const configScripts: AdminScriptMeta[] = scriptConfigs.map((script) => ({
+      args: script.args ?? [],
       description: script.description,
       name: script.name,
     }));
@@ -605,6 +616,7 @@ export class AdminApp {
             scripts: {
               items: {
                 properties: {
+                  args: {type: "array"},
                   description: {type: "string"},
                   name: {type: "string"},
                 },
@@ -1169,6 +1181,40 @@ export class AdminApp {
         }
 
         const isWetRun = req.query.wetRun === "true";
+
+        // Collect flexible arguments from the request. Query params (except wetRun)
+        // and a JSON body are both accepted; an explicit `args` object in the body
+        // takes precedence. This mirrors the CLI so scripts read args identically
+        // regardless of how they were invoked.
+        const argValues: Record<string, ScriptArgValue> = {};
+        for (const [key, value] of Object.entries(req.query)) {
+          if (key === "wetRun" || value === undefined) {
+            continue;
+          }
+          argValues[key] = value as ScriptArgValue;
+        }
+        const rawBody =
+          req.body && typeof req.body === "object" && !Array.isArray(req.body)
+            ? (req.body as Record<string, unknown>)
+            : {};
+        const bodyValues =
+          rawBody.args && typeof rawBody.args === "object" && !Array.isArray(rawBody.args)
+            ? (rawBody.args as Record<string, ScriptArgValue>)
+            : (rawBody as Record<string, ScriptArgValue>);
+        Object.assign(argValues, bodyValues);
+
+        const {args, errors: argErrors} = createScriptArgs({
+          defs: script.args ?? [],
+          values: argValues,
+        });
+        if (argErrors.length > 0) {
+          throw new APIError({
+            detail: argErrors.join("; "),
+            status: 400,
+            title: `Invalid arguments for script: ${script.name}`,
+          });
+        }
+
         const now = DateTime.now().toJSDate();
 
         let task: BackgroundTaskDocument;
@@ -1194,7 +1240,7 @@ export class AdminApp {
           });
         }
 
-        // Build context for cancellation and progress reporting
+        // Build context for cancellation, progress reporting, and arguments
         const ctx: ScriptContext = {
           addLog: async (level, message) => {
             const current = await BackgroundTask.findById(task._id);
@@ -1202,6 +1248,7 @@ export class AdminApp {
               await current.addLog(level, message);
             }
           },
+          args,
           checkCancellation: async () => {
             await BackgroundTask.checkCancellation(task._id.toString());
           },

--- a/admin-backend/src/adminApp.ts
+++ b/admin-backend/src/adminApp.ts
@@ -41,6 +41,7 @@ import {
   normalizeAdminHome,
   SYSTEM_ADMIN_FIELDS,
 } from "./adminUiV2";
+import {RESERVED_SCRIPT_FLAGS} from "./scriptCli";
 
 /**
  * Configuration for a single model in the admin panel.
@@ -1182,13 +1183,13 @@ export class AdminApp {
 
         const isWetRun = req.query.wetRun === "true";
 
-        // Collect flexible arguments from the request. Query params (except wetRun)
-        // and a JSON body are both accepted; an explicit `args` object in the body
-        // takes precedence. This mirrors the CLI so scripts read args identically
-        // regardless of how they were invoked.
+        // Collect flexible arguments from the request. Query params and a JSON body
+        // are both accepted; an explicit `args` object in the body takes precedence.
+        // Reserved runner flags (wetRun, wet, dry, json, ...) are stripped so scripts
+        // read args identically over HTTP and via the CLI.
         const argValues: Record<string, ScriptArgValue> = {};
         for (const [key, value] of Object.entries(req.query)) {
-          if (key === "wetRun" || value === undefined) {
+          if (RESERVED_SCRIPT_FLAGS.includes(key) || value === undefined) {
             continue;
           }
           argValues[key] = value as ScriptArgValue;
@@ -1201,7 +1202,12 @@ export class AdminApp {
           rawBody.args && typeof rawBody.args === "object" && !Array.isArray(rawBody.args)
             ? (rawBody.args as Record<string, ScriptArgValue>)
             : (rawBody as Record<string, ScriptArgValue>);
-        Object.assign(argValues, bodyValues);
+        for (const [key, value] of Object.entries(bodyValues)) {
+          if (RESERVED_SCRIPT_FLAGS.includes(key)) {
+            continue;
+          }
+          argValues[key] = value;
+        }
 
         const {args, errors: argErrors} = createScriptArgs({
           defs: script.args ?? [],

--- a/admin-backend/src/index.ts
+++ b/admin-backend/src/index.ts
@@ -14,3 +14,5 @@ export type {
   DocumentStorageOptions,
 } from "./documentStorageApp";
 export {DocumentStorageApp} from "./documentStorageApp";
+export type {RunScriptCliOptions, RunScriptCliResult} from "./scriptCli";
+export {runScriptCli} from "./scriptCli";

--- a/admin-backend/src/scriptCli.test.ts
+++ b/admin-backend/src/scriptCli.test.ts
@@ -1,0 +1,239 @@
+import {describe, expect, it} from "bun:test";
+import type {ScriptContext} from "@terreno/api";
+
+import type {AdminScriptConfig} from "./adminApp";
+import {runScriptCli} from "./scriptCli";
+
+const countScript: AdminScriptConfig = {
+  args: [{default: "all", description: "Which collection to count", name: "model", type: "string"}],
+  description: "Count records",
+  name: "countRecords",
+  runner: async (wetRun, ctx) => {
+    const model = ctx?.args.getString("model", "all") ?? "all";
+    return {results: [`mode=${wetRun ? "wet" : "dry"}`, `model=${model}`], success: true};
+  },
+};
+
+const requiredArgScript: AdminScriptConfig = {
+  args: [{description: "Email to target", name: "email", required: true}],
+  description: "Needs an email",
+  name: "needsEmail",
+  runner: async (_wetRun, ctx) => ({
+    results: [`email=${ctx?.args.getString("email") ?? ""}`],
+    success: true,
+  }),
+};
+
+const failingScript: AdminScriptConfig = {
+  description: "Always throws",
+  name: "boom",
+  runner: async () => {
+    throw new Error("kaboom");
+  },
+};
+
+const unsuccessfulScript: AdminScriptConfig = {
+  description: "Reports failure",
+  name: "sad",
+  runner: async () => ({results: ["nope"], success: false}),
+};
+
+const loggingScript: AdminScriptConfig = {
+  description: "Logs via context",
+  name: "logger",
+  runner: async (_wetRun, ctx?: ScriptContext) => {
+    await ctx?.checkCancellation();
+    await ctx?.addLog("info", "hello");
+    await ctx?.updateProgress(50, "halfway", "still going");
+    return {results: ["logged"], success: true};
+  },
+};
+
+const richArgsScript: AdminScriptConfig = {
+  args: [
+    {
+      aliases: ["m"],
+      default: "all",
+      description: "Which model",
+      example: "todos",
+      name: "model",
+      type: "string",
+    },
+  ],
+  description: "Has a rich arg",
+  name: "rich",
+  runner: async (_wetRun, ctx) => ({
+    results: [`model=${ctx?.args.getString("model")}`],
+    success: true,
+  }),
+};
+
+const allScripts = [
+  countScript,
+  requiredArgScript,
+  failingScript,
+  unsuccessfulScript,
+  loggingScript,
+  richArgsScript,
+];
+
+/** Runs the CLI capturing output, never exiting the process. */
+const run = async (argv: string[], scripts = allScripts) => {
+  const lines: string[] = [];
+  const result = await runScriptCli({
+    argv,
+    exit: false,
+    scripts,
+    write: (line) => lines.push(line),
+  });
+  return {lines, output: lines.join("\n"), result};
+};
+
+describe("runScriptCli", () => {
+  it("prints general help and lists scripts when no script is given", async () => {
+    const {output, result} = await run([]);
+    expect(result.exitCode).toBe(0);
+    expect(output).toInclude("Available scripts:");
+    expect(output).toInclude("countRecords");
+  });
+
+  it("lists scripts with --list", async () => {
+    const {output, result} = await run(["--list"]);
+    expect(result.exitCode).toBe(0);
+    expect(output).toInclude("countRecords");
+  });
+
+  it("prints general help with --help and no script", async () => {
+    const {output, result} = await run(["--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(output).toInclude("Available scripts:");
+  });
+
+  it("shows aliases and examples in per-script help", async () => {
+    const {output, result} = await run(["rich", "--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(output).toInclude("(-m)");
+    expect(output).toInclude("(e.g. todos)");
+    expect(output).toInclude("(default: all)");
+  });
+
+  it("notes when no scripts are registered", async () => {
+    const {output} = await run(["--list"], []);
+    expect(output).toInclude("No scripts are registered.");
+  });
+
+  it("returns an error for an unknown script", async () => {
+    const {output, result} = await run(["doesNotExist"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.success).toBe(false);
+    expect(output).toInclude("Unknown script: doesNotExist");
+  });
+
+  it("prints per-script help including declared args", async () => {
+    const {output, result} = await run(["countRecords", "--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(output).toInclude("--model");
+    expect(output).toInclude("Which collection to count");
+  });
+
+  it("runs as a dry run by default", async () => {
+    const {result} = await run(["countRecords"]);
+    expect(result.success).toBe(true);
+    expect(result.wetRun).toBe(false);
+    expect(result.results).toContain("mode=dry");
+    expect(result.results).toContain("model=all");
+  });
+
+  it("runs in wet mode with --wet", async () => {
+    const {result} = await run(["countRecords", "--wet"]);
+    expect(result.wetRun).toBe(true);
+    expect(result.results).toContain("mode=wet");
+  });
+
+  it("lets --dry override --wet", async () => {
+    const {result} = await run(["countRecords", "--wet", "--dry"]);
+    expect(result.wetRun).toBe(false);
+    expect(result.results).toContain("mode=dry");
+  });
+
+  it("forwards declared args to the runner", async () => {
+    const {result} = await run(["countRecords", "--model", "todos"]);
+    expect(result.results).toContain("model=todos");
+  });
+
+  it("does not leak reserved flags into script args", async () => {
+    const seen: Record<string, unknown> = {};
+    const spyScript: AdminScriptConfig = {
+      description: "spy",
+      name: "spy",
+      runner: async (_wetRun, ctx) => {
+        Object.assign(seen, ctx?.args.raw);
+        return {results: ["ok"], success: true};
+      },
+    };
+    await run(["spy", "--wet", "--json", "--keep=yes"], [spyScript]);
+    expect(seen.wet).toBeUndefined();
+    expect(seen.json).toBeUndefined();
+    expect(seen.keep).toBe("yes");
+  });
+
+  it("fails when a required argument is missing", async () => {
+    const {output, result} = await run(["needsEmail"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.success).toBe(false);
+    expect(output).toInclude("Missing required argument: --email");
+    expect(output).toInclude("Usage:");
+  });
+
+  it("accepts a provided required argument", async () => {
+    const {result} = await run(["needsEmail", "--email", "a@b.com"]);
+    expect(result.success).toBe(true);
+    expect(result.results).toContain("email=a@b.com");
+  });
+
+  it("returns a non-zero exit when the script throws", async () => {
+    const {output, result} = await run(["boom"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.errors).toContain("kaboom");
+    expect(output).toInclude("Error: kaboom");
+  });
+
+  it("returns a non-zero exit when the script reports failure", async () => {
+    const {output, result} = await run(["sad"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.success).toBe(false);
+    expect(output).toInclude("Script reported failure.");
+  });
+
+  it("emits a JSON line in --json mode", async () => {
+    const {lines, result} = await run(["countRecords", "--json", "--model", "users"]);
+    expect(result.success).toBe(true);
+    const jsonLine = lines.find((line) => line.startsWith("{"));
+    expect(jsonLine).toBeDefined();
+    const parsed = JSON.parse(jsonLine as string);
+    expect(parsed.script).toBe("countRecords");
+    expect(parsed.results).toContain("model=users");
+  });
+
+  it("emits JSON on error in --json mode", async () => {
+    const {lines, result} = await run(["boom", "--json"]);
+    expect(result.exitCode).toBe(1);
+    const jsonLine = lines.find((line) => line.startsWith("{"));
+    const parsed = JSON.parse(jsonLine as string);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toBe("kaboom");
+  });
+
+  it("routes context logs and progress to output (non-json)", async () => {
+    const {output} = await run(["logger"]);
+    expect(output).toInclude("[info] hello");
+    expect(output).toInclude("[progress] 50%");
+    expect(output).toInclude("halfway");
+  });
+
+  it("suppresses context logs in --json mode", async () => {
+    const {output} = await run(["logger", "--json"]);
+    expect(output).not.toInclude("[info] hello");
+    expect(output).not.toInclude("[progress]");
+  });
+});

--- a/admin-backend/src/scriptCli.test.ts
+++ b/admin-backend/src/scriptCli.test.ts
@@ -177,6 +177,13 @@ describe("runScriptCli", () => {
     expect(seen.keep).toBe("yes");
   });
 
+  it("errors when a declared value flag is missing its value", async () => {
+    const {output, result} = await run(["countRecords", "--model"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.success).toBe(false);
+    expect(output).toInclude("--model expects a string value");
+  });
+
   it("fails when a required argument is missing", async () => {
     const {output, result} = await run(["needsEmail"]);
     expect(result.exitCode).toBe(1);

--- a/admin-backend/src/scriptCli.ts
+++ b/admin-backend/src/scriptCli.ts
@@ -1,0 +1,271 @@
+import {
+  logger,
+  parseScriptArgs,
+  type ScriptArgDef,
+  type ScriptContext,
+  type ScriptResult,
+} from "@terreno/api";
+
+import type {AdminScriptConfig} from "./adminApp";
+
+/**
+ * Flag names reserved by the CLI itself. They control how a script is invoked and
+ * are stripped from the arguments handed to the script runner, so script authors
+ * should avoid declaring args with these names.
+ */
+const RESERVED_FLAGS = ["help", "h", "list", "json", "wet", "wetRun", "dry"];
+
+export interface RunScriptCliOptions {
+  /** The same script configs registered on {@link AdminApp}. */
+  scripts: AdminScriptConfig[];
+  /** Tokens to parse. Defaults to `process.argv.slice(2)`. */
+  argv?: string[];
+  /** Line writer for human-readable output. Defaults to stdout. */
+  write?: (line: string) => void;
+  /**
+   * When true (default), the process exits with the resulting exit code after the
+   * run. Pass false in tests or when embedding the runner in a larger CLI.
+   */
+  exit?: boolean;
+  /** Program name shown in help text. Defaults to "script". */
+  programName?: string;
+}
+
+export interface RunScriptCliResult {
+  exitCode: number;
+  script?: string;
+  wetRun: boolean;
+  success: boolean;
+  results: string[];
+  errors: string[];
+}
+
+const formatArgUsage = (arg: ScriptArgDef): string => {
+  const type = arg.type ?? "string";
+  const base = type === "boolean" ? `--${arg.name}` : `--${arg.name} <${type}>`;
+  return arg.required ? base : `[${base}]`;
+};
+
+const describeArg = (arg: ScriptArgDef): string => {
+  const parts = [`    --${arg.name}`];
+  if (arg.aliases && arg.aliases.length > 0) {
+    parts.push(`(-${arg.aliases.join(", -")})`);
+  }
+  parts.push(`[${arg.type ?? "string"}${arg.required ? ", required" : ""}]`);
+  parts.push(`- ${arg.description}`);
+  if (arg.default !== undefined) {
+    parts.push(`(default: ${String(arg.default)})`);
+  }
+  if (arg.example !== undefined) {
+    parts.push(`(e.g. ${arg.example})`);
+  }
+  return parts.join(" ");
+};
+
+const printGeneralHelp = (
+  scripts: AdminScriptConfig[],
+  programName: string,
+  write: (line: string) => void
+): void => {
+  write(`Usage: ${programName} <script> [--wet] [args...]`);
+  write("");
+  write("Runs a registered admin script. Defaults to a dry run; pass --wet to apply changes.");
+  write("");
+  write("Options:");
+  write("  --wet, --wetRun   Run in wet mode (applies changes). Default is a dry run.");
+  write("  --dry             Force a dry run (overrides --wet).");
+  write("  --json            Emit the result as a single JSON line.");
+  write("  --list            List available scripts and exit.");
+  write("  --help, -h        Show help. Combine with a script name for per-script help.");
+  write("");
+  if (scripts.length === 0) {
+    write("No scripts are registered.");
+    return;
+  }
+  write("Available scripts:");
+  for (const script of scripts) {
+    write(`  ${script.name}  - ${script.description}`);
+  }
+  write("");
+  write(`Run "${programName} <script> --help" for a script's arguments.`);
+};
+
+const printScriptHelp = (
+  script: AdminScriptConfig,
+  programName: string,
+  write: (line: string) => void
+): void => {
+  const args = script.args ?? [];
+  const usageArgs = args.map(formatArgUsage).join(" ");
+  write(`Usage: ${programName} ${script.name} [--wet] ${usageArgs}`.trimEnd());
+  write("");
+  write(script.description);
+  if (args.length > 0) {
+    write("");
+    write("Arguments:");
+    for (const arg of args) {
+      write(describeArg(arg));
+    }
+  }
+};
+
+/**
+ * Runs a registered admin script from the command line. Exposes every script
+ * configured on {@link AdminApp} as a CLI so they can be invoked directly from the
+ * project (e.g. by an AI assistant) using the same definitions and argument
+ * handling as the admin HTTP routes.
+ *
+ * The caller is responsible for any environment setup the scripts need (typically
+ * connecting to MongoDB) before calling this, and for tearing it down afterwards.
+ */
+export const runScriptCli = async (options: RunScriptCliOptions): Promise<RunScriptCliResult> => {
+  const {scripts} = options;
+  const argv = options.argv ?? process.argv.slice(2);
+  const write = options.write ?? ((line: string) => process.stdout.write(`${line}\n`));
+  const shouldExit = options.exit !== false;
+  const programName = options.programName ?? "script";
+
+  const finish = (result: RunScriptCliResult): RunScriptCliResult => {
+    if (shouldExit) {
+      process.exit(result.exitCode);
+    }
+    return result;
+  };
+
+  const wantsHelp = argv.includes("--help") || argv.includes("-h");
+  const wantsList = argv.includes("--list");
+  const wantsJson = argv.includes("--json");
+  const scriptName = argv.find((token) => !token.startsWith("-"));
+
+  if (wantsList || (!scriptName && !wantsHelp)) {
+    printGeneralHelp(scripts, programName, write);
+    return finish({errors: [], exitCode: 0, results: [], success: true, wetRun: false});
+  }
+
+  if (!scriptName) {
+    printGeneralHelp(scripts, programName, write);
+    return finish({errors: [], exitCode: 0, results: [], success: true, wetRun: false});
+  }
+
+  const script = scripts.find((s) => s.name === scriptName);
+  if (!script) {
+    const available = scripts.map((s) => s.name).join(", ") || "(none)";
+    const message = `Unknown script: ${scriptName}. Available scripts: ${available}`;
+    write(message);
+    return finish({
+      errors: [message],
+      exitCode: 1,
+      results: [],
+      script: scriptName,
+      success: false,
+      wetRun: false,
+    });
+  }
+
+  if (wantsHelp) {
+    printScriptHelp(script, programName, write);
+    return finish({
+      errors: [],
+      exitCode: 0,
+      results: [],
+      script: script.name,
+      success: true,
+      wetRun: false,
+    });
+  }
+
+  // Everything after removing the script name is treated as arguments.
+  const nameIndex = argv.indexOf(scriptName);
+  const argTokens = [...argv.slice(0, nameIndex), ...argv.slice(nameIndex + 1)];
+
+  const {args, errors} = parseScriptArgs(argTokens, script.args ?? []);
+
+  // Reserved flags control the CLI; resolve them, then strip from the script's args.
+  const dryRequested = args.getBoolean("dry");
+  const wetRequested = args.getBoolean("wet") || args.getBoolean("wetRun");
+  const wetRun = wetRequested && !dryRequested;
+  for (const reserved of RESERVED_FLAGS) {
+    delete args.raw[reserved];
+  }
+
+  if (errors.length > 0) {
+    for (const error of errors) {
+      write(error);
+    }
+    write("");
+    printScriptHelp(script, programName, write);
+    return finish({
+      errors,
+      exitCode: 1,
+      results: [],
+      script: script.name,
+      success: false,
+      wetRun,
+    });
+  }
+
+  const ctx: ScriptContext = {
+    addLog: async (level, message) => {
+      if (!wantsJson) {
+        write(`[${level}] ${message}`);
+      }
+    },
+    args,
+    checkCancellation: async () => {
+      // No background task to cancel against when running from the CLI.
+    },
+    updateProgress: async (percentage, stage, message) => {
+      if (!wantsJson) {
+        const suffix = [stage, message].filter(Boolean).join(" - ");
+        write(`[progress] ${percentage}%${suffix ? ` ${suffix}` : ""}`);
+      }
+    },
+  };
+
+  if (!wantsJson) {
+    write(`Running "${script.name}" (${wetRun ? "wet run" : "dry run"})...`);
+  }
+
+  try {
+    const result: ScriptResult = await script.runner(wetRun, ctx);
+    if (wantsJson) {
+      write(
+        JSON.stringify({
+          results: result.results,
+          script: script.name,
+          success: result.success,
+          wetRun,
+        })
+      );
+    } else {
+      for (const line of result.results) {
+        write(line);
+      }
+      write(result.success ? "Done." : "Script reported failure.");
+    }
+    return finish({
+      errors: [],
+      exitCode: result.success ? 0 : 1,
+      results: result.results,
+      script: script.name,
+      success: result.success,
+      wetRun,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(`Script ${script.name} failed: ${message}`);
+    if (wantsJson) {
+      write(JSON.stringify({error: message, script: script.name, success: false, wetRun}));
+    } else {
+      write(`Error: ${message}`);
+    }
+    return finish({
+      errors: [message],
+      exitCode: 1,
+      results: [],
+      script: script.name,
+      success: false,
+      wetRun,
+    });
+  }
+};

--- a/admin-backend/src/scriptCli.ts
+++ b/admin-backend/src/scriptCli.ts
@@ -9,11 +9,13 @@ import {
 import type {AdminScriptConfig} from "./adminApp";
 
 /**
- * Flag names reserved by the CLI itself. They control how a script is invoked and
- * are stripped from the arguments handed to the script runner, so script authors
- * should avoid declaring args with these names.
+ * Flag names reserved by the script runner itself. They control how a script is
+ * invoked (CLI flags and the HTTP `wetRun` query) and are stripped from the
+ * arguments handed to the script runner, so script authors should avoid declaring
+ * args with these names. Exported so the admin HTTP route can strip the same set
+ * and keep `ctx.args` identical across CLI and HTTP invocations.
  */
-const RESERVED_FLAGS = ["help", "h", "list", "json", "wet", "wetRun", "dry"];
+export const RESERVED_SCRIPT_FLAGS = ["help", "h", "list", "json", "wet", "wetRun", "dry"];
 
 export interface RunScriptCliOptions {
   /** The same script configs registered on {@link AdminApp}. */
@@ -184,7 +186,7 @@ export const runScriptCli = async (options: RunScriptCliOptions): Promise<RunScr
   const dryRequested = args.getBoolean("dry");
   const wetRequested = args.getBoolean("wet") || args.getBoolean("wetRun");
   const wetRun = wetRequested && !dryRequested;
-  for (const reserved of RESERVED_FLAGS) {
+  for (const reserved of RESERVED_SCRIPT_FLAGS) {
     delete args.raw[reserved];
   }
 

--- a/api/src/scriptRunner.test.ts
+++ b/api/src/scriptRunner.test.ts
@@ -1,0 +1,156 @@
+import {describe, expect, it} from "bun:test";
+
+import {createScriptArgs, parseScriptArgs, type ScriptArgDef} from "./scriptRunner";
+
+describe("parseScriptArgs", () => {
+  it("parses --name=value form", () => {
+    const {args} = parseScriptArgs(["--model=todos"]);
+    expect(args.getString("model")).toBe("todos");
+    expect(args.has("model")).toBe(true);
+  });
+
+  it("parses --name value form", () => {
+    const {args} = parseScriptArgs(["--model", "todos"]);
+    expect(args.getString("model")).toBe("todos");
+  });
+
+  it("treats a lone --flag as boolean true", () => {
+    const {args} = parseScriptArgs(["--wet"]);
+    expect(args.getBoolean("wet")).toBe(true);
+  });
+
+  it("parses --no-flag as boolean false", () => {
+    const {args} = parseScriptArgs(["--no-cache"]);
+    expect(args.getBoolean("cache")).toBe(false);
+  });
+
+  it("treats short -x like --x", () => {
+    const {args} = parseScriptArgs(["-v"]);
+    expect(args.getBoolean("v")).toBe(true);
+  });
+
+  it("collects positional arguments", () => {
+    const {args} = parseScriptArgs(["one", "two", "-"]);
+    expect(args.positional).toEqual(["one", "two", "-"]);
+  });
+
+  it("collapses repeated flags into an array", () => {
+    const {args} = parseScriptArgs(["--tag", "a", "--tag", "b", "--tag=c"]);
+    expect(args.getStringArray("tag")).toEqual(["a", "b", "c"]);
+  });
+
+  it("does not consume the next token for declared boolean flags", () => {
+    const defs: ScriptArgDef[] = [{description: "verbose", name: "verbose", type: "boolean"}];
+    const {args} = parseScriptArgs(["--verbose", "leftover"], defs);
+    expect(args.getBoolean("verbose")).toBe(true);
+    expect(args.positional).toEqual(["leftover"]);
+  });
+
+  it("resolves aliases to the canonical name", () => {
+    const defs: ScriptArgDef[] = [
+      {aliases: ["m"], description: "model", name: "model", type: "string"},
+    ];
+    const {args} = parseScriptArgs(["-m", "users"], defs);
+    expect(args.getString("model")).toBe("users");
+  });
+
+  it("treats a trailing flag with no value as boolean true", () => {
+    const {args} = parseScriptArgs(["--model", "todos", "--wet"]);
+    expect(args.getString("model")).toBe("todos");
+    expect(args.getBoolean("wet")).toBe(true);
+  });
+});
+
+describe("createScriptArgs", () => {
+  it("applies declared defaults when missing", () => {
+    const defs: ScriptArgDef[] = [{default: "all", description: "model", name: "model"}];
+    const {args, errors} = createScriptArgs({defs, values: {}});
+    expect(errors).toHaveLength(0);
+    expect(args.getString("model")).toBe("all");
+  });
+
+  it("reports an error for missing required args", () => {
+    const defs: ScriptArgDef[] = [{description: "model", name: "model", required: true}];
+    const {errors} = createScriptArgs({defs, values: {}});
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toInclude("Missing required argument: --model");
+  });
+
+  it("coerces declared number args and reports invalid numbers", () => {
+    const defs: ScriptArgDef[] = [{description: "limit", name: "limit", type: "number"}];
+    const ok = createScriptArgs({defs, values: {limit: "10"}});
+    expect(ok.errors).toHaveLength(0);
+    expect(ok.args.getNumber("limit")).toBe(10);
+
+    const bad = createScriptArgs({defs, values: {limit: "nope"}});
+    expect(bad.errors).toHaveLength(1);
+    expect(bad.errors[0]).toInclude("expected a number");
+  });
+
+  it("coerces declared boolean args", () => {
+    const defs: ScriptArgDef[] = [{description: "force", name: "force", type: "boolean"}];
+    expect(createScriptArgs({defs, values: {force: "yes"}}).args.getBoolean("force")).toBe(true);
+    expect(createScriptArgs({defs, values: {force: "off"}}).args.getBoolean("force")).toBe(false);
+    const bad = createScriptArgs({defs, values: {force: "maybe"}});
+    expect(bad.errors[0]).toInclude("expected a boolean");
+  });
+
+  it("coerces booleans and numbers from array values (first element)", () => {
+    const defs: ScriptArgDef[] = [
+      {description: "force", name: "force", type: "boolean"},
+      {description: "limit", name: "limit", type: "number"},
+    ];
+    const {args} = createScriptArgs({
+      defs,
+      values: {force: ["true", "false"], limit: ["5", "6"]},
+    });
+    expect(args.getBoolean("force")).toBe(true);
+    expect(args.getNumber("limit")).toBe(5);
+  });
+
+  describe("getters", () => {
+    it("getString returns fallback when missing and stringifies non-strings", () => {
+      const {args} = createScriptArgs({values: {count: 3, flag: true}});
+      expect(args.getString("missing", "fallback")).toBe("fallback");
+      expect(args.getString("count")).toBe("3");
+      expect(args.getString("flag")).toBe("true");
+    });
+
+    it("getNumber handles native numbers, strings, NaN, and missing", () => {
+      const {args} = createScriptArgs({values: {a: 7, b: "8", c: "x"}});
+      expect(args.getNumber("a")).toBe(7);
+      expect(args.getNumber("b")).toBe(8);
+      expect(args.getNumber("c", 1)).toBe(1);
+      expect(args.getNumber("missing", 99)).toBe(99);
+      expect(args.getNumber("missing")).toBeUndefined();
+    });
+
+    it("getBoolean honors native booleans, string truthiness, and fallback", () => {
+      const {args} = createScriptArgs({values: {a: true, b: "on", c: "nope"}});
+      expect(args.getBoolean("a")).toBe(true);
+      expect(args.getBoolean("b")).toBe(true);
+      expect(args.getBoolean("c")).toBe(false);
+      expect(args.getBoolean("missing")).toBe(false);
+      expect(args.getBoolean("missing", true)).toBe(true);
+    });
+
+    it("reads undeclared array values via getString/getNumber (first element)", () => {
+      const {args} = createScriptArgs({values: {nums: ["3", "4"], tags: ["x", "y"]}});
+      expect(args.getString("tags")).toBe("x");
+      expect(args.getNumber("nums")).toBe(3);
+    });
+
+    it("getStringArray normalizes single values and missing keys", () => {
+      const {args} = createScriptArgs({values: {many: ["a", "b"], one: "x"}});
+      expect(args.getStringArray("one")).toEqual(["x"]);
+      expect(args.getStringArray("many")).toEqual(["a", "b"]);
+      expect(args.getStringArray("missing")).toEqual([]);
+    });
+
+    it("exposes raw values and positional list", () => {
+      const {args} = createScriptArgs({positional: ["p"], values: {x: "1"}});
+      expect(args.raw.x).toBe("1");
+      expect(args.positional).toEqual(["p"]);
+    });
+  });
+});

--- a/api/src/scriptRunner.test.ts
+++ b/api/src/scriptRunner.test.ts
@@ -59,6 +59,25 @@ describe("parseScriptArgs", () => {
     expect(args.getString("model")).toBe("todos");
     expect(args.getBoolean("wet")).toBe(true);
   });
+
+  it("errors when a declared string flag is missing its value", () => {
+    const defs: ScriptArgDef[] = [{description: "model", name: "model", type: "string"}];
+    const {errors} = parseScriptArgs(["--model"], defs);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toInclude("--model expects a string value");
+  });
+
+  it("errors when a declared number flag is followed by another flag", () => {
+    const defs: ScriptArgDef[] = [{description: "limit", name: "limit", type: "number"}];
+    const {errors} = parseScriptArgs(["--limit", "--wet"], defs);
+    expect(errors.some((e) => e.includes("--limit expects a number value"))).toBe(true);
+  });
+
+  it("still treats an undeclared value-less flag as boolean true", () => {
+    const {args, errors} = parseScriptArgs(["--unknown"]);
+    expect(errors).toHaveLength(0);
+    expect(args.getBoolean("unknown")).toBe(true);
+  });
 });
 
 describe("createScriptArgs", () => {

--- a/api/src/scriptRunner.ts
+++ b/api/src/scriptRunner.ts
@@ -211,6 +211,7 @@ export const parseScriptArgs = (
 
   const values: Record<string, ScriptArgValue> = {};
   const positional: string[] = [];
+  const missingValueErrors: string[] = [];
 
   const assign = (key: string, value: ScriptArgValue): void => {
     const name = aliasToName.get(key) ?? key;
@@ -247,7 +248,17 @@ export const parseScriptArgs = (
     const def = defByName.get(canonical);
     const next = tokens[i + 1];
     const nextIsValue = next !== undefined && (next === "-" || !next.startsWith("-"));
-    if (def?.type === "boolean" || !nextIsValue) {
+    if (def?.type === "boolean") {
+      assign(flag, true);
+      continue;
+    }
+    if (!nextIsValue) {
+      // A declared string/number flag was given without a value. Record an error
+      // instead of silently storing `true` (which would coerce to 1 / "true").
+      if (def) {
+        missingValueErrors.push(`Argument --${canonical} expects a ${def.type ?? "string"} value`);
+        continue;
+      }
       assign(flag, true);
       continue;
     }
@@ -255,7 +266,8 @@ export const parseScriptArgs = (
     i++;
   }
 
-  return createScriptArgs({defs, positional, values});
+  const {args, errors} = createScriptArgs({defs, positional, values});
+  return {args, errors: [...missingValueErrors, ...errors]};
 };
 
 export class TaskCancelledError extends Error {

--- a/api/src/scriptRunner.ts
+++ b/api/src/scriptRunner.ts
@@ -10,6 +10,56 @@ export interface ScriptResult {
   results: string[];
 }
 
+// --- Flexible Script Arguments ---
+
+/** A single parsed argument value. Repeated flags collapse into a string array. */
+export type ScriptArgValue = string | number | boolean | string[];
+
+/**
+ * Optional declaration for a single script argument. Declarations are purely
+ * advisory: they drive validation, type coercion, default values, and help text
+ * but a script can still read any argument the caller supplied. This keeps
+ * argument handling flexible — declare the args you care about, ignore the rest.
+ */
+export interface ScriptArgDef {
+  /** Canonical name (used as `--name` on the CLI and as the key in the args map). */
+  name: string;
+  /** Human-readable description shown in CLI help and the admin UI. */
+  description: string;
+  /** Type used for coercion and validation. Defaults to "string". */
+  type?: "string" | "number" | "boolean";
+  /** When true, parsing fails if the argument is missing. */
+  required?: boolean;
+  /** Default applied when the argument is not provided. */
+  default?: ScriptArgValue;
+  /** Alternate names accepted on the CLI (e.g. ["l"] enables `-l`). */
+  aliases?: string[];
+  /** Example value shown in help text. */
+  example?: string;
+}
+
+/**
+ * Typed, ergonomic accessor over the parsed arguments passed to a script. Scripts
+ * read values via the typed getters; `raw` and `positional` expose everything for
+ * advanced cases.
+ */
+export interface ScriptArgs {
+  /** All named values keyed by canonical name. */
+  raw: Record<string, ScriptArgValue>;
+  /** Positional (non-flag) arguments, in order. */
+  positional: string[];
+  /** Whether a named argument was supplied (or has a default). */
+  has: (name: string) => boolean;
+  /** Read a string value (coerces numbers/booleans; first element of arrays). */
+  getString: (name: string, fallback?: string) => string | undefined;
+  /** Read a numeric value (coerces strings; returns fallback when missing/NaN). */
+  getNumber: (name: string, fallback?: number) => number | undefined;
+  /** Read a boolean value ("true"/"1"/"yes"/"on" are truthy). */
+  getBoolean: (name: string, fallback?: boolean) => boolean;
+  /** Read a string array (single values become a one-element array). */
+  getStringArray: (name: string) => string[];
+}
+
 export interface ScriptContext {
   /** Check if the task has been cancelled. Throws TaskCancelledError if so. */
   checkCancellation: () => Promise<void>;
@@ -17,9 +67,196 @@ export interface ScriptContext {
   addLog: (level: "info" | "warn" | "error", message: string) => Promise<void>;
   /** Update progress on the task. */
   updateProgress: (percentage: number, stage?: string, message?: string) => Promise<void>;
+  /** Arguments supplied to this run (from the CLI, HTTP body, or admin UI). */
+  args: ScriptArgs;
 }
 
 export type ScriptRunner = (wetRun: boolean, ctx?: ScriptContext) => Promise<ScriptResult>;
+
+const coerceArgValue = (
+  value: ScriptArgValue,
+  type: ScriptArgDef["type"]
+): {value: ScriptArgValue; error?: string} => {
+  if (type === "number") {
+    const num = typeof value === "number" ? value : Number(Array.isArray(value) ? value[0] : value);
+    if (Number.isNaN(num)) {
+      return {error: `expected a number but received "${String(value)}"`, value};
+    }
+    return {value: num};
+  }
+  if (type === "boolean") {
+    if (typeof value === "boolean") {
+      return {value};
+    }
+    const normalized = String(Array.isArray(value) ? value[0] : value).toLowerCase();
+    if (["true", "1", "yes", "on"].includes(normalized)) {
+      return {value: true};
+    }
+    if (["false", "0", "no", "off"].includes(normalized)) {
+      return {value: false};
+    }
+    return {error: `expected a boolean but received "${String(value)}"`, value};
+  }
+  return {value};
+};
+
+const toStringValue = (value: ScriptArgValue | undefined): string | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return String(value);
+};
+
+/**
+ * Build a {@link ScriptArgs} accessor from a raw values map and optional declarations.
+ * Applies declared defaults, coerces declared types, and validates required args.
+ * Returns the accessor plus any validation errors (callers decide how to surface them).
+ */
+export const createScriptArgs = ({
+  values,
+  positional = [],
+  defs = [],
+}: {
+  values: Record<string, ScriptArgValue>;
+  positional?: string[];
+  defs?: ScriptArgDef[];
+}): {args: ScriptArgs; errors: string[]} => {
+  const errors: string[] = [];
+  const raw: Record<string, ScriptArgValue> = {...values};
+
+  for (const def of defs) {
+    if (raw[def.name] === undefined) {
+      if (def.default !== undefined) {
+        raw[def.name] = def.default;
+      } else if (def.required) {
+        errors.push(`Missing required argument: --${def.name} (${def.description})`);
+      }
+      continue;
+    }
+    const coerced = coerceArgValue(raw[def.name], def.type);
+    if (coerced.error) {
+      errors.push(`Invalid argument --${def.name}: ${coerced.error}`);
+      continue;
+    }
+    raw[def.name] = coerced.value;
+  }
+
+  const args: ScriptArgs = {
+    getBoolean: (name, fallback = false) => {
+      const value = raw[name];
+      if (value === undefined) {
+        return fallback;
+      }
+      if (typeof value === "boolean") {
+        return value;
+      }
+      const normalized = toStringValue(value)?.toLowerCase();
+      return normalized !== undefined && ["true", "1", "yes", "on"].includes(normalized);
+    },
+    getNumber: (name, fallback) => {
+      const value = raw[name];
+      if (value === undefined) {
+        return fallback;
+      }
+      const num = typeof value === "number" ? value : Number(toStringValue(value));
+      return Number.isNaN(num) ? fallback : num;
+    },
+    getString: (name, fallback) => toStringValue(raw[name]) ?? fallback,
+    getStringArray: (name) => {
+      const value = raw[name];
+      if (value === undefined) {
+        return [];
+      }
+      if (Array.isArray(value)) {
+        return value;
+      }
+      return [String(value)];
+    },
+    has: (name) => raw[name] !== undefined,
+    positional,
+    raw,
+  };
+
+  return {args, errors};
+};
+
+/**
+ * Parse CLI-style tokens into a {@link ScriptArgs} accessor. Supports a flexible set
+ * of conventions so callers and scripts do not need to agree on a rigid format:
+ *
+ * - `--name=value` and `--name value`
+ * - `--flag` (boolean true) and `--no-flag` (boolean false)
+ * - short aliases `-x` (treated like `--x`)
+ * - repeated flags collapse into a string array
+ * - bare tokens become positional arguments
+ *
+ * When {@link ScriptArgDef declarations} are supplied, values are coerced to the
+ * declared type, defaults are applied, and required args are validated.
+ */
+export const parseScriptArgs = (
+  tokens: string[],
+  defs: ScriptArgDef[] = []
+): {args: ScriptArgs; errors: string[]} => {
+  const aliasToName = new Map<string, string>();
+  const defByName = new Map<string, ScriptArgDef>();
+  for (const def of defs) {
+    defByName.set(def.name, def);
+    for (const alias of def.aliases ?? []) {
+      aliasToName.set(alias, def.name);
+    }
+  }
+
+  const values: Record<string, ScriptArgValue> = {};
+  const positional: string[] = [];
+
+  const assign = (key: string, value: ScriptArgValue): void => {
+    const name = aliasToName.get(key) ?? key;
+    const existing = values[name];
+    if (existing === undefined) {
+      values[name] = value;
+      return;
+    }
+    // Repeated flag: collapse into an array of strings.
+    const asArray = Array.isArray(existing) ? existing : [String(existing)];
+    values[name] = [...asArray, String(value)];
+  };
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (!token.startsWith("-") || token === "-") {
+      positional.push(token);
+      continue;
+    }
+
+    const flag = token.replace(/^-+/, "");
+    if (flag.startsWith("no-") && !flag.includes("=")) {
+      assign(flag.slice(3), false);
+      continue;
+    }
+
+    const eqIndex = flag.indexOf("=");
+    if (eqIndex !== -1) {
+      assign(flag.slice(0, eqIndex), flag.slice(eqIndex + 1));
+      continue;
+    }
+
+    const canonical = aliasToName.get(flag) ?? flag;
+    const def = defByName.get(canonical);
+    const next = tokens[i + 1];
+    const nextIsValue = next !== undefined && (next === "-" || !next.startsWith("-"));
+    if (def?.type === "boolean" || !nextIsValue) {
+      assign(flag, true);
+      continue;
+    }
+    assign(flag, next);
+    i++;
+  }
+
+  return createScriptArgs({defs, positional, values});
+};
 
 export class TaskCancelledError extends Error {
   constructor(taskId: string) {

--- a/example-backend/package.json
+++ b/example-backend/package.json
@@ -61,6 +61,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "lint:unsafefix": "biome check --write --unsafe .",
+    "script": "bun run src/scripts/runAdminScript.ts",
     "seed": "bun run src/scripts/seed-test-data.ts",
     "start": "bun run src/index.ts",
     "start:prod": "bun run dist/index.js",

--- a/example-backend/src/__snapshots__/openapi.test.ts.snap
+++ b/example-backend/src/__snapshots__/openapi.test.ts.snap
@@ -1178,6 +1178,9 @@ exports[`OpenAPI spec generation matches snapshot 1`] = `
                     "scripts": {
                       "items": {
                         "properties": {
+                          "args": {
+                            "type": "array",
+                          },
                           "description": {
                             "type": "string",
                           },

--- a/example-backend/src/adminScripts.ts
+++ b/example-backend/src/adminScripts.ts
@@ -1,0 +1,97 @@
+import type {AdminScriptConfig} from "@terreno/admin-backend";
+import {syncConsents} from "@terreno/api";
+
+import {consentDefinitions} from "./consentDefinitions";
+import {Todo} from "./models/todo";
+import {User} from "./models/user";
+import {seedFeatureFlags} from "./scripts/seed-feature-flags";
+
+/**
+ * Scripts registered on the admin panel. Exported separately from the server so the
+ * same definitions can be exposed both via the admin HTTP routes (AdminApp) and as a
+ * project CLI (`bun run script <name>`). Argument handling is identical in both.
+ */
+export const adminScripts: AdminScriptConfig[] = [
+  {
+    args: [
+      {
+        default: "all",
+        description: "Which collection to count: todos, users, or all",
+        example: "todos",
+        name: "model",
+        type: "string",
+      },
+    ],
+    description: "Count all todos and users in the database",
+    name: "countRecords",
+    runner: async (wetRun, ctx) => {
+      const model = ctx?.args.getString("model", "all") ?? "all";
+      const results: string[] = [];
+
+      if (model === "todos" || model === "all") {
+        const todoCount = await Todo.countDocuments();
+        results.push(`Found ${todoCount} todos`);
+      }
+      if (model === "users" || model === "all") {
+        const userCount = await User.countDocuments();
+        results.push(`Found ${userCount} users`);
+      }
+      if (results.length === 0) {
+        results.push(`Unknown model "${model}". Use one of: todos, users, all`);
+        return {results, success: false};
+      }
+
+      if (wetRun) {
+        results.push("Wet run: no additional changes made by this script");
+      } else {
+        results.push("Dry run: no changes made");
+      }
+      return {results, success: true};
+    },
+  },
+  {
+    description:
+      "Sync consent forms (Terms of Service, Privacy Policy) from code definitions to the database",
+    name: "syncConsents",
+    runner: async (wetRun) => {
+      const result = await syncConsents(consentDefinitions, {
+        deactivateRemoved: true,
+        dryRun: !wetRun,
+      });
+      const results: string[] = [];
+      if (result.created.length > 0) {
+        results.push(`Created: ${result.created.join(", ")}`);
+      }
+      if (result.updated.length > 0) {
+        results.push(`Updated: ${result.updated.join(", ")}`);
+      }
+      if (result.deactivated.length > 0) {
+        results.push(`Deactivated: ${result.deactivated.join(", ")}`);
+      }
+      if (result.unchanged.length > 0) {
+        results.push(`Unchanged: ${result.unchanged.join(", ")}`);
+      }
+      if (results.length === 0) {
+        results.push("Nothing to do");
+      }
+      return {results, success: true};
+    },
+  },
+  {
+    description:
+      "Seed example feature flags (boolean and variant). Skips flags that already exist.",
+    name: "seedFeatureFlags",
+    runner: async (wetRun) => {
+      if (!wetRun) {
+        return {
+          results: [
+            "Dry run: would create up to 5 example feature flags",
+            "Run as wet run to actually create them",
+          ],
+          success: true,
+        };
+      }
+      return seedFeatureFlags();
+    },
+  },
+];

--- a/example-backend/src/scripts/README.md
+++ b/example-backend/src/scripts/README.md
@@ -7,6 +7,47 @@ Scripts can be run with:
 bun run src/scripts/yourScript.ts
 ```
 
+## Admin scripts as a CLI
+
+Every script registered on the admin panel (see [`../adminScripts.ts`](../adminScripts.ts))
+is also runnable from the command line via [`runAdminScript.ts`](./runAdminScript.ts).
+This lets you (and AI assistants) run the exact same scripts that the admin UI
+exposes, without going through HTTP.
+
+```bash
+# List all available admin scripts
+bun run script --list
+
+# Show a script's arguments
+bun run script countRecords --help
+
+# Dry run by default (no changes applied)
+bun run script countRecords --model todos
+
+# Apply changes with --wet
+bun run script seedFeatureFlags --wet
+
+# Machine-readable output for tooling
+bun run script countRecords --json --model users
+```
+
+### Arguments
+
+Scripts read arguments through `ctx.args` in a flexible way. The CLI accepts:
+
+- `--name=value` or `--name value`
+- `--flag` (boolean true) and `--no-flag` (boolean false)
+- short aliases `-x`
+- repeated flags (collected into an array)
+- positional arguments (via `ctx.args.positional`)
+
+Declare the args a script expects with the `args` field on its
+`AdminScriptConfig` to get type coercion, defaults, validation, and help text.
+The same arguments can be passed over HTTP (query params or a JSON body) when
+running a script from the admin UI, so a script reads them identically no matter
+how it was invoked. Reserved CLI flags (`--wet`, `--wetRun`, `--dry`, `--json`,
+`--list`, `--help`/`-h`) control the runner and are not passed to the script.
+
 ## Example
 
 ```typescript

--- a/example-backend/src/scripts/runAdminScript.ts
+++ b/example-backend/src/scripts/runAdminScript.ts
@@ -25,7 +25,14 @@ import {connectToMongoDB} from "../utils/database";
 
 const main = async (): Promise<void> => {
   const argv = process.argv.slice(2);
-  const needsDb = !argv.includes("--list") && !argv.includes("--help") && !argv.includes("-h");
+
+  // Only connect to MongoDB when an actual registered script will run. Help, list,
+  // no-args, and unknown-script invocations just print text and need no database.
+  const scriptName = argv.find((token) => !token.startsWith("-"));
+  const wantsHelp = argv.includes("--help") || argv.includes("-h");
+  const wantsList = argv.includes("--list");
+  const needsDb =
+    !!scriptName && !wantsHelp && !wantsList && adminScripts.some((s) => s.name === scriptName);
 
   if (needsDb) {
     await connectToMongoDB();

--- a/example-backend/src/scripts/runAdminScript.ts
+++ b/example-backend/src/scripts/runAdminScript.ts
@@ -1,0 +1,53 @@
+/**
+ * Run any admin script from the command line.
+ *
+ * Exposes every script registered on the admin panel (see ../adminScripts.ts) as a
+ * CLI so they can be run directly from the project. Scripts default to a dry run;
+ * pass --wet to apply changes. Arguments are forwarded to the script.
+ *
+ * Examples:
+ *   bun run src/scripts/runAdminScript.ts --list
+ *   bun run src/scripts/runAdminScript.ts countRecords --help
+ *   bun run src/scripts/runAdminScript.ts countRecords --model todos
+ *   bun run src/scripts/runAdminScript.ts seedFeatureFlags --wet
+ *
+ * Or via the package script:
+ *   bun run script <name> [--wet] [args...]
+ */
+
+import {runScriptCli} from "@terreno/admin-backend";
+import {logger} from "@terreno/api";
+import mongoose from "mongoose";
+
+import {adminScripts} from "../adminScripts";
+import {Configuration} from "../models/configuration";
+import {connectToMongoDB} from "../utils/database";
+
+const main = async (): Promise<void> => {
+  const argv = process.argv.slice(2);
+  const needsDb = !argv.includes("--list") && !argv.includes("--help") && !argv.includes("-h");
+
+  if (needsDb) {
+    await connectToMongoDB();
+  }
+
+  // Defer the process exit to us so we can disconnect from MongoDB cleanly.
+  const result = await runScriptCli({
+    argv,
+    exit: false,
+    programName: "bun run script",
+    scripts: adminScripts,
+  });
+
+  if (needsDb) {
+    await Configuration.shutdown();
+    await mongoose.disconnect();
+  }
+
+  process.exit(result.exitCode);
+};
+
+main().catch((error: unknown) => {
+  logger.error(`Failed to run admin script: ${error}`);
+  process.exit(1);
+});

--- a/example-backend/src/server.ts
+++ b/example-backend/src/server.ts
@@ -24,6 +24,7 @@ import {HealthApp} from "@terreno/api-health";
 import {FeatureFlagsApp, featureFlagAdminConfig} from "@terreno/feature-flags";
 import express from "express";
 import mongoose from "mongoose";
+import {adminScripts} from "./adminScripts";
 import {addAdminUserRoutes} from "./api/adminUsers";
 import {addAiRoutes} from "./api/ai";
 import {addSettingsRoutes} from "./api/settings";
@@ -36,7 +37,6 @@ import {AppConfiguration} from "./models/appConfiguration";
 import {Configuration} from "./models/configuration";
 import {Todo} from "./models/todo";
 import {User} from "./models/user";
-import {seedFeatureFlags} from "./scripts/seed-feature-flags";
 import {connectToMongoDB} from "./utils/database";
 import {io} from "./websockets";
 
@@ -459,68 +459,7 @@ export async function start(skipListen = false): Promise<express.Application> {
               verb: event.verb,
             });
           },
-          scripts: [
-            {
-              description: "Count all todos and users in the database",
-              name: "countRecords",
-              runner: async (wetRun) => {
-                const todoCount = await Todo.countDocuments();
-                const userCount = await User.countDocuments();
-                const results = [`Found ${todoCount} todos`, `Found ${userCount} users`];
-                if (wetRun) {
-                  results.push("Wet run: no additional changes made by this script");
-                } else {
-                  results.push("Dry run: no changes made");
-                }
-                return {results, success: true};
-              },
-            },
-            {
-              description:
-                "Sync consent forms (Terms of Service, Privacy Policy) from code definitions to the database",
-              name: "syncConsents",
-              runner: async (wetRun) => {
-                const result = await syncConsents(consentDefinitions, {
-                  deactivateRemoved: true,
-                  dryRun: !wetRun,
-                });
-                const results: string[] = [];
-                if (result.created.length > 0) {
-                  results.push(`Created: ${result.created.join(", ")}`);
-                }
-                if (result.updated.length > 0) {
-                  results.push(`Updated: ${result.updated.join(", ")}`);
-                }
-                if (result.deactivated.length > 0) {
-                  results.push(`Deactivated: ${result.deactivated.join(", ")}`);
-                }
-                if (result.unchanged.length > 0) {
-                  results.push(`Unchanged: ${result.unchanged.join(", ")}`);
-                }
-                if (results.length === 0) {
-                  results.push("Nothing to do");
-                }
-                return {results, success: true};
-              },
-            },
-            {
-              description:
-                "Seed example feature flags (boolean and variant). Skips flags that already exist.",
-              name: "seedFeatureFlags",
-              runner: async (wetRun) => {
-                if (!wetRun) {
-                  return {
-                    results: [
-                      "Dry run: would create up to 5 example feature flags",
-                      "Run as wet run to actually create them",
-                    ],
-                    success: true,
-                  };
-                }
-                return seedFeatureFlags();
-              },
-            },
-          ],
+          scripts: adminScripts,
         })
       )
       .register(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes every script registered on the admin **Script Runner** runnable from the command line, and adds a flexible argument-handling scheme shared across the CLI and the admin HTTP routes. The goal is to let AI assistants (and humans) actually *run* the scripts they write, with first-class arguments.

## What changed

**`@terreno/api` — argument primitives (`src/scriptRunner.ts`)**
- New types: `ScriptArgValue`, `ScriptArgDef`, `ScriptArgs`.
- `ScriptContext` now carries `args: ScriptArgs`, so runners read arguments via `ctx.args` (typed getters: `getString` / `getNumber` / `getBoolean` / `getStringArray`, plus `raw` and `positional`).
- `parseScriptArgs(tokens, defs?)` parses CLI-style tokens flexibly: `--name=value`, `--name value`, `--flag`, `--no-flag`, short `-x` aliases, repeated flags (→ array), and positionals. `createScriptArgs({values, positional, defs})` applies declared defaults, coerces declared types, and validates required args. A declared string/number flag given without a value is rejected (instead of silently coercing to `true`).
- `ScriptRunner` signature is unchanged, so this is backward compatible — existing scripts that ignore `ctx` keep working.

**`@terreno/admin-backend` — CLI runner + HTTP args (`src/scriptCli.ts`, `src/adminApp.ts`)**
- New `runScriptCli({scripts, argv?, write?, exit?, programName?})` exposes the same `AdminScriptConfig[]` registered on `AdminApp` as a CLI: `--list`, per-script `--help`, dry run by default, `--wet`/`--wetRun` to apply, `--dry` to force dry, and `--json` for machine-readable output. Reserved flags are stripped before reaching the script.
- `AdminScriptConfig` gains an optional `args` declaration; it's surfaced in `GET /admin/config` so the UI/tooling can discover a script's arguments.
- `POST /admin/scripts/:name/run` accepts arguments via query params and/or a JSON body, validates them against the declared `args`, strips the same reserved runner flags as the CLI, and forwards them on `ctx.args` — so a script reads arguments identically whether invoked via CLI or HTTP.

**`example-backend` — wiring + docs**
- Extracted the admin scripts into a shared `src/adminScripts.ts` used by both `server.ts` and the CLI (no duplication). `countRecords` now demonstrates a declared `--model` argument.
- Added `src/scripts/runAdminScript.ts` and a `bun run script <name> [--wet] [args...]` package script. It connects to MongoDB only when a registered script will actually run (help/list/no-arg/unknown-script paths skip the DB).
- Updated `src/scripts/README.md`; refreshed the OpenAPI snapshot for the new `args` field.

**CI**
- New workflow `.github/workflows/example-backend-script-runner.yml` builds the workspace dependency chain, starts a real MongoDB, and exercises the CLI end-to-end against the example backend: `--list`, a `countRecords` dry run with `--model`, a `seedFeatureFlags` `--wet` mutating run, and an unknown-script non-zero exit.

## Usage

```bash
bun run script --list
bun run script countRecords --help
bun run script countRecords --model todos        # dry run
bun run script seedFeatureFlags --wet            # applies changes
bun run script countRecords --json --model users # machine-readable
```

## Testing

- `api`: full suite green; `scriptRunner.test.ts` covers the parser/getters and the value-less-flag error path.
- `admin-backend`: full suite green; `scriptCli.test.ts` (~99% line coverage of `scriptCli.ts`) plus HTTP-args tests (incl. reserved-flag stripping) in `adminApp.test.ts`.
- `example-backend`: full suite green; refreshed OpenAPI snapshot. Verified the CLI end-to-end against a local MongoDB (dry, `--wet`, `--json`, unknown-script failure) — the same assertions the new workflow runs.
- `bun run compile` passes for all packages; lint clean on `api`, `admin-backend`, and `example-backend`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf32f1a6-a949-4cc5-9406-210472545189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf32f1a6-a949-4cc5-9406-210472545189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

