### PR TITLE
docs: document GCP_SA_* service account secrets in cloud instructions

### DIFF
--- a/.cursor/rules/00-root.mdc
+++ b/.cursor/rules/00-root.mdc
@@ -377,6 +377,13 @@ Shared install script (in **flourish** repo): `bash /agent/repos/flourish/script
 - `bun run lint`, `bun run api:test`, `bun run ui:test` (root `bun run test` may fail if optional workspace packages lack tests).
 - `demo:start` serves the UI component demo on port **8085**.
 
+### GCP service account secrets
+
+When present, these are injected as environment variables holding GCP service-account credentials (each scoped with viewer plus some write permissions for its environment):
+
+- `GCP_SA_TERRENO` — terreno GCP service account (viewer + some write); use it for gcloud / GCP API access for terreno.
+- The sibling apps in this workspace have their own: `GCP_SA_PRD` (flourish production), `GCP_SA_STG` (flourish staging), and `GCP_SA_ZAPLING` (zapling).
+
 ### Gotchas
 
 - **Port 8082** is shared by `example-frontend` and the separate **gitsight** app in this workspace — run only one web UI on 8082 at a time.

--- a/.cursor/rules/00-root.mdc
+++ b/.cursor/rules/00-root.mdc
@@ -384,6 +384,10 @@ When present, these are injected as environment variables holding GCP service-ac
 - `GCP_SA_TERRENO` — terreno GCP service account (viewer + some write); use it for gcloud / GCP API access for terreno.
 - The sibling apps in this workspace have their own: `GCP_SA_PRD` (flourish production), `GCP_SA_STG` (flourish staging), and `GCP_SA_ZAPLING` (zapling).
 
+### Sentry API access
+
+When present, `SENTRY_CLIENT_SECRET` is injected as an environment variable holding the Sentry API key (auth token) for programmatic Sentry API access.
+
 ### Gotchas
 
 - **Port 8082** is shared by `example-frontend` and the separate **gitsight** app in this workspace — run only one web UI on 8082 at a time.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -372,6 +372,13 @@ Shared install script (in **flourish** repo): `bash /agent/repos/flourish/script
 - `bun run lint`, `bun run api:test`, `bun run ui:test` (root `bun run test` may fail if optional workspace packages lack tests).
 - `demo:start` serves the UI component demo on port **8085**.
 
+### GCP service account secrets
+
+When present, these are injected as environment variables holding GCP service-account credentials (each scoped with viewer plus some write permissions for its environment):
+
+- `GCP_SA_TERRENO` — terreno GCP service account (viewer + some write); use it for gcloud / GCP API access for terreno.
+- The sibling apps in this workspace have their own: `GCP_SA_PRD` (flourish production), `GCP_SA_STG` (flourish staging), and `GCP_SA_ZAPLING` (zapling).
+
 ### Gotchas
 
 - **Port 8082** is shared by `example-frontend` and the separate **gitsight** app in this workspace — run only one web UI on 8082 at a time.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -379,6 +379,10 @@ When present, these are injected as environment variables holding GCP service-ac
 - `GCP_SA_TERRENO` — terreno GCP service account (viewer + some write); use it for gcloud / GCP API access for terreno.
 - The sibling apps in this workspace have their own: `GCP_SA_PRD` (flourish production), `GCP_SA_STG` (flourish staging), and `GCP_SA_ZAPLING` (zapling).
 
+### Sentry API access
+
+When present, `SENTRY_CLIENT_SECRET` is injected as an environment variable holding the Sentry API key (auth token) for programmatic Sentry API access.
+
 ### Gotchas
 
 - **Port 8082** is shared by `example-frontend` and the separate **gitsight** app in this workspace — run only one web UI on 8082 at a time.

--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -386,6 +386,10 @@ When present, these are injected as environment variables holding GCP service-ac
 - `GCP_SA_TERRENO` — terreno GCP service account (viewer + some write); use it for gcloud / GCP API access for terreno.
 - The sibling apps in this workspace have their own: `GCP_SA_PRD` (flourish production), `GCP_SA_STG` (flourish staging), and `GCP_SA_ZAPLING` (zapling).
 
+### Sentry API access
+
+When present, `SENTRY_CLIENT_SECRET` is injected as an environment variable holding the Sentry API key (auth token) for programmatic Sentry API access.
+
 ### Gotchas
 
 - **Port 8082** is shared by `example-frontend` and the separate **gitsight** app in this workspace — run only one web UI on 8082 at a time.

--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -379,6 +379,13 @@ Shared install script (in **flourish** repo): `bash /agent/repos/flourish/script
 - `bun run lint`, `bun run api:test`, `bun run ui:test` (root `bun run test` may fail if optional workspace packages lack tests).
 - `demo:start` serves the UI component demo on port **8085**.
 
+### GCP service account secrets
+
+When present, these are injected as environment variables holding GCP service-account credentials (each scoped with viewer plus some write permissions for its environment):
+
+- `GCP_SA_TERRENO` — terreno GCP service account (viewer + some write); use it for gcloud / GCP API access for terreno.
+- The sibling apps in this workspace have their own: `GCP_SA_PRD` (flourish production), `GCP_SA_STG` (flourish staging), and `GCP_SA_ZAPLING` (zapling).
+
 ### Gotchas
 
 - **Port 8082** is shared by `example-frontend` and the separate **gitsight** app in this workspace — run only one web UI on 8082 at a time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,6 +383,10 @@ When present, these are injected as environment variables holding GCP service-ac
 - `GCP_SA_TERRENO` — terreno GCP service account (viewer + some write); use it for gcloud / GCP API access for terreno.
 - The sibling apps in this workspace have their own: `GCP_SA_PRD` (flourish production), `GCP_SA_STG` (flourish staging), and `GCP_SA_ZAPLING` (zapling).
 
+### Sentry API access
+
+When present, `SENTRY_CLIENT_SECRET` is injected as an environment variable holding the Sentry API key (auth token) for programmatic Sentry API access.
+
 ### Gotchas
 
 - **Port 8082** is shared by `example-frontend` and the separate **gitsight** app in this workspace — run only one web UI on 8082 at a time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,6 +376,13 @@ Shared install script (in **flourish** repo): `bash /agent/repos/flourish/script
 - `bun run lint`, `bun run api:test`, `bun run ui:test` (root `bun run test` may fail if optional workspace packages lack tests).
 - `demo:start` serves the UI component demo on port **8085**.
 
+### GCP service account secrets
+
+When present, these are injected as environment variables holding GCP service-account credentials (each scoped with viewer plus some write permissions for its environment):
+
+- `GCP_SA_TERRENO` — terreno GCP service account (viewer + some write); use it for gcloud / GCP API access for terreno.
+- The sibling apps in this workspace have their own: `GCP_SA_PRD` (flourish production), `GCP_SA_STG` (flourish staging), and `GCP_SA_ZAPLING` (zapling).
+
 ### Gotchas
 
 - **Port 8082** is shared by `example-frontend` and the separate **gitsight** app in this workspace — run only one web UI on 8082 at a time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,6 +372,13 @@ Shared install script (in **flourish** repo): `bash /agent/repos/flourish/script
 - `bun run lint`, `bun run api:test`, `bun run ui:test` (root `bun run test` may fail if optional workspace packages lack tests).
 - `demo:start` serves the UI component demo on port **8085**.
 
+### GCP service account secrets
+
+When present, these are injected as environment variables holding GCP service-account credentials (each scoped with viewer plus some write permissions for its environment):
+
+- `GCP_SA_TERRENO` — terreno GCP service account (viewer + some write); use it for gcloud / GCP API access for terreno.
+- The sibling apps in this workspace have their own: `GCP_SA_PRD` (flourish production), `GCP_SA_STG` (flourish staging), and `GCP_SA_ZAPLING` (zapling).
+
 ### Gotchas
 
 - **Port 8082** is shared by `example-frontend` and the separate **gitsight** app in this workspace — run only one web UI on 8082 at a time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,6 +379,10 @@ When present, these are injected as environment variables holding GCP service-ac
 - `GCP_SA_TERRENO` — terreno GCP service account (viewer + some write); use it for gcloud / GCP API access for terreno.
 - The sibling apps in this workspace have their own: `GCP_SA_PRD` (flourish production), `GCP_SA_STG` (flourish staging), and `GCP_SA_ZAPLING` (zapling).
 
+### Sentry API access
+
+When present, `SENTRY_CLIENT_SECRET` is injected as an environment variable holding the Sentry API key (auth token) for programmatic Sentry API access.
+
 ### Gotchas
 
 - **Port 8082** is shared by `example-frontend` and the separate **gitsight** app in this workspace — run only one web UI on 8082 at a time.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents workspace secrets in the `## Cursor Cloud specific instructions` section.

**GCP service-account secrets** (env vars; viewer + some write per environment): `GCP_SA_TERRENO` (terreno) is called out for this repo, with sibling apps cross-referenced (`GCP_SA_PRD` flourish production, `GCP_SA_STG` flourish staging, `GCP_SA_ZAPLING` zapling).

**Sentry API access:** `SENTRY_CLIENT_SECRET` — Sentry API key (auth token) for programmatic Sentry API access.

The source edit is in `.rulesync/rules/00-root.md`; the generated mirrors (`AGENTS.md`, `CLAUDE.md`, `.cursor/rules/00-root.mdc`, `.github/copilot-instructions.md`) were regenerated via `bun run rules` (rulesync). No other content changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb7d1506-2682-465f-910f-9984d9e209c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb7d1506-2682-465f-910f-9984d9e209c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

