### PR TITLE
fix(ui): equalize MarkdownEditor edit and preview pane heights

### DIFF
--- a/ui/src/MarkdownEditor.tsx
+++ b/ui/src/MarkdownEditor.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useMemo} from "react";
 import {ScrollView, useWindowDimensions} from "react-native";
 import {Box} from "./Box";
 import {Heading} from "./Heading";
@@ -17,6 +17,7 @@ interface MarkdownEditorProps {
 
 const DEFAULT_MAX_HEIGHT = 500;
 const MIN_PANE_HEIGHT = 200;
+const TEXT_FIELD_ROW_HEIGHT = 40;
 
 export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   value,
@@ -37,6 +38,11 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     minHeight: MIN_PANE_HEIGHT,
   };
 
+  const editorRows = useMemo(
+    () => Math.max(5, Math.floor(maxHeight / TEXT_FIELD_ROW_HEIGHT)),
+    [maxHeight]
+  );
+
   return (
     <Box direction="column" gap={2} testID={testID}>
       {Boolean(title) && <Heading size="sm">{title}</Heading>}
@@ -48,18 +54,17 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
             marginTop={1}
             overflow="hidden"
           >
-            <ScrollView style={{flex: 1}}>
+            <Box height="100%" overflow="hidden">
               <TextField
                 disabled={disabled}
-                grow
                 multiline
                 onChange={onChange}
                 placeholder={placeholder}
-                rows={10}
+                rows={editorRows}
                 testID={testID ? `${testID}-input` : undefined}
                 value={value}
               />
-            </ScrollView>
+            </Box>
           </Box>
         </Box>
         <Box dangerouslySetInlineStyle={{__style: {flexBasis: 0}}} direction="column" flex="grow">
@@ -72,7 +77,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
             rounding="sm"
             testID={testID ? `${testID}-preview` : undefined}
           >
-            <ScrollView style={{flex: 1}}>
+            <ScrollView style={{flex: 1, height: maxHeight, maxHeight}}>
               <Box padding={3}>
                 <MarkdownView>{value || " "}</MarkdownView>
               </Box>

--- a/ui/src/MarkdownEditor.tsx
+++ b/ui/src/MarkdownEditor.tsx
@@ -15,6 +15,9 @@ interface MarkdownEditorProps {
   maxHeight?: number;
 }
 
+const DEFAULT_MAX_HEIGHT = 500;
+const MIN_PANE_HEIGHT = 200;
+
 export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   value,
   onChange,
@@ -22,43 +25,55 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   title,
   disabled,
   testID,
-  maxHeight = 500,
+  maxHeight = DEFAULT_MAX_HEIGHT,
 }) => {
   const {width} = useWindowDimensions();
   const isDesktop = width >= 768;
 
+  const paneContainerStyle = {
+    flex: 1,
+    height: maxHeight,
+    maxHeight,
+    minHeight: MIN_PANE_HEIGHT,
+  };
+
   return (
     <Box direction="column" gap={2} testID={testID}>
       {Boolean(title) && <Heading size="sm">{title}</Heading>}
-      <Box direction={isDesktop ? "row" : "column"} gap={3}>
-        <Box dangerouslySetInlineStyle={{__style: {flexBasis: 0}}} flex="grow">
+      <Box alignItems="stretch" direction={isDesktop ? "row" : "column"} gap={3}>
+        <Box dangerouslySetInlineStyle={{__style: {flexBasis: 0}}} direction="column" flex="grow">
           <Heading size="sm">Edit</Heading>
-          <Box marginTop={1}>
-            <TextField
-              disabled={disabled}
-              grow
-              multiline
-              onChange={onChange}
-              placeholder={placeholder}
-              rows={10}
-              testID={testID ? `${testID}-input` : undefined}
-              value={value}
-            />
+          <Box marginTop={1} dangerouslySetInlineStyle={{__style: paneContainerStyle}} overflow="hidden">
+            <ScrollView style={{flex: 1}}>
+              <TextField
+                disabled={disabled}
+                grow
+                multiline
+                onChange={onChange}
+                placeholder={placeholder}
+                rows={10}
+                testID={testID ? `${testID}-input` : undefined}
+                value={value}
+              />
+            </ScrollView>
           </Box>
         </Box>
-        <Box dangerouslySetInlineStyle={{__style: {flexBasis: 0}}} flex="grow">
+        <Box dangerouslySetInlineStyle={{__style: {flexBasis: 0}}} direction="column" flex="grow">
           <Heading size="sm">Preview</Heading>
-          <ScrollView style={{maxHeight, minHeight: 100}}>
-            <Box
-              border="default"
-              marginTop={1}
-              padding={3}
-              rounding="sm"
-              testID={testID ? `${testID}-preview` : undefined}
-            >
-              <MarkdownView>{value || " "}</MarkdownView>
-            </Box>
-          </ScrollView>
+          <Box
+            border="default"
+            marginTop={1}
+            overflow="hidden"
+            rounding="sm"
+            testID={testID ? `${testID}-preview` : undefined}
+            dangerouslySetInlineStyle={{__style: paneContainerStyle}}
+          >
+            <ScrollView style={{flex: 1}}>
+              <Box padding={3}>
+                <MarkdownView>{value || " "}</MarkdownView>
+              </Box>
+            </ScrollView>
+          </Box>
         </Box>
       </Box>
     </Box>

--- a/ui/src/MarkdownEditor.tsx
+++ b/ui/src/MarkdownEditor.tsx
@@ -43,7 +43,11 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
       <Box alignItems="stretch" direction={isDesktop ? "row" : "column"} gap={3}>
         <Box dangerouslySetInlineStyle={{__style: {flexBasis: 0}}} direction="column" flex="grow">
           <Heading size="sm">Edit</Heading>
-          <Box marginTop={1} dangerouslySetInlineStyle={{__style: paneContainerStyle}} overflow="hidden">
+          <Box
+            dangerouslySetInlineStyle={{__style: paneContainerStyle}}
+            marginTop={1}
+            overflow="hidden"
+          >
             <ScrollView style={{flex: 1}}>
               <TextField
                 disabled={disabled}
@@ -62,11 +66,11 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
           <Heading size="sm">Preview</Heading>
           <Box
             border="default"
+            dangerouslySetInlineStyle={{__style: paneContainerStyle}}
             marginTop={1}
             overflow="hidden"
             rounding="sm"
             testID={testID ? `${testID}-preview` : undefined}
-            dangerouslySetInlineStyle={{__style: paneContainerStyle}}
           >
             <ScrollView style={{flex: 1}}>
               <Box padding={3}>

--- a/ui/src/MarkdownEditor.tsx
+++ b/ui/src/MarkdownEditor.tsx
@@ -18,6 +18,7 @@ interface MarkdownEditorProps {
 const DEFAULT_MAX_HEIGHT = 500;
 const MIN_PANE_HEIGHT = 200;
 const TEXT_FIELD_ROW_HEIGHT = 40;
+const TEXT_FIELD_CHROME_HEIGHT = 20;
 
 export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   value,
@@ -39,7 +40,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   };
 
   const editorRows = useMemo(
-    () => Math.max(5, Math.floor(maxHeight / TEXT_FIELD_ROW_HEIGHT)),
+    () => Math.max(3, Math.floor((maxHeight - TEXT_FIELD_CHROME_HEIGHT) / TEXT_FIELD_ROW_HEIGHT)),
     [maxHeight]
   );
 

--- a/ui/src/MarkdownEditorField.tsx
+++ b/ui/src/MarkdownEditorField.tsx
@@ -38,7 +38,7 @@ const TOOLBAR_BUTTONS: ToolbarButton[] = [
 
 const DEFAULT_MAX_HEIGHT = 500;
 const MIN_PANE_HEIGHT = 200;
-const TOOLBAR_HEIGHT = 34;
+const TOOLBAR_MIN_HEIGHT = 34;
 
 export const MarkdownEditorField: React.FC<MarkdownEditorFieldProps> = ({
   title,
@@ -67,7 +67,7 @@ export const MarkdownEditorField: React.FC<MarkdownEditorFieldProps> = ({
     minHeight: MIN_PANE_HEIGHT,
   };
 
-  const editorAreaHeight = disabled ? maxHeight : maxHeight - TOOLBAR_HEIGHT;
+  const editorAreaMinHeight = Math.max(MIN_PANE_HEIGHT - TOOLBAR_MIN_HEIGHT, 120);
 
   return (
     <View testID={testID}>
@@ -81,32 +81,34 @@ export const MarkdownEditorField: React.FC<MarkdownEditorFieldProps> = ({
         rounding="md"
       >
         <View style={{...paneContainerStyle, flexDirection: "column"}}>
-          <TextInput
-            editable={!disabled}
-            multiline
-            onChangeText={onChange}
-            placeholder={placeholder ?? "Enter markdown..."}
-            placeholderTextColor={theme.text.secondaryDark}
-            ref={inputRef}
-            scrollEnabled
-            style={{
-              backgroundColor: theme.surface.base,
-              borderBottomWidth: isWeb ? 0 : 1,
-              borderColor: theme.border.default,
-              borderRightWidth: isWeb ? 1 : 0,
-              color: theme.text.primary,
-              fontFamily: monoFont,
-              fontSize: 14,
-              height: editorAreaHeight,
-              maxHeight: editorAreaHeight,
-              minHeight: Math.max(MIN_PANE_HEIGHT - TOOLBAR_HEIGHT, 120),
-              padding: 12,
-              textAlignVertical: "top",
-              width: "100%",
-            }}
-            testID={testID ? `${testID}-input` : undefined}
-            value={value}
-          />
+          <View style={{flex: 1, minHeight: editorAreaMinHeight}}>
+            <TextInput
+              editable={!disabled}
+              multiline
+              onChangeText={onChange}
+              placeholder={placeholder ?? "Enter markdown..."}
+              placeholderTextColor={theme.text.secondaryDark}
+              ref={inputRef}
+              scrollEnabled
+              style={{
+                backgroundColor: theme.surface.base,
+                borderBottomWidth: isWeb ? 0 : 1,
+                borderColor: theme.border.default,
+                borderRightWidth: isWeb ? 1 : 0,
+                color: theme.text.primary,
+                flex: 1,
+                fontFamily: monoFont,
+                fontSize: 14,
+                height: "100%",
+                minHeight: editorAreaMinHeight,
+                padding: 12,
+                textAlignVertical: "top",
+                width: "100%",
+              }}
+              testID={testID ? `${testID}-input` : undefined}
+              value={value}
+            />
+          </View>
           {!disabled && (
             <View
               style={{
@@ -114,9 +116,10 @@ export const MarkdownEditorField: React.FC<MarkdownEditorFieldProps> = ({
                 borderColor: theme.border.default,
                 borderTopWidth: 1,
                 flexDirection: "row",
+                flexShrink: 0,
                 flexWrap: "wrap",
                 gap: 2,
-                height: TOOLBAR_HEIGHT,
+                minHeight: TOOLBAR_MIN_HEIGHT,
                 paddingHorizontal: 4,
                 paddingVertical: 3,
               }}

--- a/ui/src/MarkdownEditorField.tsx
+++ b/ui/src/MarkdownEditorField.tsx
@@ -36,6 +36,10 @@ const TOOLBAR_BUTTONS: ToolbarButton[] = [
   {insert: (v) => `${v}[text](url)`, label: "🔗"},
 ];
 
+const DEFAULT_MAX_HEIGHT = 500;
+const MIN_PANE_HEIGHT = 200;
+const TOOLBAR_HEIGHT = 34;
+
 export const MarkdownEditorField: React.FC<MarkdownEditorFieldProps> = ({
   title,
   value = "",
@@ -45,7 +49,7 @@ export const MarkdownEditorField: React.FC<MarkdownEditorFieldProps> = ({
   errorText,
   helperText,
   testID,
-  maxHeight = 500,
+  maxHeight = DEFAULT_MAX_HEIGHT,
 }) => {
   const {theme} = useTheme();
   const isWeb = Platform.OS === "web";
@@ -56,42 +60,53 @@ export const MarkdownEditorField: React.FC<MarkdownEditorFieldProps> = ({
     [isWeb]
   );
 
+  const paneContainerStyle = {
+    flex: 1,
+    height: maxHeight,
+    maxHeight,
+    minHeight: MIN_PANE_HEIGHT,
+  };
+
+  const editorAreaHeight = disabled ? maxHeight : maxHeight - TOOLBAR_HEIGHT;
+
   return (
     <View testID={testID}>
       {Boolean(title) && <FieldTitle text={title!} />}
       <Box
+        alignItems="stretch"
         border={errorText ? "error" : "default"}
         direction={isWeb ? "row" : "column"}
         gap={0}
         overflow="hidden"
         rounding="md"
       >
-        <View style={{flex: 1, maxHeight, minHeight: 200}}>
-          <ScrollView style={{flex: 1}}>
-            <TextInput
-              editable={!disabled}
-              multiline
-              onChangeText={onChange}
-              placeholder={placeholder ?? "Enter markdown..."}
-              placeholderTextColor={theme.text.secondaryDark}
-              ref={inputRef}
-              style={{
-                backgroundColor: theme.surface.base,
-                borderBottomWidth: isWeb ? 0 : 1,
-                borderColor: theme.border.default,
-                borderRightWidth: isWeb ? 1 : 0,
-                color: theme.text.primary,
-                flex: 1,
-                fontFamily: monoFont,
-                fontSize: 14,
-                minHeight: 200,
-                padding: 12,
-                textAlignVertical: "top",
-              }}
-              testID={testID ? `${testID}-input` : undefined}
-              value={value}
-            />
-          </ScrollView>
+        <View style={{...paneContainerStyle, flexDirection: "column"}}>
+          <TextInput
+            editable={!disabled}
+            multiline
+            onChangeText={onChange}
+            placeholder={placeholder ?? "Enter markdown..."}
+            placeholderTextColor={theme.text.secondaryDark}
+            ref={inputRef}
+            scrollEnabled
+            style={{
+              backgroundColor: theme.surface.base,
+              borderBottomWidth: isWeb ? 0 : 1,
+              borderColor: theme.border.default,
+              borderRightWidth: isWeb ? 1 : 0,
+              color: theme.text.primary,
+              fontFamily: monoFont,
+              fontSize: 14,
+              height: editorAreaHeight,
+              maxHeight: editorAreaHeight,
+              minHeight: Math.max(MIN_PANE_HEIGHT - TOOLBAR_HEIGHT, 120),
+              padding: 12,
+              textAlignVertical: "top",
+              width: "100%",
+            }}
+            testID={testID ? `${testID}-input` : undefined}
+            value={value}
+          />
           {!disabled && (
             <View
               style={{
@@ -101,6 +116,7 @@ export const MarkdownEditorField: React.FC<MarkdownEditorFieldProps> = ({
                 flexDirection: "row",
                 flexWrap: "wrap",
                 gap: 2,
+                height: TOOLBAR_HEIGHT,
                 paddingHorizontal: 4,
                 paddingVertical: 3,
               }}
@@ -139,17 +155,19 @@ export const MarkdownEditorField: React.FC<MarkdownEditorFieldProps> = ({
             </View>
           )}
         </View>
-        <ScrollView style={{flex: 1, maxHeight, minHeight: 200}}>
-          <Box color="base" padding={3} style={{minHeight: 200}}>
-            {value ? (
-              <MarkdownView>{value}</MarkdownView>
-            ) : (
-              <Text color="secondaryDark" size="sm">
-                Preview
-              </Text>
-            )}
-          </Box>
-        </ScrollView>
+        <View style={paneContainerStyle}>
+          <ScrollView style={{flex: 1, height: maxHeight, maxHeight}}>
+            <Box color="base" padding={3} style={{minHeight: MIN_PANE_HEIGHT}}>
+              {value ? (
+                <MarkdownView>{value}</MarkdownView>
+              ) : (
+                <Text color="secondaryDark" size="sm">
+                  Preview
+                </Text>
+              )}
+            </Box>
+          </ScrollView>
+        </View>
       </Box>
       {Boolean(errorText) && <FieldError text={errorText!} />}
       {Boolean(helperText) && <FieldHelperText text={helperText!} />}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Consent form editing uses markdown editors in two admin paths:
- `MarkdownEditorField` via `LocaleContentEditor` (generic admin form)
- `MarkdownEditor` via `ConsentFormEditor` (dedicated consent form screen)

Both edit and preview panes now share the same fixed height (default 500px) so they align side by side on desktop.

## Changes

- **MarkdownEditorField**: Equal-height panes; editor input fills remaining space above a flexible formatting toolbar; preview scrolls independently.
- **MarkdownEditor**: Equal-height edit/preview panes; row count accounts for TextField border/padding chrome.
- Toolbar uses `minHeight` instead of fixed height so wrapped buttons are not clipped on narrow columns.

## Testing

- `bun run lint` and `bun run compile` in `ui/` pass.
- Verified locally with example backend + frontend: both columns measure 500px on the consent form admin screen.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9f0c554-f63c-4672-aab1-46d83cb92bb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9f0c554-f63c-4672-aab1-46d83cb92bb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

