### PR TITLE
docs: correct Cursor Cloud dev-environment setup for example-backend MongoDB

### DIFF
--- a/.cursor/rules/00-root.mdc
+++ b/.cursor/rules/00-root.mdc
@@ -370,7 +370,26 @@ Shared install script (in **flourish** repo): `bash /agent/repos/flourish/script
 | example-backend | 4000 | `bun run backend:dev` (from repo root) |
 | example-frontend web | 8082 | `bun run frontend:web` |
 
-`example-frontend` uses in-memory Mongo via `example-backend` — no system MongoDB required for the example apps.
+The running `example-backend` needs a **real MongoDB replica set** (change streams power the realtime/feature-flag sync) at `MONGO_URI`, plus auth secrets `TOKEN_SECRET`, `TOKEN_ISSUER`, `REFRESH_TOKEN_SECRET`, `SESSION_SECRET`. (Only the bun **test** suites use the auto-managed in-memory Mongo from `@terreno/test`; the dev server does not.)
+
+A standalone `mongod` binary is available from the `mongodb-memory-server` cache (e.g. `~/.cache/mongodb-binaries/mongod-*`) after the test suites have run once. Run it as a single-node replica set, then point the backend at it:
+
+```bash
+# 1. start mongod (replica set required for change streams)
+"$(ls ~/.cache/mongodb-binaries/mongod-* | head -1)" \
+  --replSet rs0 --port 27017 --bind_ip 127.0.0.1 --dbpath /workspace/.devdata/mongo &
+# 2. initiate the replica set once (use node, not bun — the mongodb driver's bson
+#    package hits a "node:v8 isBuildingSnapshot" error under bun). From example-backend/:
+#    node -e 'import("mongodb").then(async ({MongoClient})=>{const c=new MongoClient("mongodb://127.0.0.1:27017/?directConnection=true");await c.connect();await c.db("admin").command({replSetInitiate:{_id:"rs0",members:[{_id:0,host:"127.0.0.1:27017"}]}}).catch(()=>{});await c.close();})'
+# 3. run backend + frontend
+MONGO_URI="mongodb://127.0.0.1:27017/terreno-example?replicaSet=rs0" \
+  TOKEN_SECRET=dev-token-secret TOKEN_ISSUER=terreno-dev \
+  REFRESH_TOKEN_SECRET=dev-refresh-secret SESSION_SECRET=dev-session-secret \
+  PORT=4000 bun run backend:dev
+EXPO_PUBLIC_API_URL=http://localhost:4000 bun run frontend:web
+```
+
+Seed login users with `bun run backend:seed` (same env vars): creates `test@example.com` and admin `superuser@example.com`, both password `testpassword123`. Health check: `curl localhost:4000/health` → `"healthy":true`. The web app shows one-time Terms/Privacy/Consent modals (with a signature draw) on first login before the Todos screen.
 
 ### Tests and lint
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -365,7 +365,26 @@ Shared install script (in **flourish** repo): `bash /agent/repos/flourish/script
 | example-backend | 4000 | `bun run backend:dev` (from repo root) |
 | example-frontend web | 8082 | `bun run frontend:web` |
 
-`example-frontend` uses in-memory Mongo via `example-backend` — no system MongoDB required for the example apps.
+The running `example-backend` needs a **real MongoDB replica set** (change streams power the realtime/feature-flag sync) at `MONGO_URI`, plus auth secrets `TOKEN_SECRET`, `TOKEN_ISSUER`, `REFRESH_TOKEN_SECRET`, `SESSION_SECRET`. (Only the bun **test** suites use the auto-managed in-memory Mongo from `@terreno/test`; the dev server does not.)
+
+A standalone `mongod` binary is available from the `mongodb-memory-server` cache (e.g. `~/.cache/mongodb-binaries/mongod-*`) after the test suites have run once. Run it as a single-node replica set, then point the backend at it:
+
+```bash
+# 1. start mongod (replica set required for change streams)
+"$(ls ~/.cache/mongodb-binaries/mongod-* | head -1)" \
+  --replSet rs0 --port 27017 --bind_ip 127.0.0.1 --dbpath /workspace/.devdata/mongo &
+# 2. initiate the replica set once (use node, not bun — the mongodb driver's bson
+#    package hits a "node:v8 isBuildingSnapshot" error under bun). From example-backend/:
+#    node -e 'import("mongodb").then(async ({MongoClient})=>{const c=new MongoClient("mongodb://127.0.0.1:27017/?directConnection=true");await c.connect();await c.db("admin").command({replSetInitiate:{_id:"rs0",members:[{_id:0,host:"127.0.0.1:27017"}]}}).catch(()=>{});await c.close();})'
+# 3. run backend + frontend
+MONGO_URI="mongodb://127.0.0.1:27017/terreno-example?replicaSet=rs0" \
+  TOKEN_SECRET=dev-token-secret TOKEN_ISSUER=terreno-dev \
+  REFRESH_TOKEN_SECRET=dev-refresh-secret SESSION_SECRET=dev-session-secret \
+  PORT=4000 bun run backend:dev
+EXPO_PUBLIC_API_URL=http://localhost:4000 bun run frontend:web
+```
+
+Seed login users with `bun run backend:seed` (same env vars): creates `test@example.com` and admin `superuser@example.com`, both password `testpassword123`. Health check: `curl localhost:4000/health` → `"healthy":true`. The web app shows one-time Terms/Privacy/Consent modals (with a signature draw) on first login before the Todos screen.
 
 ### Tests and lint
 

--- a/.rulesync/rules/00-root.md
+++ b/.rulesync/rules/00-root.md
@@ -372,7 +372,26 @@ Shared install script (in **flourish** repo): `bash /agent/repos/flourish/script
 | example-backend | 4000 | `bun run backend:dev` (from repo root) |
 | example-frontend web | 8082 | `bun run frontend:web` |
 
-`example-frontend` uses in-memory Mongo via `example-backend` — no system MongoDB required for the example apps.
+The running `example-backend` needs a **real MongoDB replica set** (change streams power the realtime/feature-flag sync) at `MONGO_URI`, plus auth secrets `TOKEN_SECRET`, `TOKEN_ISSUER`, `REFRESH_TOKEN_SECRET`, `SESSION_SECRET`. (Only the bun **test** suites use the auto-managed in-memory Mongo from `@terreno/test`; the dev server does not.)
+
+A standalone `mongod` binary is available from the `mongodb-memory-server` cache (e.g. `~/.cache/mongodb-binaries/mongod-*`) after the test suites have run once. Run it as a single-node replica set, then point the backend at it:
+
+```bash
+# 1. start mongod (replica set required for change streams)
+"$(ls ~/.cache/mongodb-binaries/mongod-* | head -1)" \
+  --replSet rs0 --port 27017 --bind_ip 127.0.0.1 --dbpath /workspace/.devdata/mongo &
+# 2. initiate the replica set once (use node, not bun — the mongodb driver's bson
+#    package hits a "node:v8 isBuildingSnapshot" error under bun). From example-backend/:
+#    node -e 'import("mongodb").then(async ({MongoClient})=>{const c=new MongoClient("mongodb://127.0.0.1:27017/?directConnection=true");await c.connect();await c.db("admin").command({replSetInitiate:{_id:"rs0",members:[{_id:0,host:"127.0.0.1:27017"}]}}).catch(()=>{});await c.close();})'
+# 3. run backend + frontend
+MONGO_URI="mongodb://127.0.0.1:27017/terreno-example?replicaSet=rs0" \
+  TOKEN_SECRET=dev-token-secret TOKEN_ISSUER=terreno-dev \
+  REFRESH_TOKEN_SECRET=dev-refresh-secret SESSION_SECRET=dev-session-secret \
+  PORT=4000 bun run backend:dev
+EXPO_PUBLIC_API_URL=http://localhost:4000 bun run frontend:web
+```
+
+Seed login users with `bun run backend:seed` (same env vars): creates `test@example.com` and admin `superuser@example.com`, both password `testpassword123`. Health check: `curl localhost:4000/health` → `"healthy":true`. The web app shows one-time Terms/Privacy/Consent modals (with a signature draw) on first login before the Todos screen.
 
 ### Tests and lint
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,7 +369,26 @@ Shared install script (in **flourish** repo): `bash /agent/repos/flourish/script
 | example-backend | 4000 | `bun run backend:dev` (from repo root) |
 | example-frontend web | 8082 | `bun run frontend:web` |
 
-`example-frontend` uses in-memory Mongo via `example-backend` — no system MongoDB required for the example apps.
+The running `example-backend` needs a **real MongoDB replica set** (change streams power the realtime/feature-flag sync) at `MONGO_URI`, plus auth secrets `TOKEN_SECRET`, `TOKEN_ISSUER`, `REFRESH_TOKEN_SECRET`, `SESSION_SECRET`. (Only the bun **test** suites use the auto-managed in-memory Mongo from `@terreno/test`; the dev server does not.)
+
+A standalone `mongod` binary is available from the `mongodb-memory-server` cache (e.g. `~/.cache/mongodb-binaries/mongod-*`) after the test suites have run once. Run it as a single-node replica set, then point the backend at it:
+
+```bash
+# 1. start mongod (replica set required for change streams)
+"$(ls ~/.cache/mongodb-binaries/mongod-* | head -1)" \
+  --replSet rs0 --port 27017 --bind_ip 127.0.0.1 --dbpath /workspace/.devdata/mongo &
+# 2. initiate the replica set once (use node, not bun — the mongodb driver's bson
+#    package hits a "node:v8 isBuildingSnapshot" error under bun). From example-backend/:
+#    node -e 'import("mongodb").then(async ({MongoClient})=>{const c=new MongoClient("mongodb://127.0.0.1:27017/?directConnection=true");await c.connect();await c.db("admin").command({replSetInitiate:{_id:"rs0",members:[{_id:0,host:"127.0.0.1:27017"}]}}).catch(()=>{});await c.close();})'
+# 3. run backend + frontend
+MONGO_URI="mongodb://127.0.0.1:27017/terreno-example?replicaSet=rs0" \
+  TOKEN_SECRET=dev-token-secret TOKEN_ISSUER=terreno-dev \
+  REFRESH_TOKEN_SECRET=dev-refresh-secret SESSION_SECRET=dev-session-secret \
+  PORT=4000 bun run backend:dev
+EXPO_PUBLIC_API_URL=http://localhost:4000 bun run frontend:web
+```
+
+Seed login users with `bun run backend:seed` (same env vars): creates `test@example.com` and admin `superuser@example.com`, both password `testpassword123`. Health check: `curl localhost:4000/health` → `"healthy":true`. The web app shows one-time Terms/Privacy/Consent modals (with a signature draw) on first login before the Todos screen.
 
 ### Tests and lint
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,7 +365,26 @@ Shared install script (in **flourish** repo): `bash /agent/repos/flourish/script
 | example-backend | 4000 | `bun run backend:dev` (from repo root) |
 | example-frontend web | 8082 | `bun run frontend:web` |
 
-`example-frontend` uses in-memory Mongo via `example-backend` — no system MongoDB required for the example apps.
+The running `example-backend` needs a **real MongoDB replica set** (change streams power the realtime/feature-flag sync) at `MONGO_URI`, plus auth secrets `TOKEN_SECRET`, `TOKEN_ISSUER`, `REFRESH_TOKEN_SECRET`, `SESSION_SECRET`. (Only the bun **test** suites use the auto-managed in-memory Mongo from `@terreno/test`; the dev server does not.)
+
+A standalone `mongod` binary is available from the `mongodb-memory-server` cache (e.g. `~/.cache/mongodb-binaries/mongod-*`) after the test suites have run once. Run it as a single-node replica set, then point the backend at it:
+
+```bash
+# 1. start mongod (replica set required for change streams)
+"$(ls ~/.cache/mongodb-binaries/mongod-* | head -1)" \
+  --replSet rs0 --port 27017 --bind_ip 127.0.0.1 --dbpath /workspace/.devdata/mongo &
+# 2. initiate the replica set once (use node, not bun — the mongodb driver's bson
+#    package hits a "node:v8 isBuildingSnapshot" error under bun). From example-backend/:
+#    node -e 'import("mongodb").then(async ({MongoClient})=>{const c=new MongoClient("mongodb://127.0.0.1:27017/?directConnection=true");await c.connect();await c.db("admin").command({replSetInitiate:{_id:"rs0",members:[{_id:0,host:"127.0.0.1:27017"}]}}).catch(()=>{});await c.close();})'
+# 3. run backend + frontend
+MONGO_URI="mongodb://127.0.0.1:27017/terreno-example?replicaSet=rs0" \
+  TOKEN_SECRET=dev-token-secret TOKEN_ISSUER=terreno-dev \
+  REFRESH_TOKEN_SECRET=dev-refresh-secret SESSION_SECRET=dev-session-secret \
+  PORT=4000 bun run backend:dev
+EXPO_PUBLIC_API_URL=http://localhost:4000 bun run frontend:web
+```
+
+Seed login users with `bun run backend:seed` (same env vars): creates `test@example.com` and admin `superuser@example.com`, both password `testpassword123`. Health check: `curl localhost:4000/health` → `"healthy":true`. The web app shows one-time Terms/Privacy/Consent modals (with a signature draw) on first login before the Todos screen.
 
 ### Tests and lint
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up the development environment for the Terreno monorepo and verified the example full stack runs end-to-end. The only code change is a documentation fix: the prior `AGENTS.md` note ("example-frontend uses in-memory Mongo … no system MongoDB required") was inaccurate for the **running** `example-backend`, which needs a real MongoDB **replica set** (change streams) plus auth secrets. Only the bun test suites use the auto-managed in-memory Mongo.

Updated the rulesync source (`.rulesync/rules/00-root.md`) and regenerated `CLAUDE.md`, `.cursor/rules/00-root.mdc`, and `.github/copilot-instructions.md`; also updated standalone `AGENTS.md` to match. New docs cover: starting `mongod` as a single-node replica set from the `mongodb-memory-server` cached binary, initiating the replica set (must use `node`, not `bun`, due to a bson incompatibility), the required env vars, and the `backend:seed` login flow.

## Environment verification

- Installed Bun 1.3.14, ran `bun install` + `bun run compile` (all packages compile).
- `bun run api:test` → 1230 pass / 0 fail; `bun run ui:test` → 1730 pass / 0 fail.
- `bun run lint` runs; one **pre-existing** import-ordering error in `admin-backend` (unrelated to setup, working tree was clean).
- Started `example-backend` (port 4000, `/health` → `healthy:true`) against a local mongod replica set, and `example-frontend` web (port 8082).
- Hello-world: logged in as `test@example.com`, completed onboarding consent modals, and created a todo "Hello from Cursor Cloud" that appears in the list.

[terreno_login_create_todo_demo.mp4](https://cursor.com/agents/bc-cc824515-b75c-4989-b2a7-621433bc1ff6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fterreno_login_create_todo_demo.mp4)

[Login screen](https://cursor.com/agents/bc-cc824515-b75c-4989-b2a7-621433bc1ff6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin_screen.webp)
[Todos after login](https://cursor.com/agents/bc-cc824515-b75c-4989-b2a7-621433bc1ff6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftodos_after_login.webp)
[New todo created](https://cursor.com/agents/bc-cc824515-b75c-4989-b2a7-621433bc1ff6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftodo_created.webp)

## Update script (VM startup dependency refresh)

```
"$HOME/.bun/bin/bun" run bootstrap
```

(`bun bootstrap` = `bun install && bun run compile`.)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc824515-b75c-4989-b2a7-621433bc1ff6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc824515-b75c-4989-b2a7-621433bc1ff6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

