### PR TITLE
ci: make Demo Appium non-blocking unless a mobile build feature changes

### DIFF
--- a/.github/workflows/demo-appium-ci.yml
+++ b/.github/workflows/demo-appium-ci.yml
@@ -1,5 +1,20 @@
 name: Demo Appium CI
 
+# The Appium suite spins up real EAS builds on emulators/simulators, which is
+# slow and inherently flaky. By default it runs as a NON-BLOCKING signal: the
+# jobs still execute and upload artifacts, but a failure does not fail the
+# workflow (each job sets `continue-on-error`).
+#
+# The exception is a "mobile build feature" change — a push that touches the
+# files that define the native build (eas.json, app config, native deps, or the
+# ios/android projects). Those changes are exactly the ones Appium is meant to
+# guard, so when they are detected the jobs become BLOCKING (continue-on-error
+# is disabled) and a failure fails the workflow. Manual `workflow_dispatch` runs
+# are always treated as deliberate and therefore blocking.
+#
+# The `detect-mobile-build` job computes this distinction and the Appium jobs
+# read its `is_mobile_build` output.
+
 on:
   push:
     paths:
@@ -7,6 +22,7 @@ on:
       - "demo/appium/**"
       - "demo/package.json"
       - "demo/app.json"
+      - "demo/app.config.ts"
       - "demo/eas.json"
       - ".github/workflows/demo-appium-ci.yml"
   workflow_dispatch:
@@ -44,9 +60,65 @@ on:
           - development:simulator
 
 jobs:
+  detect-mobile-build:
+    name: Detect mobile build change
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      is_mobile_build: ${{ steps.detect.outputs.is_mobile_build }}
+    steps:
+      - uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Detect mobile build changes
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Manual dispatch is always a deliberate run, so treat it as blocking.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Manual dispatch → Appium runs as a blocking check."
+            echo "is_mobile_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base="$PUSH_BEFORE"
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            # First push to a branch (or unknown base): diff against master's merge-base.
+            git fetch --quiet origin master || true
+            base="$(git merge-base origin/master HEAD 2>/dev/null || true)"
+          fi
+
+          if [ -z "$base" ] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+            echo "Could not determine a diff base → defaulting to non-blocking."
+            echo "is_mobile_build=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed="$(git diff --name-only "$base" "$HEAD_SHA" || true)"
+          echo "Changed files between $base and $HEAD_SHA:"
+          echo "$changed"
+
+          # Files that define the native/mobile build. Touching these makes the
+          # Appium suite a meaningful gate, so the jobs block on failure.
+          if echo "$changed" | grep -Eq '^demo/(eas\.json|app\.config\.ts|app\.json|package\.json|ios/|android/)'; then
+            echo "Mobile build files changed → Appium is a blocking check."
+            echo "is_mobile_build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No mobile build files changed → Appium is a non-blocking check."
+            echo "is_mobile_build=false" >> "$GITHUB_OUTPUT"
+          fi
+
   appium-android:
     name: Demo Appium · Android
+    needs: detect-mobile-build
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'android' }}
+    # Non-blocking unless the change is a mobile build feature (see detect-mobile-build).
+    continue-on-error: ${{ needs.detect-mobile-build.outputs.is_mobile_build != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -142,7 +214,10 @@ jobs:
 
   appium-ios:
     name: Demo Appium · iOS
+    needs: detect-mobile-build
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'ios' }}
+    # Non-blocking unless the change is a mobile build feature (see detect-mobile-build).
+    continue-on-error: ${{ needs.detect-mobile-build.outputs.is_mobile_build != 'true' }}
     # macos-latest resolves to macos-26 with iOS 26.x beta runtimes that break WDA (xcodebuild exit 70).
     runs-on: macos-15
     timeout-minutes: 60


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Demo Appium CI suite spins up real EAS builds on emulators/simulators, which is slow and inherently flaky. Today any push that touches `ui/**`, `demo/appium/**`, or the demo build config runs Appium as a hard gate, so transient/flaky failures block unrelated work.

This makes the Appium jobs **non-blocking by default**, while keeping them **blocking for the cases Appium is actually meant to guard** — changes that affect the native/mobile build.

## How it works

- Adds a lightweight `detect-mobile-build` job that diffs the push and decides whether the change is a "mobile build feature".
- A change is treated as a **mobile build feature** (→ blocking) when it touches any of:
  - `demo/eas.json`
  - `demo/app.config.ts`
  - `demo/app.json`
  - `demo/package.json` (native deps)
  - `demo/ios/**` or `demo/android/**`
- Manual `workflow_dispatch` runs are always treated as deliberate, and therefore **blocking**.
- Both Appium jobs (`appium-android`, `appium-ios`) now `needs: detect-mobile-build` and set:

  ```yaml
  continue-on-error: ${{ needs.detect-mobile-build.outputs.is_mobile_build != 'true' }}
  ```

  When the change is not a mobile build feature, `continue-on-error` is `true` so the jobs still run and upload artifacts/snapshots, but a failure does **not** fail the workflow. When it is a mobile build feature (or a manual dispatch), `continue-on-error` is `false` and failures block as before.

## Notes

- The detect job falls back to the merge-base with `master` for first-pushes / unknown bases, and defaults to non-blocking if a diff base can't be determined.
- Added `demo/app.config.ts` to the push path filters so config-driven build changes still trigger the workflow.
- Behavior change only in CI; no application code touched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37508d6c-f4af-47ec-890f-bd37c23dbfe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37508d6c-f4af-47ec-890f-bd37c23dbfe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

