### PR TITLE
feat(demo): AI palette generator

### DIFF
--- a/demo/app/palette/_layout.tsx
+++ b/demo/app/palette/_layout.tsx
@@ -1,0 +1,40 @@
+import {isMobileDevice} from "@terreno/ui";
+import {router, Stack} from "expo-router";
+import {StatusBar} from "expo-status-bar";
+import {Pressable, StyleSheet, Text} from "react-native";
+
+const Layout = () => {
+  return (
+    <>
+      <StatusBar style="auto" />
+      <Stack
+        screenOptions={{
+          headerBackTitle: "Back",
+          headerBackVisible: isMobileDevice(),
+          headerRight: () => (
+            <Pressable
+              onPress={async () => {
+                router.navigate("demo");
+              }}
+              style={styles.header}
+            >
+              <Text style={{fontWeight: "bold"}}>Demo Mode</Text>
+            </Pressable>
+          ),
+          title: "Palette Generator",
+        }}
+      />
+    </>
+  );
+};
+
+export default Layout;
+
+const styles = StyleSheet.create({
+  header: {
+    alignItems: "center",
+    height: "100%",
+    justifyContent: "center",
+    marginRight: isMobileDevice() ? 0 : 16,
+  },
+});

--- a/demo/app/palette/index.tsx
+++ b/demo/app/palette/index.tsx
@@ -1,0 +1,7 @@
+import {PaletteGenerator} from "@components";
+
+const Route = () => {
+  return <PaletteGenerator />;
+};
+
+export default Route;

--- a/demo/components/DemoHomePage.tsx
+++ b/demo/components/DemoHomePage.tsx
@@ -1,6 +1,6 @@
 import {DemoConfig, type DemoConfiguration} from "@config";
-import {Box, Heading, Text} from "@terreno/ui";
-import {useNavigation} from "expo-router";
+import {Box, Button, Heading, Text} from "@terreno/ui";
+import {router, useNavigation} from "expo-router";
 import React, {useCallback, useEffect} from "react";
 import {Pressable, ScrollView, View} from "react-native";
 
@@ -94,6 +94,32 @@ export const DemoHomePage: React.FC<{
       }}
       style={{padding: 20, width: "100%"}}
     >
+      <Box
+        alignItems="center"
+        color="secondaryLight"
+        direction="row"
+        gap={4}
+        justifyContent="between"
+        margin={2}
+        padding={4}
+        rounding="md"
+        width="100%"
+        wrap
+      >
+        <Box flex="grow" gap={1} minWidth={220}>
+          <Heading size="md">AI Palette Generator</Heading>
+          <Text>
+            Generate a full, WCAG-checked theme palette from a few colors or a prompt, then preview
+            it on every component.
+          </Text>
+        </Box>
+        <Button
+          iconName="wand-magic-sparkles"
+          onClick={() => router.navigate("/palette")}
+          text="Open palette generator"
+          variant="primary"
+        />
+      </Box>
       {DemoConfig.map((config) => (
         <DemoCard config={config} key={config.name} onPress={onPress} />
       ))}

--- a/demo/components/index.tsx
+++ b/demo/components/index.tsx
@@ -2,3 +2,4 @@ export * from "./customIcons";
 export * from "./DemoHomePage";
 export * from "./DevHomePage";
 export * from "./ErrorBoundary";
+export * from "./palette/PaletteGenerator";

--- a/demo/components/palette/AnchorControls.tsx
+++ b/demo/components/palette/AnchorControls.tsx
@@ -3,7 +3,13 @@ import React, {useCallback} from "react";
 import {ColorPicker} from "./ColorPicker";
 import type {PaletteAnchors} from "./colorUtils";
 import {normalizeHex, readableTextColor} from "./colorUtils";
-import {ANCHOR_FAMILIES, FAMILY_LABELS, type MainFamily, type StatusFamily} from "./paletteTypes";
+import {
+  ANCHOR_FAMILIES,
+  FAMILY_LABELS,
+  type MainFamily,
+  type StatusFamily,
+  TONE_LOCK_HINTS,
+} from "./paletteTypes";
 
 /**
  * The manual editing surface: a swatch per anchor family that you tap to select, plus the full
@@ -79,6 +85,8 @@ export const AnchorControls: React.FC<AnchorControlsProps> = ({
     [onChangeAnchor, selectedFamily]
   );
 
+  const toneHint = TONE_LOCK_HINTS[selectedFamily];
+
   return (
     <Box gap={4}>
       <Box direction="row" gap={2} wrap>
@@ -99,6 +107,11 @@ export const AnchorControls: React.FC<AnchorControlsProps> = ({
         onChange={handleColorChange}
         value={anchors[selectedFamily]}
       />
+      {toneHint ? (
+        <Text color="secondaryLight" size="sm">
+          {toneHint}
+        </Text>
+      ) : null}
     </Box>
   );
 };

--- a/demo/components/palette/AnchorControls.tsx
+++ b/demo/components/palette/AnchorControls.tsx
@@ -17,15 +17,19 @@ interface AnchorSwatchProps {
   family: Family;
   hex: string;
   selected: boolean;
+  disabled?: boolean;
   onSelect: (family: Family) => void;
 }
 
-const AnchorSwatch: React.FC<AnchorSwatchProps> = ({family, hex, selected, onSelect}) => {
+const AnchorSwatch: React.FC<AnchorSwatchProps> = ({family, hex, selected, disabled, onSelect}) => {
   const normalized = normalizeHex(hex) ?? "#000000";
   const textColor = readableTextColor(normalized) === "#ffffff" ? "inverted" : "primary";
   const handlePress = useCallback((): void => {
+    if (disabled) {
+      return;
+    }
     onSelect(family);
-  }, [family, onSelect]);
+  }, [disabled, family, onSelect]);
 
   return (
     <Box
@@ -33,7 +37,9 @@ const AnchorSwatch: React.FC<AnchorSwatchProps> = ({family, hex, selected, onSel
       accessibilityLabel={`${FAMILY_LABELS[family]} anchor`}
       alignItems="center"
       border={selected ? "activeAccent" : "default"}
-      dangerouslySetInlineStyle={{__style: {backgroundColor: normalized}}}
+      dangerouslySetInlineStyle={{
+        __style: {backgroundColor: normalized, opacity: disabled ? 0.6 : 1},
+      }}
       gap={1}
       justifyContent="center"
       onClick={handlePress}
@@ -54,6 +60,7 @@ const AnchorSwatch: React.FC<AnchorSwatchProps> = ({family, hex, selected, onSel
 interface AnchorControlsProps {
   anchors: PaletteAnchors;
   selectedFamily: Family;
+  disabled?: boolean;
   onSelectFamily: (family: Family) => void;
   onChangeAnchor: (family: Family, hex: string) => void;
 }
@@ -61,6 +68,7 @@ interface AnchorControlsProps {
 export const AnchorControls: React.FC<AnchorControlsProps> = ({
   anchors,
   selectedFamily,
+  disabled,
   onSelectFamily,
   onChangeAnchor,
 }) => {
@@ -76,6 +84,7 @@ export const AnchorControls: React.FC<AnchorControlsProps> = ({
       <Box direction="row" gap={2} wrap>
         {ANCHOR_FAMILIES.map((family) => (
           <AnchorSwatch
+            disabled={disabled}
             family={family}
             hex={anchors[family]}
             key={family}
@@ -85,6 +94,7 @@ export const AnchorControls: React.FC<AnchorControlsProps> = ({
         ))}
       </Box>
       <ColorPicker
+        disabled={disabled}
         label={FAMILY_LABELS[selectedFamily]}
         onChange={handleColorChange}
         value={anchors[selectedFamily]}

--- a/demo/components/palette/AnchorControls.tsx
+++ b/demo/components/palette/AnchorControls.tsx
@@ -1,0 +1,94 @@
+import {Box, Text} from "@terreno/ui";
+import React, {useCallback} from "react";
+import {ColorPicker} from "./ColorPicker";
+import type {PaletteAnchors} from "./colorUtils";
+import {normalizeHex, readableTextColor} from "./colorUtils";
+import {ANCHOR_FAMILIES, FAMILY_LABELS, type MainFamily, type StatusFamily} from "./paletteTypes";
+
+/**
+ * The manual editing surface: a swatch per anchor family that you tap to select, plus the full
+ * Hue/Saturation/Lightness + hex picker for whichever family is selected. Editing an anchor here
+ * regenerates the whole palette, exactly like a change coming from the chat assistant.
+ */
+
+type Family = MainFamily | StatusFamily;
+
+interface AnchorSwatchProps {
+  family: Family;
+  hex: string;
+  selected: boolean;
+  onSelect: (family: Family) => void;
+}
+
+const AnchorSwatch: React.FC<AnchorSwatchProps> = ({family, hex, selected, onSelect}) => {
+  const normalized = normalizeHex(hex) ?? "#000000";
+  const textColor = readableTextColor(normalized) === "#ffffff" ? "inverted" : "primary";
+  const handlePress = useCallback((): void => {
+    onSelect(family);
+  }, [family, onSelect]);
+
+  return (
+    <Box
+      accessibilityHint={`Edit the ${FAMILY_LABELS[family]} anchor color`}
+      accessibilityLabel={`${FAMILY_LABELS[family]} anchor`}
+      alignItems="center"
+      border={selected ? "activeAccent" : "default"}
+      dangerouslySetInlineStyle={{__style: {backgroundColor: normalized}}}
+      gap={1}
+      justifyContent="center"
+      onClick={handlePress}
+      padding={2}
+      rounding="md"
+      width={104}
+    >
+      <Text bold color={textColor} size="sm">
+        {FAMILY_LABELS[family]}
+      </Text>
+      <Text color={textColor} size="sm">
+        {normalized.toUpperCase()}
+      </Text>
+    </Box>
+  );
+};
+
+interface AnchorControlsProps {
+  anchors: PaletteAnchors;
+  selectedFamily: Family;
+  onSelectFamily: (family: Family) => void;
+  onChangeAnchor: (family: Family, hex: string) => void;
+}
+
+export const AnchorControls: React.FC<AnchorControlsProps> = ({
+  anchors,
+  selectedFamily,
+  onSelectFamily,
+  onChangeAnchor,
+}) => {
+  const handleColorChange = useCallback(
+    (hex: string): void => {
+      onChangeAnchor(selectedFamily, hex);
+    },
+    [onChangeAnchor, selectedFamily]
+  );
+
+  return (
+    <Box gap={4}>
+      <Box direction="row" gap={2} wrap>
+        {ANCHOR_FAMILIES.map((family) => (
+          <AnchorSwatch
+            family={family}
+            hex={anchors[family]}
+            key={family}
+            onSelect={onSelectFamily}
+            selected={family === selectedFamily}
+          />
+        ))}
+      </Box>
+      <ColorPicker
+        label={FAMILY_LABELS[selectedFamily]}
+        onChange={handleColorChange}
+        value={anchors[selectedFamily]}
+      />
+    </Box>
+  );
+};

--- a/demo/components/palette/ChatPanel.tsx
+++ b/demo/components/palette/ChatPanel.tsx
@@ -17,6 +17,40 @@ export const EXAMPLE_PROMPTS: string[] = [
   "High-contrast dark-friendly palette with a vivid coral accent",
 ];
 
+interface PromptChipProps {
+  prompt: string;
+  disabled?: boolean;
+  onSelect: (prompt: string) => void;
+}
+
+/**
+ * Full-width, text-wrapping starter prompt. Uses a pressable Box (not Button) so long prompts wrap
+ * instead of overflowing the chat column.
+ */
+const PromptChip: React.FC<PromptChipProps> = ({prompt, disabled, onSelect}) => {
+  const handlePress = useCallback((): void => {
+    if (disabled) {
+      return;
+    }
+    onSelect(prompt);
+  }, [disabled, onSelect, prompt]);
+
+  return (
+    <Box
+      accessibilityHint="Send this starter prompt to the assistant"
+      accessibilityLabel={prompt}
+      border="default"
+      dangerouslySetInlineStyle={{__style: {opacity: disabled ? 0.6 : 1}}}
+      onClick={handlePress}
+      padding={3}
+      rounding="md"
+      width="100%"
+    >
+      <Text color="link">{prompt}</Text>
+    </Box>
+  );
+};
+
 interface MessageBubbleProps {
   message: ChatMessage;
 }
@@ -78,12 +112,11 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
             </Text>
             <Box gap={2}>
               {EXAMPLE_PROMPTS.map((prompt) => (
-                <Button
+                <PromptChip
                   disabled={disabled || isLoading}
                   key={prompt}
-                  onClick={() => handleExample(prompt)}
-                  text={prompt}
-                  variant="outline"
+                  onSelect={handleExample}
+                  prompt={prompt}
                 />
               ))}
             </Box>

--- a/demo/components/palette/ChatPanel.tsx
+++ b/demo/components/palette/ChatPanel.tsx
@@ -1,0 +1,121 @@
+import {Banner, Box, Button, Spinner, Text, TextField} from "@terreno/ui";
+import React, {useCallback, useState} from "react";
+
+import type {ChatMessage} from "./paletteTypes";
+
+/**
+ * The conversational surface: shows the running exchange with the palette assistant, offers a few
+ * starter prompts, and lets the user send free-form requests / feedback ("make it warmer", "swap
+ * primary to teal"). Sending is delegated to the parent, which calls Gemini and updates the palette.
+ */
+
+/** Starter prompts that showcase both vibe-based and color-anchored requests. */
+export const EXAMPLE_PROMPTS: string[] = [
+  "I want a warm, earthy palette for a cozy recipe app",
+  "Stylish modern SaaS dashboard with indigo as the primary color",
+  "Calm, trustworthy healthcare app with teal accents",
+  "High-contrast dark-friendly palette with a vivid coral accent",
+];
+
+interface MessageBubbleProps {
+  message: ChatMessage;
+}
+
+const MessageBubble: React.FC<MessageBubbleProps> = ({message}) => {
+  const isUser = message.role === "user";
+  return (
+    <Box alignItems={isUser ? "end" : "start"} width="100%">
+      <Box color={isUser ? "primary" : "neutralLight"} maxWidth="90%" padding={3} rounding="md">
+        <Text color={isUser ? "inverted" : "primary"}>{message.text}</Text>
+      </Box>
+    </Box>
+  );
+};
+
+interface ChatPanelProps {
+  messages: ChatMessage[];
+  isLoading: boolean;
+  error?: string;
+  disabled?: boolean;
+  onSend: (text: string) => void;
+}
+
+export const ChatPanel: React.FC<ChatPanelProps> = ({
+  messages,
+  isLoading,
+  error,
+  disabled,
+  onSend,
+}) => {
+  const [draft, setDraft] = useState<string>("");
+
+  const handleSend = useCallback((): void => {
+    const trimmed = draft.trim();
+    if (!trimmed || isLoading) {
+      return;
+    }
+    onSend(trimmed);
+    setDraft("");
+  }, [draft, isLoading, onSend]);
+
+  const handleExample = useCallback(
+    (prompt: string): void => {
+      if (isLoading) {
+        return;
+      }
+      onSend(prompt);
+    },
+    [isLoading, onSend]
+  );
+
+  return (
+    <Box flex="grow" gap={3}>
+      <Box flex="grow" gap={3} scroll>
+        {messages.length === 0 && (
+          <Box gap={3}>
+            <Text color="secondaryLight">
+              Describe the palette you want, or tweak the colors on the right. Try one of these:
+            </Text>
+            <Box gap={2}>
+              {EXAMPLE_PROMPTS.map((prompt) => (
+                <Button
+                  disabled={disabled || isLoading}
+                  key={prompt}
+                  onClick={() => handleExample(prompt)}
+                  text={prompt}
+                  variant="outline"
+                />
+              ))}
+            </Box>
+          </Box>
+        )}
+        {messages.map((message) => (
+          <MessageBubble key={message.id} message={message} />
+        ))}
+        {isLoading && (
+          <Box alignItems="center" direction="row" gap={2}>
+            <Spinner size="sm" />
+            <Text color="secondaryLight">Generating palette…</Text>
+          </Box>
+        )}
+      </Box>
+      {Boolean(error) && <Banner id="palette-chat-error" status="alert" text={error!} />}
+      <Box direction="row" gap={2}>
+        <Box flex="grow">
+          <TextField
+            disabled={disabled}
+            onChange={setDraft}
+            placeholder="e.g. make the primary a deeper teal"
+            value={draft}
+          />
+        </Box>
+        <Button
+          disabled={disabled || isLoading || !draft.trim()}
+          onClick={handleSend}
+          text="Send"
+          variant="primary"
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/demo/components/palette/CodeOutput.tsx
+++ b/demo/components/palette/CodeOutput.tsx
@@ -1,0 +1,69 @@
+import {Box, Button, Heading, SegmentedControl, Text} from "@terreno/ui";
+import * as Clipboard from "expo-clipboard";
+import React, {useCallback, useMemo, useState} from "react";
+import {Platform, Text as RNText, ScrollView} from "react-native";
+
+import {buildPrimitivesObjectCode, buildSetPrimitivesCode} from "./codeExport";
+
+/**
+ * Emits the exact, copy-pasteable code for the generated palette in two forms: a `ThemePrimitives`
+ * object literal for a theme file, and a runtime `setPrimitives({...})` call. This is the "output
+ * the exact code" deliverable — what a developer drops into their Terreno app to adopt the palette.
+ */
+
+interface CodeOutputProps {
+  primitives: Record<string, string>;
+}
+
+const MONOSPACE = Platform.select({default: "monospace", ios: "Menlo", web: "monospace"});
+
+export const CodeOutput: React.FC<CodeOutputProps> = ({primitives}) => {
+  const [form, setForm] = useState<number>(0);
+  const [copied, setCopied] = useState<boolean>(false);
+
+  const code = useMemo(() => {
+    return form === 0 ? buildPrimitivesObjectCode(primitives) : buildSetPrimitivesCode(primitives);
+  }, [form, primitives]);
+
+  const handleCopy = useCallback(async (): Promise<void> => {
+    await Clipboard.setStringAsync(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }, [code]);
+
+  const handleFormChange = useCallback((index: number): void => {
+    setForm(index);
+  }, []);
+
+  return (
+    <Box gap={3}>
+      <Box alignItems="center" direction="row" gap={3} justifyContent="between" wrap>
+        <Heading size="sm">Export code</Heading>
+        <Button
+          iconName="copy"
+          onClick={handleCopy}
+          text={copied ? "Copied!" : "Copy"}
+          variant="outline"
+        />
+      </Box>
+      <SegmentedControl
+        items={["Theme primitives", "setPrimitives()"]}
+        onChange={handleFormChange}
+        selectedIndex={form}
+      />
+      <Box color="neutralDark" padding={3} rounding="md">
+        <ScrollView horizontal showsHorizontalScrollIndicator style={{maxHeight: 320}}>
+          <ScrollView showsVerticalScrollIndicator>
+            <RNText style={{color: "#f2f2f2", fontFamily: MONOSPACE, fontSize: 12, lineHeight: 18}}>
+              {code}
+            </RNText>
+          </ScrollView>
+        </ScrollView>
+      </Box>
+      <Text color="secondaryLight" size="sm">
+        Paste the primitives into your theme, or call setPrimitives() from a component to preview it
+        live.
+      </Text>
+    </Box>
+  );
+};

--- a/demo/components/palette/CodeOutput.tsx
+++ b/demo/components/palette/CodeOutput.tsx
@@ -3,27 +3,36 @@ import * as Clipboard from "expo-clipboard";
 import React, {useCallback, useMemo, useState} from "react";
 import {Platform, Text as RNText, ScrollView} from "react-native";
 
-import {buildPrimitivesObjectCode, buildSetPrimitivesCode} from "./codeExport";
+import {buildFontConfigCode, buildPrimitivesObjectCode, buildSetPrimitivesCode} from "./codeExport";
+import type {FontSelection} from "./fonts";
 
 /**
- * Emits the exact, copy-pasteable code for the generated palette in two forms: a `ThemePrimitives`
- * object literal for a theme file, and a runtime `setPrimitives({...})` call. This is the "output
- * the exact code" deliverable — what a developer drops into their Terreno app to adopt the palette.
+ * Emits the exact, copy-pasteable code for the generated palette: a `ThemePrimitives` object
+ * literal for a theme file, a runtime `setPrimitives({...})` call, and the recommended `theme.font`
+ * config. This is the "output the exact code" deliverable — what a developer drops into their
+ * Terreno app to adopt the palette.
  */
 
 interface CodeOutputProps {
   primitives: Record<string, string>;
+  fonts: FontSelection;
 }
 
 const MONOSPACE = Platform.select({default: "monospace", ios: "Menlo", web: "monospace"});
 
-export const CodeOutput: React.FC<CodeOutputProps> = ({primitives}) => {
+export const CodeOutput: React.FC<CodeOutputProps> = ({primitives, fonts}) => {
   const [form, setForm] = useState<number>(0);
   const [copied, setCopied] = useState<boolean>(false);
 
   const code = useMemo(() => {
-    return form === 0 ? buildPrimitivesObjectCode(primitives) : buildSetPrimitivesCode(primitives);
-  }, [form, primitives]);
+    if (form === 1) {
+      return buildSetPrimitivesCode(primitives);
+    }
+    if (form === 2) {
+      return buildFontConfigCode(fonts);
+    }
+    return buildPrimitivesObjectCode(primitives);
+  }, [fonts, form, primitives]);
 
   const handleCopy = useCallback(async (): Promise<void> => {
     await Clipboard.setStringAsync(code);
@@ -47,7 +56,7 @@ export const CodeOutput: React.FC<CodeOutputProps> = ({primitives}) => {
         />
       </Box>
       <SegmentedControl
-        items={["Theme primitives", "setPrimitives()"]}
+        items={["Theme primitives", "setPrimitives()", "Fonts"]}
         onChange={handleFormChange}
         selectedIndex={form}
       />

--- a/demo/components/palette/ColorPicker.tsx
+++ b/demo/components/palette/ColorPicker.tsx
@@ -1,0 +1,98 @@
+import {Box, Slider, Text, TextField} from "@terreno/ui";
+import React, {useCallback, useMemo, useState} from "react";
+
+import {hexToHsl, hslToHex, normalizeHex, readableTextColor} from "./colorUtils";
+
+/**
+ * Cross-platform color picker: a live swatch, a hex text field ("type in colors"), and Hue /
+ * Saturation / Lightness sliders. Works identically on web and native since it is built on the
+ * Terreno `Slider` rather than a DOM `<input type="color">`.
+ */
+
+interface ColorPickerProps {
+  value: string;
+  onChange: (hex: string) => void;
+  label?: string;
+}
+
+export const ColorPicker: React.FC<ColorPickerProps> = ({value, onChange, label}) => {
+  // Track raw hex text separately so partially-typed values don't get clobbered mid-edit.
+  const [hexDraft, setHexDraft] = useState<string>(value);
+
+  // Keep the draft in sync when the value changes from outside (LLM output, slider drag).
+  React.useEffect(() => {
+    setHexDraft(value);
+  }, [value]);
+
+  const hsl = useMemo(() => hexToHsl(value) ?? {h: 0, l: 0.5, s: 0}, [value]);
+  const normalizedValue = normalizeHex(value) ?? "#000000";
+  // The picker renders under the default (light) theme, where `inverted` is white and
+  // `primary` is near-black — enough to label any swatch legibly.
+  const swatchTextColor = readableTextColor(normalizedValue) === "#ffffff" ? "inverted" : "primary";
+
+  const handleHexChange = useCallback(
+    (next: string): void => {
+      setHexDraft(next);
+      const normalized = normalizeHex(next);
+      if (normalized) {
+        onChange(normalized);
+      }
+    },
+    [onChange]
+  );
+
+  const handleHslChange = useCallback(
+    (partial: Partial<{h: number; s: number; l: number}>): void => {
+      onChange(hslToHex({...hsl, ...partial}));
+    },
+    [hsl, onChange]
+  );
+
+  return (
+    <Box gap={2}>
+      <Box
+        alignItems="center"
+        dangerouslySetInlineStyle={{__style: {backgroundColor: normalizedValue}}}
+        height={48}
+        justifyContent="center"
+        rounding="md"
+      >
+        <Text bold color={swatchTextColor}>
+          {label ? `${label} · ` : ""}
+          {normalizedValue.toUpperCase()}
+        </Text>
+      </Box>
+      <TextField onChange={handleHexChange} placeholder="#0086b3" title="Hex" value={hexDraft} />
+      <Slider
+        inlineLabels
+        labels={{min: "Hue"}}
+        maximumValue={360}
+        minimumValue={0}
+        onChange={(next) => handleHslChange({h: next})}
+        showSelection
+        step={1}
+        value={hsl.h}
+      />
+      <Slider
+        inlineLabels
+        labels={{min: "Sat"}}
+        maximumValue={100}
+        minimumValue={0}
+        onChange={(next) => handleHslChange({s: next / 100})}
+        showSelection
+        step={1}
+        value={Math.round(hsl.s * 100)}
+      />
+      <Slider
+        inlineLabels
+        labels={{min: "Light"}}
+        maximumValue={100}
+        minimumValue={0}
+        onChange={(next) => handleHslChange({l: next / 100})}
+        showSelection
+        step={1}
+        value={Math.round(hsl.l * 100)}
+      />
+    </Box>
+  );
+};

--- a/demo/components/palette/ColorPicker.tsx
+++ b/demo/components/palette/ColorPicker.tsx
@@ -13,9 +13,10 @@ interface ColorPickerProps {
   value: string;
   onChange: (hex: string) => void;
   label?: string;
+  disabled?: boolean;
 }
 
-export const ColorPicker: React.FC<ColorPickerProps> = ({value, onChange, label}) => {
+export const ColorPicker: React.FC<ColorPickerProps> = ({value, onChange, label, disabled}) => {
   // Track raw hex text separately so partially-typed values don't get clobbered mid-edit.
   const [hexDraft, setHexDraft] = useState<string>(value);
 
@@ -62,8 +63,15 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({value, onChange, label}
           {normalizedValue.toUpperCase()}
         </Text>
       </Box>
-      <TextField onChange={handleHexChange} placeholder="#0086b3" title="Hex" value={hexDraft} />
+      <TextField
+        disabled={disabled}
+        onChange={handleHexChange}
+        placeholder="#0086b3"
+        title="Hex"
+        value={hexDraft}
+      />
       <Slider
+        disabled={disabled}
         inlineLabels
         labels={{min: "Hue"}}
         maximumValue={360}
@@ -74,6 +82,7 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({value, onChange, label}
         value={hsl.h}
       />
       <Slider
+        disabled={disabled}
         inlineLabels
         labels={{min: "Sat"}}
         maximumValue={100}
@@ -84,6 +93,7 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({value, onChange, label}
         value={Math.round(hsl.s * 100)}
       />
       <Slider
+        disabled={disabled}
         inlineLabels
         labels={{min: "Light"}}
         maximumValue={100}

--- a/demo/components/palette/ComponentPreview.tsx
+++ b/demo/components/palette/ComponentPreview.tsx
@@ -115,7 +115,7 @@ const ShowcaseCard: React.FC = () => {
 
 const AllComponentsGrid: React.FC = () => {
   return (
-    <Box direction="row" gap={3} wrap>
+    <Box direction="row" gap={3} overflow="hidden" width="100%" wrap>
       {DemoConfig.map((config) => {
         if (!config.name || !config.demo) {
           return null;
@@ -127,6 +127,8 @@ const AllComponentsGrid: React.FC = () => {
               borderColor: "#ccc",
               borderRadius: 4,
               borderWidth: 1,
+              // Clamp to the container so a narrow preview column never overflows horizontally.
+              maxWidth: "100%",
               overflow: "hidden",
               width: CARD_WIDTH,
             }}
@@ -187,9 +189,9 @@ export const ComponentPreview: React.FC<ComponentPreviewProps> = ({primitives}) 
               selectedIndex={mode === "dark" ? 1 : 0}
             />
           </Box>
-          <Box minWidth={220}>
+          <Box minWidth={200}>
             <SegmentedControl
-              items={["Showcase", "All components"]}
+              items={["Showcase", "All"]}
               onChange={handleViewChange}
               selectedIndex={view}
             />

--- a/demo/components/palette/ComponentPreview.tsx
+++ b/demo/components/palette/ComponentPreview.tsx
@@ -1,0 +1,165 @@
+import {DemoConfig} from "@config";
+import {
+  Badge,
+  BooleanField,
+  Box,
+  Button,
+  Card,
+  Heading,
+  SegmentedControl,
+  SelectField,
+  Text,
+  TextField,
+  type ThemePrimitiveColors,
+  ThemeProvider,
+} from "@terreno/ui";
+import React, {useCallback, useMemo, useState} from "react";
+import {View} from "react-native";
+
+import {ErrorBoundary} from "../ErrorBoundary";
+
+/**
+ * Live preview of real Terreno components rendered under the generated palette. A nested
+ * `ThemeProvider` (keyed by the palette so it re-initializes on every change) scopes the palette to
+ * this subtree only, leaving the rest of the demo app on the default theme. Two views are offered:
+ * a hand-built "showcase" mini-app and the full grid of every component demo.
+ */
+
+interface ComponentPreviewProps {
+  primitives: Partial<ThemePrimitiveColors>;
+}
+
+const CARD_WIDTH = 260;
+const CARD_PREVIEW_HEIGHT = 160;
+
+const ShowcaseCard: React.FC = () => {
+  const [checked, setChecked] = useState<boolean>(true);
+  const [segment, setSegment] = useState<number>(0);
+  const [text, setText] = useState<string>("");
+  const [choice, setChoice] = useState<string>("one");
+
+  return (
+    <Box gap={4}>
+      <Box gap={2}>
+        <Heading size="lg">The quick brown fox</Heading>
+        <Text>
+          This paragraph shows body copy on the base surface. Adjust the anchors or ask the
+          assistant for a new vibe and everything below re-themes instantly.
+        </Text>
+        <Text color="link">A themed link within the copy.</Text>
+      </Box>
+
+      <Box direction="row" gap={2} wrap>
+        <Button onClick={() => {}} text="Primary" variant="primary" />
+        <Button onClick={() => {}} text="Secondary" variant="secondary" />
+        <Button onClick={() => {}} text="Outline" variant="outline" />
+        <Button onClick={() => {}} text="Muted" variant="muted" />
+        <Button onClick={() => {}} text="Destructive" variant="destructive" />
+      </Box>
+
+      <Box direction="row" gap={2} wrap>
+        <Badge status="info" value="Info" />
+        <Badge status="success" value="Success" />
+        <Badge status="warning" value="Warning" />
+        <Badge status="error" value="Error" />
+        <Badge status="neutral" value="Neutral" />
+      </Box>
+
+      <SegmentedControl
+        items={["Overview", "Details", "Activity"]}
+        onChange={setSegment}
+        selectedIndex={segment}
+      />
+
+      <Card>
+        <Box gap={3} padding={2}>
+          <Heading size="sm">Sign in</Heading>
+          <TextField onChange={setText} placeholder="you@example.com" title="Email" value={text} />
+          <SelectField
+            onChange={setChoice}
+            options={[
+              {label: "Option one", value: "one"},
+              {label: "Option two", value: "two"},
+            ]}
+            title="Plan"
+            value={choice}
+          />
+          <BooleanField onChange={setChecked} title="Keep me signed in" value={checked} />
+          <Button fullWidth onClick={() => {}} text="Continue" variant="primary" />
+        </Box>
+      </Card>
+    </Box>
+  );
+};
+
+const AllComponentsGrid: React.FC = () => {
+  return (
+    <Box direction="row" gap={3} wrap>
+      {DemoConfig.map((config) => {
+        if (!config.name || !config.demo) {
+          return null;
+        }
+        return (
+          <View
+            key={config.name}
+            style={{
+              borderColor: "#ccc",
+              borderRadius: 4,
+              borderWidth: 1,
+              overflow: "hidden",
+              width: CARD_WIDTH,
+            }}
+          >
+            <Box
+              alignItems="center"
+              color="neutralLight"
+              height={CARD_PREVIEW_HEIGHT}
+              justifyContent="center"
+              overflow="hidden"
+              padding={3}
+            >
+              <ErrorBoundary>{config.demo({preview: true})}</ErrorBoundary>
+            </Box>
+            <Box color="base" padding={2}>
+              <Text bold size="sm">
+                {config.name}
+              </Text>
+            </Box>
+          </View>
+        );
+      })}
+    </Box>
+  );
+};
+
+export const ComponentPreview: React.FC<ComponentPreviewProps> = ({primitives}) => {
+  const [view, setView] = useState<number>(0);
+
+  // Remount the themed subtree whenever the palette changes so the nested ThemeProvider re-reads
+  // its initial primitives (it only consumes `initialPrimitives` on mount).
+  const paletteKey = useMemo(() => JSON.stringify(primitives), [primitives]);
+
+  const handleViewChange = useCallback((index: number): void => {
+    setView(index);
+  }, []);
+
+  return (
+    <Box gap={4}>
+      <Box alignItems="center" direction="row" gap={3} justifyContent="between" wrap>
+        <Heading size="sm">Component preview</Heading>
+        <Box minWidth={220}>
+          <SegmentedControl
+            items={["Showcase", "All components"]}
+            onChange={handleViewChange}
+            selectedIndex={view}
+          />
+        </Box>
+      </Box>
+      <Box color="base" padding={4} rounding="md">
+        <ThemeProvider initialPrimitives={primitives} key={paletteKey}>
+          {view === 0 ? <ShowcaseCard /> : <AllComponentsGrid />}
+        </ThemeProvider>
+      </Box>
+    </Box>
+  );
+};

--- a/demo/components/palette/ComponentPreview.tsx
+++ b/demo/components/palette/ComponentPreview.tsx
@@ -12,22 +12,43 @@ import {
   TextField,
   type ThemePrimitiveColors,
   ThemeProvider,
+  useTheme,
 } from "@terreno/ui";
-import React, {useCallback, useMemo, useState} from "react";
+import React, {useCallback, useEffect, useMemo, useState} from "react";
 import {View} from "react-native";
 
 import {ErrorBoundary} from "../ErrorBoundary";
+import {DARK_THEME_CONFIG} from "./darkTheme";
+import type {ThemeMode} from "./paletteTypes";
 
 /**
- * Live preview of real Terreno components rendered under the generated palette. A nested
- * `ThemeProvider` (keyed by the palette so it re-initializes on every change) scopes the palette to
- * this subtree only, leaving the rest of the demo app on the default theme. Two views are offered:
- * a hand-built "showcase" mini-app and the full grid of every component demo.
+ * Live preview of real Terreno components rendered under the generated palette, in light or dark
+ * mode. A nested `ThemeProvider` (keyed by the palette + mode so it re-initializes on every change)
+ * scopes the palette to this subtree only. Two views are offered: a hand-built "showcase" mini-app
+ * and the full grid of every component demo.
  */
 
 interface ComponentPreviewProps {
   primitives: Partial<ThemePrimitiveColors>;
 }
+
+/**
+ * Applies the dark role remapping to the nested provider once it has mounted. Dark mode remaps
+ * semantic roles rather than inverting primitives, so `setTheme` is the right lever here.
+ */
+const ThemeModeApplier: React.FC<{mode: ThemeMode; children: React.ReactNode}> = ({
+  mode,
+  children,
+}) => {
+  const {setTheme} = useTheme();
+  // Applied on mount (the provider is remounted whenever mode/palette change via its key).
+  useEffect(() => {
+    if (mode === "dark") {
+      setTheme(DARK_THEME_CONFIG);
+    }
+  }, [mode, setTheme]);
+  return <>{children}</>;
+};
 
 const CARD_WIDTH = 260;
 const CARD_PREVIEW_HEIGHT = 160;
@@ -134,30 +155,56 @@ const AllComponentsGrid: React.FC = () => {
 
 export const ComponentPreview: React.FC<ComponentPreviewProps> = ({primitives}) => {
   const [view, setView] = useState<number>(0);
+  const [mode, setMode] = useState<ThemeMode>("light");
 
-  // Remount the themed subtree whenever the palette changes so the nested ThemeProvider re-reads
-  // its initial primitives (it only consumes `initialPrimitives` on mount).
-  const paletteKey = useMemo(() => JSON.stringify(primitives), [primitives]);
+  // Remount the themed subtree whenever the palette or mode changes so the nested ThemeProvider
+  // re-reads its initial primitives (it only consumes `initialPrimitives` on mount) and re-applies
+  // the correct role mapping from a clean default.
+  const paletteKey = useMemo(() => `${mode}-${JSON.stringify(primitives)}`, [mode, primitives]);
 
   const handleViewChange = useCallback((index: number): void => {
     setView(index);
   }, []);
 
+  const handleModeChange = useCallback((index: number): void => {
+    setMode(index === 1 ? "dark" : "light");
+  }, []);
+
+  const baseHex =
+    mode === "dark"
+      ? ((primitives as Record<string, string>).neutral900 ?? "#1c1c1c")
+      : ((primitives as Record<string, string>).neutral000 ?? "#ffffff");
+
   return (
     <Box gap={4}>
       <Box alignItems="center" direction="row" gap={3} justifyContent="between" wrap>
         <Heading size="sm">Component preview</Heading>
-        <Box minWidth={220}>
-          <SegmentedControl
-            items={["Showcase", "All components"]}
-            onChange={handleViewChange}
-            selectedIndex={view}
-          />
+        <Box direction="row" gap={2} wrap>
+          <Box minWidth={160}>
+            <SegmentedControl
+              items={["Light", "Dark"]}
+              onChange={handleModeChange}
+              selectedIndex={mode === "dark" ? 1 : 0}
+            />
+          </Box>
+          <Box minWidth={220}>
+            <SegmentedControl
+              items={["Showcase", "All components"]}
+              onChange={handleViewChange}
+              selectedIndex={view}
+            />
+          </Box>
         </Box>
       </Box>
-      <Box color="base" padding={4} rounding="md">
+      <Box
+        dangerouslySetInlineStyle={{__style: {backgroundColor: baseHex}}}
+        padding={4}
+        rounding="md"
+      >
         <ThemeProvider initialPrimitives={primitives} key={paletteKey}>
-          {view === 0 ? <ShowcaseCard /> : <AllComponentsGrid />}
+          <ThemeModeApplier mode={mode}>
+            {view === 0 ? <ShowcaseCard /> : <AllComponentsGrid />}
+          </ThemeModeApplier>
         </ThemeProvider>
       </Box>
     </Box>

--- a/demo/components/palette/ContrastReport.tsx
+++ b/demo/components/palette/ContrastReport.tsx
@@ -62,14 +62,18 @@ const ContrastRow: React.FC<ContrastRowProps> = ({result}) => {
 
 interface ContrastReportProps {
   results: ContrastResult[];
+  title?: string;
 }
 
-export const ContrastReport: React.FC<ContrastReportProps> = ({results}) => {
+export const ContrastReport: React.FC<ContrastReportProps> = ({
+  results,
+  title = "Accessibility (WCAG)",
+}) => {
   const failures = results.filter((result) => !result.passes).length;
   return (
     <Box gap={3}>
       <Box alignItems="center" direction="row" gap={2}>
-        <Heading size="sm">Accessibility (WCAG)</Heading>
+        <Heading size="sm">{title}</Heading>
         <Badge
           status={failures === 0 ? "success" : "error"}
           value={failures === 0 ? "All pass" : `${failures} issue${failures === 1 ? "" : "s"}`}

--- a/demo/components/palette/ContrastReport.tsx
+++ b/demo/components/palette/ContrastReport.tsx
@@ -1,0 +1,85 @@
+import {Badge, Box, Heading, Text} from "@terreno/ui";
+import React from "react";
+import {Text as RNText} from "react-native";
+
+import {formatRatio} from "./colorUtils";
+import type {ContrastResult} from "./paletteTypes";
+
+/**
+ * Runs the generated palette through the curated WCAG 2.1 contrast checks and flags any pairing
+ * that will not meet its required AA threshold. Each row shows the measured ratio, a live preview
+ * of the foreground-on-background text, and a pass/fail (plus AAA) badge.
+ */
+
+interface ContrastRowProps {
+  result: ContrastResult;
+}
+
+const ContrastRow: React.FC<ContrastRowProps> = ({result}) => {
+  const requirement = result.largeText ? "AA large 3:1" : "AA 4.5:1";
+  return (
+    <Box
+      alignItems="center"
+      border="default"
+      direction="row"
+      gap={3}
+      justifyContent="between"
+      padding={3}
+      rounding="md"
+      wrap
+    >
+      <Box
+        alignItems="center"
+        dangerouslySetInlineStyle={{__style: {backgroundColor: result.backgroundHex}}}
+        justifyContent="center"
+        minWidth={64}
+        paddingX={3}
+        paddingY={2}
+        rounding="sm"
+      >
+        {/* Sample text uses the exact generated foreground hex, which the themed Text color prop
+            cannot express, so a raw RN Text style is required here. */}
+        <RNText style={{color: result.foregroundHex, fontSize: 16, fontWeight: "700"}}>Aa</RNText>
+      </Box>
+      <Box flex="grow" gap={1} minWidth={160}>
+        <Text bold size="sm">
+          {result.label}
+        </Text>
+        <Text color="secondaryLight" size="sm">
+          {formatRatio(result.ratio)} · needs {requirement}
+        </Text>
+      </Box>
+      <Box direction="row" gap={2}>
+        <Badge
+          status={result.passes ? "success" : "error"}
+          value={result.passes ? "AA pass" : "AA fail"}
+        />
+        {result.passes && result.passesAaa && <Badge status="info" value="AAA" />}
+      </Box>
+    </Box>
+  );
+};
+
+interface ContrastReportProps {
+  results: ContrastResult[];
+}
+
+export const ContrastReport: React.FC<ContrastReportProps> = ({results}) => {
+  const failures = results.filter((result) => !result.passes).length;
+  return (
+    <Box gap={3}>
+      <Box alignItems="center" direction="row" gap={2}>
+        <Heading size="sm">Accessibility (WCAG)</Heading>
+        <Badge
+          status={failures === 0 ? "success" : "error"}
+          value={failures === 0 ? "All pass" : `${failures} issue${failures === 1 ? "" : "s"}`}
+        />
+      </Box>
+      <Box gap={2}>
+        {results.map((result) => (
+          <ContrastRow key={result.label} result={result} />
+        ))}
+      </Box>
+    </Box>
+  );
+};

--- a/demo/components/palette/DarkModeAudit.tsx
+++ b/demo/components/palette/DarkModeAudit.tsx
@@ -1,0 +1,50 @@
+import {Badge, Box, Heading, Text} from "@terreno/ui";
+import React from "react";
+
+import {DARK_MODE_AUDIT, type DarkModeStatus} from "./darkTheme";
+
+/**
+ * Static read-out of the `@terreno/ui` dark-mode audit: which parts of the library adapt to a
+ * remapped dark theme and which will not (hardcoded colors, light-surface assumptions). Pairs with
+ * the live WCAG contrast report, which flags dynamic color issues for the current palette.
+ */
+
+const STATUS_BADGE: Record<
+  DarkModeStatus,
+  {status: "success" | "warning" | "error"; label: string}
+> = {
+  adapts: {label: "Adapts", status: "success"},
+  breaks: {label: "Breaks", status: "error"},
+  partial: {label: "Partial", status: "warning"},
+};
+
+export const DarkModeAudit: React.FC = () => {
+  return (
+    <Box gap={3}>
+      <Heading size="sm">Dark mode audit</Heading>
+      <Text color="secondaryLight" size="sm">
+        How Terreno components respond to a remapped dark theme. "Breaks" items have hardcoded
+        colors or assume a light surface in the library source and need a fix to fully support dark
+        mode.
+      </Text>
+      <Box gap={2}>
+        {DARK_MODE_AUDIT.map((item) => {
+          const badge = STATUS_BADGE[item.status];
+          return (
+            <Box border="default" gap={2} key={item.area} padding={3} rounding="md">
+              <Box alignItems="center" direction="row" gap={2} justifyContent="between">
+                <Text bold size="sm">
+                  {item.area}
+                </Text>
+                <Badge status={badge.status} value={badge.label} />
+              </Box>
+              <Text color="secondaryLight" size="sm">
+                {item.detail}
+              </Text>
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};

--- a/demo/components/palette/FontControls.tsx
+++ b/demo/components/palette/FontControls.tsx
@@ -8,8 +8,8 @@ import {
   FONT_PAIRINGS,
   type FontSelection,
   HEADING_FONTS,
-  loadWebFonts,
 } from "./fonts";
+import {loadWebFonts} from "./webFonts";
 
 /**
  * Font selection + live preview. The heading and body families can be chosen manually (or suggested
@@ -22,22 +22,28 @@ interface FontControlsProps {
   fonts: FontSelection;
   onChange: (fonts: FontSelection) => void;
   rationale?: string;
+  disabled?: boolean;
 }
 
 const PairingButton: React.FC<{
   name: string;
   fonts: FontSelection;
   active: boolean;
+  disabled?: boolean;
   onSelect: (fonts: FontSelection) => void;
-}> = ({name, fonts, active, onSelect}) => {
+}> = ({name, fonts, active, disabled, onSelect}) => {
   const handlePress = useCallback((): void => {
+    if (disabled) {
+      return;
+    }
     onSelect(fonts);
-  }, [fonts, onSelect]);
+  }, [disabled, fonts, onSelect]);
   return (
     <Box
       accessibilityHint={`Use the ${name} font pairing`}
       accessibilityLabel={name}
       border={active ? "activeAccent" : "default"}
+      dangerouslySetInlineStyle={{__style: {opacity: disabled ? 0.6 : 1}}}
       onClick={handlePress}
       paddingX={3}
       paddingY={2}
@@ -48,7 +54,12 @@ const PairingButton: React.FC<{
   );
 };
 
-export const FontControls: React.FC<FontControlsProps> = ({fonts, onChange, rationale}) => {
+export const FontControls: React.FC<FontControlsProps> = ({
+  fonts,
+  onChange,
+  rationale,
+  disabled,
+}) => {
   const headingOptions = useMemo(
     () => buildFontOptions(HEADING_FONTS, fonts.headingFont),
     [fonts.headingFont]
@@ -79,6 +90,7 @@ export const FontControls: React.FC<FontControlsProps> = ({fonts, onChange, rati
       <Box direction="column" gap={3} mdDirection="row">
         <Box flex="grow">
           <SelectField
+            disabled={disabled}
             onChange={handleHeading}
             options={headingOptions}
             requireValue
@@ -88,6 +100,7 @@ export const FontControls: React.FC<FontControlsProps> = ({fonts, onChange, rati
         </Box>
         <Box flex="grow">
           <SelectField
+            disabled={disabled}
             onChange={handleBody}
             options={bodyOptions}
             requireValue
@@ -104,6 +117,7 @@ export const FontControls: React.FC<FontControlsProps> = ({fonts, onChange, rati
               pairing.fonts.headingFont === fonts.headingFont &&
               pairing.fonts.bodyFont === fonts.bodyFont
             }
+            disabled={disabled}
             fonts={pairing.fonts}
             key={pairing.name}
             name={pairing.name}

--- a/demo/components/palette/FontControls.tsx
+++ b/demo/components/palette/FontControls.tsx
@@ -1,0 +1,135 @@
+import {Box, SelectField, Text} from "@terreno/ui";
+import React, {useCallback, useEffect, useMemo} from "react";
+import {Text as RNText} from "react-native";
+
+import {
+  BODY_FONTS,
+  buildFontOptions,
+  FONT_PAIRINGS,
+  type FontSelection,
+  HEADING_FONTS,
+  loadWebFonts,
+} from "./fonts";
+
+/**
+ * Font selection + live preview. The heading and body families can be chosen manually (or suggested
+ * by the assistant), and are rendered in the real typeface via a web font loader. `theme.font` in
+ * the stock Terreno theme currently hardcodes Nunito/Titillium, so this drives the export and the
+ * preview here rather than re-theming every library component.
+ */
+
+interface FontControlsProps {
+  fonts: FontSelection;
+  onChange: (fonts: FontSelection) => void;
+  rationale?: string;
+}
+
+const PairingButton: React.FC<{
+  name: string;
+  fonts: FontSelection;
+  active: boolean;
+  onSelect: (fonts: FontSelection) => void;
+}> = ({name, fonts, active, onSelect}) => {
+  const handlePress = useCallback((): void => {
+    onSelect(fonts);
+  }, [fonts, onSelect]);
+  return (
+    <Box
+      accessibilityHint={`Use the ${name} font pairing`}
+      accessibilityLabel={name}
+      border={active ? "activeAccent" : "default"}
+      onClick={handlePress}
+      paddingX={3}
+      paddingY={2}
+      rounding="md"
+    >
+      <Text size="sm">{name}</Text>
+    </Box>
+  );
+};
+
+export const FontControls: React.FC<FontControlsProps> = ({fonts, onChange, rationale}) => {
+  const headingOptions = useMemo(
+    () => buildFontOptions(HEADING_FONTS, fonts.headingFont),
+    [fonts.headingFont]
+  );
+  const bodyOptions = useMemo(() => buildFontOptions(BODY_FONTS, fonts.bodyFont), [fonts.bodyFont]);
+
+  // Load the selected families on web so the preview renders in the real typeface.
+  useEffect(() => {
+    loadWebFonts([fonts.headingFont, fonts.bodyFont]);
+  }, [fonts.headingFont, fonts.bodyFont]);
+
+  const handleHeading = useCallback(
+    (value: string): void => {
+      onChange({...fonts, headingFont: value});
+    },
+    [fonts, onChange]
+  );
+
+  const handleBody = useCallback(
+    (value: string): void => {
+      onChange({...fonts, bodyFont: value});
+    },
+    [fonts, onChange]
+  );
+
+  return (
+    <Box gap={4}>
+      <Box direction="column" gap={3} mdDirection="row">
+        <Box flex="grow">
+          <SelectField
+            onChange={handleHeading}
+            options={headingOptions}
+            requireValue
+            title="Heading font"
+            value={fonts.headingFont}
+          />
+        </Box>
+        <Box flex="grow">
+          <SelectField
+            onChange={handleBody}
+            options={bodyOptions}
+            requireValue
+            title="Body font"
+            value={fonts.bodyFont}
+          />
+        </Box>
+      </Box>
+
+      <Box direction="row" gap={2} wrap>
+        {FONT_PAIRINGS.map((pairing) => (
+          <PairingButton
+            active={
+              pairing.fonts.headingFont === fonts.headingFont &&
+              pairing.fonts.bodyFont === fonts.bodyFont
+            }
+            fonts={pairing.fonts}
+            key={pairing.name}
+            name={pairing.name}
+            onSelect={onChange}
+          />
+        ))}
+      </Box>
+
+      {Boolean(rationale) && (
+        <Text color="secondaryLight" size="sm">
+          {rationale}
+        </Text>
+      )}
+
+      <Box border="default" gap={2} padding={4} rounding="md">
+        {/* Rendered with raw RN Text so the exact chosen family applies (loaded on web above). */}
+        <RNText style={{fontFamily: fonts.headingFont, fontSize: 26, fontWeight: "700"}}>
+          {fonts.headingFont}
+        </RNText>
+        <RNText style={{fontFamily: fonts.bodyFont, fontSize: 15, lineHeight: 22}}>
+          The quick brown fox jumps over the lazy dog. Body copy in {fonts.bodyFont} — 0123456789.
+        </RNText>
+        <RNText style={{color: "#888", fontFamily: fonts.bodyFont, fontSize: 12}}>
+          Heading: {fonts.headingFont} · Body: {fonts.bodyFont}
+        </RNText>
+      </Box>
+    </Box>
+  );
+};

--- a/demo/components/palette/PaletteGenerator.tsx
+++ b/demo/components/palette/PaletteGenerator.tsx
@@ -1,6 +1,6 @@
-import {Box, Button, Heading, Text, TextField, useStoredState} from "@terreno/ui";
+import {Box, Button, Heading, SelectField, Text, TextField, useStoredState} from "@terreno/ui";
 import {DateTime} from "luxon";
-import React, {useCallback, useMemo, useState} from "react";
+import React, {useCallback, useEffect, useMemo, useRef, useState} from "react";
 
 import {AnchorControls} from "./AnchorControls";
 import {ChatPanel} from "./ChatPanel";
@@ -10,8 +10,13 @@ import {ContrastReport} from "./ContrastReport";
 import {generatePrimitivesFromAnchors, type PaletteAnchors} from "./colorUtils";
 import {DarkModeAudit} from "./DarkModeAudit";
 import {FontControls} from "./FontControls";
-import {DEFAULT_FONTS, type FontSelection} from "./fonts";
-import {DEFAULT_GEMINI_MODEL, generatePaletteFromChat} from "./geminiClient";
+import {buildFontOptions, DEFAULT_FONTS, type FontSelection} from "./fonts";
+import {
+  DEFAULT_GEMINI_MODEL,
+  DEFAULT_GEMINI_MODELS,
+  generatePaletteFromChat,
+  listGeminiModels,
+} from "./geminiClient";
 import {PaletteRamps} from "./PaletteRamps";
 import {
   type ChatMessage,
@@ -54,6 +59,24 @@ export const PaletteGenerator: React.FC = () => {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | undefined>(undefined);
+  const [availableModels, setAvailableModels] = useState<string[]>(DEFAULT_GEMINI_MODELS);
+
+  // Guards against overlapping generations: state updates are async, so a rapid second Send (or a
+  // starter prompt) could otherwise start a concurrent request before `isLoading` re-renders.
+  const generatingRef = useRef<boolean>(false);
+
+  const resolvedModel = model || DEFAULT_GEMINI_MODEL;
+  const modelOptions = useMemo(
+    () => buildFontOptions(availableModels, resolvedModel),
+    [availableModels, resolvedModel]
+  );
+
+  const handleModelChange = useCallback(
+    (value: string): void => {
+      void setModel(value);
+    },
+    [setModel]
+  );
 
   const primitives = useMemo(
     () => generatePrimitivesFromAnchors(anchors) as Record<string, string>,
@@ -61,6 +84,24 @@ export const PaletteGenerator: React.FC = () => {
   );
   const lightContrast = useMemo(() => runContrastChecks(primitives, "light"), [primitives]);
   const darkContrast = useMemo(() => runContrastChecks(primitives, "dark"), [primitives]);
+
+  // Populate the model dropdown with the live set of chat models for the current key, falling back
+  // to the curated defaults when no key is set or the listing fails.
+  useEffect(() => {
+    if (!apiKey) {
+      setAvailableModels(DEFAULT_GEMINI_MODELS);
+      return;
+    }
+    let cancelled = false;
+    void listGeminiModels({apiKey}).then((models) => {
+      if (!cancelled && models && models.length > 0) {
+        setAvailableModels(models);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [apiKey]);
 
   const handleChangeAnchor = useCallback((family: Family, hex: string): void => {
     setAnchors((prev) => ({...prev, [family]: hex}));
@@ -72,6 +113,12 @@ export const PaletteGenerator: React.FC = () => {
         setError("Add your Gemini API key above to use the assistant.");
         return;
       }
+      // Ignore overlapping sends; the ref updates synchronously, unlike isLoading.
+      if (generatingRef.current) {
+        return;
+      }
+      generatingRef.current = true;
+
       const userMessage = makeMessage("user", text);
       const history = [...messages, userMessage];
       setMessages(history);
@@ -97,6 +144,7 @@ export const PaletteGenerator: React.FC = () => {
         const message = caught instanceof Error ? caught.message : "Something went wrong.";
         setError(message);
       } finally {
+        generatingRef.current = false;
         setIsLoading(false);
       }
     },
@@ -142,12 +190,14 @@ export const PaletteGenerator: React.FC = () => {
               value={apiKey}
             />
           </Box>
-          <Box minWidth={220}>
-            <TextField
-              onChange={setModel}
-              placeholder={DEFAULT_GEMINI_MODEL}
+          <Box minWidth={240}>
+            <SelectField
+              helperText={apiKey ? undefined : "Add a key to load models"}
+              onChange={handleModelChange}
+              options={modelOptions}
+              requireValue
               title="Model"
-              value={model}
+              value={resolvedModel}
             />
           </Box>
         </Box>
@@ -172,6 +222,7 @@ export const PaletteGenerator: React.FC = () => {
             </Text>
             <AnchorControls
               anchors={anchors}
+              disabled={isLoading}
               onChangeAnchor={handleChangeAnchor}
               onSelectFamily={setSelectedFamily}
               selectedFamily={selectedFamily}
@@ -183,7 +234,12 @@ export const PaletteGenerator: React.FC = () => {
               Pick a heading + body pairing (or let the assistant suggest one). The preview uses the
               real typefaces on web; the export includes the theme.font config.
             </Text>
-            <FontControls fonts={fonts} onChange={setFonts} rationale={fontRationale} />
+            <FontControls
+              disabled={isLoading}
+              fonts={fonts}
+              onChange={setFonts}
+              rationale={fontRationale}
+            />
           </Box>
         </Box>
 

--- a/demo/components/palette/PaletteGenerator.tsx
+++ b/demo/components/palette/PaletteGenerator.tsx
@@ -9,7 +9,12 @@ import {ChatPanel} from "./ChatPanel";
 import {CodeOutput} from "./CodeOutput";
 import {ComponentPreview} from "./ComponentPreview";
 import {ContrastReport} from "./ContrastReport";
-import {generatePrimitivesFromAnchors, type PaletteAnchors} from "./colorUtils";
+import {
+  constrainAnchorsToFamilyTones,
+  constrainAnchorToFamilyTone,
+  generatePrimitivesFromAnchors,
+  type PaletteAnchors,
+} from "./colorUtils";
 import {DarkModeAudit} from "./DarkModeAudit";
 import {FontControls} from "./FontControls";
 import {buildFontOptions, DEFAULT_FONTS, type FontSelection} from "./fonts";
@@ -62,7 +67,9 @@ export const PaletteGenerator: React.FC = () => {
     decodeShareState(typeof searchParams.s === "string" ? searchParams.s : undefined)
   ).current;
 
-  const [anchors, setAnchors] = useState<PaletteAnchors>(sharedState?.anchors ?? DEFAULT_ANCHORS);
+  const [anchors, setAnchors] = useState<PaletteAnchors>(
+    constrainAnchorsToFamilyTones(sharedState?.anchors ?? DEFAULT_ANCHORS)
+  );
   const [fonts, setFonts] = useState<FontSelection>(sharedState?.fonts ?? DEFAULT_FONTS);
   const [shareCopied, setShareCopied] = useState<boolean>(false);
   const [fontRationale, setFontRationale] = useState<string | undefined>(undefined);
@@ -115,7 +122,9 @@ export const PaletteGenerator: React.FC = () => {
   }, [apiKey]);
 
   const handleChangeAnchor = useCallback((family: Family, hex: string): void => {
-    setAnchors((prev) => ({...prev, [family]: hex}));
+    // Semantic families (error/warning/success/neutral) are locked to their conventional tones so a
+    // manual edit can't turn "error" blue or "success" purple; other families are free brand colors.
+    setAnchors((prev) => ({...prev, [family]: constrainAnchorToFamilyTone(family, hex)}));
   }, []);
 
   const handleSend = useCallback(
@@ -144,7 +153,7 @@ export const PaletteGenerator: React.FC = () => {
           messages: history,
           model: model || DEFAULT_GEMINI_MODEL,
         });
-        setAnchors(result.anchors);
+        setAnchors(constrainAnchorsToFamilyTones(result.anchors));
         setFonts(result.fonts);
         setFontRationale(result.fontRationale);
         const reply = result.fontRationale

--- a/demo/components/palette/PaletteGenerator.tsx
+++ b/demo/components/palette/PaletteGenerator.tsx
@@ -1,0 +1,177 @@
+import {Box, Button, Heading, Text, TextField, useStoredState} from "@terreno/ui";
+import {DateTime} from "luxon";
+import React, {useCallback, useMemo, useState} from "react";
+
+import {AnchorControls} from "./AnchorControls";
+import {ChatPanel} from "./ChatPanel";
+import {CodeOutput} from "./CodeOutput";
+import {ComponentPreview} from "./ComponentPreview";
+import {ContrastReport} from "./ContrastReport";
+import {generatePrimitivesFromAnchors, type PaletteAnchors} from "./colorUtils";
+import {DEFAULT_GEMINI_MODEL, generatePaletteFromChat} from "./geminiClient";
+import {PaletteRamps} from "./PaletteRamps";
+import {
+  type ChatMessage,
+  DEFAULT_ANCHORS,
+  type MainFamily,
+  runContrastChecks,
+  type StatusFamily,
+} from "./paletteTypes";
+
+/**
+ * Top-level palette generator: a chat assistant (Gemini) plus manual color pickers on the left, and
+ * a live, always-updating read-out on the right (full 000-900 ramps, WCAG contrast flags, a themed
+ * component preview, and copy-pasteable export code). The LLM only chooses anchor colors; the ramps
+ * and accessibility checks are computed deterministically so results are consistent and verifiable.
+ */
+
+type Family = MainFamily | StatusFamily;
+
+let messageCounter = 0;
+const nextId = (): string => {
+  messageCounter += 1;
+  return `msg-${Date.now()}-${messageCounter}`;
+};
+
+const makeMessage = (role: ChatMessage["role"], text: string): ChatMessage => ({
+  createdAt: DateTime.now().toISO() ?? "",
+  id: nextId(),
+  role,
+  text,
+});
+
+export const PaletteGenerator: React.FC = () => {
+  const [apiKey, setApiKey, apiKeyLoading] = useStoredState<string>("palette-gemini-key", "");
+  const [model, setModel] = useStoredState<string>("palette-gemini-model", DEFAULT_GEMINI_MODEL);
+
+  const [anchors, setAnchors] = useState<PaletteAnchors>(DEFAULT_ANCHORS);
+  const [selectedFamily, setSelectedFamily] = useState<Family>("primary");
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const primitives = useMemo(
+    () => generatePrimitivesFromAnchors(anchors) as Record<string, string>,
+    [anchors]
+  );
+  const contrastResults = useMemo(() => runContrastChecks(primitives), [primitives]);
+
+  const handleChangeAnchor = useCallback((family: Family, hex: string): void => {
+    setAnchors((prev) => ({...prev, [family]: hex}));
+  }, []);
+
+  const handleSend = useCallback(
+    async (text: string): Promise<void> => {
+      if (!apiKey) {
+        setError("Add your Gemini API key above to use the assistant.");
+        return;
+      }
+      const userMessage = makeMessage("user", text);
+      const history = [...messages, userMessage];
+      setMessages(history);
+      setIsLoading(true);
+      setError(undefined);
+
+      try {
+        const {anchors: nextAnchors, explanation} = await generatePaletteFromChat({
+          apiKey,
+          currentAnchors: anchors,
+          messages: history,
+          model: model || DEFAULT_GEMINI_MODEL,
+        });
+        setAnchors(nextAnchors);
+        setMessages((prev) => [...prev, makeMessage("assistant", explanation)]);
+      } catch (caught) {
+        const message = caught instanceof Error ? caught.message : "Something went wrong.";
+        setError(message);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [anchors, apiKey, messages, model]
+  );
+
+  const handleReset = useCallback((): void => {
+    setAnchors(DEFAULT_ANCHORS);
+    setMessages([]);
+    setError(undefined);
+  }, []);
+
+  return (
+    <Box color="base" gap={5} height="100%" padding={4} scroll>
+      <Box gap={2}>
+        <Box alignItems="center" direction="row" gap={3} justifyContent="between" wrap>
+          <Heading size="lg">AI Palette Generator</Heading>
+          <Button onClick={handleReset} text="Reset palette" variant="muted" />
+        </Box>
+        <Text color="secondaryLight">
+          Describe a vibe or set anchor colors, and Gemini builds a full Terreno palette. Every
+          shade is generated deterministically, checked against WCAG contrast, and previewed on real
+          components. Copy the exact theme code when you are happy.
+        </Text>
+      </Box>
+
+      <Box border="default" gap={3} padding={4} rounding="md">
+        <Heading size="sm">Gemini API key</Heading>
+        <Text color="secondaryLight" size="sm">
+          Uses the Gemini Developer API directly from your browser. Get a key at
+          aistudio.google.com/apikey. Stored only on this device.
+        </Text>
+        <Box direction="column" gap={3} mdDirection="row">
+          <Box flex="grow">
+            <TextField
+              disabled={apiKeyLoading}
+              onChange={setApiKey}
+              placeholder="AIza…"
+              title="API key"
+              type="password"
+              value={apiKey}
+            />
+          </Box>
+          <Box minWidth={220}>
+            <TextField
+              onChange={setModel}
+              placeholder={DEFAULT_GEMINI_MODEL}
+              title="Model"
+              value={model}
+            />
+          </Box>
+        </Box>
+      </Box>
+
+      <Box direction="column" gap={5} lgDirection="row">
+        <Box flex="grow" gap={5} maxWidth={520}>
+          <Box border="default" height={420} padding={4} rounding="md">
+            <ChatPanel
+              disabled={!apiKey}
+              error={error}
+              isLoading={isLoading}
+              messages={messages}
+              onSend={handleSend}
+            />
+          </Box>
+          <Box border="default" gap={3} padding={4} rounding="md">
+            <Heading size="sm">Anchor colors</Heading>
+            <Text color="secondaryLight" size="sm">
+              Tap a family to edit it. The anchor is the family's core (500) color; lighter and
+              darker shades are generated from it.
+            </Text>
+            <AnchorControls
+              anchors={anchors}
+              onChangeAnchor={handleChangeAnchor}
+              onSelectFamily={setSelectedFamily}
+              selectedFamily={selectedFamily}
+            />
+          </Box>
+        </Box>
+
+        <Box flex="grow" gap={6}>
+          <PaletteRamps primitives={primitives} />
+          <ContrastReport results={contrastResults} />
+          <ComponentPreview primitives={primitives} />
+          <CodeOutput primitives={primitives} />
+        </Box>
+      </Box>
+    </Box>
+  );
+};

--- a/demo/components/palette/PaletteGenerator.tsx
+++ b/demo/components/palette/PaletteGenerator.tsx
@@ -204,7 +204,7 @@ export const PaletteGenerator: React.FC = () => {
       </Box>
 
       <Box direction="column" gap={5} lgDirection="row">
-        <Box flex="grow" gap={5} maxWidth={520}>
+        <Box flex="grow" gap={5} maxWidth={520} minWidth={320}>
           <Box border="default" height={420} padding={4} rounding="md">
             <ChatPanel
               disabled={!apiKey}
@@ -243,7 +243,7 @@ export const PaletteGenerator: React.FC = () => {
           </Box>
         </Box>
 
-        <Box flex="grow" gap={6}>
+        <Box flex="grow" gap={6} minWidth={0}>
           <PaletteRamps primitives={primitives} />
           <ContrastReport results={lightContrast} title="Accessibility — light mode (WCAG)" />
           <ContrastReport results={darkContrast} title="Accessibility — dark mode (WCAG)" />

--- a/demo/components/palette/PaletteGenerator.tsx
+++ b/demo/components/palette/PaletteGenerator.tsx
@@ -8,6 +8,9 @@ import {CodeOutput} from "./CodeOutput";
 import {ComponentPreview} from "./ComponentPreview";
 import {ContrastReport} from "./ContrastReport";
 import {generatePrimitivesFromAnchors, type PaletteAnchors} from "./colorUtils";
+import {DarkModeAudit} from "./DarkModeAudit";
+import {FontControls} from "./FontControls";
+import {DEFAULT_FONTS, type FontSelection} from "./fonts";
 import {DEFAULT_GEMINI_MODEL, generatePaletteFromChat} from "./geminiClient";
 import {PaletteRamps} from "./PaletteRamps";
 import {
@@ -45,6 +48,8 @@ export const PaletteGenerator: React.FC = () => {
   const [model, setModel] = useStoredState<string>("palette-gemini-model", DEFAULT_GEMINI_MODEL);
 
   const [anchors, setAnchors] = useState<PaletteAnchors>(DEFAULT_ANCHORS);
+  const [fonts, setFonts] = useState<FontSelection>(DEFAULT_FONTS);
+  const [fontRationale, setFontRationale] = useState<string | undefined>(undefined);
   const [selectedFamily, setSelectedFamily] = useState<Family>("primary");
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -54,7 +59,8 @@ export const PaletteGenerator: React.FC = () => {
     () => generatePrimitivesFromAnchors(anchors) as Record<string, string>,
     [anchors]
   );
-  const contrastResults = useMemo(() => runContrastChecks(primitives), [primitives]);
+  const lightContrast = useMemo(() => runContrastChecks(primitives, "light"), [primitives]);
+  const darkContrast = useMemo(() => runContrastChecks(primitives, "dark"), [primitives]);
 
   const handleChangeAnchor = useCallback((family: Family, hex: string): void => {
     setAnchors((prev) => ({...prev, [family]: hex}));
@@ -73,14 +79,20 @@ export const PaletteGenerator: React.FC = () => {
       setError(undefined);
 
       try {
-        const {anchors: nextAnchors, explanation} = await generatePaletteFromChat({
+        const result = await generatePaletteFromChat({
           apiKey,
           currentAnchors: anchors,
+          currentFonts: fonts,
           messages: history,
           model: model || DEFAULT_GEMINI_MODEL,
         });
-        setAnchors(nextAnchors);
-        setMessages((prev) => [...prev, makeMessage("assistant", explanation)]);
+        setAnchors(result.anchors);
+        setFonts(result.fonts);
+        setFontRationale(result.fontRationale);
+        const reply = result.fontRationale
+          ? `${result.explanation}\n\nFonts: ${result.fontRationale}`
+          : result.explanation;
+        setMessages((prev) => [...prev, makeMessage("assistant", reply)]);
       } catch (caught) {
         const message = caught instanceof Error ? caught.message : "Something went wrong.";
         setError(message);
@@ -88,11 +100,13 @@ export const PaletteGenerator: React.FC = () => {
         setIsLoading(false);
       }
     },
-    [anchors, apiKey, messages, model]
+    [anchors, apiKey, fonts, messages, model]
   );
 
   const handleReset = useCallback((): void => {
     setAnchors(DEFAULT_ANCHORS);
+    setFonts(DEFAULT_FONTS);
+    setFontRationale(undefined);
     setMessages([]);
     setError(undefined);
   }, []);
@@ -163,13 +177,23 @@ export const PaletteGenerator: React.FC = () => {
               selectedFamily={selectedFamily}
             />
           </Box>
+          <Box border="default" gap={3} padding={4} rounding="md">
+            <Heading size="sm">Fonts</Heading>
+            <Text color="secondaryLight" size="sm">
+              Pick a heading + body pairing (or let the assistant suggest one). The preview uses the
+              real typefaces on web; the export includes the theme.font config.
+            </Text>
+            <FontControls fonts={fonts} onChange={setFonts} rationale={fontRationale} />
+          </Box>
         </Box>
 
         <Box flex="grow" gap={6}>
           <PaletteRamps primitives={primitives} />
-          <ContrastReport results={contrastResults} />
+          <ContrastReport results={lightContrast} title="Accessibility — light mode (WCAG)" />
+          <ContrastReport results={darkContrast} title="Accessibility — dark mode (WCAG)" />
           <ComponentPreview primitives={primitives} />
-          <CodeOutput primitives={primitives} />
+          <DarkModeAudit />
+          <CodeOutput fonts={fonts} primitives={primitives} />
         </Box>
       </Box>
     </Box>

--- a/demo/components/palette/PaletteGenerator.tsx
+++ b/demo/components/palette/PaletteGenerator.tsx
@@ -1,4 +1,6 @@
 import {Box, Button, Heading, SelectField, Text, TextField, useStoredState} from "@terreno/ui";
+import * as Clipboard from "expo-clipboard";
+import {useLocalSearchParams} from "expo-router";
 import {DateTime} from "luxon";
 import React, {useCallback, useEffect, useMemo, useRef, useState} from "react";
 
@@ -25,6 +27,7 @@ import {
   runContrastChecks,
   type StatusFamily,
 } from "./paletteTypes";
+import {buildShareUrl, decodeShareState} from "./shareState";
 
 /**
  * Top-level palette generator: a chat assistant (Gemini) plus manual color pickers on the left, and
@@ -52,8 +55,16 @@ export const PaletteGenerator: React.FC = () => {
   const [apiKey, setApiKey, apiKeyLoading] = useStoredState<string>("palette-gemini-key", "");
   const [model, setModel] = useStoredState<string>("palette-gemini-model", DEFAULT_GEMINI_MODEL);
 
-  const [anchors, setAnchors] = useState<PaletteAnchors>(DEFAULT_ANCHORS);
-  const [fonts, setFonts] = useState<FontSelection>(DEFAULT_FONTS);
+  // Restore a shared palette from the URL (?s=...) once at mount. Reading via a ref keeps later
+  // edits from being reset, and an invalid token simply falls back to the defaults.
+  const searchParams = useLocalSearchParams<{s?: string | string[]}>();
+  const sharedState = useRef(
+    decodeShareState(typeof searchParams.s === "string" ? searchParams.s : undefined)
+  ).current;
+
+  const [anchors, setAnchors] = useState<PaletteAnchors>(sharedState?.anchors ?? DEFAULT_ANCHORS);
+  const [fonts, setFonts] = useState<FontSelection>(sharedState?.fonts ?? DEFAULT_FONTS);
+  const [shareCopied, setShareCopied] = useState<boolean>(false);
   const [fontRationale, setFontRationale] = useState<string | undefined>(undefined);
   const [selectedFamily, setSelectedFamily] = useState<Family>("primary");
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -159,12 +170,36 @@ export const PaletteGenerator: React.FC = () => {
     setError(undefined);
   }, []);
 
+  const handleShare = useCallback(async (): Promise<void> => {
+    const url = buildShareUrl({anchors, fonts});
+    if (!url) {
+      setError("Sharing is only available on the web build.");
+      return;
+    }
+    await Clipboard.setStringAsync(url);
+    // Reflect the shared state in the address bar so a copy/paste of the URL also works.
+    const history = (
+      globalThis as {history?: {replaceState?: (a: unknown, b: string, c: string) => void}}
+    ).history;
+    history?.replaceState?.(null, "", url);
+    setShareCopied(true);
+    setTimeout(() => setShareCopied(false), 1500);
+  }, [anchors, fonts]);
+
   return (
     <Box color="base" gap={5} height="100%" padding={4} scroll>
       <Box gap={2}>
         <Box alignItems="center" direction="row" gap={3} justifyContent="between" wrap>
           <Heading size="lg">AI Palette Generator</Heading>
-          <Button onClick={handleReset} text="Reset palette" variant="muted" />
+          <Box direction="row" gap={2} wrap>
+            <Button
+              iconName="link"
+              onClick={handleShare}
+              text={shareCopied ? "Link copied!" : "Share"}
+              variant="secondary"
+            />
+            <Button onClick={handleReset} text="Reset palette" variant="muted" />
+          </Box>
         </Box>
         <Text color="secondaryLight">
           Describe a vibe or set anchor colors, and Gemini builds a full Terreno palette. Every

--- a/demo/components/palette/PaletteRamps.tsx
+++ b/demo/components/palette/PaletteRamps.tsx
@@ -1,0 +1,88 @@
+import {Box, Heading, Text} from "@terreno/ui";
+import React from "react";
+
+import {
+  MAIN_FAMILIES,
+  readableTextColor,
+  SHADE_KEYS,
+  STATUS_FAMILIES,
+  STATUS_SHADE_KEYS,
+} from "./colorUtils";
+import {FAMILY_LABELS} from "./paletteTypes";
+
+/**
+ * Visual read-out of the whole generated palette: one row per family showing every generated shade
+ * (000-900 for the main families, 000/100/200 for status). Updates live as anchors or the chat
+ * assistant change the palette.
+ */
+
+interface SwatchProps {
+  shade: string;
+  hex: string;
+}
+
+const Swatch: React.FC<SwatchProps> = ({shade, hex}) => {
+  const textColor = readableTextColor(hex) === "#ffffff" ? "inverted" : "primary";
+  return (
+    <Box
+      alignItems="center"
+      dangerouslySetInlineStyle={{__style: {backgroundColor: hex}}}
+      flex="grow"
+      gap={1}
+      justifyContent="center"
+      minWidth={56}
+      paddingY={3}
+    >
+      <Text bold color={textColor} size="sm">
+        {shade}
+      </Text>
+      <Text color={textColor} size="sm">
+        {hex.replace("#", "").toUpperCase()}
+      </Text>
+    </Box>
+  );
+};
+
+interface RampRowProps {
+  family: string;
+  shades: string[];
+  primitives: Record<string, string>;
+}
+
+const RampRow: React.FC<RampRowProps> = ({family, shades, primitives}) => {
+  return (
+    <Box gap={1}>
+      <Text bold size="sm">
+        {FAMILY_LABELS[family as keyof typeof FAMILY_LABELS]}
+      </Text>
+      <Box direction="row" overflow="hidden" rounding="md">
+        {shades.map((shade) => (
+          <Swatch hex={primitives[`${family}${shade}`] ?? "#000000"} key={shade} shade={shade} />
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+interface PaletteRampsProps {
+  primitives: Record<string, string>;
+}
+
+export const PaletteRamps: React.FC<PaletteRampsProps> = ({primitives}) => {
+  return (
+    <Box gap={4}>
+      <Heading size="sm">Generated palette</Heading>
+      {MAIN_FAMILIES.map((family) => (
+        <RampRow family={family} key={family} primitives={primitives} shades={[...SHADE_KEYS]} />
+      ))}
+      {STATUS_FAMILIES.map((family) => (
+        <RampRow
+          family={family}
+          key={family}
+          primitives={primitives}
+          shades={[...STATUS_SHADE_KEYS]}
+        />
+      ))}
+    </Box>
+  );
+};

--- a/demo/components/palette/codeExport.ts
+++ b/demo/components/palette/codeExport.ts
@@ -1,4 +1,5 @@
 import {MAIN_FAMILIES, SHADE_KEYS, STATUS_FAMILIES, STATUS_SHADE_KEYS} from "./colorUtils";
+import type {FontSelection} from "./fonts";
 
 /**
  * Turn a flat map of generated color primitives into copy-pasteable code for a Terreno app: either
@@ -36,4 +37,18 @@ export const buildPrimitivesObjectCode = (primitives: Record<string, string>): s
 /** A `setPrimitives({...})` call for applying the palette at runtime via `useTheme()`. */
 export const buildSetPrimitivesCode = (primitives: Record<string, string>): string => {
   return `// Apply at runtime with the useTheme() hook from @terreno/ui.\nconst {setPrimitives} = useTheme();\nsetPrimitives({\n${formatEntries(primitives, "  ")}\n});`;
+};
+
+/**
+ * The recommended font pairing as a `theme.font` config plus a note on wiring the fonts up (the
+ * stock Terreno theme currently hardcodes Nunito/Titillium, so custom fonts must also be loaded).
+ */
+export const buildFontConfigCode = (fonts: FontSelection): string => {
+  return [
+    "// Font pairing — set in your theme config and load the families (expo-font / @expo-google-fonts).",
+    "font: {",
+    `  primary: "${fonts.bodyFont}",`,
+    `  title: "${fonts.headingFont}",`,
+    "},",
+  ].join("\n");
 };

--- a/demo/components/palette/codeExport.ts
+++ b/demo/components/palette/codeExport.ts
@@ -1,0 +1,39 @@
+import {MAIN_FAMILIES, SHADE_KEYS, STATUS_FAMILIES, STATUS_SHADE_KEYS} from "./colorUtils";
+
+/**
+ * Turn a flat map of generated color primitives into copy-pasteable code for a Terreno app: either
+ * a `ThemePrimitives` object literal or a live `setPrimitives(...)` call. Keys are emitted family by
+ * family, lightest to darkest, so the output matches the order in `ui/src/Theme.tsx`.
+ */
+
+const orderedColorKeys = (): string[] => {
+  const keys: string[] = [];
+  for (const family of MAIN_FAMILIES) {
+    for (const shade of SHADE_KEYS) {
+      keys.push(`${family}${shade}`);
+    }
+  }
+  for (const family of STATUS_FAMILIES) {
+    for (const shade of STATUS_SHADE_KEYS) {
+      keys.push(`${family}${shade}`);
+    }
+  }
+  return keys;
+};
+
+const formatEntries = (primitives: Record<string, string>, indent: string): string => {
+  return orderedColorKeys()
+    .filter((key) => primitives[key])
+    .map((key) => `${indent}${key}: "${primitives[key]}",`)
+    .join("\n");
+};
+
+/** A `const paletteColors = {...}` object literal for pasting into a theme file. */
+export const buildPrimitivesObjectCode = (primitives: Record<string, string>): string => {
+  return `// Generated color primitives — merge these into your Terreno theme.\nexport const paletteColors = {\n${formatEntries(primitives, "  ")}\n};`;
+};
+
+/** A `setPrimitives({...})` call for applying the palette at runtime via `useTheme()`. */
+export const buildSetPrimitivesCode = (primitives: Record<string, string>): string => {
+  return `// Apply at runtime with the useTheme() hook from @terreno/ui.\nconst {setPrimitives} = useTheme();\nsetPrimitives({\n${formatEntries(primitives, "  ")}\n});`;
+};

--- a/demo/components/palette/colorUtils.test.ts
+++ b/demo/components/palette/colorUtils.test.ts
@@ -2,6 +2,9 @@ import {describe, expect, it} from "bun:test";
 
 import {
   assessContrast,
+  clampHueToBand,
+  constrainAnchorsToFamilyTones,
+  constrainAnchorToFamilyTone,
   contrastRatio,
   generateColorScale,
   generatePrimitivesFromAnchors,
@@ -107,6 +110,118 @@ describe("generatePrimitivesFromAnchors", () => {
     expect(primitives.success000).toBeDefined();
     // 4 families * 11 shades + 3 status families * 3 shades = 53 keys
     expect(Object.keys(primitives).length).toBe(53);
+  });
+});
+
+describe("clampHueToBand", () => {
+  it("leaves an in-band hue unchanged", () => {
+    expect(clampHueToBand(130, 130, 45)).toBe(130);
+    expect(clampHueToBand(100, 130, 45)).toBe(100);
+  });
+
+  it("snaps an out-of-band hue to the nearest edge", () => {
+    expect(clampHueToBand(240, 130, 45)).toBe(175);
+    expect(clampHueToBand(60, 130, 45)).toBe(85);
+  });
+
+  it("wraps correctly around 0/360 for red", () => {
+    expect(clampHueToBand(350, 0, 18)).toBe(350);
+    expect(clampHueToBand(10, 0, 18)).toBe(10);
+    // Blue is far from red on both sides; snaps to the nearer edge (342).
+    expect(clampHueToBand(220, 0, 18)).toBe(342);
+    // Just past the warm edge snaps down to +18.
+    expect(clampHueToBand(90, 0, 18)).toBe(18);
+  });
+});
+
+describe("constrainAnchorToFamilyTone", () => {
+  // Circular distance (degrees) between two hues, tolerant of ±1° hex round-trip rounding.
+  const hueDistance = (hue: number, center: number): number => {
+    const diff = Math.abs((((hue - center) % 360) + 360) % 360);
+    return Math.min(diff, 360 - diff);
+  };
+  const hueOf = (hex: string): number => hexToHsl(hex)!.h;
+
+  it("keeps unlocked families (primary/secondary/accent) unchanged", () => {
+    expect(constrainAnchorToFamilyTone("primary", "#0000ff")).toBe("#0000ff");
+    expect(constrainAnchorToFamilyTone("accent", "#00ff00")).toBe("#00ff00");
+  });
+
+  it("returns an in-tone anchor verbatim", () => {
+    expect(constrainAnchorToFamilyTone("error", "#d33232")).toBe("#d33232");
+    expect(constrainAnchorToFamilyTone("success", "#3ea45c")).toBe("#3ea45c");
+    expect(constrainAnchorToFamilyTone("warning", "#f36719")).toBe("#f36719");
+  });
+
+  it("snaps a blue 'error' back into the red band", () => {
+    const result = constrainAnchorToFamilyTone("error", "#2b6cff");
+    // Red band is centered on 0 with an 18° tolerance (plus rounding slack).
+    expect(hueDistance(hueOf(result), 0)).toBeLessThanOrEqual(20);
+  });
+
+  it("snaps a purple 'success' back into the green band", () => {
+    const result = constrainAnchorToFamilyTone("success", "#8a2be2");
+    expect(hueDistance(hueOf(result), 130)).toBeLessThanOrEqual(47);
+  });
+
+  it("snaps a magenta 'warning' back into the amber band", () => {
+    const result = constrainAnchorToFamilyTone("warning", "#ff00ff");
+    expect(hueDistance(hueOf(result), 35)).toBeLessThanOrEqual(22);
+  });
+
+  it("caps neutral saturation to keep it gray", () => {
+    const result = constrainAnchorToFamilyTone("neutral", "#1e90ff");
+    expect(hexToHsl(result)!.s).toBeLessThanOrEqual(0.12 + 1e-6);
+  });
+
+  it("preserves lightness when snapping the hue", () => {
+    const result = constrainAnchorToFamilyTone("error", "#2b6cff");
+    expect(Math.abs(hexToHsl(result)!.l - hexToHsl("#2b6cff")!.l)).toBeLessThanOrEqual(0.01);
+  });
+
+  it("returns invalid input as-is", () => {
+    expect(constrainAnchorToFamilyTone("error", "nope")).toBe("nope");
+  });
+});
+
+describe("constrainAnchorsToFamilyTones", () => {
+  const hueDistance = (hue: number, center: number): number => {
+    const diff = Math.abs((((hue - center) % 360) + 360) % 360);
+    return Math.min(diff, 360 - diff);
+  };
+
+  it("locks status/neutral families but preserves brand families", () => {
+    const anchors: PaletteAnchors = {
+      accent: "#123456",
+      error: "#3355ff",
+      neutral: "#1e90ff",
+      primary: "#8a2be2",
+      secondary: "#00ffcc",
+      success: "#ff00ff",
+      warning: "#0000ff",
+    };
+    const locked = constrainAnchorsToFamilyTones(anchors);
+    // Brand families are untouched.
+    expect(locked.primary).toBe("#8a2be2");
+    expect(locked.secondary).toBe("#00ffcc");
+    expect(locked.accent).toBe("#123456");
+    // Neutral is desaturated toward gray.
+    expect(hexToHsl(locked.neutral)!.s).toBeLessThanOrEqual(0.12 + 1e-6);
+    // Success is forced into the green band.
+    expect(hueDistance(hexToHsl(locked.success)!.h, 130)).toBeLessThanOrEqual(47);
+  });
+
+  it("leaves the default anchors unchanged", () => {
+    const defaults: PaletteAnchors = {
+      accent: "#d69c0e",
+      error: "#d33232",
+      neutral: "#9a9a9a",
+      primary: "#0086b3",
+      secondary: "#2b6072",
+      success: "#3ea45c",
+      warning: "#f36719",
+    };
+    expect(constrainAnchorsToFamilyTones(defaults)).toEqual(defaults);
   });
 });
 

--- a/demo/components/palette/colorUtils.test.ts
+++ b/demo/components/palette/colorUtils.test.ts
@@ -1,0 +1,138 @@
+import {describe, expect, it} from "bun:test";
+
+import {
+  assessContrast,
+  contrastRatio,
+  generateColorScale,
+  generatePrimitivesFromAnchors,
+  generateStatusScale,
+  hexToHsl,
+  hexToRgb,
+  hslToHex,
+  normalizeHex,
+  type PaletteAnchors,
+  readableTextColor,
+  relativeLuminance,
+  rgbToHex,
+  SHADE_KEYS,
+  STATUS_SHADE_KEYS,
+} from "./colorUtils";
+
+describe("normalizeHex", () => {
+  it("expands 3-digit shorthand", () => {
+    expect(normalizeHex("#abc")).toBe("#aabbcc");
+    expect(normalizeHex("f00")).toBe("#ff0000");
+  });
+
+  it("normalizes 6-digit values and casing", () => {
+    expect(normalizeHex("#AABBCC")).toBe("#aabbcc");
+    expect(normalizeHex("0086B3")).toBe("#0086b3");
+  });
+
+  it("returns undefined for invalid input", () => {
+    expect(normalizeHex("")).toBeUndefined();
+    expect(normalizeHex("nope")).toBeUndefined();
+    expect(normalizeHex("#12345")).toBeUndefined();
+  });
+});
+
+describe("rgb/hsl conversions", () => {
+  it("round-trips hex through rgb", () => {
+    expect(rgbToHex(hexToRgb("#0086b3")!)).toBe("#0086b3");
+  });
+
+  it("round-trips hex through hsl within tolerance", () => {
+    const original = "#0086b3";
+    const roundTripped = hslToHex(hexToHsl(original)!);
+    const a = hexToRgb(original)!;
+    const b = hexToRgb(roundTripped)!;
+    expect(Math.abs(a.r - b.r)).toBeLessThanOrEqual(2);
+    expect(Math.abs(a.g - b.g)).toBeLessThanOrEqual(2);
+    expect(Math.abs(a.b - b.b)).toBeLessThanOrEqual(2);
+  });
+
+  it("treats grays as zero saturation", () => {
+    expect(hexToHsl("#808080")!.s).toBe(0);
+  });
+});
+
+describe("generateColorScale", () => {
+  it("produces all 11 shades", () => {
+    const scale = generateColorScale("#0086b3");
+    expect(Object.keys(scale).sort()).toEqual([...SHADE_KEYS].sort());
+  });
+
+  it("places the anchor verbatim at 500", () => {
+    expect(generateColorScale("#0086b3")["500"]).toBe("#0086b3");
+  });
+
+  it("ramps from light to dark monotonically", () => {
+    const scale = generateColorScale("#0086b3");
+    const luminances = SHADE_KEYS.map((shade) => relativeLuminance(scale[shade]));
+    for (let i = 1; i < luminances.length; i += 1) {
+      expect(luminances[i]).toBeLessThanOrEqual(luminances[i - 1] + 0.0001);
+    }
+  });
+
+  it("throws on invalid anchor", () => {
+    expect(() => generateColorScale("bogus")).toThrow();
+  });
+});
+
+describe("generateStatusScale", () => {
+  it("produces the compact 3-step ramp", () => {
+    const scale = generateStatusScale("#d33232");
+    expect(Object.keys(scale).sort()).toEqual([...STATUS_SHADE_KEYS].sort());
+  });
+});
+
+describe("generatePrimitivesFromAnchors", () => {
+  const anchors: PaletteAnchors = {
+    accent: "#d69c0e",
+    error: "#d33232",
+    neutral: "#9a9a9a",
+    primary: "#0086b3",
+    secondary: "#2b6072",
+    success: "#3ea45c",
+    warning: "#f36719",
+  };
+
+  it("emits every expected primitive key", () => {
+    const primitives = generatePrimitivesFromAnchors(anchors);
+    expect(primitives.primary500).toBe("#0086b3");
+    expect(primitives.neutral000).toBeDefined();
+    expect(primitives.accent900).toBeDefined();
+    expect(primitives.error100).toBeDefined();
+    expect(primitives.warning200).toBeDefined();
+    expect(primitives.success000).toBeDefined();
+    // 4 families * 11 shades + 3 status families * 3 shades = 53 keys
+    expect(Object.keys(primitives).length).toBe(53);
+  });
+});
+
+describe("WCAG contrast", () => {
+  it("computes the canonical black/white ratio as 21", () => {
+    expect(Math.round(contrastRatio("#000000", "#ffffff"))).toBe(21);
+  });
+
+  it("computes identical colors as 1", () => {
+    expect(contrastRatio("#123456", "#123456")).toBe(1);
+  });
+
+  it("flags a failing low-contrast pair", () => {
+    const assessment = assessContrast("#cccccc", "#ffffff");
+    expect(assessment.aa).toBe(false);
+    expect(assessment.aaLarge).toBe(false);
+  });
+
+  it("passes AA and AAA for strong contrast", () => {
+    const assessment = assessContrast("#1c1c1c", "#ffffff");
+    expect(assessment.aa).toBe(true);
+    expect(assessment.aaa).toBe(true);
+  });
+
+  it("picks a readable text color for a background", () => {
+    expect(readableTextColor("#ffffff")).toBe("#000000");
+    expect(readableTextColor("#013749")).toBe("#ffffff");
+  });
+});

--- a/demo/components/palette/colorUtils.ts
+++ b/demo/components/palette/colorUtils.ts
@@ -289,6 +289,95 @@ export const generatePrimitivesFromAnchors = (
 };
 
 /**
+ * A tone constraint applied to a semantic family so its meaning stays legible: an optional hue band
+ * (center + max deviation, in degrees) plus optional saturation limits (0-1). Families without a
+ * lock (primary/secondary/accent) are free brand colors.
+ */
+export interface ToneLock {
+  /** Center hue in degrees the family should stay near. */
+  hueCenter?: number;
+  /** Maximum allowed deviation from `hueCenter` in degrees (circular). */
+  hueTolerance?: number;
+  /** Maximum saturation (0-1); values above are clamped down (keeps neutral gray). */
+  maxSaturation?: number;
+  /** Minimum saturation (0-1); values below are clamped up. */
+  minSaturation?: number;
+}
+
+/**
+ * The semantic families whose tone is locked so they keep conveying their meaning: error stays red,
+ * warning orange/amber, success green, and neutral a low-saturation gray. Bands are intentionally
+ * generous so users still have room to pick a specific shade within the correct tone.
+ */
+export const FAMILY_TONE_LOCKS: Partial<Record<MainFamily | StatusFamily, ToneLock>> = {
+  error: {hueCenter: 0, hueTolerance: 18},
+  neutral: {maxSaturation: 0.12},
+  success: {hueCenter: 130, hueTolerance: 45},
+  warning: {hueCenter: 35, hueTolerance: 20},
+};
+
+/**
+ * Snap a hue (degrees) into a band centered on `center` with a maximum deviation of `tolerance`,
+ * taking the shorter way around the color wheel so bands that straddle 0/360 (e.g. red) wrap
+ * correctly. Returns a value in [0, 360).
+ */
+export const clampHueToBand = (hue: number, center: number, tolerance: number): number => {
+  const normalized = ((hue % 360) + 360) % 360;
+  const signedDistance = ((normalized - center + 540) % 360) - 180;
+  if (Math.abs(signedDistance) <= tolerance) {
+    return normalized;
+  }
+  const edge = signedDistance > 0 ? center + tolerance : center - tolerance;
+  return ((edge % 360) + 360) % 360;
+};
+
+/**
+ * Constrain an anchor color to its family's locked tone: status families (error/warning/success)
+ * are snapped into their hue band (red/amber/green) and neutral is pulled toward gray by capping
+ * saturation. Unlocked families (primary/secondary/accent) and invalid input are returned as-is, and
+ * an already-in-tone color is returned verbatim so the exact anchor is preserved at its ramp step.
+ */
+export const constrainAnchorToFamilyTone = (
+  family: MainFamily | StatusFamily,
+  hex: string
+): string => {
+  const normalized = normalizeHex(hex);
+  const lock = FAMILY_TONE_LOCKS[family];
+  if (!normalized || !lock) {
+    return normalized ?? hex;
+  }
+  const hsl = hexToHsl(normalized);
+  if (!hsl) {
+    return normalized;
+  }
+  let hue = hsl.h;
+  let saturation = hsl.s;
+  // A pure gray has a meaningless hue, so only snap the hue when there is real chroma to place.
+  if (lock.hueCenter !== undefined && lock.hueTolerance !== undefined && saturation > 0) {
+    hue = clampHueToBand(hue, lock.hueCenter, lock.hueTolerance);
+  }
+  if (lock.maxSaturation !== undefined) {
+    saturation = Math.min(saturation, lock.maxSaturation);
+  }
+  if (lock.minSaturation !== undefined) {
+    saturation = Math.max(saturation, lock.minSaturation);
+  }
+  if (hue === hsl.h && saturation === hsl.s) {
+    return normalized;
+  }
+  return hslToHex({h: hue, l: hsl.l, s: saturation});
+};
+
+/** Apply {@link constrainAnchorToFamilyTone} to every family in an anchor set. */
+export const constrainAnchorsToFamilyTones = (anchors: PaletteAnchors): PaletteAnchors => {
+  const result = {...anchors};
+  for (const family of [...MAIN_FAMILIES, ...STATUS_FAMILIES]) {
+    result[family] = constrainAnchorToFamilyTone(family, anchors[family]);
+  }
+  return result;
+};
+
+/**
  * Relative luminance of an sRGB color per the WCAG 2.1 definition. Used as the basis for contrast
  * ratio computation.
  */

--- a/demo/components/palette/colorUtils.ts
+++ b/demo/components/palette/colorUtils.ts
@@ -1,0 +1,350 @@
+import type {ThemePrimitiveColors} from "@terreno/ui";
+
+/**
+ * Color math utilities for the palette generator: hex/RGB/HSL conversions, deterministic
+ * 000-900 shade ramp generation from a single anchor color, and WCAG 2.1 contrast checks.
+ * Kept dependency-free so it can be unit tested with `bun test` and reused on web + native.
+ */
+
+export interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+export interface Hsl {
+  /** Hue in degrees, 0-360. */
+  h: number;
+  /** Saturation, 0-1. */
+  s: number;
+  /** Lightness, 0-1. */
+  l: number;
+}
+
+/** The 11 shade steps used by the four main Terreno color families. */
+export const SHADE_KEYS = [
+  "000",
+  "050",
+  "100",
+  "200",
+  "300",
+  "400",
+  "500",
+  "600",
+  "700",
+  "800",
+  "900",
+] as const;
+
+/** The 3 shade steps used by the status families (error/warning/success). */
+export const STATUS_SHADE_KEYS = ["000", "100", "200"] as const;
+
+export type ShadeKey = (typeof SHADE_KEYS)[number];
+export type StatusShadeKey = (typeof STATUS_SHADE_KEYS)[number];
+
+/** The four main tonal families the generator produces full 000-900 ramps for. */
+export const MAIN_FAMILIES = ["neutral", "primary", "secondary", "accent"] as const;
+/** Status families use a compact 000/100/200 ramp. */
+export const STATUS_FAMILIES = ["error", "warning", "success"] as const;
+
+export type MainFamily = (typeof MAIN_FAMILIES)[number];
+export type StatusFamily = (typeof STATUS_FAMILIES)[number];
+
+/**
+ * How far to blend each shade away from the anchor, keeping the anchor color verbatim at 500.
+ * Positive values interpolate toward white (lighter shades); negative values toward black (darker
+ * shades). This preserves the user's exact typed color at 500 while guaranteeing a monotonic ramp.
+ */
+const SHADE_BLEND: Record<Exclude<ShadeKey, "500">, number> = {
+  "000": 0.93,
+  "050": 0.8,
+  "100": 0.64,
+  "200": 0.46,
+  "300": 0.28,
+  "400": 0.12,
+  "600": -0.15,
+  "700": -0.32,
+  "800": -0.52,
+  "900": -0.72,
+};
+
+/** Blend factors for the compact status ramp; the anchor is kept verbatim at 100. */
+const STATUS_BLEND: Record<StatusShadeKey, number> = {
+  "000": 0.82,
+  "100": 0,
+  "200": -0.28,
+};
+
+/**
+ * Blend an anchor's HSL toward white (t > 0) or black (t < 0) by adjusting lightness only, easing
+ * saturation down toward the extremes so light steps do not look neon and dark steps stay rich.
+ */
+const blendShade = (anchor: Hsl, t: number): string => {
+  if (t === 0) {
+    return hslToHex(anchor);
+  }
+  const magnitude = Math.abs(t);
+  const targetL = t > 0 ? anchor.l + (1 - anchor.l) * t : anchor.l * (1 + t);
+  const saturation = clamp(anchor.s * (1 - magnitude * 0.3), 0, 1);
+  return hslToHex({h: anchor.h, l: targetL, s: saturation});
+};
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+};
+
+const toHexChannel = (value: number): string => {
+  const clamped = Math.round(clamp(value, 0, 255));
+  return clamped.toString(16).padStart(2, "0");
+};
+
+/**
+ * Normalize user input into a `#rrggbb` string, expanding 3-digit shorthand and adding a leading
+ * `#`. Returns `undefined` when the input is not a valid hex color.
+ */
+export const normalizeHex = (input: string): string | undefined => {
+  if (!input) {
+    return undefined;
+  }
+  const trimmed = input.trim().replace(/^#/, "").toLowerCase();
+  if (/^[0-9a-f]{3}$/.test(trimmed)) {
+    const [r, g, b] = trimmed.split("");
+    return `#${r}${r}${g}${g}${b}${b}`;
+  }
+  if (/^[0-9a-f]{6}$/.test(trimmed)) {
+    return `#${trimmed}`;
+  }
+  return undefined;
+};
+
+/** Parse a hex string into an RGB triple, or `undefined` when invalid. */
+export const hexToRgb = (hex: string): Rgb | undefined => {
+  const normalized = normalizeHex(hex);
+  if (!normalized) {
+    return undefined;
+  }
+  const value = normalized.slice(1);
+  return {
+    b: Number.parseInt(value.slice(4, 6), 16),
+    g: Number.parseInt(value.slice(2, 4), 16),
+    r: Number.parseInt(value.slice(0, 2), 16),
+  };
+};
+
+/** Convert an RGB triple to a `#rrggbb` string. */
+export const rgbToHex = ({r, g, b}: Rgb): string => {
+  return `#${toHexChannel(r)}${toHexChannel(g)}${toHexChannel(b)}`;
+};
+
+/** Convert an RGB triple (0-255) to HSL. */
+export const rgbToHsl = ({r, g, b}: Rgb): Hsl => {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const delta = max - min;
+  const l = (max + min) / 2;
+
+  if (delta === 0) {
+    return {h: 0, l, s: 0};
+  }
+
+  const s = delta / (1 - Math.abs(2 * l - 1));
+  let h = 0;
+  if (max === rn) {
+    h = ((gn - bn) / delta) % 6;
+  } else if (max === gn) {
+    h = (bn - rn) / delta + 2;
+  } else {
+    h = (rn - gn) / delta + 4;
+  }
+  h = Math.round(h * 60);
+  if (h < 0) {
+    h += 360;
+  }
+  return {h, l, s};
+};
+
+/** Convert HSL to an RGB triple (0-255). */
+export const hslToRgb = ({h, s, l}: Hsl): Rgb => {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const hp = (((h % 360) + 360) % 360) / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let r1 = 0;
+  let g1 = 0;
+  let b1 = 0;
+  if (hp >= 0 && hp < 1) {
+    [r1, g1, b1] = [c, x, 0];
+  } else if (hp < 2) {
+    [r1, g1, b1] = [x, c, 0];
+  } else if (hp < 3) {
+    [r1, g1, b1] = [0, c, x];
+  } else if (hp < 4) {
+    [r1, g1, b1] = [0, x, c];
+  } else if (hp < 5) {
+    [r1, g1, b1] = [x, 0, c];
+  } else {
+    [r1, g1, b1] = [c, 0, x];
+  }
+  const m = l - c / 2;
+  return {
+    b: (b1 + m) * 255,
+    g: (g1 + m) * 255,
+    r: (r1 + m) * 255,
+  };
+};
+
+export const hexToHsl = (hex: string): Hsl | undefined => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) {
+    return undefined;
+  }
+  return rgbToHsl(rgb);
+};
+
+export const hslToHex = (hsl: Hsl): string => {
+  return rgbToHex(hslToRgb(hsl));
+};
+
+/**
+ * Generate the full 000-900 ramp for a main color family from a single anchor color. The anchor is
+ * placed verbatim at the 500 step; lighter and darker steps track fixed target lightness values
+ * while preserving the anchor hue. Saturation is eased toward the extremes so very light and very
+ * dark steps do not look neon.
+ */
+export const generateColorScale = (anchorHex: string): Record<ShadeKey, string> => {
+  const anchorHsl = hexToHsl(anchorHex);
+  const normalizedAnchor = normalizeHex(anchorHex);
+  if (!anchorHsl || !normalizedAnchor) {
+    throw new Error(`Invalid anchor color: ${anchorHex}`);
+  }
+
+  const result = {} as Record<ShadeKey, string>;
+  for (const shade of SHADE_KEYS) {
+    if (shade === "500") {
+      result[shade] = normalizedAnchor;
+      continue;
+    }
+    result[shade] = blendShade(anchorHsl, SHADE_BLEND[shade]);
+  }
+  return result;
+};
+
+/** Generate the compact 000/100/200 ramp for a status family from an anchor color. */
+export const generateStatusScale = (anchorHex: string): Record<StatusShadeKey, string> => {
+  const anchorHsl = hexToHsl(anchorHex);
+  const normalizedAnchor = normalizeHex(anchorHex);
+  if (!anchorHsl || !normalizedAnchor) {
+    throw new Error(`Invalid anchor color: ${anchorHex}`);
+  }
+  const result = {} as Record<StatusShadeKey, string>;
+  for (const shade of STATUS_SHADE_KEYS) {
+    result[shade] = shade === "100" ? normalizedAnchor : blendShade(anchorHsl, STATUS_BLEND[shade]);
+  }
+  return result;
+};
+
+/** Anchor colors (one per family) that seed the generated palette. */
+export interface PaletteAnchors {
+  neutral: string;
+  primary: string;
+  secondary: string;
+  accent: string;
+  error: string;
+  warning: string;
+  success: string;
+}
+
+/**
+ * Expand a set of anchor colors into the full flat map of color primitives consumed by
+ * `ThemeProvider` / `setPrimitives` (e.g. `primary500`, `neutral050`, `error100`, ...).
+ */
+export const generatePrimitivesFromAnchors = (
+  anchors: PaletteAnchors
+): Partial<ThemePrimitiveColors> => {
+  const primitives: Record<string, string> = {};
+
+  for (const family of MAIN_FAMILIES) {
+    const scale = generateColorScale(anchors[family]);
+    for (const shade of SHADE_KEYS) {
+      primitives[`${family}${shade}`] = scale[shade];
+    }
+  }
+
+  for (const family of STATUS_FAMILIES) {
+    const scale = generateStatusScale(anchors[family]);
+    for (const shade of STATUS_SHADE_KEYS) {
+      primitives[`${family}${shade}`] = scale[shade];
+    }
+  }
+
+  return primitives as Partial<ThemePrimitiveColors>;
+};
+
+/**
+ * Relative luminance of an sRGB color per the WCAG 2.1 definition. Used as the basis for contrast
+ * ratio computation.
+ */
+export const relativeLuminance = (hex: string): number => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) {
+    return 0;
+  }
+  const channel = (value: number): number => {
+    const srgb = value / 255;
+    return srgb <= 0.03928 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(rgb.r) + 0.7152 * channel(rgb.g) + 0.0722 * channel(rgb.b);
+};
+
+/** WCAG contrast ratio between two colors, from 1 (identical) to 21 (black on white). */
+export const contrastRatio = (foreground: string, background: string): number => {
+  const l1 = relativeLuminance(foreground);
+  const l2 = relativeLuminance(background);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+export interface WcagAssessment {
+  ratio: number;
+  /** Passes AA for normal text (>= 4.5:1). */
+  aa: boolean;
+  /** Passes AA for large text (>= 3:1). */
+  aaLarge: boolean;
+  /** Passes AAA for normal text (>= 7:1). */
+  aaa: boolean;
+  /** Passes AAA for large text (>= 4.5:1). */
+  aaaLarge: boolean;
+}
+
+/** Assess a foreground/background pair against all WCAG 2.1 contrast thresholds. */
+export const assessContrast = (foreground: string, background: string): WcagAssessment => {
+  const ratio = contrastRatio(foreground, background);
+  return {
+    aa: ratio >= 4.5,
+    aaa: ratio >= 7,
+    aaaLarge: ratio >= 4.5,
+    aaLarge: ratio >= 3,
+    ratio,
+  };
+};
+
+/** Round a contrast ratio to a readable `x.xx` string. */
+export const formatRatio = (ratio: number): string => {
+  return `${Math.round(ratio * 100) / 100}:1`;
+};
+
+/** Pick black or white text for the strongest contrast against a given background. */
+export const readableTextColor = (background: string): string => {
+  const white = contrastRatio("#ffffff", background);
+  const black = contrastRatio("#000000", background);
+  return white >= black ? "#ffffff" : "#000000";
+};

--- a/demo/components/palette/darkTheme.ts
+++ b/demo/components/palette/darkTheme.ts
@@ -1,10 +1,16 @@
 import type {TerrenoThemeConfig} from "@terreno/ui";
 
+import type {RoleMap} from "./paletteTypes";
+
 /**
  * Dark-mode support for the palette preview. Terreno ships a single light theme, so a dark theme is
  * produced by REMAPPING semantic roles to darker primitives (not by inverting the neutral ramp).
  * `text.inverted` is intentionally kept light because many components use it as "text on a colored
  * surface" — see `DARK_MODE_AUDIT` for the components that do and do not adapt cleanly.
+ *
+ * `DARK_THEME_CONFIG` is the single source of truth for dark semantics: it is applied to the live
+ * preview via `setTheme`, and `DARK_ROLE_MAP` (used by the dark WCAG audit) is derived from it so
+ * the two can never drift.
  */
 
 type DeepPartial<T> = {
@@ -62,6 +68,30 @@ export const DARK_THEME_CONFIG: DeepPartial<TerrenoThemeConfig> = {
     secondaryLight: "neutral300",
     success: "success100",
     warning: "warning100",
+  },
+};
+
+/**
+ * Dark-mode role → primitive map used by the WCAG audit, DERIVED from `DARK_THEME_CONFIG` so the
+ * contrast checks always evaluate the same primitives the preview renders.
+ */
+export const DARK_ROLE_MAP: RoleMap = {
+  border: {default: DARK_THEME_CONFIG.border?.default as string},
+  surface: {
+    base: DARK_THEME_CONFIG.surface?.base as string,
+    error: DARK_THEME_CONFIG.surface?.error as string,
+    primary: DARK_THEME_CONFIG.surface?.primary as string,
+    secondaryDark: DARK_THEME_CONFIG.surface?.secondaryDark as string,
+    success: DARK_THEME_CONFIG.surface?.success as string,
+    warning: DARK_THEME_CONFIG.surface?.warning as string,
+  },
+  text: {
+    accent: DARK_THEME_CONFIG.text?.accent as string,
+    error: DARK_THEME_CONFIG.text?.error as string,
+    inverted: DARK_THEME_CONFIG.text?.inverted as string,
+    link: DARK_THEME_CONFIG.text?.link as string,
+    primary: DARK_THEME_CONFIG.text?.primary as string,
+    secondaryLight: DARK_THEME_CONFIG.text?.secondaryLight as string,
   },
 };
 

--- a/demo/components/palette/darkTheme.ts
+++ b/demo/components/palette/darkTheme.ts
@@ -1,0 +1,130 @@
+import type {TerrenoThemeConfig} from "@terreno/ui";
+
+/**
+ * Dark-mode support for the palette preview. Terreno ships a single light theme, so a dark theme is
+ * produced by REMAPPING semantic roles to darker primitives (not by inverting the neutral ramp).
+ * `text.inverted` is intentionally kept light because many components use it as "text on a colored
+ * surface" — see `DARK_MODE_AUDIT` for the components that do and do not adapt cleanly.
+ */
+
+type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
+/**
+ * Role → primitive remapping applied (via `setTheme`) to the nested preview provider for dark mode.
+ * Covers the surface/text/border/status roles that most components read.
+ */
+export const DARK_THEME_CONFIG: DeepPartial<TerrenoThemeConfig> = {
+  border: {
+    activeAccent: "accent300",
+    activeNeutral: "neutral300",
+    dark: "neutral500",
+    default: "neutral700",
+    error: "error100",
+    focus: "primary300",
+    hover: "neutral600",
+    success: "success100",
+    warning: "warning100",
+  },
+  status: {
+    active: "success100",
+    away: "neutral400",
+    doNotDisturb: "error100",
+  },
+  surface: {
+    base: "neutral900",
+    disabled: "neutral600",
+    error: "error200",
+    errorLight: "error000",
+    neutral: "neutral600",
+    neutralDark: "neutral700",
+    neutralLight: "neutral800",
+    primary: "primary400",
+    secondaryDark: "secondary400",
+    secondaryExtraDark: "secondary200",
+    secondaryLight: "secondary700",
+    success: "success200",
+    successLight: "success000",
+    warning: "warning100",
+    warningLight: "warning000",
+  },
+  text: {
+    accent: "accent200",
+    error: "error100",
+    extraLight: "neutral400",
+    // Kept light on purpose — this role sits on colored/dark surfaces across the library.
+    inverted: "neutral000",
+    link: "primary200",
+    linkLight: "primary300",
+    primary: "neutral000",
+    secondaryDark: "secondary100",
+    secondaryLight: "neutral300",
+    success: "success100",
+    warning: "warning100",
+  },
+};
+
+export type DarkModeStatus = "adapts" | "partial" | "breaks";
+
+export interface DarkModeAuditItem {
+  area: string;
+  status: DarkModeStatus;
+  detail: string;
+}
+
+/**
+ * Findings from auditing `@terreno/ui` for dark-mode readiness. Most components read semantic theme
+ * tokens and adapt when roles are remapped; the entries below call out where a naive dark theme
+ * still breaks because of hardcoded colors or light-surface assumptions in the library source.
+ */
+export const DARK_MODE_AUDIT: DarkModeAuditItem[] = [
+  {
+    area: "Layout, typography & forms",
+    detail:
+      "Box, Card, Page, Text, Heading, TextField, SelectField, DataTable, Accordion and most components read theme.surface / theme.text and re-theme correctly.",
+    status: "adapts",
+  },
+  {
+    area: "text.inverted role",
+    detail:
+      "Mapped to the lightest neutral and used as 'text on colored surfaces' (Button, Badge, Banner, Toast, Tooltip, Avatar). Kept light here so it stays legible — inverting the neutral ramp instead would break all of these.",
+    status: "partial",
+  },
+  {
+    area: "Button / Badge / Banner text",
+    detail:
+      "Labels use text.inverted on saturated fills. Fine as long as the colored surface stays dark enough for white text (watch the WCAG flags for primary/warning).",
+    status: "partial",
+  },
+  {
+    area: "Spinner",
+    detail:
+      'color="light"/"dark" read raw neutral primitives, not semantic roles, so the variant names assume a light background. Pass an explicit color on dark surfaces.',
+    status: "partial",
+  },
+  {
+    area: "Modal / ActionSheet / mobile pickers",
+    detail:
+      "Overlays and iOS picker chrome hardcode white backgrounds and rgba(0,0,0,…) scrims/shadows (Modal.tsx, ActionSheet.tsx, PickerSelect.tsx). These stay light in dark mode.",
+    status: "breaks",
+  },
+  {
+    area: "Box/Card shadow & Slider thumb",
+    detail:
+      "Box shadow uses a fixed gray and the web Slider thumb is hardcoded white with a black shadow, so elevation reads oddly on dark surfaces.",
+    status: "breaks",
+  },
+  {
+    area: "IconButton muted/navigation/destructive",
+    detail:
+      "These variants use theme.text.inverted (white) as the button background, so the pill stays white on a dark page.",
+    status: "breaks",
+  },
+  {
+    area: "Banner inner action button text",
+    detail:
+      "Renders a raw React Native Text with no theme color on a surface.base pill, so the label can disappear when surface.base is dark.",
+    status: "breaks",
+  },
+];

--- a/demo/components/palette/fonts.ts
+++ b/demo/components/palette/fonts.ts
@@ -1,10 +1,7 @@
-import {Platform} from "react-native";
-
 /**
  * Font selection support for the palette generator: curated Google Font choices for headings and
- * body, ready-made pairings, and a web-only loader that injects the chosen families so previews
- * render in the real typeface. On native the family name is still applied (and falls back to the
- * system font if the family is not bundled), since the demo's primary target is web.
+ * body, ready-made pairings, and helpers. This module is intentionally dependency-free (no
+ * react-native import) so it can be unit tested; the web font loader lives in `webFonts.ts`.
  */
 
 export interface FontSelection {
@@ -67,31 +64,6 @@ export const googleFontsUrl = (families: string[]): string => {
     .map((family) => `family=${encodeURIComponent(family)}:wght@400;500;600;700`)
     .join("&");
   return `https://fonts.googleapis.com/css2?${params}&display=swap`;
-};
-
-const WEB_FONT_LINK_ID = "palette-generator-fonts";
-
-/**
- * Inject (or update) a `<link>` in the document head so the chosen families are actually available
- * to the preview on web. No-op on native and during SSR.
- */
-export const loadWebFonts = (families: string[]): void => {
-  if (Platform.OS !== "web" || typeof document === "undefined") {
-    return;
-  }
-  const href = googleFontsUrl(families);
-  const existing = document.getElementById(WEB_FONT_LINK_ID) as HTMLLinkElement | null;
-  if (existing) {
-    if (existing.href !== href) {
-      existing.href = href;
-    }
-    return;
-  }
-  const link = document.createElement("link");
-  link.id = WEB_FONT_LINK_ID;
-  link.rel = "stylesheet";
-  link.href = href;
-  document.head.appendChild(link);
 };
 
 /** Merge a base option list with an extra value (e.g. an LLM suggestion) so it stays selectable. */

--- a/demo/components/palette/fonts.ts
+++ b/demo/components/palette/fonts.ts
@@ -1,0 +1,104 @@
+import {Platform} from "react-native";
+
+/**
+ * Font selection support for the palette generator: curated Google Font choices for headings and
+ * body, ready-made pairings, and a web-only loader that injects the chosen families so previews
+ * render in the real typeface. On native the family name is still applied (and falls back to the
+ * system font if the family is not bundled), since the demo's primary target is web.
+ */
+
+export interface FontSelection {
+  /** Family used for headings/display (e.g. "Titillium Web"). */
+  headingFont: string;
+  /** Family used for body copy and UI text (e.g. "Nunito"). */
+  bodyFont: string;
+}
+
+/** Matches the stock Terreno theme fonts so the tool opens on a known-good pairing. */
+export const DEFAULT_FONTS: FontSelection = {
+  bodyFont: "Nunito",
+  headingFont: "Titillium Web",
+};
+
+/** Curated display/heading families. */
+export const HEADING_FONTS: string[] = [
+  "Titillium Web",
+  "Poppins",
+  "Montserrat",
+  "Space Grotesk",
+  "Archivo",
+  "Libre Franklin",
+  "Sora",
+  "Playfair Display",
+  "Fraunces",
+  "DM Serif Display",
+  "Bricolage Grotesque",
+];
+
+/** Curated body/UI families. */
+export const BODY_FONTS: string[] = [
+  "Nunito",
+  "Inter",
+  "Roboto",
+  "Open Sans",
+  "Source Sans 3",
+  "Work Sans",
+  "Lato",
+  "IBM Plex Sans",
+  "Mulish",
+  "DM Sans",
+  "Rubik",
+];
+
+/** Hand-picked heading/body pairings the assistant can also suggest. */
+export const FONT_PAIRINGS: {name: string; fonts: FontSelection}[] = [
+  {fonts: DEFAULT_FONTS, name: "Terreno default"},
+  {fonts: {bodyFont: "Inter", headingFont: "Space Grotesk"}, name: "Modern SaaS"},
+  {fonts: {bodyFont: "Source Sans 3", headingFont: "Playfair Display"}, name: "Editorial"},
+  {fonts: {bodyFont: "Nunito", headingFont: "Poppins"}, name: "Friendly"},
+  {fonts: {bodyFont: "Roboto", headingFont: "Montserrat"}, name: "Corporate"},
+  {fonts: {bodyFont: "Mulish", headingFont: "Fraunces"}, name: "Warm serif"},
+];
+
+/** Build a Google Fonts CSS2 URL that loads all requested families with common weights. */
+export const googleFontsUrl = (families: string[]): string => {
+  const unique = Array.from(new Set(families.filter(Boolean)));
+  const params = unique
+    .map((family) => `family=${encodeURIComponent(family)}:wght@400;500;600;700`)
+    .join("&");
+  return `https://fonts.googleapis.com/css2?${params}&display=swap`;
+};
+
+const WEB_FONT_LINK_ID = "palette-generator-fonts";
+
+/**
+ * Inject (or update) a `<link>` in the document head so the chosen families are actually available
+ * to the preview on web. No-op on native and during SSR.
+ */
+export const loadWebFonts = (families: string[]): void => {
+  if (Platform.OS !== "web" || typeof document === "undefined") {
+    return;
+  }
+  const href = googleFontsUrl(families);
+  const existing = document.getElementById(WEB_FONT_LINK_ID) as HTMLLinkElement | null;
+  if (existing) {
+    if (existing.href !== href) {
+      existing.href = href;
+    }
+    return;
+  }
+  const link = document.createElement("link");
+  link.id = WEB_FONT_LINK_ID;
+  link.rel = "stylesheet";
+  link.href = href;
+  document.head.appendChild(link);
+};
+
+/** Merge a base option list with an extra value (e.g. an LLM suggestion) so it stays selectable. */
+export const buildFontOptions = (
+  base: string[],
+  extra?: string
+): {label: string; value: string}[] => {
+  const values = extra && !base.includes(extra) ? [extra, ...base] : base;
+  return values.map((value) => ({label: value, value}));
+};

--- a/demo/components/palette/geminiClient.test.ts
+++ b/demo/components/palette/geminiClient.test.ts
@@ -1,0 +1,168 @@
+import {describe, expect, it, mock} from "bun:test";
+
+import {DEFAULT_FONTS} from "./fonts";
+import {generatePaletteFromChat, listGeminiModels} from "./geminiClient";
+import {type ChatMessage, DEFAULT_ANCHORS} from "./paletteTypes";
+
+/**
+ * Unit tests for the Gemini client. All network access is injected via `fetchImpl`, so these cover
+ * request assembly, error handling, JSON parsing, and the hex/font fallback merging without hitting
+ * the real API.
+ */
+
+const makeResponse = (body: unknown, ok = true, status = 200): Response =>
+  ({
+    json: async () => body,
+    ok,
+    status,
+  }) as unknown as Response;
+
+const geminiContent = (payload: unknown): unknown => ({
+  candidates: [{content: {parts: [{text: JSON.stringify(payload)}]}}],
+});
+
+const baseMessages: ChatMessage[] = [
+  {createdAt: "", id: "1", role: "user", text: "warm and modern"},
+];
+
+describe("generatePaletteFromChat", () => {
+  it("throws when no api key is provided", async () => {
+    await expect(
+      generatePaletteFromChat({
+        apiKey: "",
+        currentAnchors: DEFAULT_ANCHORS,
+        currentFonts: DEFAULT_FONTS,
+        messages: baseMessages,
+        model: "gemini-2.5-flash",
+      })
+    ).rejects.toThrow(/api key/i);
+  });
+
+  it("parses anchors and fonts from a valid response", async () => {
+    const fetchImpl = mock(async () =>
+      makeResponse(
+        geminiContent({
+          accent: "#123456",
+          bodyFont: "Inter",
+          error: "#ff0000",
+          explanation: "A warm modern palette.",
+          fontRationale: "Poppins pairs cleanly with Inter.",
+          headingFont: "Poppins",
+          neutral: "#888888",
+          primary: "#0a0b0c",
+          secondary: "#010203",
+          success: "#00ff00",
+          warning: "#ffaa00",
+        })
+      )
+    );
+
+    const result = await generatePaletteFromChat({
+      apiKey: "key",
+      currentAnchors: DEFAULT_ANCHORS,
+      currentFonts: DEFAULT_FONTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      messages: baseMessages,
+      model: "gemini-2.5-flash",
+    });
+
+    expect(result.anchors.primary).toBe("#0a0b0c");
+    expect(result.fonts.headingFont).toBe("Poppins");
+    expect(result.fonts.bodyFont).toBe("Inter");
+    expect(result.fontRationale).toContain("Poppins");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to current anchors/fonts for missing or invalid values", async () => {
+    const fetchImpl = mock(async () =>
+      makeResponse(
+        geminiContent({
+          accent: "not-a-color",
+          explanation: "partial",
+          primary: "#abcdef",
+        })
+      )
+    );
+
+    const result = await generatePaletteFromChat({
+      apiKey: "key",
+      currentAnchors: DEFAULT_ANCHORS,
+      currentFonts: DEFAULT_FONTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      messages: baseMessages,
+      model: "gemini-2.5-flash",
+    });
+
+    expect(result.anchors.primary).toBe("#abcdef");
+    // Invalid hex keeps the current anchor.
+    expect(result.anchors.accent).toBe(DEFAULT_ANCHORS.accent);
+    // Missing fonts keep current selection.
+    expect(result.fonts.headingFont).toBe(DEFAULT_FONTS.headingFont);
+    expect(result.fontRationale).toBeUndefined();
+  });
+
+  it("throws a helpful error on a non-ok response", async () => {
+    const fetchImpl = mock(async () =>
+      makeResponse({error: {message: "Invalid API key"}}, false, 400)
+    );
+
+    await expect(
+      generatePaletteFromChat({
+        apiKey: "bad",
+        currentAnchors: DEFAULT_ANCHORS,
+        currentFonts: DEFAULT_FONTS,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        messages: baseMessages,
+        model: "gemini-2.5-flash",
+      })
+    ).rejects.toThrow("Invalid API key");
+  });
+
+  it("throws when the response is not valid JSON", async () => {
+    const fetchImpl = mock(async () =>
+      makeResponse({candidates: [{content: {parts: [{text: "not json"}]}}]})
+    );
+
+    await expect(
+      generatePaletteFromChat({
+        apiKey: "key",
+        currentAnchors: DEFAULT_ANCHORS,
+        currentFonts: DEFAULT_FONTS,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        messages: baseMessages,
+        model: "gemini-2.5-flash",
+      })
+    ).rejects.toThrow(/parse/i);
+  });
+});
+
+describe("listGeminiModels", () => {
+  it("returns only chat-capable models, normalized", async () => {
+    const fetchImpl = mock(async () =>
+      makeResponse({
+        models: [
+          {name: "models/gemini-2.5-flash", supportedGenerationMethods: ["generateContent"]},
+          {name: "models/text-embedding", supportedGenerationMethods: ["embedContent"]},
+          {name: "models/gemini-2.5-pro", supportedGenerationMethods: ["generateContent"]},
+        ],
+      })
+    );
+
+    const models = await listGeminiModels({
+      apiKey: "key",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(models).toEqual(["gemini-2.5-flash", "gemini-2.5-pro"]);
+  });
+
+  it("returns undefined without a key", async () => {
+    expect(await listGeminiModels({apiKey: ""})).toBeUndefined();
+  });
+
+  it("returns undefined on a non-ok response", async () => {
+    const fetchImpl = mock(async () => makeResponse({}, false, 403));
+    expect(
+      await listGeminiModels({apiKey: "key", fetchImpl: fetchImpl as unknown as typeof fetch})
+    ).toBeUndefined();
+  });
+});

--- a/demo/components/palette/geminiClient.test.ts
+++ b/demo/components/palette/geminiClient.test.ts
@@ -33,7 +33,7 @@ describe("generatePaletteFromChat", () => {
         currentAnchors: DEFAULT_ANCHORS,
         currentFonts: DEFAULT_FONTS,
         messages: baseMessages,
-        model: "gemini-2.5-flash",
+        model: "gemini-3.5-flash",
       })
     ).rejects.toThrow(/api key/i);
   });
@@ -63,7 +63,7 @@ describe("generatePaletteFromChat", () => {
       currentFonts: DEFAULT_FONTS,
       fetchImpl: fetchImpl as unknown as typeof fetch,
       messages: baseMessages,
-      model: "gemini-2.5-flash",
+      model: "gemini-3.5-flash",
     });
 
     expect(result.anchors.primary).toBe("#0a0b0c");
@@ -90,7 +90,7 @@ describe("generatePaletteFromChat", () => {
       currentFonts: DEFAULT_FONTS,
       fetchImpl: fetchImpl as unknown as typeof fetch,
       messages: baseMessages,
-      model: "gemini-2.5-flash",
+      model: "gemini-3.5-flash",
     });
 
     expect(result.anchors.primary).toBe("#abcdef");
@@ -113,7 +113,7 @@ describe("generatePaletteFromChat", () => {
         currentFonts: DEFAULT_FONTS,
         fetchImpl: fetchImpl as unknown as typeof fetch,
         messages: baseMessages,
-        model: "gemini-2.5-flash",
+        model: "gemini-3.5-flash",
       })
     ).rejects.toThrow("Invalid API key");
   });
@@ -130,7 +130,7 @@ describe("generatePaletteFromChat", () => {
         currentFonts: DEFAULT_FONTS,
         fetchImpl: fetchImpl as unknown as typeof fetch,
         messages: baseMessages,
-        model: "gemini-2.5-flash",
+        model: "gemini-3.5-flash",
       })
     ).rejects.toThrow(/parse/i);
   });
@@ -141,9 +141,9 @@ describe("listGeminiModels", () => {
     const fetchImpl = mock(async () =>
       makeResponse({
         models: [
-          {name: "models/gemini-2.5-flash", supportedGenerationMethods: ["generateContent"]},
+          {name: "models/gemini-3.5-flash", supportedGenerationMethods: ["generateContent"]},
           {name: "models/text-embedding", supportedGenerationMethods: ["embedContent"]},
-          {name: "models/gemini-2.5-pro", supportedGenerationMethods: ["generateContent"]},
+          {name: "models/gemini-3.1-pro-preview", supportedGenerationMethods: ["generateContent"]},
         ],
       })
     );
@@ -152,7 +152,7 @@ describe("listGeminiModels", () => {
       apiKey: "key",
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
-    expect(models).toEqual(["gemini-2.5-flash", "gemini-2.5-pro"]);
+    expect(models).toEqual(["gemini-3.5-flash", "gemini-3.1-pro-preview"]);
   });
 
   it("returns undefined without a key", async () => {

--- a/demo/components/palette/geminiClient.ts
+++ b/demo/components/palette/geminiClient.ts
@@ -11,14 +11,17 @@ import {ANCHOR_FAMILIES, type ChatMessage, FAMILY_LABELS} from "./paletteTypes";
  */
 
 export const GEMINI_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
-export const DEFAULT_GEMINI_MODEL = "gemini-2.5-flash";
+export const DEFAULT_GEMINI_MODEL = "gemini-3.5-flash";
 
-/** Curated fallback models for the picker when the live model list cannot be fetched. */
+/**
+ * Curated fallback models (Gemini 3 family) for the picker when the live model list cannot be
+ * fetched. When an API key is set, `listGeminiModels` replaces these with the live set for the key.
+ */
 export const DEFAULT_GEMINI_MODELS = [
-  "gemini-2.5-flash",
-  "gemini-2.5-pro",
-  "gemini-2.5-flash-lite",
-  "gemini-flash-latest",
+  "gemini-3.5-flash",
+  "gemini-3.1-pro-preview",
+  "gemini-3-flash-preview",
+  "gemini-3-pro-preview",
 ];
 
 const MAX_MODEL_LIST_PAGES = 10;

--- a/demo/components/palette/geminiClient.ts
+++ b/demo/components/palette/geminiClient.ts
@@ -111,9 +111,14 @@ You design palettes for a React Native design system with seven color families:
 - primary: the main brand/action color used for buttons and links.
 - secondary: a supporting brand color for headers and secondary surfaces.
 - accent: a warm highlight color used sparingly for emphasis.
-- error: red-ish, for destructive/error states.
+- error: red, for destructive/error states.
 - warning: orange/amber, for cautionary states.
 - success: green, for positive states.
+
+The error, warning, success, and neutral families are automatically constrained to their
+conventional tones (red, orange/amber, green, and low-saturation gray, respectively), so keep their
+anchors within those tones — any out-of-tone hue you return will be snapped back. primary,
+secondary, and accent are free brand colors with no tone restriction.
 
 For EACH family you return exactly ONE anchor hex color. The design system will automatically
 generate the lighter and darker 000-900 shades from your anchor, so pick a mid-tone (~500 level)

--- a/demo/components/palette/geminiClient.ts
+++ b/demo/components/palette/geminiClient.ts
@@ -1,4 +1,5 @@
 import {normalizeHex, type PaletteAnchors} from "./colorUtils";
+import {BODY_FONTS, type FontSelection, HEADING_FONTS} from "./fonts";
 import {ANCHOR_FAMILIES, type ChatMessage, FAMILY_LABELS} from "./paletteTypes";
 
 /**
@@ -44,15 +45,26 @@ Examples of the kind of requests you will get and how to reason about them:
 - "Calm, trustworthy healthcare app" -> teal/blue primary, muted green secondary, soft accent,
   clean light-gray neutrals.
 
-Respond ONLY with a JSON object. Include every family key plus a short "explanation" (1-3 sentences)
-describing the palette's mood and any accessibility trade-offs you made.`;
+You also recommend a font pairing that fits the palette's mood: a "headingFont" for
+titles/display and a "bodyFont" for body copy and UI. Choose from these Google Fonts only.
+Heading fonts: ${HEADING_FONTS.join(", ")}.
+Body fonts: ${BODY_FONTS.join(", ")}.
+Pick a pairing with clear contrast between heading and body, and briefly justify it in
+"fontRationale".
+
+Respond ONLY with a JSON object. Include every family key, a short "explanation" (1-3 sentences)
+describing the palette's mood and any accessibility trade-offs you made, plus "headingFont",
+"bodyFont", and "fontRationale".`;
 
 /** Shape the Gemini responseSchema so the model always returns parseable anchors. */
 const RESPONSE_SCHEMA = {
   properties: {
     accent: {description: "Anchor hex for the accent family", type: "string"},
+    bodyFont: {description: "Recommended body font family", type: "string"},
     error: {description: "Anchor hex for the error family", type: "string"},
     explanation: {description: "Short description of the palette and trade-offs", type: "string"},
+    fontRationale: {description: "Why this font pairing fits the palette", type: "string"},
+    headingFont: {description: "Recommended heading font family", type: "string"},
     neutral: {description: "Anchor hex for the neutral family, e.g. #4E4E4E", type: "string"},
     primary: {description: "Anchor hex for the primary family", type: "string"},
     secondary: {description: "Anchor hex for the secondary family", type: "string"},
@@ -66,6 +78,8 @@ const RESPONSE_SCHEMA = {
 export interface GeminiPaletteResponse {
   anchors: PaletteAnchors;
   explanation: string;
+  fonts: FontSelection;
+  fontRationale?: string;
 }
 
 interface GeminiPart {
@@ -82,11 +96,11 @@ interface GeminiResponseBody {
 }
 
 /** Build the running "current palette" context so the model iterates instead of starting over. */
-const buildAnchorContext = (anchors: PaletteAnchors): string => {
+const buildAnchorContext = (anchors: PaletteAnchors, fonts: FontSelection): string => {
   const lines = ANCHOR_FAMILIES.map(
     (family) => `- ${FAMILY_LABELS[family]}: ${anchors[family]}`
   ).join("\n");
-  return `The current palette anchors are:\n${lines}\n\nUpdate them based on the latest request. Keep families the user did not mention unless a cohesive change requires it.`;
+  return `The current palette anchors are:\n${lines}\n\nCurrent fonts: heading "${fonts.headingFont}", body "${fonts.bodyFont}".\n\nUpdate them based on the latest request. Keep families and fonts the user did not mention unless a cohesive change requires it.`;
 };
 
 const mapRoleToGemini = (role: ChatMessage["role"]): "user" | "model" => {
@@ -103,12 +117,14 @@ export const generatePaletteFromChat = async ({
   model,
   messages,
   currentAnchors,
+  currentFonts,
   fetchImpl,
 }: {
   apiKey: string;
   model: string;
   messages: ChatMessage[];
   currentAnchors: PaletteAnchors;
+  currentFonts: FontSelection;
   fetchImpl?: typeof fetch;
 }): Promise<GeminiPaletteResponse> => {
   if (!apiKey) {
@@ -129,7 +145,7 @@ export const generatePaletteFromChat = async ({
 
   // Prepend the current-palette context as a user turn so the model always has fresh state.
   const contents = [
-    {parts: [{text: buildAnchorContext(currentAnchors)}], role: "user" as const},
+    {parts: [{text: buildAnchorContext(currentAnchors, currentFonts)}], role: "user" as const},
     ...conversation,
   ];
 
@@ -159,7 +175,12 @@ export const generatePaletteFromChat = async ({
     throw new Error("Gemini returned an empty response.");
   }
 
-  let parsed: Partial<Record<keyof PaletteAnchors | "explanation", string>>;
+  let parsed: Partial<
+    Record<
+      keyof PaletteAnchors | "explanation" | "headingFont" | "bodyFont" | "fontRationale",
+      string
+    >
+  >;
   try {
     parsed = JSON.parse(text);
   } catch {
@@ -174,8 +195,15 @@ export const generatePaletteFromChat = async ({
     }
   }
 
+  const fonts: FontSelection = {
+    bodyFont: parsed.bodyFont?.trim() || currentFonts.bodyFont,
+    headingFont: parsed.headingFont?.trim() || currentFonts.headingFont,
+  };
+
   return {
     anchors,
     explanation: parsed.explanation ?? "Updated the palette.",
+    fontRationale: parsed.fontRationale?.trim() || undefined,
+    fonts,
   };
 };

--- a/demo/components/palette/geminiClient.ts
+++ b/demo/components/palette/geminiClient.ts
@@ -1,0 +1,181 @@
+import {normalizeHex, type PaletteAnchors} from "./colorUtils";
+import {ANCHOR_FAMILIES, type ChatMessage, FAMILY_LABELS} from "./paletteTypes";
+
+/**
+ * Minimal browser/native client for the Gemini Developer API (the API-key based
+ * `generativelanguage.googleapis.com` service). The palette generator calls this directly with a
+ * user-supplied key so the demo app needs no backend. The model's only job is to pick a set of
+ * anchor colors (one hex per family); deterministic color math in `colorUtils` expands those
+ * anchors into the full 000-900 ramps, so the palette is always smooth and WCAG-checkable.
+ */
+
+export const GEMINI_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
+export const DEFAULT_GEMINI_MODEL = "gemini-2.5-flash";
+
+/** System instruction: describes the assistant's role, the required output, and worked examples. */
+export const COLOR_SYSTEM_PROMPT = `You are an expert product designer and color systemist who builds accessible UI color palettes.
+
+You design palettes for a React Native design system with seven color families:
+- neutral: grays used for text, borders, and page backgrounds.
+- primary: the main brand/action color used for buttons and links.
+- secondary: a supporting brand color for headers and secondary surfaces.
+- accent: a warm highlight color used sparingly for emphasis.
+- error: red-ish, for destructive/error states.
+- warning: orange/amber, for cautionary states.
+- success: green, for positive states.
+
+For EACH family you return exactly ONE anchor hex color. The design system will automatically
+generate the lighter and darker 000-900 shades from your anchor, so pick a mid-tone (~500 level)
+that reads well as the core of the family. The anchor you give is preserved verbatim, so choose it
+carefully with WCAG AA contrast in mind:
+- The neutral anchor's DARKEST shade is used for body text on a white page — keep neutral dark and
+  close to gray (low saturation).
+- primary, secondary, error, warning, and success anchors are used as button/surface fills with
+  WHITE text on top, so prefer anchors dark enough that white text on them clears 4.5:1 contrast.
+
+Interpret vibe/keyword requests thoughtfully and iterate when the user gives feedback (e.g. "make
+it warmer", "too saturated", "swap primary to teal"). Always keep the whole palette cohesive.
+
+Examples of the kind of requests you will get and how to reason about them:
+- "I want a warm, earthy palette" -> primary in terracotta/amber, secondary in olive/brown,
+  accent in mustard, neutrals slightly warm.
+- "Stylish modern SaaS with indigo as the primary color" -> indigo primary, cool slate secondary,
+  a vivid accent (e.g. violet or cyan), crisp near-neutral grays.
+- "Calm, trustworthy healthcare app" -> teal/blue primary, muted green secondary, soft accent,
+  clean light-gray neutrals.
+
+Respond ONLY with a JSON object. Include every family key plus a short "explanation" (1-3 sentences)
+describing the palette's mood and any accessibility trade-offs you made.`;
+
+/** Shape the Gemini responseSchema so the model always returns parseable anchors. */
+const RESPONSE_SCHEMA = {
+  properties: {
+    accent: {description: "Anchor hex for the accent family", type: "string"},
+    error: {description: "Anchor hex for the error family", type: "string"},
+    explanation: {description: "Short description of the palette and trade-offs", type: "string"},
+    neutral: {description: "Anchor hex for the neutral family, e.g. #4E4E4E", type: "string"},
+    primary: {description: "Anchor hex for the primary family", type: "string"},
+    secondary: {description: "Anchor hex for the secondary family", type: "string"},
+    success: {description: "Anchor hex for the success family", type: "string"},
+    warning: {description: "Anchor hex for the warning family", type: "string"},
+  },
+  required: [...ANCHOR_FAMILIES, "explanation"],
+  type: "object",
+} as const;
+
+export interface GeminiPaletteResponse {
+  anchors: PaletteAnchors;
+  explanation: string;
+}
+
+interface GeminiPart {
+  text?: string;
+}
+
+interface GeminiCandidate {
+  content?: {parts?: GeminiPart[]};
+}
+
+interface GeminiResponseBody {
+  candidates?: GeminiCandidate[];
+  error?: {message?: string};
+}
+
+/** Build the running "current palette" context so the model iterates instead of starting over. */
+const buildAnchorContext = (anchors: PaletteAnchors): string => {
+  const lines = ANCHOR_FAMILIES.map(
+    (family) => `- ${FAMILY_LABELS[family]}: ${anchors[family]}`
+  ).join("\n");
+  return `The current palette anchors are:\n${lines}\n\nUpdate them based on the latest request. Keep families the user did not mention unless a cohesive change requires it.`;
+};
+
+const mapRoleToGemini = (role: ChatMessage["role"]): "user" | "model" => {
+  return role === "assistant" ? "model" : "user";
+};
+
+/**
+ * Send the conversation plus the current anchors to Gemini and parse the returned anchor set.
+ * Invalid or missing hex values fall back to the current anchor for that family so a partial model
+ * response never corrupts the palette.
+ */
+export const generatePaletteFromChat = async ({
+  apiKey,
+  model,
+  messages,
+  currentAnchors,
+  fetchImpl,
+}: {
+  apiKey: string;
+  model: string;
+  messages: ChatMessage[];
+  currentAnchors: PaletteAnchors;
+  fetchImpl?: typeof fetch;
+}): Promise<GeminiPaletteResponse> => {
+  if (!apiKey) {
+    throw new Error("A Gemini API key is required. Add your key above to generate palettes.");
+  }
+
+  const doFetch = fetchImpl ?? globalThis.fetch;
+  if (!doFetch) {
+    throw new Error("No fetch implementation available in this environment.");
+  }
+
+  const conversation = messages
+    .filter((message) => message.role !== "system")
+    .map((message) => ({
+      parts: [{text: message.text}],
+      role: mapRoleToGemini(message.role),
+    }));
+
+  // Prepend the current-palette context as a user turn so the model always has fresh state.
+  const contents = [
+    {parts: [{text: buildAnchorContext(currentAnchors)}], role: "user" as const},
+    ...conversation,
+  ];
+
+  const url = `${GEMINI_API_BASE_URL}/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(apiKey)}`;
+
+  const response = await doFetch(url, {
+    body: JSON.stringify({
+      contents,
+      generationConfig: {
+        responseMimeType: "application/json",
+        responseSchema: RESPONSE_SCHEMA,
+        temperature: 0.9,
+      },
+      systemInstruction: {parts: [{text: COLOR_SYSTEM_PROMPT}]},
+    }),
+    headers: {"Content-Type": "application/json"},
+    method: "POST",
+  });
+
+  const body = (await response.json()) as GeminiResponseBody;
+  if (!response.ok) {
+    throw new Error(body.error?.message ?? `Gemini request failed (${response.status}).`);
+  }
+
+  const text = body.candidates?.[0]?.content?.parts?.map((part) => part.text ?? "").join("") ?? "";
+  if (!text) {
+    throw new Error("Gemini returned an empty response.");
+  }
+
+  let parsed: Partial<Record<keyof PaletteAnchors | "explanation", string>>;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("Could not parse the palette Gemini returned. Try rephrasing your request.");
+  }
+
+  const anchors = {...currentAnchors};
+  for (const family of ANCHOR_FAMILIES) {
+    const normalized = normalizeHex(parsed[family] ?? "");
+    if (normalized) {
+      anchors[family] = normalized;
+    }
+  }
+
+  return {
+    anchors,
+    explanation: parsed.explanation ?? "Updated the palette.",
+  };
+};

--- a/demo/components/palette/geminiClient.ts
+++ b/demo/components/palette/geminiClient.ts
@@ -13,6 +13,93 @@ import {ANCHOR_FAMILIES, type ChatMessage, FAMILY_LABELS} from "./paletteTypes";
 export const GEMINI_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 export const DEFAULT_GEMINI_MODEL = "gemini-2.5-flash";
 
+/** Curated fallback models for the picker when the live model list cannot be fetched. */
+export const DEFAULT_GEMINI_MODELS = [
+  "gemini-2.5-flash",
+  "gemini-2.5-pro",
+  "gemini-2.5-flash-lite",
+  "gemini-flash-latest",
+];
+
+const MAX_MODEL_LIST_PAGES = 10;
+const MODEL_LIST_PAGE_SIZE = "200";
+const GENERATE_CONTENT_METHOD = "generateContent";
+
+interface GeminiApiModel {
+  name?: string;
+  supportedGenerationMethods?: string[];
+}
+
+/** Strip the "models/" resource prefix from a Gemini model name. */
+export const normalizeGeminiModelId = (name: string): string => {
+  return name.trim().replace(/^models\//, "");
+};
+
+/**
+ * List chat-capable models available to a Gemini Developer API key, so the model picker reflects the
+ * live set for that key (mirrors `listGeminiApiModels` in `@terreno/ai`). Returns `undefined` when
+ * the list can't be retrieved (missing key, network error, non-200), so callers fall back to
+ * `DEFAULT_GEMINI_MODELS`.
+ */
+export const listGeminiModels = async ({
+  apiKey,
+  baseUrl,
+  fetchImpl,
+}: {
+  apiKey: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<string[] | undefined> => {
+  if (!apiKey) {
+    return undefined;
+  }
+  const doFetch = fetchImpl ?? globalThis.fetch;
+  if (!doFetch) {
+    return undefined;
+  }
+
+  const resolvedBase = baseUrl ?? GEMINI_API_BASE_URL;
+  const models: string[] = [];
+  let pageToken: string | undefined;
+  let pages = 0;
+
+  try {
+    do {
+      const url = new URL(`${resolvedBase}/models`);
+      url.searchParams.set("key", apiKey);
+      url.searchParams.set("pageSize", MODEL_LIST_PAGE_SIZE);
+      if (pageToken) {
+        url.searchParams.set("pageToken", pageToken);
+      }
+
+      const response = await doFetch(url.toString());
+      if (!response.ok) {
+        return undefined;
+      }
+
+      const body = (await response.json()) as {
+        models?: GeminiApiModel[];
+        nextPageToken?: string;
+      };
+      for (const model of body.models ?? []) {
+        if (!model.name) {
+          continue;
+        }
+        if (!(model.supportedGenerationMethods ?? []).includes(GENERATE_CONTENT_METHOD)) {
+          continue;
+        }
+        models.push(normalizeGeminiModelId(model.name));
+      }
+      pageToken = body.nextPageToken;
+      pages += 1;
+    } while (pageToken && pages < MAX_MODEL_LIST_PAGES);
+  } catch {
+    return undefined;
+  }
+
+  return models;
+};
+
 /** System instruction: describes the assistant's role, the required output, and worked examples. */
 export const COLOR_SYSTEM_PROMPT = `You are an expert product designer and color systemist who builds accessible UI color palettes.
 

--- a/demo/components/palette/paletteChecks.test.ts
+++ b/demo/components/palette/paletteChecks.test.ts
@@ -1,0 +1,66 @@
+import {describe, expect, it} from "bun:test";
+
+import {buildFontConfigCode} from "./codeExport";
+import {generatePrimitivesFromAnchors} from "./colorUtils";
+import {DARK_ROLE_MAP, DARK_THEME_CONFIG} from "./darkTheme";
+import {DEFAULT_FONTS} from "./fonts";
+import {CONTRAST_CHECKS, DEFAULT_ANCHORS, LIGHT_ROLE_MAP, runContrastChecks} from "./paletteTypes";
+
+/**
+ * Tests for the mode-aware WCAG audit and font export. In particular, guards that the dark role map
+ * used by the audit stays derived from `DARK_THEME_CONFIG` (the source applied to the preview), so
+ * the two cannot drift.
+ */
+
+const primitives = generatePrimitivesFromAnchors(DEFAULT_ANCHORS) as Record<string, string>;
+
+describe("runContrastChecks", () => {
+  it("produces a result per curated check", () => {
+    expect(runContrastChecks(primitives, "light")).toHaveLength(CONTRAST_CHECKS.length);
+  });
+
+  it("resolves the same check to different colors in light vs dark", () => {
+    const light = runContrastChecks(primitives, "light");
+    const dark = runContrastChecks(primitives, "dark");
+    const bodyLight = light.find((r) => r.label === "Body text on page");
+    const bodyDark = dark.find((r) => r.label === "Body text on page");
+    // Body text on page: dark background differs from light background.
+    expect(bodyLight?.backgroundHex).not.toBe(bodyDark?.backgroundHex);
+    expect(bodyLight?.foregroundHex).toBe(primitives.neutral900);
+    expect(bodyDark?.foregroundHex).toBe(primitives.neutral000);
+  });
+
+  it("flags a failing pairing", () => {
+    const light = runContrastChecks(primitives, "light");
+    const invertedOnPrimary = light.find((r) => r.label === "Inverted text on primary surface");
+    // The stock primary surface fails white-text AA — the audit must flag it.
+    expect(invertedOnPrimary?.passes).toBe(false);
+  });
+});
+
+describe("dark role map / preview config consistency", () => {
+  it("resolves error and success surfaces to the same primitive the preview renders", () => {
+    // Regression guard for the reviewer finding that the dark audit and preview diverged.
+    expect(DARK_ROLE_MAP.surface.error).toBe(DARK_THEME_CONFIG.surface?.error as string);
+    expect(DARK_ROLE_MAP.surface.success).toBe(DARK_THEME_CONFIG.surface?.success as string);
+    expect(DARK_ROLE_MAP.surface.base).toBe(DARK_THEME_CONFIG.surface?.base as string);
+    expect(DARK_ROLE_MAP.text.primary).toBe(DARK_THEME_CONFIG.text?.primary as string);
+  });
+
+  it("keeps text.inverted light in dark mode", () => {
+    expect(DARK_ROLE_MAP.text.inverted).toBe("neutral000");
+  });
+
+  it("differs from the light role map on the base surface", () => {
+    expect(LIGHT_ROLE_MAP.surface.base).not.toBe(DARK_ROLE_MAP.surface.base);
+  });
+});
+
+describe("buildFontConfigCode", () => {
+  it("emits a theme.font config with the selected families", () => {
+    const code = buildFontConfigCode(DEFAULT_FONTS);
+    expect(code).toContain(`primary: "${DEFAULT_FONTS.bodyFont}"`);
+    expect(code).toContain(`title: "${DEFAULT_FONTS.headingFont}"`);
+    expect(code).toContain("font: {");
+  });
+});

--- a/demo/components/palette/paletteTypes.ts
+++ b/demo/components/palette/paletteTypes.ts
@@ -6,6 +6,10 @@ import {
   STATUS_FAMILIES,
   type StatusFamily,
 } from "./colorUtils";
+// DARK_ROLE_MAP is derived from DARK_THEME_CONFIG (the source applied to the live preview) so the
+// dark-mode WCAG audit always evaluates the same primitives the preview renders. `import type` in
+// darkTheme keeps this from being a runtime import cycle.
+import {DARK_ROLE_MAP} from "./darkTheme";
 
 /**
  * Shared types and constants for the palette generator: chat messages, the anchor set the LLM and
@@ -97,30 +101,6 @@ export const LIGHT_ROLE_MAP: RoleMap = {
     link: "primary600",
     primary: "neutral900",
     secondaryLight: "neutral600",
-  },
-};
-
-/**
- * A dark theme mapping built by remapping roles (not inverting the neutral ramp). `text.inverted`
- * is deliberately kept light so text on colored surfaces stays legible — see the dark-mode audit.
- */
-export const DARK_ROLE_MAP: RoleMap = {
-  border: {default: "neutral700"},
-  surface: {
-    base: "neutral900",
-    error: "error100",
-    primary: "primary400",
-    secondaryDark: "secondary400",
-    success: "success100",
-    warning: "warning100",
-  },
-  text: {
-    accent: "accent200",
-    error: "error100",
-    inverted: "neutral000",
-    link: "primary200",
-    primary: "neutral000",
-    secondaryLight: "neutral300",
   },
 };
 

--- a/demo/components/palette/paletteTypes.ts
+++ b/demo/components/palette/paletteTypes.ts
@@ -44,6 +44,17 @@ export const ANCHOR_FAMILIES: (MainFamily | StatusFamily)[] = [
   ...STATUS_FAMILIES,
 ];
 
+/**
+ * Short helper copy shown under the picker for the families whose tone is locked (see
+ * `FAMILY_TONE_LOCKS`), so users understand why an out-of-tone color snaps back.
+ */
+export const TONE_LOCK_HINTS: Partial<Record<MainFamily | StatusFamily, string>> = {
+  error: "Locked to red tones so error states stay recognizable.",
+  neutral: "Locked to low-saturation gray for text, borders, and backgrounds.",
+  success: "Locked to green tones so success states stay recognizable.",
+  warning: "Locked to orange/amber tones so warnings stay recognizable.",
+};
+
 /** The default anchor set, matching the stock Terreno theme so the tool opens on a known-good palette. */
 export const DEFAULT_ANCHORS: PaletteAnchors = {
   accent: "#d69c0e",

--- a/demo/components/palette/paletteTypes.ts
+++ b/demo/components/palette/paletteTypes.ts
@@ -51,43 +51,137 @@ export const DEFAULT_ANCHORS: PaletteAnchors = {
   warning: "#f36719",
 };
 
+export type ThemeMode = "light" | "dark";
+
+/** A semantic theme role, resolved to a concrete primitive via the active light/dark role map. */
+export interface RoleRef {
+  group: "text" | "surface" | "border";
+  key: string;
+}
+
 /**
- * A single foreground/background contrast pairing to evaluate. `foreground` and `background` are
- * theme primitive keys (e.g. `neutral900`), matching the role→primitive mapping in the stock theme.
+ * A single foreground/background contrast pairing to evaluate, expressed in semantic theme roles so
+ * the same check can be resolved against either the light or the dark role map.
  */
 export interface ContrastCheckDef {
   label: string;
-  foreground: string;
-  background: string;
+  fg: RoleRef;
+  bg: RoleRef;
   /**
    * Large text and UI component boundaries only need 3:1 (AA). Normal body text needs 4.5:1.
    */
   largeText?: boolean;
 }
 
+/** Nested role → primitive-key map (a subset of a `TerrenoThemeConfig`). */
+export type RoleMap = Record<RoleRef["group"], Record<string, string>>;
+
 /**
- * Curated set of the most important text/surface pairings in the stock Terreno theme. These mirror
- * `defaultTheme` in `ui/src/Theme.tsx`, so flagging one here flags a real accessibility risk in an
- * app using the generated palette.
+ * The stock Terreno light theme mapping (subset used by the audit + preview), mirroring
+ * `defaultTheme` in `ui/src/Theme.tsx`.
+ */
+export const LIGHT_ROLE_MAP: RoleMap = {
+  border: {default: "neutral300"},
+  surface: {
+    base: "neutral000",
+    error: "error200",
+    primary: "primary400",
+    secondaryDark: "secondary500",
+    success: "success200",
+    warning: "warning100",
+  },
+  text: {
+    accent: "accent700",
+    error: "error200",
+    inverted: "neutral000",
+    link: "primary600",
+    primary: "neutral900",
+    secondaryLight: "neutral600",
+  },
+};
+
+/**
+ * A dark theme mapping built by remapping roles (not inverting the neutral ramp). `text.inverted`
+ * is deliberately kept light so text on colored surfaces stays legible — see the dark-mode audit.
+ */
+export const DARK_ROLE_MAP: RoleMap = {
+  border: {default: "neutral700"},
+  surface: {
+    base: "neutral900",
+    error: "error100",
+    primary: "primary400",
+    secondaryDark: "secondary400",
+    success: "success100",
+    warning: "warning100",
+  },
+  text: {
+    accent: "accent200",
+    error: "error100",
+    inverted: "neutral000",
+    link: "primary200",
+    primary: "neutral000",
+    secondaryLight: "neutral300",
+  },
+};
+
+/**
+ * Curated set of the most important text/surface pairings. Flagging one here flags a real
+ * accessibility risk in an app using the generated palette in that mode.
  */
 export const CONTRAST_CHECKS: ContrastCheckDef[] = [
-  {background: "neutral000", foreground: "neutral900", label: "Body text on page"},
-  {background: "neutral000", foreground: "neutral600", label: "Secondary text on page"},
-  {background: "neutral000", foreground: "primary600", label: "Link text on page"},
-  {background: "neutral000", foreground: "accent700", label: "Accent text on page"},
-  {background: "primary400", foreground: "neutral000", label: "Inverted text on primary surface"},
   {
-    background: "secondary500",
-    foreground: "neutral000",
+    bg: {group: "surface", key: "base"},
+    fg: {group: "text", key: "primary"},
+    label: "Body text on page",
+  },
+  {
+    bg: {group: "surface", key: "base"},
+    fg: {group: "text", key: "secondaryLight"},
+    label: "Secondary text on page",
+  },
+  {
+    bg: {group: "surface", key: "base"},
+    fg: {group: "text", key: "link"},
+    label: "Link text on page",
+  },
+  {
+    bg: {group: "surface", key: "base"},
+    fg: {group: "text", key: "accent"},
+    label: "Accent text on page",
+  },
+  {
+    bg: {group: "surface", key: "primary"},
+    fg: {group: "text", key: "inverted"},
+    label: "Inverted text on primary surface",
+  },
+  {
+    bg: {group: "surface", key: "secondaryDark"},
+    fg: {group: "text", key: "inverted"},
     label: "Inverted text on secondary surface",
   },
-  {background: "error200", foreground: "neutral000", label: "Inverted text on error surface"},
-  {background: "success200", foreground: "neutral000", label: "Inverted text on success surface"},
-  {background: "warning100", foreground: "neutral000", label: "Inverted text on warning surface"},
-  {background: "neutral000", foreground: "error200", label: "Error text on page"},
   {
-    background: "neutral000",
-    foreground: "neutral300",
+    bg: {group: "surface", key: "error"},
+    fg: {group: "text", key: "inverted"},
+    label: "Inverted text on error surface",
+  },
+  {
+    bg: {group: "surface", key: "success"},
+    fg: {group: "text", key: "inverted"},
+    label: "Inverted text on success surface",
+  },
+  {
+    bg: {group: "surface", key: "warning"},
+    fg: {group: "text", key: "inverted"},
+    label: "Inverted text on warning surface",
+  },
+  {
+    bg: {group: "surface", key: "base"},
+    fg: {group: "text", key: "error"},
+    label: "Error text on page",
+  },
+  {
+    bg: {group: "surface", key: "base"},
+    fg: {group: "border", key: "default"},
     label: "Default border on page (UI)",
     largeText: true,
   },
@@ -103,11 +197,28 @@ export interface ContrastResult extends ContrastCheckDef {
   passesAaa: boolean;
 }
 
-/** Run every curated contrast check against a flat map of generated primitives. */
-export const runContrastChecks = (primitives: Record<string, string>): ContrastResult[] => {
+const resolveRole = (
+  ref: RoleRef,
+  roleMap: RoleMap,
+  primitives: Record<string, string>,
+  fallback: string
+): string => {
+  const primitiveKey = roleMap[ref.group]?.[ref.key];
+  return (primitiveKey && primitives[primitiveKey]) || fallback;
+};
+
+/**
+ * Run every curated contrast check against a flat map of generated primitives, using the light or
+ * dark role mapping depending on `mode`.
+ */
+export const runContrastChecks = (
+  primitives: Record<string, string>,
+  mode: ThemeMode = "light"
+): ContrastResult[] => {
+  const roleMap = mode === "dark" ? DARK_ROLE_MAP : LIGHT_ROLE_MAP;
   return CONTRAST_CHECKS.map((check) => {
-    const foregroundHex = primitives[check.foreground] ?? "#000000";
-    const backgroundHex = primitives[check.background] ?? "#ffffff";
+    const foregroundHex = resolveRole(check.fg, roleMap, primitives, "#000000");
+    const backgroundHex = resolveRole(check.bg, roleMap, primitives, "#ffffff");
     const assessment = assessContrast(foregroundHex, backgroundHex);
     const passes = check.largeText ? assessment.aaLarge : assessment.aa;
     const passesAaa = check.largeText ? assessment.aaaLarge : assessment.aaa;

--- a/demo/components/palette/paletteTypes.ts
+++ b/demo/components/palette/paletteTypes.ts
@@ -1,0 +1,131 @@
+import type {PaletteAnchors} from "./colorUtils";
+import {
+  assessContrast,
+  MAIN_FAMILIES,
+  type MainFamily,
+  STATUS_FAMILIES,
+  type StatusFamily,
+} from "./colorUtils";
+
+/**
+ * Shared types and constants for the palette generator: chat messages, the anchor set the LLM and
+ * the color pickers both drive, and the curated WCAG contrast checks that run against the generated
+ * theme primitives.
+ */
+
+export type ChatRole = "user" | "assistant" | "system";
+
+export interface ChatMessage {
+  id: string;
+  role: ChatRole;
+  text: string;
+  /** ISO timestamp (Luxon) for ordering/display. */
+  createdAt: string;
+}
+
+/** Human-friendly labels for each anchor family, shown next to the color pickers. */
+export const FAMILY_LABELS: Record<MainFamily | StatusFamily, string> = {
+  accent: "Accent",
+  error: "Error",
+  neutral: "Neutral",
+  primary: "Primary",
+  secondary: "Secondary",
+  success: "Success",
+  warning: "Warning",
+};
+
+/** Ordered list of every anchor family the UI exposes as a color input. */
+export const ANCHOR_FAMILIES: (MainFamily | StatusFamily)[] = [
+  ...MAIN_FAMILIES,
+  ...STATUS_FAMILIES,
+];
+
+/** The default anchor set, matching the stock Terreno theme so the tool opens on a known-good palette. */
+export const DEFAULT_ANCHORS: PaletteAnchors = {
+  accent: "#d69c0e",
+  error: "#d33232",
+  neutral: "#9a9a9a",
+  primary: "#0086b3",
+  secondary: "#2b6072",
+  success: "#3ea45c",
+  warning: "#f36719",
+};
+
+/**
+ * A single foreground/background contrast pairing to evaluate. `foreground` and `background` are
+ * theme primitive keys (e.g. `neutral900`), matching the role→primitive mapping in the stock theme.
+ */
+export interface ContrastCheckDef {
+  label: string;
+  foreground: string;
+  background: string;
+  /**
+   * Large text and UI component boundaries only need 3:1 (AA). Normal body text needs 4.5:1.
+   */
+  largeText?: boolean;
+}
+
+/**
+ * Curated set of the most important text/surface pairings in the stock Terreno theme. These mirror
+ * `defaultTheme` in `ui/src/Theme.tsx`, so flagging one here flags a real accessibility risk in an
+ * app using the generated palette.
+ */
+export const CONTRAST_CHECKS: ContrastCheckDef[] = [
+  {background: "neutral000", foreground: "neutral900", label: "Body text on page"},
+  {background: "neutral000", foreground: "neutral600", label: "Secondary text on page"},
+  {background: "neutral000", foreground: "primary600", label: "Link text on page"},
+  {background: "neutral000", foreground: "accent700", label: "Accent text on page"},
+  {background: "primary400", foreground: "neutral000", label: "Inverted text on primary surface"},
+  {
+    background: "secondary500",
+    foreground: "neutral000",
+    label: "Inverted text on secondary surface",
+  },
+  {background: "error200", foreground: "neutral000", label: "Inverted text on error surface"},
+  {background: "success200", foreground: "neutral000", label: "Inverted text on success surface"},
+  {background: "warning100", foreground: "neutral000", label: "Inverted text on warning surface"},
+  {background: "neutral000", foreground: "error200", label: "Error text on page"},
+  {
+    background: "neutral000",
+    foreground: "neutral300",
+    label: "Default border on page (UI)",
+    largeText: true,
+  },
+];
+
+export interface ContrastResult extends ContrastCheckDef {
+  ratio: number;
+  foregroundHex: string;
+  backgroundHex: string;
+  /** True when the pairing meets its required WCAG AA threshold (4.5:1, or 3:1 for large/UI). */
+  passes: boolean;
+  /** True when the pairing also meets AAA (7:1, or 4.5:1 for large/UI). */
+  passesAaa: boolean;
+}
+
+/** Run every curated contrast check against a flat map of generated primitives. */
+export const runContrastChecks = (primitives: Record<string, string>): ContrastResult[] => {
+  return CONTRAST_CHECKS.map((check) => {
+    const foregroundHex = primitives[check.foreground] ?? "#000000";
+    const backgroundHex = primitives[check.background] ?? "#ffffff";
+    const assessment = assessContrast(foregroundHex, backgroundHex);
+    const passes = check.largeText ? assessment.aaLarge : assessment.aa;
+    const passesAaa = check.largeText ? assessment.aaaLarge : assessment.aaa;
+    return {
+      ...check,
+      backgroundHex,
+      foregroundHex,
+      passes,
+      passesAaa,
+      ratio: assessment.ratio,
+    };
+  });
+};
+
+/** Convenience aggregate for the header badge ("3 issues"). */
+export const countContrastFailures = (results: ContrastResult[]): number => {
+  return results.filter((result) => !result.passes).length;
+};
+
+export type {MainFamily, StatusFamily};
+export {MAIN_FAMILIES, STATUS_FAMILIES};

--- a/demo/components/palette/shareState.test.ts
+++ b/demo/components/palette/shareState.test.ts
@@ -1,0 +1,56 @@
+import {describe, expect, it} from "bun:test";
+
+import {DEFAULT_FONTS} from "./fonts";
+import {DEFAULT_ANCHORS} from "./paletteTypes";
+import {decodeShareState, encodeShareState, type ShareState} from "./shareState";
+
+/**
+ * Tests for the shareable-link encoding. Round-trips state and verifies that malformed or partial
+ * tokens are rejected rather than corrupting the palette.
+ */
+
+const state: ShareState = {anchors: DEFAULT_ANCHORS, fonts: DEFAULT_FONTS};
+
+describe("share state encode/decode", () => {
+  it("round-trips anchors and fonts", () => {
+    const decoded = decodeShareState(encodeShareState(state));
+    expect(decoded).toEqual(state);
+  });
+
+  it("produces a URL-safe token (no +, /, or =)", () => {
+    const token = encodeShareState(state);
+    expect(token).not.toMatch(/[+/=]/);
+  });
+
+  it("normalizes hex values on decode", () => {
+    const token = encodeShareState({
+      anchors: {...DEFAULT_ANCHORS, primary: "#ABC"},
+      fonts: DEFAULT_FONTS,
+    });
+    expect(decodeShareState(token)?.anchors.primary).toBe("#aabbcc");
+  });
+
+  it("returns undefined for empty or garbage tokens", () => {
+    expect(decodeShareState(undefined)).toBeUndefined();
+    expect(decodeShareState("")).toBeUndefined();
+    expect(decodeShareState("!!!not-base64!!!")).toBeUndefined();
+  });
+
+  it("returns undefined when a family is missing", () => {
+    const {primary, ...partial} = DEFAULT_ANCHORS;
+    const token = encodeShareState({
+      anchors: partial as typeof DEFAULT_ANCHORS,
+      fonts: DEFAULT_FONTS,
+    });
+    expect(decodeShareState(token)).toBeUndefined();
+  });
+
+  it("returns undefined when fonts are missing", () => {
+    const token = globalThis
+      .btoa(JSON.stringify({a: DEFAULT_ANCHORS}))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(decodeShareState(token)).toBeUndefined();
+  });
+});

--- a/demo/components/palette/shareState.ts
+++ b/demo/components/palette/shareState.ts
@@ -1,0 +1,101 @@
+import {normalizeHex, type PaletteAnchors} from "./colorUtils";
+import type {FontSelection} from "./fonts";
+import {ANCHOR_FAMILIES} from "./paletteTypes";
+
+/**
+ * Encodes/decodes the shareable part of the palette generator state (anchor colors + fonts) into a
+ * compact URL token so a palette can be shared via a link. The API key and chat history are
+ * intentionally excluded — the key is a secret and the palette is fully reconstructable from the
+ * anchors and fonts.
+ */
+
+/** Query-string parameter that carries the encoded state. */
+export const SHARE_PARAM = "s";
+
+export interface ShareState {
+  anchors: PaletteAnchors;
+  fonts: FontSelection;
+}
+
+const toBase64Url = (input: string): string => {
+  const base64 = typeof globalThis.btoa === "function" ? globalThis.btoa(input) : input;
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+};
+
+const fromBase64Url = (token: string): string | undefined => {
+  const base64 = token.replace(/-/g, "+").replace(/_/g, "/");
+  try {
+    return typeof globalThis.atob === "function" ? globalThis.atob(base64) : base64;
+  } catch {
+    return undefined;
+  }
+};
+
+/** Encode anchors + fonts into a compact, URL-safe token. */
+export const encodeShareState = (state: ShareState): string => {
+  const payload = JSON.stringify({a: state.anchors, f: state.fonts});
+  return toBase64Url(payload);
+};
+
+/**
+ * Decode a share token back into a `ShareState`. Returns `undefined` if the token is missing,
+ * malformed, or does not contain a full, valid set of anchors and fonts, so a bad link never
+ * corrupts the palette.
+ */
+export const decodeShareState = (token: string | undefined): ShareState | undefined => {
+  if (!token) {
+    return undefined;
+  }
+  const json = fromBase64Url(token);
+  if (!json) {
+    return undefined;
+  }
+  let parsed: {a?: Record<string, string>; f?: {headingFont?: string; bodyFont?: string}};
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return undefined;
+  }
+  const rawAnchors = parsed.a;
+  const rawFonts = parsed.f;
+  if (!rawAnchors || !rawFonts) {
+    return undefined;
+  }
+
+  const anchors = {} as PaletteAnchors;
+  for (const family of ANCHOR_FAMILIES) {
+    const hex = normalizeHex(rawAnchors[family] ?? "");
+    if (!hex) {
+      return undefined;
+    }
+    anchors[family] = hex;
+  }
+
+  if (typeof rawFonts.headingFont !== "string" || typeof rawFonts.bodyFont !== "string") {
+    return undefined;
+  }
+
+  return {
+    anchors,
+    fonts: {bodyFont: rawFonts.bodyFont, headingFont: rawFonts.headingFont},
+  };
+};
+
+/**
+ * Build a full share URL for the current state, based on the current web location. Returns
+ * `undefined` when there is no location (native / SSR).
+ */
+export const buildShareUrl = (state: ShareState): string | undefined => {
+  const location = (globalThis as {location?: {href?: string}}).location;
+  if (!location?.href) {
+    return undefined;
+  }
+  try {
+    const url = new URL(location.href);
+    url.searchParams.set(SHARE_PARAM, encodeShareState(state));
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+};

--- a/demo/components/palette/webFonts.ts
+++ b/demo/components/palette/webFonts.ts
@@ -1,0 +1,33 @@
+import {Platform} from "react-native";
+
+import {googleFontsUrl} from "./fonts";
+
+/**
+ * Web-only font loader for the palette generator. Kept separate from `fonts.ts` so that module can
+ * stay free of the react-native import and remain unit-testable.
+ */
+
+const WEB_FONT_LINK_ID = "palette-generator-fonts";
+
+/**
+ * Inject (or update) a `<link>` in the document head so the chosen families are actually available
+ * to the preview on web. No-op on native and during SSR.
+ */
+export const loadWebFonts = (families: string[]): void => {
+  if (Platform.OS !== "web" || typeof document === "undefined") {
+    return;
+  }
+  const href = googleFontsUrl(families);
+  const existing = document.getElementById(WEB_FONT_LINK_ID) as HTMLLinkElement | null;
+  if (existing) {
+    if (existing.href !== href) {
+      existing.href = href;
+    }
+    return;
+  }
+  const link = document.createElement("link");
+  link.id = WEB_FONT_LINK_ID;
+  link.rel = "stylesheet";
+  link.href = href;
+  document.head.appendChild(link);
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an **AI Palette Generator** to the demo app (`/palette`, linked from the demo home page). You describe a vibe or set anchor colors, and Gemini builds a full Terreno theme — colors **and** fonts. Every shade is generated deterministically, checked against WCAG contrast (light **and** dark), previewed on real components in both modes, and exported as exact theme code.

The LLM only ever chooses **anchor colors** (one hex per family) and a **font pairing**; all 000–900 ramps and the accessibility checks are computed by deterministic color math, so results are smooth, consistent, and verifiable.

## Features

**Palette**
- **Chat assistant (Gemini):** Free-form prompts and iterative feedback. Starter prompts included. Calls the Gemini Developer API directly from the browser with a user-supplied key (stored on-device); no backend.
- **Model dropdown:** Pick the model from a `SelectField` that lists the live chat-capable models for your key (via `listGeminiModels`), falling back to a curated set when no key is set.
- **Color pickers + typing:** Tap any family to edit with H/S/L sliders + hex field. Full 000–900 ramps generated deterministically from a single anchor per family.
- **Live palette ramps** and **copy-pasteable export** (`ThemePrimitives` object, `setPrimitives({...})`, and `theme.font`).

**Fonts**
- Heading + body **font selection** from curated Google Fonts, ready-made pairings, and a **live preview** in the real typefaces (web font loader). Gemini **suggests a pairing** with a rationale.

**Dark mode + WCAG**
- **Light/Dark toggle** in the preview; dark mode re-themes via a **role remapping** (`DARK_THEME_CONFIG`) rather than inverting the neutral ramp.
- The contrast report runs against **both** light and dark role maps and flags AA/AAA per mode.

**Dark-mode audit**
- A panel documenting where `@terreno/ui` adapts to a dark theme and where it breaks (hardcoded overlays/scrims, iOS picker chrome, `Box`/`Slider` shadows, `IconButton` muted/nav/destructive using `text.inverted` as a bg, `Banner` inner text, `Spinner` light/dark variants, and the overloaded `text.inverted` role).

## Review feedback addressed

- **Concurrent Gemini requests (cursor bot, medium):** `handleSend` now guards with a synchronous `generatingRef`, so a rapid double-Send or two starter prompts can't start overlapping requests.
- **Chat overwrites manual anchor edits (cursor bot, medium):** the anchor and font editing controls are now disabled while a generation is in flight, so a returning response can't discard edits made during the wait.
- **Dark WCAG map mismatches preview / split dark-theme definitions (cursor bot + architecture, medium):** `DARK_ROLE_MAP` (used by the dark audit) is now **derived from `DARK_THEME_CONFIG`** (the config applied to the preview), so `surface.error`/`success` and every other role can no longer diverge. A regression test guards this.
- **`geminiClient` lacks tests / dark contrast logic lacks tests (cursor bot, low):** added `geminiClient.test.ts` (request assembly, error handling, JSON parsing, hex/font fallback, and `listGeminiModels`) and `paletteChecks.test.ts` (mode-aware `runContrastChecks`, dark map↔config consistency, and `buildFontConfigCode`). Also split the web-only font loader into `webFonts.ts` so `fonts.ts` is import-clean and unit-testable. Total palette tests: 32.
- **Stock theme semantics duplicated in the demo module (architecture, medium):** partially addressed and otherwise a deliberate scoping choice. The dark theme is now single-sourced. The remaining mirrors (`SHADE_KEYS`/family lists, `DEFAULT_ANCHORS`, `LIGHT_ROLE_MAP`) intentionally live in the demo because `@terreno/ui` does not currently export `defaultTheme`/`defaultPrimitives` or the shade schema; importing them would require widening the library's public API, which is out of scope for a demo tool. `generatePrimitivesFromAnchors` is typed to `Partial<ThemePrimitiveColors>`, so primitive-key renames in the library surface as type errors here. Exporting these constants from `@terreno/ui` is a reasonable follow-up.

## Implementation notes

- New files under `demo/components/palette/`; thin route at `demo/app/palette/`.
- Color math (`colorUtils.ts`) is dependency-free; WCAG checks are role-based so the same definitions resolve against light or dark mappings.
- Prompts are constants; the Gemini client validates every returned hex/font and falls back to current values so a partial response never corrupts state.
- No new dependencies added.

## Verification

- `bun run compile` (demo) — passes
- `bun run lint` (demo) — passes
- `bun test components/palette/` — 32/32 pass
- Web build + screenshots (below); `/palette` server-render returns 200 with no page errors.

### Model dropdown
[Model dropdown](https://cursor.com/agents/bc-3e81efe7-c8be-4642-a499-e918b76fcdc6/artifacts?path=%2Ftmp%2Fpalette3-model-open.png)

### Light mode
[Palette generator (light)](https://cursor.com/agents/bc-3e81efe7-c8be-4642-a499-e918b76fcdc6/artifacts?path=%2Ftmp%2Fpalette2-full.png)

### Dark mode preview + dark-mode WCAG report
[Palette generator dark mode](https://cursor.com/agents/bc-3e81efe7-c8be-4642-a499-e918b76fcdc6/artifacts?path=%2Ftmp%2Fpalette2-dark.png)

### Full component grid under the dark theme (light-only components remain light)
[All components under the dark theme](https://cursor.com/agents/bc-3e81efe7-c8be-4642-a499-e918b76fcdc6/artifacts?path=%2Ftmp%2Fpalette2-dark-all.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e81efe7-c8be-4642-a499-e918b76fcdc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e81efe7-c8be-4642-a499-e918b76fcdc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

