### PR TITLE
Rework AiSuggestionBox per design feedback (hidden state, sparkles icon, small buttons)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "admin-backend": {
       "name": "@terreno/admin-backend",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "dependencies": {
         "@google-cloud/storage": "catalog:",
         "@terreno/api": "workspace:*",
@@ -40,7 +40,7 @@
     },
     "admin-frontend": {
       "name": "@terreno/admin-frontend",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "dependencies": {
         "@terreno/ui": "workspace:*",
         "expo-router": "catalog:",
@@ -71,7 +71,7 @@
     },
     "admin-spa": {
       "name": "@terreno/admin-spa",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "dependencies": {
         "@expo/vector-icons": "catalog:",
         "@react-native-async-storage/async-storage": "catalog:",
@@ -122,7 +122,7 @@
     },
     "ai": {
       "name": "@terreno/ai",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "dependencies": {
         "@ai-sdk/mcp": "^1.0.21",
         "@google-cloud/storage": "catalog:",
@@ -158,7 +158,7 @@
     },
     "api": {
       "name": "@terreno/api",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@sentry/bun": "catalog:",
@@ -234,7 +234,7 @@
     },
     "api-health": {
       "name": "@terreno/api-health",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "dependencies": {
         "@terreno/api": "workspace:*",
         "express": "catalog:",
@@ -439,7 +439,7 @@
     },
     "feature-flags": {
       "name": "@terreno/feature-flags",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "dependencies": {
         "@openfeature/server-sdk": "catalog:",
         "@terreno/api": "workspace:*",
@@ -463,7 +463,7 @@
     },
     "mcp-server": {
       "name": "@terreno/mcp",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "bin": {
         "terreno-mcp": "./dist/index.js",
         "terreno-mcp-local": "./dist/local/index.js",
@@ -484,7 +484,7 @@
     },
     "rtk": {
       "name": "@terreno/rtk",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "dependencies": {
         "@better-auth/expo": "^1.2.8",
         "@openfeature/core": "catalog:",
@@ -528,7 +528,7 @@
     },
     "test": {
       "name": "@terreno/test",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "dependencies": {
         "express": "catalog:",
         "lodash": "catalog:",
@@ -553,7 +553,7 @@
     },
     "ui": {
       "name": "@terreno/ui",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "dependencies": {
         "@expo-google-fonts/nunito": "catalog:",
         "@expo-google-fonts/titillium-web": "catalog:",

--- a/demo/stories/AiSuggestionBox.stories.tsx
+++ b/demo/stories/AiSuggestionBox.stories.tsx
@@ -60,7 +60,19 @@ export const AiSuggestionReady = (): ReactElement => (
 );
 
 export const AiSuggestionAdded = (): ReactElement => (
-  <AiSuggestionDemo initialStatus="added" label="Added" text={SAMPLE_TEXT} />
+  <AiSuggestionDemo
+    initialStatus="added"
+    label="Added (collapsed, Show re-expands)"
+    text={SAMPLE_TEXT}
+  />
+);
+
+export const AiSuggestionHidden = (): ReactElement => (
+  <AiSuggestionDemo
+    initialStatus="hidden"
+    label="Hidden (collapsed, Show re-expands)"
+    text={SAMPLE_TEXT}
+  />
 );
 
 export const AiSuggestionMainDemo = (): ReactElement => {
@@ -83,5 +95,6 @@ export const AiSuggestionAllStates = (): ReactElement => (
     <AiSuggestionGenerating />
     <AiSuggestionReady />
     <AiSuggestionAdded />
+    <AiSuggestionHidden />
   </Box>
 );

--- a/demo/story-config/AiSuggestionBox.config.tsx
+++ b/demo/story-config/AiSuggestionBox.config.tsx
@@ -3,6 +3,7 @@ import {
   AiSuggestionAdded,
   AiSuggestionAllStates,
   AiSuggestionGenerating,
+  AiSuggestionHidden,
   AiSuggestionMainDemo,
   AiSuggestionNotStarted,
   AiSuggestionReady,
@@ -14,7 +15,7 @@ export const AiSuggestionBoxConfiguration: DemoConfiguration = {
   component: AiSuggestionBox,
   related: ["Text area", "Text field"],
   description:
-    "An AI suggestion block that renders inside TextField or TextArea. Shows AI-generated content with feedback controls and add-to-note actions. Supports multiple states: not-started, generating, ready, and added.",
+    "An AI suggestion block that renders inside TextField or TextArea. Shows AI-generated content with feedback controls and add-to-note actions. Supports multiple states: not-started, generating, ready, added, and hidden. Hidden and added suggestions condense into a collapsed row that can be re-expanded with Show.",
   a11yNotes: [
     "Thumbs up and thumbs down buttons have accessibility labels.",
     "Show/Hide and Add to note buttons have accessibility roles.",
@@ -51,6 +52,7 @@ export const AiSuggestionBoxConfiguration: DemoConfiguration = {
     Generating: {render: AiSuggestionGenerating},
     Ready: {render: AiSuggestionReady},
     Added: {render: AiSuggestionAdded},
+    Hidden: {render: AiSuggestionHidden},
     AllStates: {render: AiSuggestionAllStates},
   },
 };

--- a/ui/src/AiSuggestionBox.test.tsx
+++ b/ui/src/AiSuggestionBox.test.tsx
@@ -1,8 +1,21 @@
 import {describe, expect, it, mock} from "bun:test";
-import {fireEvent} from "@testing-library/react-native";
+import {act, fireEvent} from "@testing-library/react-native";
+import type {ReactTestInstance} from "react-test-renderer";
 
+import {AiSuggestionBox} from "./AiSuggestionBox";
 import {TextArea} from "./TextArea";
 import {renderWithTheme} from "./test-utils";
+
+/**
+ * Presses a Button-backed element and waits out the press handler's async haptic +
+ * leading-edge debounce so the onClick side effects have applied before asserting.
+ */
+const pressButton = async (element: ReactTestInstance): Promise<void> => {
+  await act(async () => {
+    fireEvent.press(element);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  });
+};
 
 describe("AiSuggestionBox in TextArea", () => {
   describe("not-started state", () => {
@@ -100,7 +113,7 @@ describe("AiSuggestionBox in TextArea", () => {
       expect(getByText("Add to note")).toBeTruthy();
     });
 
-    it("should call onAdd when Add to note is pressed", () => {
+    it("should call onAdd when Add to note is pressed", async () => {
       const mockOnAdd = mock(() => {});
       const {getByLabelText} = renderWithTheme(
         <TextArea
@@ -115,11 +128,11 @@ describe("AiSuggestionBox in TextArea", () => {
         />
       );
 
-      fireEvent.press(getByLabelText("Add to note"));
+      await pressButton(getByLabelText("Add to note"));
       expect(mockOnAdd).toHaveBeenCalledTimes(1);
     });
 
-    it("should collapse when Hide is pressed", () => {
+    it("should collapse when Hide is pressed", async () => {
       const {getByLabelText, getByText, queryByText} = renderWithTheme(
         <TextArea
           aiSuggestion={{
@@ -135,14 +148,14 @@ describe("AiSuggestionBox in TextArea", () => {
 
       expect(getByText("Suggestion text")).toBeTruthy();
 
-      fireEvent.press(getByLabelText("Hide suggestion"));
+      await pressButton(getByLabelText("Hide"));
 
       expect(queryByText("Suggestion text")).toBeNull();
       expect(getByText("AI-generated note (hidden)")).toBeTruthy();
       expect(getByText("Show")).toBeTruthy();
     });
 
-    it("should expand when Show is pressed after collapsing", () => {
+    it("should expand when Show is pressed after collapsing", async () => {
       const {getByLabelText, getByText} = renderWithTheme(
         <TextArea
           aiSuggestion={{
@@ -156,15 +169,15 @@ describe("AiSuggestionBox in TextArea", () => {
         />
       );
 
-      fireEvent.press(getByLabelText("Hide suggestion"));
+      await pressButton(getByLabelText("Hide"));
       expect(getByText("AI-generated note (hidden)")).toBeTruthy();
 
-      fireEvent.press(getByLabelText("Show suggestion"));
+      await pressButton(getByLabelText("Show"));
       expect(getByText("Suggestion text")).toBeTruthy();
       expect(getByText("AI-generated note")).toBeTruthy();
     });
 
-    it("should call onHide when Hide is pressed", () => {
+    it("should call onHide when Hide is pressed", async () => {
       const mockOnHide = mock(() => {});
       const {getByLabelText} = renderWithTheme(
         <TextArea
@@ -180,11 +193,11 @@ describe("AiSuggestionBox in TextArea", () => {
         />
       );
 
-      fireEvent.press(getByLabelText("Hide suggestion"));
+      await pressButton(getByLabelText("Hide"));
       expect(mockOnHide).toHaveBeenCalledTimes(1);
     });
 
-    it("should call onShow when Show is pressed", () => {
+    it("should call onShow when Show is pressed", async () => {
       const mockOnShow = mock(() => {});
       const {getByLabelText} = renderWithTheme(
         <TextArea
@@ -200,15 +213,57 @@ describe("AiSuggestionBox in TextArea", () => {
         />
       );
 
-      fireEvent.press(getByLabelText("Hide suggestion"));
-      fireEvent.press(getByLabelText("Show suggestion"));
+      await pressButton(getByLabelText("Hide"));
+      await pressButton(getByLabelText("Show"));
       expect(mockOnShow).toHaveBeenCalledTimes(1);
     });
   });
 
+  describe("hidden state", () => {
+    it("should render collapsed with the hidden heading", () => {
+      const {getByText, queryByText} = renderWithTheme(
+        <TextArea
+          aiSuggestion={{
+            onAdd: () => {},
+            status: "hidden",
+            text: "Hidden suggestion",
+          }}
+          onChange={() => {}}
+          value=""
+        />
+      );
+
+      expect(getByText("AI-generated note (hidden)")).toBeTruthy();
+      expect(getByText("Show")).toBeTruthy();
+      expect(queryByText("Hidden suggestion")).toBeNull();
+    });
+
+    it("should call onShow and expand when Show is pressed", async () => {
+      const mockOnShow = mock(() => {});
+      const {getByLabelText, getByText} = renderWithTheme(
+        <TextArea
+          aiSuggestion={{
+            onAdd: () => {},
+            onShow: mockOnShow,
+            status: "hidden",
+            text: "Hidden suggestion",
+          }}
+          onChange={() => {}}
+          testID="test"
+          value=""
+        />
+      );
+
+      await pressButton(getByLabelText("Show"));
+
+      expect(mockOnShow).toHaveBeenCalledTimes(1);
+      expect(getByText("Hidden suggestion")).toBeTruthy();
+    });
+  });
+
   describe("added state", () => {
-    it("should render added heading", () => {
-      const {getByText} = renderWithTheme(
+    it("should render collapsed with the added heading", () => {
+      const {getByText, queryByText} = renderWithTheme(
         <TextArea
           aiSuggestion={{
             onAdd: () => {},
@@ -221,7 +276,104 @@ describe("AiSuggestionBox in TextArea", () => {
       );
 
       expect(getByText("AI-generated note added!")).toBeTruthy();
+      expect(getByText("Show")).toBeTruthy();
+      expect(queryByText("Added suggestion")).toBeNull();
+    });
+
+    it("should expand locally on Show without persisting, keeping Add to note available", async () => {
+      const mockOnShow = mock(() => {});
+      const {getByLabelText, getByText} = renderWithTheme(
+        <TextArea
+          aiSuggestion={{
+            onAdd: () => {},
+            onShow: mockOnShow,
+            status: "added",
+            text: "Added suggestion",
+          }}
+          onChange={() => {}}
+          testID="test"
+          value=""
+        />
+      );
+
+      await pressButton(getByLabelText("Show"));
+
+      // Expanding an added suggestion must not call onShow — that would reset the
+      // persisted acceptance record.
+      expect(mockOnShow).not.toHaveBeenCalled();
       expect(getByText("Added suggestion")).toBeTruthy();
+      expect(getByText("Add to note")).toBeTruthy();
+    });
+
+    it("should collapse locally on Hide without persisting", async () => {
+      const mockOnHide = mock(() => {});
+      const {getByLabelText, getByText} = renderWithTheme(
+        <TextArea
+          aiSuggestion={{
+            onAdd: () => {},
+            onHide: mockOnHide,
+            status: "added",
+            text: "Added suggestion",
+          }}
+          onChange={() => {}}
+          testID="test"
+          value=""
+        />
+      );
+
+      await pressButton(getByLabelText("Show"));
+      await pressButton(getByLabelText("Hide"));
+
+      expect(mockOnHide).not.toHaveBeenCalled();
+      expect(getByText("AI-generated note added!")).toBeTruthy();
+    });
+  });
+
+  describe("collapse behavior across status transitions", () => {
+    it("should collapse when the status transitions from ready to added", () => {
+      const {getByText, queryByText, rerender} = renderWithTheme(
+        <AiSuggestionBox onAdd={() => {}} status="ready" text="Suggestion text" />
+      );
+
+      expect(getByText("Suggestion text")).toBeTruthy();
+
+      rerender(<AiSuggestionBox onAdd={() => {}} status="added" text="Suggestion text" />);
+
+      expect(getByText("AI-generated note added!")).toBeTruthy();
+      expect(queryByText("Suggestion text")).toBeNull();
+    });
+
+    it("should keep the box expanded when a stale hide lands after a newer Show click", async () => {
+      const mockOnHide = mock(() => {});
+      const mockOnShow = mock(() => {});
+      const suggestion = {
+        onAdd: () => {},
+        onHide: mockOnHide,
+        onShow: mockOnShow,
+        text: "Suggestion text",
+      };
+      const {getByLabelText, getByText, queryByText, rerender} = renderWithTheme(
+        <AiSuggestionBox status="ready" {...suggestion} />
+      );
+
+      await pressButton(getByLabelText("Hide"));
+      expect(mockOnHide).toHaveBeenCalledTimes(1);
+
+      await pressButton(getByLabelText("Show"));
+      // A Show clicked while the hide is still in flight must persist the un-hide too,
+      // so the backend converges on the user's latest choice.
+      expect(mockOnShow).toHaveBeenCalledTimes(1);
+      expect(getByText("Suggestion text")).toBeTruthy();
+
+      // The earlier hide's refetch lands after the newer Show click — the box must not
+      // snap back to collapsed.
+      rerender(<AiSuggestionBox status="hidden" {...suggestion} />);
+      expect(getByText("Suggestion text")).toBeTruthy();
+      expect(queryByText("AI-generated note (hidden)")).toBeNull();
+
+      // The show mutation then lands and the box stays expanded.
+      rerender(<AiSuggestionBox status="ready" {...suggestion} />);
+      expect(getByText("Suggestion text")).toBeTruthy();
     });
   });
 
@@ -343,6 +495,23 @@ describe("AiSuggestionBox in TextArea", () => {
             feedback: null,
             onAdd: () => {},
             status: "ready",
+            text: "AI-generated suggestion text.",
+          }}
+          onChange={() => {}}
+          testID="test"
+          value=""
+        />
+      );
+      expect(component.toJSON()).toMatchSnapshot();
+    });
+
+    it("should match snapshot for hidden state", () => {
+      const component = renderWithTheme(
+        <TextArea
+          aiSuggestion={{
+            feedback: null,
+            onAdd: () => {},
+            status: "hidden",
             text: "AI-generated suggestion text.",
           }}
           onChange={() => {}}

--- a/ui/src/AiSuggestionBox.tsx
+++ b/ui/src/AiSuggestionBox.tsx
@@ -1,8 +1,10 @@
 import {type FC, useCallback, useEffect, useState} from "react";
 import {Pressable, View} from "react-native";
 
+import {Button} from "./Button";
 import type {AiSuggestionProps} from "./Common";
 import {Icon} from "./Icon";
+import {SparklesIcon} from "./icons";
 import {Text} from "./Text";
 import {useTheme} from "./Theme";
 
@@ -10,6 +12,17 @@ export interface AiSuggestionBoxProps extends AiSuggestionProps {
   testID?: string;
 }
 
+/**
+ * Inline AI suggestion box rendered inside TextField/TextArea via the `aiSuggestion` prop.
+ *
+ * Expansion is derived from the persisted `status` (`ready` expands; `hidden` and `added`
+ * condense into the collapsed header row), but an explicit user Show/Hide toggle always
+ * wins — including while a hide/show mutation is still in flight — so a quick
+ * Hide-then-Show never snaps back to collapsed when the earlier hide's refetch lands.
+ * Hide/Show on a non-`added` suggestion also invoke `onHide`/`onShow` so consumers can
+ * persist the choice; toggling an `added` suggestion is purely local so the acceptance
+ * record is never reset. "Add to note" stays available after a first add for re-adds.
+ */
 export const AiSuggestionBox: FC<AiSuggestionBoxProps> = ({
   status,
   text,
@@ -23,15 +36,26 @@ export const AiSuggestionBox: FC<AiSuggestionBoxProps> = ({
   testID,
 }) => {
   const {theme} = useTheme();
-  const [expanded, setExpanded] = useState(true);
+  // The user's last explicit Show/Hide choice. While set, it overrides the
+  // status-derived default so in-flight hide/show mutations can't undo a newer click.
+  const [expandedIntent, setExpandedIntent] = useState<boolean | null>(null);
 
-  // Re-expand when a new suggestion arrives or is added
+  // Reconcile the local intent with persisted status transitions. Accepting a suggestion
+  // (`added`) always condenses the box, and once the persisted status agrees with the
+  // user's intent the override is dropped so later transitions (e.g. a regenerated
+  // suggestion flipping back to `ready`) use their status defaults. An intent that
+  // disagrees with the incoming status is kept — that status is a stale in-flight
+  // hide/show landing after a newer click, and must not undo it.
   useEffect(() => {
-    if (status === "ready" || status === "added") {
-      setExpanded(true);
-    }
+    setExpandedIntent((current) => {
+      if (current === null || status === "added") {
+        return null;
+      }
+      return current === (status === "ready") ? null : current;
+    });
   }, [status]);
 
+  const expanded = expandedIntent ?? status === "ready";
   const isAdded = status === "added";
 
   const backgroundColor = isAdded
@@ -68,14 +92,24 @@ export const AiSuggestionBox: FC<AiSuggestionBoxProps> = ({
             : "AI-generated note (hidden)";
 
   const handleHide = useCallback(() => {
-    setExpanded(false);
-    onHide?.();
-  }, [onHide]);
+    setExpandedIntent(false);
+    // Persist the hide for any non-`added` suggestion — even when the status still reads
+    // `hidden` locally (an un-hide may be in flight). Hiding an `added` suggestion is a
+    // purely local collapse so the acceptance record stays intact.
+    if (status !== "added") {
+      onHide?.();
+    }
+  }, [status, onHide]);
 
   const handleShow = useCallback(() => {
-    setExpanded(true);
-    onShow?.();
-  }, [onShow]);
+    setExpandedIntent(true);
+    // Persist the un-hide for any non-`added` suggestion — even when the status still
+    // reads `ready` locally (a hide may be in flight, and this Show must override it).
+    // Expanding an `added` suggestion must not reset its status.
+    if (status !== "added") {
+      onShow?.();
+    }
+  }, [status, onShow]);
 
   const handleThumbsUp = useCallback(() => {
     if (!onFeedback) {
@@ -106,7 +140,7 @@ export const AiSuggestionBox: FC<AiSuggestionBoxProps> = ({
         <Icon
           color={feedback === "like" ? "secondaryDark" : "secondaryLight"}
           iconName="thumbs-up"
-          size="xs"
+          size="md"
           type={feedback === "like" ? "solid" : "regular"}
         />
       </Pressable>
@@ -120,7 +154,7 @@ export const AiSuggestionBox: FC<AiSuggestionBoxProps> = ({
         <Icon
           color={feedback === "dislike" ? "secondaryDark" : "secondaryLight"}
           iconName="thumbs-down"
-          size="xs"
+          size="md"
           type={feedback === "dislike" ? "solid" : "regular"}
         />
       </Pressable>
@@ -131,7 +165,7 @@ export const AiSuggestionBox: FC<AiSuggestionBoxProps> = ({
     return (
       <View style={containerStyle} testID={testID}>
         <View style={{alignItems: "center", flexDirection: "row", gap: 4, width: "100%"}}>
-          <Icon color="secondaryDark" iconName="wand-magic-sparkles" size="xs" />
+          <SparklesIcon fill={theme.text.secondaryDark} />
           <View style={{flex: 1}}>
             <Text color="secondaryDark" size="sm">
               {headingText}
@@ -146,24 +180,20 @@ export const AiSuggestionBox: FC<AiSuggestionBoxProps> = ({
     return (
       <View style={{...containerStyle, flexDirection: "column"}} testID={testID}>
         <View style={{alignItems: "center", flexDirection: "row", gap: 4, width: "100%"}}>
-          <Icon color="secondaryDark" iconName="wand-magic-sparkles" size="xs" />
+          <SparklesIcon fill={theme.text.secondaryDark} />
           <View style={{flex: 1}}>
             <Text color="secondaryDark" size="sm">
               {headingText}
             </Text>
           </View>
           <View style={{alignItems: "center", flexDirection: "row", gap: 4}}>
-            <Pressable
-              accessibilityLabel="Show suggestion"
-              accessibilityRole="button"
-              onPress={handleShow}
-              style={{height: 28, justifyContent: "center", paddingHorizontal: 16}}
+            <Button
+              onClick={handleShow}
+              size="sm"
               testID={testID ? `${testID}-show` : undefined}
-            >
-              <Text bold color="secondaryDark" size="sm">
-                Show
-              </Text>
-            </Pressable>
+              text="Show"
+              variant="ghost"
+            />
             {renderFeedback()}
           </View>
         </View>
@@ -174,7 +204,7 @@ export const AiSuggestionBox: FC<AiSuggestionBoxProps> = ({
   return (
     <View style={{...containerStyle, alignItems: "flex-end"}} testID={testID}>
       <View style={{alignItems: "center", flexDirection: "row", gap: 4, width: "100%"}}>
-        <Icon color="secondaryDark" iconName="wand-magic-sparkles" size="xs" />
+        <SparklesIcon fill={theme.text.secondaryDark} />
         <View style={{flex: 1}}>
           <Text color="secondaryDark" size="sm">
             {headingText}
@@ -198,35 +228,22 @@ export const AiSuggestionBox: FC<AiSuggestionBoxProps> = ({
           width: "100%",
         }}
       >
-        <Pressable
-          accessibilityLabel="Hide suggestion"
-          accessibilityRole="button"
-          onPress={handleHide}
-          style={{height: 28, justifyContent: "center", paddingHorizontal: 16}}
+        <Button
+          onClick={handleHide}
+          size="sm"
           testID={testID ? `${testID}-hide` : undefined}
-        >
-          <Text bold color="secondaryDark" size="sm">
-            Hide
-          </Text>
-        </Pressable>
-        <Pressable
-          accessibilityLabel="Add to note"
-          accessibilityRole="button"
-          onPress={onAdd}
-          style={{
-            alignItems: "center",
-            backgroundColor: theme.surface.secondaryDark,
-            borderRadius: 360,
-            height: 28,
-            justifyContent: "center",
-            paddingHorizontal: 16,
-          }}
-          testID={testID ? `${testID}-add` : undefined}
-        >
-          <Text bold color="inverted" size="sm">
-            Add to note
-          </Text>
-        </Pressable>
+          text="Hide"
+          variant="ghost"
+        />
+        {Boolean(onAdd) && (
+          <Button
+            onClick={onAdd!}
+            size="sm"
+            testID={testID ? `${testID}-add` : undefined}
+            text="Add to note"
+            variant="secondary"
+          />
+        )}
       </View>
     </View>
   );

--- a/ui/src/Common.ts
+++ b/ui/src/Common.ts
@@ -762,10 +762,18 @@ export interface ErrorTextProps {
 }
 
 export interface AiSuggestionProps {
-  status: "not-started" | "generating" | "ready" | "added";
+  /**
+   * Persisted suggestion state. `ready` renders expanded; `hidden` and `added` render
+   * condensed into the collapsed header row (re-expandable with "Show") so a hidden or
+   * accepted suggestion never disappears entirely.
+   */
+  status: "not-started" | "generating" | "ready" | "added" | "hidden";
   text?: string;
+  /** Adds the suggestion text to the note. Stays available after adding for re-adds. */
   onAdd?: () => void;
+  /** Persists a hide. Called for any non-`added` status when the user presses "Hide". */
   onHide?: () => void;
+  /** Persists an un-hide. Called for any non-`added` status when the user presses "Show". */
   onShow?: () => void;
   onFeedback?: (feedback: "like" | "dislike" | null) => void;
   feedback?: "like" | "dislike" | null;

--- a/ui/src/__snapshots__/AiSuggestionBox.test.tsx.snap
+++ b/ui/src/__snapshots__/AiSuggestionBox.test.tsx.snap
@@ -18,6 +18,26 @@ exports[`AiSuggestionBox in TextArea snapshots should match snapshot for not-sta
                   "children": [
                     {
                       "$$typeof": Symbol(react.test.json),
+                      "children": null,
+                      "props": {
+                        "d": "M 200 72 Q 232 240 400 272 Q 232 304 200 472 Q 168 304 0 272 Q 168 240 200 72 Z M 420 4 Q 434.08 77.92 508 92 Q 434.08 106.08 420 180 Q 405.92 106.08 332 92 Q 405.92 77.92 420 4 Z M 420 348 Q 432.8 415.2 500 428 Q 432.8 440.8 420 508 Q 407.2 440.8 340 428 Q 407.2 415.2 420 348 Z",
+                      },
+                      "type": "Path",
+                    },
+                  ],
+                  "props": {
+                    "fill": "#092E3A",
+                    "height": 16,
+                    "viewBox": "0 0 512 512",
+                    "width": 16,
+                  },
+                  "type": "Svg",
+                },
+                {
+                  "$$typeof": Symbol(react.test.json),
+                  "children": [
+                    {
+                      "$$typeof": Symbol(react.test.json),
                       "children": [
                         {
                           "$$typeof": Symbol(react.test.json),
@@ -176,6 +196,26 @@ exports[`AiSuggestionBox in TextArea snapshots should match snapshot for generat
             {
               "$$typeof": Symbol(react.test.json),
               "children": [
+                {
+                  "$$typeof": Symbol(react.test.json),
+                  "children": [
+                    {
+                      "$$typeof": Symbol(react.test.json),
+                      "children": null,
+                      "props": {
+                        "d": "M 200 72 Q 232 240 400 272 Q 232 304 200 472 Q 168 304 0 272 Q 168 240 200 72 Z M 420 4 Q 434.08 77.92 508 92 Q 434.08 106.08 420 180 Q 405.92 106.08 332 92 Q 405.92 77.92 420 4 Z M 420 348 Q 432.8 415.2 500 428 Q 432.8 440.8 420 508 Q 407.2 440.8 340 428 Q 407.2 415.2 420 348 Z",
+                      },
+                      "type": "Path",
+                    },
+                  ],
+                  "props": {
+                    "fill": "#092E3A",
+                    "height": 16,
+                    "viewBox": "0 0 512 512",
+                    "width": 16,
+                  },
+                  "type": "Svg",
+                },
                 {
                   "$$typeof": Symbol(react.test.json),
                   "children": [
@@ -344,6 +384,26 @@ exports[`AiSuggestionBox in TextArea snapshots should match snapshot for ready s
                   "children": [
                     {
                       "$$typeof": Symbol(react.test.json),
+                      "children": null,
+                      "props": {
+                        "d": "M 200 72 Q 232 240 400 272 Q 232 304 200 472 Q 168 304 0 272 Q 168 240 200 72 Z M 420 4 Q 434.08 77.92 508 92 Q 434.08 106.08 420 180 Q 405.92 106.08 332 92 Q 405.92 77.92 420 4 Z M 420 348 Q 432.8 415.2 500 428 Q 432.8 440.8 420 508 Q 407.2 440.8 340 428 Q 407.2 415.2 420 348 Z",
+                      },
+                      "type": "Path",
+                    },
+                  ],
+                  "props": {
+                    "fill": "#092E3A",
+                    "height": 16,
+                    "viewBox": "0 0 512 512",
+                    "width": 16,
+                  },
+                  "type": "Svg",
+                },
+                {
+                  "$$typeof": Symbol(react.test.json),
+                  "children": [
+                    {
+                      "$$typeof": Symbol(react.test.json),
                       "children": [
                         {
                           "$$typeof": Symbol(react.test.json),
@@ -485,38 +545,65 @@ exports[`AiSuggestionBox in TextArea snapshots should match snapshot for ready s
                         {
                           "$$typeof": Symbol(react.test.json),
                           "children": [
-                            "Hide",
+                            {
+                              "$$typeof": Symbol(react.test.json),
+                              "children": [
+                                "Hide",
+                              ],
+                              "props": {
+                                "style": {
+                                  "color": "#2B6072",
+                                  "fontSize": 14,
+                                  "fontWeight": "700",
+                                },
+                              },
+                              "type": "Text",
+                            },
                           ],
                           "props": {
-                            "numberOfLines": 0,
-                            "selectable": undefined,
                             "style": {
-                              "color": "#092E3A",
-                              "fontFamily": "text-bold",
-                              "fontSize": 10,
-                              "textAlign": "left",
+                              "flexDirection": "row",
                             },
                             "testID": undefined,
                           },
-                          "type": "Text",
+                          "type": "View",
                         },
                       ],
-                      "props": {},
+                      "props": {
+                        "style": {
+                          "flexDirection": "row",
+                        },
+                        "testID": undefined,
+                      },
                       "type": "View",
                     },
                   ],
                   "props": {
-                    "accessibilityLabel": "Hide suggestion",
+                    "accessibilityHint": "Press to perform action",
+                    "accessibilityLabel": "Hide",
                     "accessibilityRole": "button",
-                    "onPress": [Function],
+                    "accessibilityState": {
+                      "disabled": false,
+                    },
+                    "disabled": false,
+                    "onPress": [Function: debounced],
                     "style": {
+                      "alignItems": "center",
+                      "alignSelf": "flex-start",
+                      "backgroundColor": "transparent",
+                      "borderColor": undefined,
+                      "borderRadius": 360,
+                      "borderWidth": undefined,
+                      "flexDirection": "column",
                       "height": 28,
                       "justifyContent": "center",
                       "paddingHorizontal": 16,
+                      "paddingVertical": 0,
+                      "width": "auto",
                     },
                     "testID": "test-ai-suggestion-hide",
                   },
-                  "type": "Pressable",
+                  "type": "PressableScale",
                 },
                 {
                   "$$typeof": Symbol(react.test.json),
@@ -527,41 +614,65 @@ exports[`AiSuggestionBox in TextArea snapshots should match snapshot for ready s
                         {
                           "$$typeof": Symbol(react.test.json),
                           "children": [
-                            "Add to note",
+                            {
+                              "$$typeof": Symbol(react.test.json),
+                              "children": [
+                                "Add to note",
+                              ],
+                              "props": {
+                                "style": {
+                                  "color": "#FFFFFF",
+                                  "fontSize": 14,
+                                  "fontWeight": "700",
+                                },
+                              },
+                              "type": "Text",
+                            },
                           ],
                           "props": {
-                            "numberOfLines": 0,
-                            "selectable": undefined,
                             "style": {
-                              "color": "#FFFFFF",
-                              "fontFamily": "text-bold",
-                              "fontSize": 10,
-                              "textAlign": "left",
+                              "flexDirection": "row",
                             },
                             "testID": undefined,
                           },
-                          "type": "Text",
+                          "type": "View",
                         },
                       ],
-                      "props": {},
+                      "props": {
+                        "style": {
+                          "flexDirection": "row",
+                        },
+                        "testID": undefined,
+                      },
                       "type": "View",
                     },
                   ],
                   "props": {
+                    "accessibilityHint": "Press to perform action",
                     "accessibilityLabel": "Add to note",
                     "accessibilityRole": "button",
-                    "onPress": [Function],
+                    "accessibilityState": {
+                      "disabled": false,
+                    },
+                    "disabled": false,
+                    "onPress": [Function: debounced],
                     "style": {
                       "alignItems": "center",
+                      "alignSelf": "flex-start",
                       "backgroundColor": "#2B6072",
+                      "borderColor": undefined,
                       "borderRadius": 360,
+                      "borderWidth": undefined,
+                      "flexDirection": "column",
                       "height": 28,
                       "justifyContent": "center",
                       "paddingHorizontal": 16,
+                      "paddingVertical": 0,
+                      "width": "auto",
                     },
                     "testID": "test-ai-suggestion-add",
                   },
-                  "type": "Pressable",
+                  "type": "PressableScale",
                 },
               ],
               "props": {
@@ -678,6 +789,320 @@ exports[`AiSuggestionBox in TextArea snapshots should match snapshot for ready s
 }
 `;
 
+exports[`AiSuggestionBox in TextArea snapshots should match snapshot for hidden state 1`] = `
+{
+  "$$typeof": Symbol(react.test.json),
+  "children": [
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": [
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            {
+              "$$typeof": Symbol(react.test.json),
+              "children": [
+                {
+                  "$$typeof": Symbol(react.test.json),
+                  "children": [
+                    {
+                      "$$typeof": Symbol(react.test.json),
+                      "children": null,
+                      "props": {
+                        "d": "M 200 72 Q 232 240 400 272 Q 232 304 200 472 Q 168 304 0 272 Q 168 240 200 72 Z M 420 4 Q 434.08 77.92 508 92 Q 434.08 106.08 420 180 Q 405.92 106.08 332 92 Q 405.92 77.92 420 4 Z M 420 348 Q 432.8 415.2 500 428 Q 432.8 440.8 420 508 Q 407.2 440.8 340 428 Q 407.2 415.2 420 348 Z",
+                      },
+                      "type": "Path",
+                    },
+                  ],
+                  "props": {
+                    "fill": "#092E3A",
+                    "height": 16,
+                    "viewBox": "0 0 512 512",
+                    "width": 16,
+                  },
+                  "type": "Svg",
+                },
+                {
+                  "$$typeof": Symbol(react.test.json),
+                  "children": [
+                    {
+                      "$$typeof": Symbol(react.test.json),
+                      "children": [
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": [
+                            "AI-generated note (hidden)",
+                          ],
+                          "props": {
+                            "numberOfLines": 0,
+                            "selectable": undefined,
+                            "style": {
+                              "color": "#092E3A",
+                              "fontFamily": "text-regular",
+                              "fontSize": 10,
+                              "textAlign": "left",
+                            },
+                            "testID": undefined,
+                          },
+                          "type": "Text",
+                        },
+                      ],
+                      "props": {},
+                      "type": "View",
+                    },
+                  ],
+                  "props": {
+                    "style": {
+                      "flex": 1,
+                    },
+                    "testID": undefined,
+                  },
+                  "type": "View",
+                },
+                {
+                  "$$typeof": Symbol(react.test.json),
+                  "children": [
+                    {
+                      "$$typeof": Symbol(react.test.json),
+                      "children": [
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": [
+                            {
+                              "$$typeof": Symbol(react.test.json),
+                              "children": [
+                                {
+                                  "$$typeof": Symbol(react.test.json),
+                                  "children": [
+                                    "Show",
+                                  ],
+                                  "props": {
+                                    "style": {
+                                      "color": "#2B6072",
+                                      "fontSize": 14,
+                                      "fontWeight": "700",
+                                    },
+                                  },
+                                  "type": "Text",
+                                },
+                              ],
+                              "props": {
+                                "style": {
+                                  "flexDirection": "row",
+                                },
+                                "testID": undefined,
+                              },
+                              "type": "View",
+                            },
+                          ],
+                          "props": {
+                            "style": {
+                              "flexDirection": "row",
+                            },
+                            "testID": undefined,
+                          },
+                          "type": "View",
+                        },
+                      ],
+                      "props": {
+                        "accessibilityHint": "Press to perform action",
+                        "accessibilityLabel": "Show",
+                        "accessibilityRole": "button",
+                        "accessibilityState": {
+                          "disabled": false,
+                        },
+                        "disabled": false,
+                        "onPress": [Function: debounced],
+                        "style": {
+                          "alignItems": "center",
+                          "alignSelf": "flex-start",
+                          "backgroundColor": "transparent",
+                          "borderColor": undefined,
+                          "borderRadius": 360,
+                          "borderWidth": undefined,
+                          "flexDirection": "column",
+                          "height": 28,
+                          "justifyContent": "center",
+                          "paddingHorizontal": 16,
+                          "paddingVertical": 0,
+                          "width": "auto",
+                        },
+                        "testID": "test-ai-suggestion-show",
+                      },
+                      "type": "PressableScale",
+                    },
+                    {
+                      "$$typeof": Symbol(react.test.json),
+                      "children": [
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": null,
+                          "props": {
+                            "accessibilityLabel": "Thumbs up",
+                            "accessibilityRole": "button",
+                            "onPress": [Function],
+                            "style": {
+                              "alignItems": "center",
+                              "height": 24,
+                              "justifyContent": "center",
+                              "width": 24,
+                            },
+                            "testID": "test-ai-suggestion-thumbs-up",
+                          },
+                          "type": "Pressable",
+                        },
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": null,
+                          "props": {
+                            "accessibilityLabel": "Thumbs down",
+                            "accessibilityRole": "button",
+                            "onPress": [Function],
+                            "style": {
+                              "alignItems": "center",
+                              "height": 24,
+                              "justifyContent": "center",
+                              "width": 24,
+                            },
+                            "testID": "test-ai-suggestion-thumbs-down",
+                          },
+                          "type": "Pressable",
+                        },
+                      ],
+                      "props": {
+                        "style": {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                        },
+                        "testID": "test-ai-suggestion-feedback",
+                      },
+                      "type": "View",
+                    },
+                  ],
+                  "props": {
+                    "style": {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "gap": 4,
+                    },
+                    "testID": undefined,
+                  },
+                  "type": "View",
+                },
+              ],
+              "props": {
+                "style": {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 4,
+                  "width": "100%",
+                },
+                "testID": undefined,
+              },
+              "type": "View",
+            },
+          ],
+          "props": {
+            "style": {
+              "backgroundColor": "#EBFAFF",
+              "borderColor": "#90D8F0",
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "flexDirection": "column",
+              "gap": 8,
+              "padding": 8,
+              "width": "100%",
+            },
+            "testID": "test-ai-suggestion",
+          },
+          "type": "View",
+        },
+        {
+          "$$typeof": Symbol(react.test.json),
+          "children": [
+            {
+              "$$typeof": Symbol(react.test.json),
+              "children": null,
+              "props": {
+                "accessibilityHint": "Enter text here",
+                "accessibilityState": {
+                  "disabled": undefined,
+                },
+                "aria-label": "Text input field",
+                "autoCapitalize": "sentences",
+                "autoCorrect": true,
+                "blurOnSubmit": true,
+                "enterKeyHint": undefined,
+                "keyboardType": "default",
+                "multiline": true,
+                "nativeID": undefined,
+                "numberOfLines": 1,
+                "onBlur": [Function],
+                "onChangeText": [Function],
+                "onContentSizeChange": [Function],
+                "onFocus": [Function],
+                "onSubmitEditing": [Function],
+                "placeholder": undefined,
+                "placeholderTextColor": "#686868",
+                "readOnly": undefined,
+                "ref": [Function],
+                "secureTextEntry": false,
+                "style": {
+                  "color": "#1C1C1C",
+                  "flex": 1,
+                  "fontFamily": "text",
+                  "fontSize": 16,
+                  "gap": 10,
+                  "height": 40,
+                  "paddingVertical": 0,
+                  "width": "100%",
+                },
+                "testID": "test",
+                "textContentType": "none",
+                "underlineColorAndroid": "transparent",
+                "value": "",
+              },
+              "type": "TextInput",
+            },
+          ],
+          "props": {
+            "style": {
+              "alignItems": "center",
+              "flexDirection": "row",
+            },
+            "testID": undefined,
+          },
+          "type": "View",
+        },
+      ],
+      "props": {
+        "style": {
+          "backgroundColor": "#FFFFFF",
+          "borderColor": "#9A9A9A",
+          "borderRadius": 4,
+          "borderWidth": 1,
+          "flexDirection": "column",
+          "gap": 10,
+          "overflow": "hidden",
+          "paddingHorizontal": 12,
+          "paddingVertical": 8,
+        },
+        "testID": undefined,
+      },
+      "type": "View",
+    },
+  ],
+  "props": {
+    "style": {
+      "flexDirection": "column",
+      "width": "100%",
+    },
+    "testID": undefined,
+  },
+  "type": "View",
+}
+`;
+
 exports[`AiSuggestionBox in TextArea snapshots should match snapshot for added state 1`] = `
 {
   "$$typeof": Symbol(react.test.json),
@@ -691,6 +1116,26 @@ exports[`AiSuggestionBox in TextArea snapshots should match snapshot for added s
             {
               "$$typeof": Symbol(react.test.json),
               "children": [
+                {
+                  "$$typeof": Symbol(react.test.json),
+                  "children": [
+                    {
+                      "$$typeof": Symbol(react.test.json),
+                      "children": null,
+                      "props": {
+                        "d": "M 200 72 Q 232 240 400 272 Q 232 304 200 472 Q 168 304 0 272 Q 168 240 200 72 Z M 420 4 Q 434.08 77.92 508 92 Q 434.08 106.08 420 180 Q 405.92 106.08 332 92 Q 405.92 77.92 420 4 Z M 420 348 Q 432.8 415.2 500 428 Q 432.8 440.8 420 508 Q 407.2 440.8 340 428 Q 407.2 415.2 420 348 Z",
+                      },
+                      "type": "Path",
+                    },
+                  ],
+                  "props": {
+                    "fill": "#092E3A",
+                    "height": 16,
+                    "viewBox": "0 0 512 512",
+                    "width": 16,
+                  },
+                  "type": "Svg",
+                },
                 {
                   "$$typeof": Symbol(react.test.json),
                   "children": [
@@ -733,45 +1178,128 @@ exports[`AiSuggestionBox in TextArea snapshots should match snapshot for added s
                   "children": [
                     {
                       "$$typeof": Symbol(react.test.json),
-                      "children": null,
+                      "children": [
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": [
+                            {
+                              "$$typeof": Symbol(react.test.json),
+                              "children": [
+                                {
+                                  "$$typeof": Symbol(react.test.json),
+                                  "children": [
+                                    "Show",
+                                  ],
+                                  "props": {
+                                    "style": {
+                                      "color": "#2B6072",
+                                      "fontSize": 14,
+                                      "fontWeight": "700",
+                                    },
+                                  },
+                                  "type": "Text",
+                                },
+                              ],
+                              "props": {
+                                "style": {
+                                  "flexDirection": "row",
+                                },
+                                "testID": undefined,
+                              },
+                              "type": "View",
+                            },
+                          ],
+                          "props": {
+                            "style": {
+                              "flexDirection": "row",
+                            },
+                            "testID": undefined,
+                          },
+                          "type": "View",
+                        },
+                      ],
                       "props": {
-                        "accessibilityLabel": "Thumbs up",
+                        "accessibilityHint": "Press to perform action",
+                        "accessibilityLabel": "Show",
                         "accessibilityRole": "button",
-                        "onPress": [Function],
+                        "accessibilityState": {
+                          "disabled": false,
+                        },
+                        "disabled": false,
+                        "onPress": [Function: debounced],
                         "style": {
                           "alignItems": "center",
-                          "height": 24,
+                          "alignSelf": "flex-start",
+                          "backgroundColor": "transparent",
+                          "borderColor": undefined,
+                          "borderRadius": 360,
+                          "borderWidth": undefined,
+                          "flexDirection": "column",
+                          "height": 28,
                           "justifyContent": "center",
-                          "width": 24,
+                          "paddingHorizontal": 16,
+                          "paddingVertical": 0,
+                          "width": "auto",
                         },
-                        "testID": "test-ai-suggestion-thumbs-up",
+                        "testID": "test-ai-suggestion-show",
                       },
-                      "type": "Pressable",
+                      "type": "PressableScale",
                     },
                     {
                       "$$typeof": Symbol(react.test.json),
-                      "children": null,
+                      "children": [
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": null,
+                          "props": {
+                            "accessibilityLabel": "Thumbs up",
+                            "accessibilityRole": "button",
+                            "onPress": [Function],
+                            "style": {
+                              "alignItems": "center",
+                              "height": 24,
+                              "justifyContent": "center",
+                              "width": 24,
+                            },
+                            "testID": "test-ai-suggestion-thumbs-up",
+                          },
+                          "type": "Pressable",
+                        },
+                        {
+                          "$$typeof": Symbol(react.test.json),
+                          "children": null,
+                          "props": {
+                            "accessibilityLabel": "Thumbs down",
+                            "accessibilityRole": "button",
+                            "onPress": [Function],
+                            "style": {
+                              "alignItems": "center",
+                              "height": 24,
+                              "justifyContent": "center",
+                              "width": 24,
+                            },
+                            "testID": "test-ai-suggestion-thumbs-down",
+                          },
+                          "type": "Pressable",
+                        },
+                      ],
                       "props": {
-                        "accessibilityLabel": "Thumbs down",
-                        "accessibilityRole": "button",
-                        "onPress": [Function],
                         "style": {
                           "alignItems": "center",
-                          "height": 24,
-                          "justifyContent": "center",
-                          "width": 24,
+                          "flexDirection": "row",
                         },
-                        "testID": "test-ai-suggestion-thumbs-down",
+                        "testID": "test-ai-suggestion-feedback",
                       },
-                      "type": "Pressable",
+                      "type": "View",
                     },
                   ],
                   "props": {
                     "style": {
                       "alignItems": "center",
                       "flexDirection": "row",
+                      "gap": 4,
                     },
-                    "testID": "test-ai-suggestion-feedback",
+                    "testID": undefined,
                   },
                   "type": "View",
                 },
@@ -787,155 +1315,14 @@ exports[`AiSuggestionBox in TextArea snapshots should match snapshot for added s
               },
               "type": "View",
             },
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    {
-                      "$$typeof": Symbol(react.test.json),
-                      "children": [
-                        "AI-generated suggestion text.",
-                      ],
-                      "props": {
-                        "numberOfLines": 0,
-                        "selectable": undefined,
-                        "style": {
-                          "color": "#1C1C1C",
-                          "fontFamily": "text-regular",
-                          "fontSize": 14,
-                          "textAlign": "left",
-                        },
-                        "testID": undefined,
-                      },
-                      "type": "Text",
-                    },
-                  ],
-                  "props": {},
-                  "type": "View",
-                },
-              ],
-              "props": {
-                "style": {
-                  "paddingBottom": 4,
-                  "width": "100%",
-                },
-                "testID": undefined,
-              },
-              "type": "View",
-            },
-            {
-              "$$typeof": Symbol(react.test.json),
-              "children": [
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    {
-                      "$$typeof": Symbol(react.test.json),
-                      "children": [
-                        {
-                          "$$typeof": Symbol(react.test.json),
-                          "children": [
-                            "Hide",
-                          ],
-                          "props": {
-                            "numberOfLines": 0,
-                            "selectable": undefined,
-                            "style": {
-                              "color": "#092E3A",
-                              "fontFamily": "text-bold",
-                              "fontSize": 10,
-                              "textAlign": "left",
-                            },
-                            "testID": undefined,
-                          },
-                          "type": "Text",
-                        },
-                      ],
-                      "props": {},
-                      "type": "View",
-                    },
-                  ],
-                  "props": {
-                    "accessibilityLabel": "Hide suggestion",
-                    "accessibilityRole": "button",
-                    "onPress": [Function],
-                    "style": {
-                      "height": 28,
-                      "justifyContent": "center",
-                      "paddingHorizontal": 16,
-                    },
-                    "testID": "test-ai-suggestion-hide",
-                  },
-                  "type": "Pressable",
-                },
-                {
-                  "$$typeof": Symbol(react.test.json),
-                  "children": [
-                    {
-                      "$$typeof": Symbol(react.test.json),
-                      "children": [
-                        {
-                          "$$typeof": Symbol(react.test.json),
-                          "children": [
-                            "Add to note",
-                          ],
-                          "props": {
-                            "numberOfLines": 0,
-                            "selectable": undefined,
-                            "style": {
-                              "color": "#FFFFFF",
-                              "fontFamily": "text-bold",
-                              "fontSize": 10,
-                              "textAlign": "left",
-                            },
-                            "testID": undefined,
-                          },
-                          "type": "Text",
-                        },
-                      ],
-                      "props": {},
-                      "type": "View",
-                    },
-                  ],
-                  "props": {
-                    "accessibilityLabel": "Add to note",
-                    "accessibilityRole": "button",
-                    "onPress": [Function],
-                    "style": {
-                      "alignItems": "center",
-                      "backgroundColor": "#2B6072",
-                      "borderRadius": 360,
-                      "height": 28,
-                      "justifyContent": "center",
-                      "paddingHorizontal": 16,
-                    },
-                    "testID": "test-ai-suggestion-add",
-                  },
-                  "type": "Pressable",
-                },
-              ],
-              "props": {
-                "style": {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "gap": 8,
-                  "justifyContent": "flex-end",
-                  "width": "100%",
-                },
-                "testID": undefined,
-              },
-              "type": "View",
-            },
           ],
           "props": {
             "style": {
-              "alignItems": "flex-end",
               "backgroundColor": "#DCF2E2",
               "borderColor": "#9BE7B2",
               "borderRadius": 8,
               "borderWidth": 1,
+              "flexDirection": "column",
               "gap": 8,
               "padding": 8,
               "width": "100%",

--- a/ui/src/icons/SparklesIcon.test.tsx
+++ b/ui/src/icons/SparklesIcon.test.tsx
@@ -1,0 +1,16 @@
+import {describe, expect, it} from "bun:test";
+import {render} from "@testing-library/react-native";
+
+import {SparklesIcon} from "./SparklesIcon";
+
+describe("SparklesIcon", () => {
+  it("renders correctly", () => {
+    const {toJSON} = render(<SparklesIcon />);
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("accepts custom props", () => {
+    const {toJSON} = render(<SparklesIcon fill="#0A0A0A" height={24} width={24} />);
+    expect(toJSON()).toMatchSnapshot();
+  });
+});

--- a/ui/src/icons/SparklesIcon.tsx
+++ b/ui/src/icons/SparklesIcon.tsx
@@ -1,0 +1,38 @@
+import type React from "react";
+import Svg, {Path, type SvgProps} from "react-native-svg";
+
+/**
+ * Builds a four-pointed sparkle path with concave edges, centered at (cx, cy) with
+ * outer radius r. FontAwesome 6 free has no standalone `sparkles` glyph (it is a Pro
+ * icon), so the glyph is composed locally from three of these sparkle shapes.
+ */
+const sparklePath = (cx: number, cy: number, r: number): string => {
+  const pinch = r * 0.16;
+  return [
+    `M ${cx} ${cy - r}`,
+    `Q ${cx + pinch} ${cy - pinch} ${cx + r} ${cy}`,
+    `Q ${cx + pinch} ${cy + pinch} ${cx} ${cy + r}`,
+    `Q ${cx - pinch} ${cy + pinch} ${cx - r} ${cy}`,
+    `Q ${cx - pinch} ${cy - pinch} ${cx} ${cy - r}`,
+    "Z",
+  ].join(" ");
+};
+
+/** One large sparkle with two smaller companions, mirroring Font Awesome's sparkles layout. */
+const SPARKLES_PATH = [
+  sparklePath(200, 272, 200),
+  sparklePath(420, 92, 88),
+  sparklePath(420, 428, 80),
+].join(" ");
+
+/**
+ * Solid "sparkles" icon (three four-pointed stars). Defaults to 16x16 — pass
+ * `height`/`width` to resize and `fill` to recolor.
+ */
+export const SparklesIcon = (props: SvgProps): React.ReactElement => {
+  return (
+    <Svg fill="currentColor" height={16} viewBox="0 0 512 512" width={16} {...props}>
+      <Path d={SPARKLES_PATH} />
+    </Svg>
+  );
+};

--- a/ui/src/icons/__snapshots__/SparklesIcon.test.tsx.snap
+++ b/ui/src/icons/__snapshots__/SparklesIcon.test.tsx.snap
@@ -1,0 +1,47 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`SparklesIcon renders correctly 1`] = `
+{
+  "$$typeof": Symbol(react.test.json),
+  "children": [
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": null,
+      "props": {
+        "d": "M 200 72 Q 232 240 400 272 Q 232 304 200 472 Q 168 304 0 272 Q 168 240 200 72 Z M 420 4 Q 434.08 77.92 508 92 Q 434.08 106.08 420 180 Q 405.92 106.08 332 92 Q 405.92 77.92 420 4 Z M 420 348 Q 432.8 415.2 500 428 Q 432.8 440.8 420 508 Q 407.2 440.8 340 428 Q 407.2 415.2 420 348 Z",
+      },
+      "type": "Path",
+    },
+  ],
+  "props": {
+    "fill": "currentColor",
+    "height": 16,
+    "viewBox": "0 0 512 512",
+    "width": 16,
+  },
+  "type": "Svg",
+}
+`;
+
+exports[`SparklesIcon accepts custom props 1`] = `
+{
+  "$$typeof": Symbol(react.test.json),
+  "children": [
+    {
+      "$$typeof": Symbol(react.test.json),
+      "children": null,
+      "props": {
+        "d": "M 200 72 Q 232 240 400 272 Q 232 304 200 472 Q 168 304 0 272 Q 168 240 200 72 Z M 420 4 Q 434.08 77.92 508 92 Q 434.08 106.08 420 180 Q 405.92 106.08 332 92 Q 405.92 77.92 420 4 Z M 420 348 Q 432.8 415.2 500 428 Q 432.8 440.8 420 508 Q 407.2 440.8 340 428 Q 407.2 415.2 420 348 Z",
+      },
+      "type": "Path",
+    },
+  ],
+  "props": {
+    "fill": "#0A0A0A",
+    "height": 24,
+    "viewBox": "0 0 512 512",
+    "width": 24,
+  },
+  "type": "Svg",
+}
+`;

--- a/ui/src/icons/index.ts
+++ b/ui/src/icons/index.ts
@@ -2,3 +2,4 @@ export * from "./MobileIcon";
 export * from "./OfflineIcon";
 export * from "./OnlineIcon";
 export * from "./OutOfficeIcon";
+export * from "./SparklesIcon";


### PR DESCRIPTION
## Summary

Implements the design/functionality feedback for the AI suggestion box used inside `TextField`/`TextArea` (Flourish appointment AI notes):

- **New `hidden` status** on `AiSuggestionProps` — `hidden` and `added` suggestions render condensed into the collapsed header row (with **Show** to re-expand) instead of relying on consumers to unmount the box. Hiding a note no longer makes it disappear forever.
- **Race-safe expansion** — the box tracks the user's last explicit Show/Hide intent, which overrides the status-derived default until the persisted status agrees with it. A quick Hide-then-Show can't snap back to collapsed when the earlier hide's refetch lands. Show/Hide invoke `onShow`/`onHide` for any non-`added` suggestion so consumers can persist the latest choice.
- **Accepting condenses the box** — the `added` state collapses into the "AI-generated note added!" row; **Show** re-expands it locally (without resetting the acceptance) and **Add to note** stays available for re-adds.
- **Thumbs up/down at 16pt** (`size="md"`, previously 8px `xs`).
- **Solid sparkles icon at 16pt** replaces `wand-magic-sparkles`. FontAwesome 6 free has no standalone `sparkles` glyph (Pro-only), so a new `SparklesIcon` SVG in `ui/src/icons/` mirrors the FA sparkles layout.
- **Small button style** — Hide/Show/Add to note now use the real `Button` with `size="sm"` (14pt bold): ghost variant for Hide/Show, secondary for Add to note.

## Changes

- `ui/src/Common.ts` — `AiSuggestionProps.status` gains `"hidden"`; handler JSDoc updated.
- `ui/src/AiSuggestionBox.tsx` — intent-based expansion, small Buttons, sparkles icon, 16pt thumbs.
- `ui/src/icons/SparklesIcon.tsx` (+ test/snapshots) — new solid sparkles SVG.
- `ui/src/AiSuggestionBox.test.tsx` — updated for new labels/behavior; added hidden-state, added-state collapse, and stale-hide race regression tests.
- `demo/` — added Hidden story and updated the AiSuggestionBox config description.
- `bun.lock` — workspace version sync (0.23.0 → 0.23.1) produced by a plain `bun install`; the package.json versions were already 0.23.1 on master.

## Automated Tests

- `ui`: `bun run compile`, `bun run lint`, and the full `bun run test:ci` suite pass (1759 tests, 0 failures).
- `demo`: `bun run compile` and `bun run lint` pass.

## Consumer notes

Flourish PR FlourishHealth/flourish#6134 currently ships an app-local copy of this box (Flourish pins `@terreno/ui` 0.20.2). Once this lands and releases, Flourish will bump the dependency, delete the app-local component, and pass its suggestion state (including `hidden`) straight through the `aiSuggestion` prop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public `AiSuggestionProps` API and show/hide persistence semantics changed; consumers must pass `hidden` and wire `onHide`/`onShow` correctly, though behavior is heavily regression-tested.
> 
> **Overview**
> **`AiSuggestionBox`** now treats **`hidden`** and **`added`** as collapsed header rows (with **Show** to re-expand) instead of staying fully open or vanishing when consumers hide a suggestion. **`AiSuggestionProps.status`** gains **`hidden`**, with updated handler docs for persist vs local-only toggles.
> 
> **Expansion logic** is reworked: **`expandedIntent`** overrides status-derived expand/collapse so rapid Hide→Show does not snap closed when a stale hide refetch lands; **`onHide`/`onShow`** still persist for non-**`added`** states, while **`added`** Show/Hide is local only so acceptance is not reset. Transition to **`added`** auto-collapses; **Add to note** remains available after the first add.
> 
> **Visual/UX:** **`SparklesIcon`** replaces **`wand-magic-sparkles`**; thumbs use **`md`** (16pt); Hide/Show/Add use **`Button`** **`size="sm"`** (ghost/secondary). Demo adds a **Hidden** story; tests cover hidden/added collapse, race regression, and updated a11y labels (**Hide**/**Show** vs **Hide suggestion**).
> 
> **`bun.lock`** bumps workspace packages **0.23.0 → 0.23.1** (lockfile sync).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6920d4dcc16d720971a03c733246d7255d0f936b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->