### PR TITLE
Add authenticated HTTP client and API error normalization to @terreno/api

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -16,6 +16,7 @@ model instances.
 - **Permissions** — Fine-grained access control (IsAuthenticated, IsOwner, IsAdmin, etc.)
 - **OpenAPI** — Automatic spec generation from models and routes
 - **Logging** — Winston-based logging with scoped & feature-flagged loggers, automatic request correlation, and Google Cloud / Sentry support
+- **HTTP client** — Authenticated axios factory for third-party APIs with token caching, safe retries, and normalized error handling (see [Call external APIs](../docs/how-to/call-external-apis.md))
 
 ## Getting started
 

--- a/api/src/httpClient.test.ts
+++ b/api/src/httpClient.test.ts
@@ -8,6 +8,7 @@ import {APIError} from "./errors";
 import {
   createAuthenticatedClient,
   type HttpClientLogger,
+  markRetryUnsafe,
   normalizeApiError,
   withApiErrorHandling,
 } from "./httpClient";
@@ -656,11 +657,13 @@ describe("createAuthenticatedClient", () => {
       }
     });
 
-    it("retries a POST when the request opts in with retryUnsafe", async () => {
+    it("retries a POST when the request opts in via markRetryUnsafe, preserving config", async () => {
       let attempts = 0;
+      const seenTestHeaders: (string | undefined)[] = [];
       const server = await startTestServer((app) => {
-        app.post("/orders", (_req, res) => {
+        app.post("/orders", (req, res) => {
           attempts += 1;
+          seenTestHeaders.push(req.headers["x-test"] as string | undefined);
           if (attempts === 1) {
             res.status(500).json({message: "boom"});
             return;
@@ -674,9 +677,14 @@ describe("createAuthenticatedClient", () => {
           baseURL: server.baseURL,
           retry: FAST_RETRY,
         });
-        const response = await client.axios.post("/orders", {widget: 1}, {retryUnsafe: true});
+        const response = await client.axios.post(
+          "/orders",
+          {widget: 1},
+          markRetryUnsafe({headers: {"X-Test": "kept"}})
+        );
         expect(response.data.ok).toBe(true);
         expect(attempts).toBe(2);
+        expect(seenTestHeaders).toEqual(["kept", "kept"]);
       } finally {
         await server.close();
       }

--- a/api/src/httpClient.test.ts
+++ b/api/src/httpClient.test.ts
@@ -1,0 +1,225 @@
+import {describe, expect, it} from "bun:test";
+import {AxiosError, type AxiosRequestHeaders, type AxiosResponse} from "axios";
+
+import {APIError} from "./errors";
+import {type HttpClientLogger, normalizeApiError, withApiErrorHandling} from "./httpClient";
+
+const createRecordingLogger = (): {
+  logger: HttpClientLogger;
+  entries: {level: string; msg: string; args: unknown[]}[];
+} => {
+  const entries: {level: string; msg: string; args: unknown[]}[] = [];
+  const record =
+    (level: string) =>
+    (msg: string, ...args: unknown[]): void => {
+      entries.push({args, level, msg});
+    };
+  return {
+    entries,
+    logger: {debug: record("debug"), error: record("error"), warn: record("warn")},
+  };
+};
+
+const CONTEXT = {apiName: "testApi", operation: "getWidget"};
+
+const buildAxiosError = ({
+  status,
+  data,
+  code,
+}: {
+  status?: number;
+  data?: unknown;
+  code?: string;
+}): AxiosError => {
+  const config = {headers: {} as AxiosRequestHeaders, url: "/widgets"};
+  let response: AxiosResponse | undefined;
+  if (status !== undefined) {
+    response = {
+      config,
+      data,
+      headers: {},
+      status,
+      statusText: "",
+    } as AxiosResponse;
+  }
+  return new AxiosError(
+    status !== undefined ? `Request failed with status code ${status}` : "Network Error",
+    code,
+    config,
+    undefined,
+    response
+  );
+};
+
+describe("normalizeApiError", () => {
+  it("classifies HTTP statuses from an axios error response", () => {
+    const cases: [number, string][] = [
+      [429, "rateLimited"],
+      [401, "unauthorized"],
+      [403, "unauthorized"],
+      [404, "notFound"],
+      [400, "validation"],
+      [422, "validation"],
+      [500, "server"],
+      [503, "server"],
+    ];
+    for (const [status, classification] of cases) {
+      const normalized = normalizeApiError(buildAxiosError({status}), CONTEXT);
+      expect(normalized.isAxios).toBe(true);
+      expect(normalized.statusCode).toBe(status);
+      expect(normalized.classification).toBe(classification as typeof normalized.classification);
+    }
+  });
+
+  it("extracts messages from a {message} response body", () => {
+    const error = buildAxiosError({data: {message: "Widget not found"}, status: 404});
+    const normalized = normalizeApiError(error, CONTEXT);
+    expect(normalized.messages).toEqual(["Widget not found"]);
+  });
+
+  it("extracts messages from a JSONAPI-style {errors: [{title, detail}]} body", () => {
+    const error = buildAxiosError({
+      data: {
+        errors: [
+          {detail: "name is required", title: "Validation failed"},
+          {title: "Another problem"},
+        ],
+      },
+      status: 422,
+    });
+    const normalized = normalizeApiError(error, CONTEXT);
+    expect(normalized.messages).toEqual(["Validation failed: name is required", "Another problem"]);
+  });
+
+  it("extracts a plain-string response body as the message", () => {
+    const error = buildAxiosError({data: "Service unavailable", status: 503});
+    const normalized = normalizeApiError(error, CONTEXT);
+    expect(normalized.messages).toEqual(["Service unavailable"]);
+  });
+
+  it("falls back to the axios error message when the body has no recognizable message", () => {
+    const error = buildAxiosError({data: {unexpected: true}, status: 500});
+    const normalized = normalizeApiError(error, CONTEXT);
+    expect(normalized.messages).toEqual(["Request failed with status code 500"]);
+  });
+
+  it("classifies an axios error without a response as network", () => {
+    const error = buildAxiosError({code: "ECONNREFUSED"});
+    const normalized = normalizeApiError(error, CONTEXT);
+    expect(normalized.isAxios).toBe(true);
+    expect(normalized.statusCode).toBeUndefined();
+    expect(normalized.classification).toBe("network");
+    expect(normalized.messages).toEqual(["Network Error"]);
+  });
+
+  it("classifies a plain Error as unknown and preserves its message", () => {
+    const normalized = normalizeApiError(new Error("boom"), CONTEXT);
+    expect(normalized.isAxios).toBe(false);
+    expect(normalized.statusCode).toBeUndefined();
+    expect(normalized.classification).toBe("unknown");
+    expect(normalized.messages).toEqual(["boom"]);
+  });
+
+  it("classifies a non-Error thrown value as unknown with a stringified message", () => {
+    const normalized = normalizeApiError("total failure", CONTEXT);
+    expect(normalized.classification).toBe("unknown");
+    expect(normalized.messages).toEqual(["total failure"]);
+  });
+
+  it("echoes apiName and operation for structured logging", () => {
+    const normalized = normalizeApiError(new Error("boom"), CONTEXT);
+    expect(normalized.apiName).toBe("testApi");
+    expect(normalized.operation).toBe("getWidget");
+  });
+});
+
+describe("withApiErrorHandling", () => {
+  it("returns the wrapped function's result on success and logs nothing", async () => {
+    const {logger, entries} = createRecordingLogger();
+    const result = await withApiErrorHandling(async () => "ok", {...CONTEXT, logger});
+    expect(result).toBe("ok");
+    expect(entries).toHaveLength(0);
+  });
+
+  it("logs the normalized error and rethrows the original error by default", async () => {
+    const {logger, entries} = createRecordingLogger();
+    const original = buildAxiosError({data: {message: "nope"}, status: 404});
+    let caught: unknown;
+    try {
+      await withApiErrorHandling(
+        async () => {
+          throw original;
+        },
+        {...CONTEXT, logger}
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBe(original);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].level).toBe("error");
+    expect(entries[0].msg).toContain("testApi");
+    expect(entries[0].msg).toContain("getWidget");
+    const normalized = entries[0].args[0] as {statusCode?: number; classification?: string};
+    expect(normalized.statusCode).toBe(404);
+    expect(normalized.classification).toBe("notFound");
+  });
+
+  it("converts to an APIError when rethrowAs is apiError", async () => {
+    const {logger} = createRecordingLogger();
+    let caught: unknown;
+    try {
+      await withApiErrorHandling(
+        async () => {
+          throw buildAxiosError({data: {message: "Rate limit exceeded"}, status: 429});
+        },
+        {...CONTEXT, logger, rethrowAs: "apiError"}
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(APIError);
+    const apiError = caught as APIError;
+    expect(apiError.status).toBe(429);
+    expect(apiError.title).toBe("testApi getWidget failed: Rate limit exceeded");
+  });
+
+  it("defaults the APIError status to 500 when the failure has no status code", async () => {
+    const {logger} = createRecordingLogger();
+    let caught: unknown;
+    try {
+      await withApiErrorHandling(
+        async () => {
+          throw new Error("boom");
+        },
+        {...CONTEXT, logger, rethrowAs: "apiError"}
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(APIError);
+    expect((caught as APIError).status).toBe(500);
+  });
+
+  it("applies the redactError hook before logging", async () => {
+    const {logger, entries} = createRecordingLogger();
+    let caught: unknown;
+    try {
+      await withApiErrorHandling(
+        async () => {
+          throw buildAxiosError({data: {message: "patient 12345 not found"}, status: 404});
+        },
+        {
+          ...CONTEXT,
+          logger,
+          redactError: (normalized) => ({...normalized, messages: ["[redacted]"]}),
+        }
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeDefined();
+    const logged = entries[0].args[0] as {messages: string[]};
+    expect(logged.messages).toEqual(["[redacted]"]);
+  });
+});

--- a/api/src/httpClient.test.ts
+++ b/api/src/httpClient.test.ts
@@ -711,3 +711,262 @@ describe("createAuthenticatedClient", () => {
     });
   });
 });
+
+describe("createAuthenticatedClient hardening", () => {
+  it("rejects without looping when the oauth2 token endpoint itself returns 401", async () => {
+    let tokenRequests = 0;
+    const server = await startTestServer((app) => {
+      app.post("/oauth/token", (_req, res) => {
+        tokenRequests += 1;
+        res.status(401).json({message: "invalid client credentials"});
+      });
+      app.get("/widgets", (_req, res) => {
+        res.json({ok: true});
+      });
+    });
+    try {
+      const client = createAuthenticatedClient({
+        auth: {
+          credentials: {clientId: "bad", clientSecret: "creds"},
+          refreshOn401: true,
+          tokenUrl: `${server.baseURL}/oauth/token`,
+          type: "oauth2",
+        },
+        baseURL: server.baseURL,
+      });
+      let caught: unknown;
+      try {
+        await client.axios.get("/widgets");
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toContain("token fetch");
+      expect(tokenRequests).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects clearly when the token response has no access_token", async () => {
+    const server = await startTestServer((app) => {
+      app.post("/oauth/token", (_req, res) => {
+        res.json({unexpected: "shape"});
+      });
+    });
+    try {
+      const client = createAuthenticatedClient({
+        auth: {
+          credentials: {clientId: "client-id", clientSecret: "client-secret"},
+          refreshOn401: true,
+          tokenUrl: `${server.baseURL}/oauth/token`,
+          type: "oauth2",
+        },
+        baseURL: server.baseURL,
+      });
+      let caught: unknown;
+      try {
+        await client.axios.get("/widgets");
+      } catch (error) {
+        caught = error;
+      }
+      expect((caught as Error).message).toContain("access_token");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("shares a single token fetch across concurrent first requests", async () => {
+    const server = await startTestServer((app) => {
+      app.get("/widgets", (_req, res) => {
+        res.json({ok: true});
+      });
+    });
+    try {
+      let tokenFetches = 0;
+      const client = createAuthenticatedClient({
+        auth: {
+          getToken: async () => {
+            tokenFetches += 1;
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            return "token-shared";
+          },
+          type: "bearer",
+        },
+        baseURL: server.baseURL,
+      });
+      await Promise.all([client.axios.get("/widgets"), client.axios.get("/widgets")]);
+      expect(tokenFetches).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("retries network errors and logs the retry attempts", async () => {
+    const server = await startTestServer(() => {});
+    const {baseURL} = server;
+    await server.close();
+    const {logger, entries} = createRecordingLogger();
+    const client = createAuthenticatedClient({
+      auth: {getToken: async () => "t", type: "bearer"},
+      baseURL,
+      logger,
+      retry: {baseDelayMs: 1, maxAttempts: 2},
+    });
+    let caught: unknown;
+    try {
+      await client.axios.get("/gone");
+    } catch (error) {
+      caught = error;
+    }
+    expect(isAxiosError(caught)).toBe(true);
+    const retryLogs = entries.filter((entry) => entry.msg.includes("retrying attempt"));
+    expect(retryLogs).toHaveLength(1);
+    expect(retryLogs[0].msg).toContain("attempt 2/2");
+    expect(retryLogs[0].msg).toContain("network");
+  });
+
+  it("prefers a numeric Retry-After header over backoff", async () => {
+    let attempts = 0;
+    const server = await startTestServer((app) => {
+      app.get("/limited", (_req, res) => {
+        attempts += 1;
+        if (attempts === 1) {
+          res.set("Retry-After", "0").status(429).json({message: "slow down"});
+          return;
+        }
+        res.json({ok: true});
+      });
+    });
+    try {
+      const {logger, entries} = createRecordingLogger();
+      const client = createAuthenticatedClient({
+        auth: {getToken: async () => "t", type: "bearer"},
+        baseURL: server.baseURL,
+        logger,
+        // A base delay far above the Retry-After value: if backoff were used the log
+        // would show >=100ms, so "in 0ms" proves the header took precedence.
+        retry: {baseDelayMs: 100},
+      });
+      await client.axios.get("/limited");
+      const retryLog = entries.find((entry) => entry.msg.includes("retrying attempt"));
+      expect(retryLog?.msg).toContain("in 0ms");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("falls back to backoff for a non-numeric Retry-After header", async () => {
+    let attempts = 0;
+    const server = await startTestServer((app) => {
+      app.get("/limited", (_req, res) => {
+        attempts += 1;
+        if (attempts === 1) {
+          res
+            .set("Retry-After", "Wed, 21 Oct 2015 07:28:00 GMT")
+            .status(429)
+            .json({message: "slow down"});
+          return;
+        }
+        res.json({ok: true});
+      });
+    });
+    try {
+      const {logger, entries} = createRecordingLogger();
+      const client = createAuthenticatedClient({
+        auth: {getToken: async () => "t", type: "bearer"},
+        baseURL: server.baseURL,
+        logger,
+        retry: FAST_RETRY,
+      });
+      await client.axios.get("/limited");
+      const retryLog = entries.find((entry) => entry.msg.includes("retrying attempt"));
+      expect(retryLog?.msg).toMatch(/in [1-9]\d*ms/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("caps an excessive Retry-After header at the delay ceiling", async () => {
+    let attempts = 0;
+    const server = await startTestServer((app) => {
+      app.get("/limited", (_req, res) => {
+        attempts += 1;
+        if (attempts === 1) {
+          res.set("Retry-After", "3600").status(429).json({message: "slow down"});
+          return;
+        }
+        res.json({ok: true});
+      });
+    });
+    try {
+      const {logger, entries} = createRecordingLogger();
+      const client = createAuthenticatedClient({
+        auth: {getToken: async () => "t", type: "bearer"},
+        baseURL: server.baseURL,
+        logger,
+        retry: {...FAST_RETRY, maxDelayMs: 2},
+      });
+      await client.axios.get("/limited");
+      const retryLog = entries.find((entry) => entry.msg.includes("retrying attempt"));
+      expect(retryLog?.msg).toContain("in 2ms");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("honors a custom retryOn list", async () => {
+    let attempts = 0;
+    const server = await startTestServer((app) => {
+      app.get("/missing", (_req, res) => {
+        attempts += 1;
+        if (attempts === 1) {
+          res.status(404).json({message: "not here yet"});
+          return;
+        }
+        res.json({ok: true});
+      });
+    });
+    try {
+      const client = createAuthenticatedClient({
+        auth: {getToken: async () => "t", type: "bearer"},
+        baseURL: server.baseURL,
+        retry: {...FAST_RETRY, retryOn: ["notFound"]},
+      });
+      const response = await client.axios.get("/missing");
+      expect(response.data.ok).toBe(true);
+      expect(attempts).toBe(2);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("uses the apiName option in normalized retry context instead of the baseURL", async () => {
+    let attempts = 0;
+    const server = await startTestServer((app) => {
+      app.get("/flaky", (_req, res) => {
+        attempts += 1;
+        if (attempts === 1) {
+          res.status(500).json({message: "boom"});
+          return;
+        }
+        res.json({ok: true});
+      });
+    });
+    try {
+      const {logger, entries} = createRecordingLogger();
+      const client = createAuthenticatedClient({
+        apiName: "widgetService",
+        auth: {getToken: async () => "t", type: "bearer"},
+        baseURL: server.baseURL,
+        logger,
+        retry: FAST_RETRY,
+      });
+      await client.axios.get("/flaky");
+      const retryLog = entries.find((entry) => entry.msg.includes("retrying attempt"));
+      expect(retryLog?.msg).toContain("[widgetService]");
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/api/src/httpClient.test.ts
+++ b/api/src/httpClient.test.ts
@@ -1,7 +1,6 @@
+import {describe, expect, it} from "bun:test";
 import type {Server} from "node:http";
 import type {AddressInfo} from "node:net";
-
-import {describe, expect, it} from "bun:test";
 import {AxiosError, type AxiosRequestHeaders, type AxiosResponse, isAxiosError} from "axios";
 import express from "express";
 

--- a/api/src/httpClient.test.ts
+++ b/api/src/httpClient.test.ts
@@ -112,6 +112,38 @@ describe("normalizeApiError", () => {
     expect(normalized.messages).toEqual(["Network Error"]);
   });
 
+  it("classifies a sub-400 response status as unknown", () => {
+    const normalized = normalizeApiError(buildAxiosError({status: 302}), CONTEXT);
+    expect(normalized.classification).toBe("unknown");
+    expect(normalized.statusCode).toBe(302);
+  });
+
+  it("extracts detail-only JSONAPI error entries", () => {
+    const error = buildAxiosError({data: {errors: [{detail: "just a detail"}]}, status: 400});
+    const normalized = normalizeApiError(error, CONTEXT);
+    expect(normalized.messages).toEqual(["just a detail"]);
+  });
+
+  it("falls back to the axios message for empty-string, empty-message, and empty-errors bodies", () => {
+    for (const data of ["", {message: ""}, {errors: []}]) {
+      const normalized = normalizeApiError(buildAxiosError({data, status: 500}), CONTEXT);
+      expect(normalized.messages).toEqual(["Request failed with status code 500"]);
+    }
+  });
+
+  it("falls back to the axios message when the errors array has no usable entries", () => {
+    const error = buildAxiosError({data: {errors: ["oops", null, 42, {title: 5}]}, status: 500});
+    const normalized = normalizeApiError(error, CONTEXT);
+    expect(normalized.messages).toEqual(["Request failed with status code 500"]);
+  });
+
+  it("truncates long plain-string bodies so unbounded payloads never reach the logger", () => {
+    const error = buildAxiosError({data: "x".repeat(2000), status: 503});
+    const normalized = normalizeApiError(error, CONTEXT);
+    expect(normalized.messages[0].length).toBeLessThanOrEqual(512);
+    expect(normalized.messages[0].endsWith("…")).toBe(true);
+  });
+
   it("classifies a plain Error as unknown and preserves its message", () => {
     const normalized = normalizeApiError(new Error("boom"), CONTEXT);
     expect(normalized.isAxios).toBe(false);
@@ -165,13 +197,14 @@ describe("withApiErrorHandling", () => {
     expect(normalized.classification).toBe("notFound");
   });
 
-  it("converts to an APIError when rethrowAs is apiError", async () => {
-    const {logger} = createRecordingLogger();
+  it("converts to an APIError when rethrowAs is apiError, logging via APIError only", async () => {
+    const {logger, entries} = createRecordingLogger();
+    const original = buildAxiosError({data: {message: "Rate limit exceeded"}, status: 429});
     let caught: unknown;
     try {
       await withApiErrorHandling(
         async () => {
-          throw buildAxiosError({data: {message: "Rate limit exceeded"}, status: 429});
+          throw original;
         },
         {...CONTEXT, logger, rethrowAs: "apiError"}
       );
@@ -181,7 +214,12 @@ describe("withApiErrorHandling", () => {
     expect(caught).toBeInstanceOf(APIError);
     const apiError = caught as APIError;
     expect(apiError.status).toBe(429);
-    expect(apiError.title).toBe("testApi getWidget failed: Rate limit exceeded");
+    expect(apiError.title).toBe("testApi getWidget request failed");
+    expect(apiError.detail).toBe("Rate limit exceeded");
+    expect(apiError.error).toBe(original);
+    expect(apiError.meta?.classification).toBe("rateLimited");
+    // Logged exactly once: the APIError constructor logs, so the wrapper must not.
+    expect(entries).toHaveLength(0);
   });
 
   it("defaults the APIError status to 500 when the failure has no status code", async () => {
@@ -201,13 +239,30 @@ describe("withApiErrorHandling", () => {
     expect((caught as APIError).status).toBe(500);
   });
 
-  it("applies the redactError hook before logging", async () => {
-    const {logger, entries} = createRecordingLogger();
+  it("clamps sub-400 response statuses to a 500 APIError", async () => {
+    const {logger} = createRecordingLogger();
     let caught: unknown;
     try {
       await withApiErrorHandling(
         async () => {
-          throw buildAxiosError({data: {message: "patient 12345 not found"}, status: 404});
+          throw buildAxiosError({status: 302});
+        },
+        {...CONTEXT, logger, rethrowAs: "apiError"}
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as APIError).status).toBe(500);
+  });
+
+  it("applies the redactError hook before logging", async () => {
+    const {logger, entries} = createRecordingLogger();
+    const original = buildAxiosError({data: {message: "patient 12345 not found"}, status: 404});
+    let caught: unknown;
+    try {
+      await withApiErrorHandling(
+        async () => {
+          throw original;
         },
         {
           ...CONTEXT,
@@ -218,8 +273,52 @@ describe("withApiErrorHandling", () => {
     } catch (error) {
       caught = error;
     }
-    expect(caught).toBeDefined();
+    expect(caught).toBe(original);
     const logged = entries[0].args[0] as {messages: string[]};
     expect(logged.messages).toEqual(["[redacted]"]);
+  });
+
+  it("uses redacted messages in the APIError detail when combined with rethrowAs apiError", async () => {
+    const {logger} = createRecordingLogger();
+    let caught: unknown;
+    try {
+      await withApiErrorHandling(
+        async () => {
+          throw buildAxiosError({data: {message: "patient 12345 not found"}, status: 404});
+        },
+        {
+          ...CONTEXT,
+          logger,
+          redactError: (normalized) => ({...normalized, messages: ["[redacted]"]}),
+          rethrowAs: "apiError",
+        }
+      );
+    } catch (error) {
+      caught = error;
+    }
+    const apiError = caught as APIError;
+    expect(apiError.detail).toBe("[redacted]");
+    expect(apiError.message).not.toContain("patient 12345");
+  });
+
+  it("falls back to a generic detail when redactError strips all messages", async () => {
+    const {logger} = createRecordingLogger();
+    let caught: unknown;
+    try {
+      await withApiErrorHandling(
+        async () => {
+          throw buildAxiosError({data: {message: "sensitive"}, status: 404});
+        },
+        {
+          ...CONTEXT,
+          logger,
+          redactError: (normalized) => ({...normalized, messages: []}),
+          rethrowAs: "apiError",
+        }
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as APIError).detail).toBe("unknown error");
   });
 });

--- a/api/src/httpClient.test.ts
+++ b/api/src/httpClient.test.ts
@@ -1,8 +1,37 @@
+import type {Server} from "node:http";
+import type {AddressInfo} from "node:net";
+
 import {describe, expect, it} from "bun:test";
-import {AxiosError, type AxiosRequestHeaders, type AxiosResponse} from "axios";
+import {AxiosError, type AxiosRequestHeaders, type AxiosResponse, isAxiosError} from "axios";
+import express from "express";
 
 import {APIError} from "./errors";
-import {type HttpClientLogger, normalizeApiError, withApiErrorHandling} from "./httpClient";
+import {
+  createAuthenticatedClient,
+  type HttpClientLogger,
+  normalizeApiError,
+  withApiErrorHandling,
+} from "./httpClient";
+
+const startTestServer = async (
+  configure: (app: express.Express) => void
+): Promise<{baseURL: string; close: () => Promise<void>}> => {
+  const app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({extended: false}));
+  configure(app);
+  const server = await new Promise<Server>((resolve) => {
+    const listening = app.listen(0, () => resolve(listening));
+  });
+  const {port} = server.address() as AddressInfo;
+  return {
+    baseURL: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+  };
+};
+
+// Tests use a 1ms base delay so retry backoff doesn't slow the suite.
+const FAST_RETRY = {baseDelayMs: 1};
 
 const createRecordingLogger = (): {
   logger: HttpClientLogger;
@@ -320,5 +349,365 @@ describe("withApiErrorHandling", () => {
       caught = error;
     }
     expect((caught as APIError).detail).toBe("unknown error");
+  });
+});
+
+describe("createAuthenticatedClient", () => {
+  describe("bearer strategy", () => {
+    it("attaches the Authorization header and caches the token across requests", async () => {
+      const seenAuthHeaders: (string | undefined)[] = [];
+      const server = await startTestServer((app) => {
+        app.get("/widgets", (req, res) => {
+          seenAuthHeaders.push(req.headers.authorization);
+          res.json({ok: true});
+        });
+      });
+      try {
+        let tokenFetches = 0;
+        const client = createAuthenticatedClient({
+          auth: {
+            getToken: async () => {
+              tokenFetches += 1;
+              return "token-abc";
+            },
+            type: "bearer",
+          },
+          baseURL: server.baseURL,
+        });
+        await client.axios.get("/widgets");
+        await client.axios.get("/widgets");
+        expect(seenAuthHeaders).toEqual(["Bearer token-abc", "Bearer token-abc"]);
+        expect(tokenFetches).toBe(1);
+      } finally {
+        await server.close();
+      }
+    });
+
+    it("re-fetches the token after invalidateToken", async () => {
+      const server = await startTestServer((app) => {
+        app.get("/widgets", (_req, res) => {
+          res.json({ok: true});
+        });
+      });
+      try {
+        let tokenFetches = 0;
+        const client = createAuthenticatedClient({
+          auth: {
+            getToken: async () => {
+              tokenFetches += 1;
+              return `token-${tokenFetches}`;
+            },
+            type: "bearer",
+          },
+          baseURL: server.baseURL,
+        });
+        await client.axios.get("/widgets");
+        client.invalidateToken();
+        await client.axios.get("/widgets");
+        expect(tokenFetches).toBe(2);
+      } finally {
+        await server.close();
+      }
+    });
+  });
+
+  describe("apiKey strategy", () => {
+    it("attaches the key to the configured header", async () => {
+      const seenKeys: (string | undefined)[] = [];
+      const server = await startTestServer((app) => {
+        app.get("/widgets", (req, res) => {
+          seenKeys.push(req.headers["x-api-key"] as string | undefined);
+          res.json({ok: true});
+        });
+      });
+      try {
+        const client = createAuthenticatedClient({
+          auth: {getKey: async () => "secret-key", header: "X-Api-Key", type: "apiKey"},
+          baseURL: server.baseURL,
+        });
+        await client.axios.get("/widgets");
+        expect(seenKeys).toEqual(["secret-key"]);
+      } finally {
+        await server.close();
+      }
+    });
+  });
+
+  describe("oauth2 strategy", () => {
+    const configureOauthServer = (
+      app: express.Express,
+      state: {tokenFetches: number; validToken: string}
+    ): void => {
+      app.post("/oauth/token", (req, res) => {
+        state.tokenFetches += 1;
+        const authHeader = req.headers.authorization ?? "";
+        const decoded = Buffer.from(authHeader.replace("Basic ", ""), "base64").toString();
+        if (decoded !== "client-id:client-secret" || req.body.grant_type !== "client_credentials") {
+          res.status(400).json({message: "bad token request"});
+          return;
+        }
+        res.json({access_token: state.validToken});
+      });
+    };
+
+    it("fetches a client-credentials token and sends it as a bearer", async () => {
+      const state = {tokenFetches: 0, validToken: "oauth-token-1"};
+      const seenAuthHeaders: (string | undefined)[] = [];
+      const server = await startTestServer((app) => {
+        configureOauthServer(app, state);
+        app.get("/widgets", (req, res) => {
+          seenAuthHeaders.push(req.headers.authorization);
+          res.json({ok: true});
+        });
+      });
+      try {
+        const client = createAuthenticatedClient({
+          auth: {
+            credentials: {clientId: "client-id", clientSecret: "client-secret"},
+            refreshOn401: true,
+            tokenUrl: `${server.baseURL}/oauth/token`,
+            type: "oauth2",
+          },
+          baseURL: server.baseURL,
+        });
+        await client.axios.get("/widgets");
+        await client.axios.get("/widgets");
+        expect(seenAuthHeaders).toEqual(["Bearer oauth-token-1", "Bearer oauth-token-1"]);
+        expect(state.tokenFetches).toBe(1);
+      } finally {
+        await server.close();
+      }
+    });
+
+    it("refreshes the token and retries exactly once on a 401", async () => {
+      const state = {tokenFetches: 0, validToken: "stale-token"};
+      const server = await startTestServer((app) => {
+        configureOauthServer(app, state);
+        app.get("/widgets", (req, res) => {
+          if (req.headers.authorization === "Bearer fresh-token") {
+            res.json({ok: true});
+            return;
+          }
+          // Invalidate the stale token server-side so the refresh fetches a good one.
+          state.validToken = "fresh-token";
+          res.status(401).json({message: "expired"});
+        });
+      });
+      try {
+        const client = createAuthenticatedClient({
+          auth: {
+            credentials: {clientId: "client-id", clientSecret: "client-secret"},
+            refreshOn401: true,
+            tokenUrl: `${server.baseURL}/oauth/token`,
+            type: "oauth2",
+          },
+          baseURL: server.baseURL,
+        });
+        const response = await client.axios.get("/widgets");
+        expect(response.data.ok).toBe(true);
+        expect(state.tokenFetches).toBe(2);
+      } finally {
+        await server.close();
+      }
+    });
+
+    it("propagates a persistent 401 after a single refresh attempt", async () => {
+      const state = {tokenFetches: 0, validToken: "always-stale"};
+      let widgetRequests = 0;
+      const server = await startTestServer((app) => {
+        configureOauthServer(app, state);
+        app.get("/widgets", (_req, res) => {
+          widgetRequests += 1;
+          res.status(401).json({message: "still expired"});
+        });
+      });
+      try {
+        const client = createAuthenticatedClient({
+          auth: {
+            credentials: {clientId: "client-id", clientSecret: "client-secret"},
+            refreshOn401: true,
+            tokenUrl: `${server.baseURL}/oauth/token`,
+            type: "oauth2",
+          },
+          baseURL: server.baseURL,
+        });
+        let caught: unknown;
+        try {
+          await client.axios.get("/widgets");
+        } catch (error) {
+          caught = error;
+        }
+        expect(isAxiosError(caught)).toBe(true);
+        expect((caught as AxiosError).response?.status).toBe(401);
+        expect(widgetRequests).toBe(2);
+        expect(state.tokenFetches).toBe(2);
+      } finally {
+        await server.close();
+      }
+    });
+  });
+
+  describe("retry policy", () => {
+    const NO_AUTH = {getToken: async () => "t", type: "bearer"} as const;
+
+    it("retries an idempotent GET on 5xx and succeeds within maxAttempts", async () => {
+      let attempts = 0;
+      const server = await startTestServer((app) => {
+        app.get("/flaky", (_req, res) => {
+          attempts += 1;
+          if (attempts < 3) {
+            res.status(500).json({message: "boom"});
+            return;
+          }
+          res.json({ok: true});
+        });
+      });
+      try {
+        const client = createAuthenticatedClient({
+          auth: NO_AUTH,
+          baseURL: server.baseURL,
+          retry: FAST_RETRY,
+        });
+        const response = await client.axios.get("/flaky");
+        expect(response.data.ok).toBe(true);
+        expect(attempts).toBe(3);
+      } finally {
+        await server.close();
+      }
+    });
+
+    it("retries a GET on 429 rate limiting", async () => {
+      let attempts = 0;
+      const server = await startTestServer((app) => {
+        app.get("/limited", (_req, res) => {
+          attempts += 1;
+          if (attempts === 1) {
+            res.set("Retry-After", "0").status(429).json({message: "slow down"});
+            return;
+          }
+          res.json({ok: true});
+        });
+      });
+      try {
+        const client = createAuthenticatedClient({
+          auth: NO_AUTH,
+          baseURL: server.baseURL,
+          retry: FAST_RETRY,
+        });
+        const response = await client.axios.get("/limited");
+        expect(response.data.ok).toBe(true);
+        expect(attempts).toBe(2);
+      } finally {
+        await server.close();
+      }
+    });
+
+    it("rejects with the original error once maxAttempts is exhausted", async () => {
+      let attempts = 0;
+      const server = await startTestServer((app) => {
+        app.get("/down", (_req, res) => {
+          attempts += 1;
+          res.status(503).json({message: "unavailable"});
+        });
+      });
+      try {
+        const client = createAuthenticatedClient({
+          auth: NO_AUTH,
+          baseURL: server.baseURL,
+          retry: {...FAST_RETRY, maxAttempts: 2},
+        });
+        let caught: unknown;
+        try {
+          await client.axios.get("/down");
+        } catch (error) {
+          caught = error;
+        }
+        expect(isAxiosError(caught)).toBe(true);
+        expect((caught as AxiosError).response?.status).toBe(503);
+        expect(attempts).toBe(2);
+      } finally {
+        await server.close();
+      }
+    });
+
+    it("does not retry a POST by default even on 5xx", async () => {
+      let attempts = 0;
+      const server = await startTestServer((app) => {
+        app.post("/orders", (_req, res) => {
+          attempts += 1;
+          res.status(500).json({message: "boom"});
+        });
+      });
+      try {
+        const client = createAuthenticatedClient({
+          auth: NO_AUTH,
+          baseURL: server.baseURL,
+          retry: FAST_RETRY,
+        });
+        let caught: unknown;
+        try {
+          await client.axios.post("/orders", {widget: 1});
+        } catch (error) {
+          caught = error;
+        }
+        expect(isAxiosError(caught)).toBe(true);
+        expect(attempts).toBe(1);
+      } finally {
+        await server.close();
+      }
+    });
+
+    it("retries a POST when the request opts in with retryUnsafe", async () => {
+      let attempts = 0;
+      const server = await startTestServer((app) => {
+        app.post("/orders", (_req, res) => {
+          attempts += 1;
+          if (attempts === 1) {
+            res.status(500).json({message: "boom"});
+            return;
+          }
+          res.json({ok: true});
+        });
+      });
+      try {
+        const client = createAuthenticatedClient({
+          auth: NO_AUTH,
+          baseURL: server.baseURL,
+          retry: FAST_RETRY,
+        });
+        const response = await client.axios.post("/orders", {widget: 1}, {retryUnsafe: true});
+        expect(response.data.ok).toBe(true);
+        expect(attempts).toBe(2);
+      } finally {
+        await server.close();
+      }
+    });
+
+    it("does not retry non-retryable classifications like validation errors", async () => {
+      let attempts = 0;
+      const server = await startTestServer((app) => {
+        app.get("/bad", (_req, res) => {
+          attempts += 1;
+          res.status(400).json({message: "bad request"});
+        });
+      });
+      try {
+        const client = createAuthenticatedClient({
+          auth: NO_AUTH,
+          baseURL: server.baseURL,
+          retry: FAST_RETRY,
+        });
+        let caught: unknown;
+        try {
+          await client.axios.get("/bad");
+        } catch (error) {
+          caught = error;
+        }
+        expect((caught as AxiosError).response?.status).toBe(400);
+        expect(attempts).toBe(1);
+      } finally {
+        await server.close();
+      }
+    });
   });
 });

--- a/api/src/httpClient.ts
+++ b/api/src/httpClient.ts
@@ -1,7 +1,21 @@
-import axios from "axios";
+import axios, {type AxiosInstance, type InternalAxiosRequestConfig} from "axios";
 
 import {APIError} from "./errors";
 import {logger as defaultLogger} from "./logger";
+
+declare module "axios" {
+  export interface AxiosRequestConfig {
+    // Opts a non-idempotent request (POST/PUT/PATCH/DELETE) into the retry policy.
+    // Callers must be sure the operation is safe to repeat.
+    retryUnsafe?: boolean;
+  }
+}
+
+// Internal per-request state tracked on the axios config across interceptor retries.
+interface RetryState {
+  __httpClientRetryCount?: number;
+  __httpClientDidAuthRefresh?: boolean;
+}
 
 /**
  * Minimal logging surface used by the HTTP client utilities so consumers (and tests)
@@ -197,4 +211,185 @@ export const withApiErrorHandling = async <T>(
     log.error(`[${options.apiName}] ${options.operation} failed`, normalized);
     throw error;
   }
+};
+
+export type AuthStrategy =
+  | {type: "bearer"; getToken: () => Promise<string>}
+  | {
+      type: "oauth2";
+      tokenUrl: string;
+      credentials: {clientId: string; clientSecret: string};
+      // When true, a 401 response invalidates the cached token and the request is
+      // retried once with a freshly fetched token before the failure propagates.
+      refreshOn401: boolean;
+    }
+  | {type: "apiKey"; header: string; getKey: () => Promise<string>};
+
+export interface RetryPolicy {
+  // Total attempts including the first request.
+  maxAttempts: number;
+  retryOn: ApiErrorClassification[];
+  // Base for exponential backoff with jitter; a Retry-After response header takes
+  // precedence when present and parseable.
+  baseDelayMs: number;
+}
+
+const DEFAULT_RETRY_POLICY: RetryPolicy = {
+  baseDelayMs: 250,
+  maxAttempts: 3,
+  retryOn: ["rateLimited", "server", "network"],
+};
+
+// Retries apply only to these methods unless a request sets `retryUnsafe: true` —
+// repeating a failed POST against an external service can duplicate side effects.
+const IDEMPOTENT_METHODS = ["get", "head", "options"];
+
+export interface CreateAuthenticatedClientOptions {
+  baseURL: string;
+  auth: AuthStrategy;
+  retry?: Partial<RetryPolicy>;
+  logger?: HttpClientLogger;
+  // Rewrites the normalized error before it is logged — for consumers with bespoke
+  // redaction/classification needs.
+  redactError?: (normalized: NormalizedApiError) => NormalizedApiError;
+}
+
+export interface AuthenticatedClient {
+  axios: AxiosInstance;
+  // Drops the cached token so the next request re-authenticates.
+  invalidateToken: () => void;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const parseRetryAfterMs = (headerValue: unknown): number | undefined => {
+  if (typeof headerValue !== "string") {
+    return undefined;
+  }
+  const seconds = Number(headerValue);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds * 1000;
+  }
+  return undefined;
+};
+
+/**
+ * Creates an axios instance with a pluggable auth strategy, token caching, and a retry
+ * policy for transient failures.
+ *
+ * Auth: tokens/keys are fetched lazily on the first request and cached on the client;
+ * `invalidateToken()` drops the cache. The oauth2 strategy fetches a client-credentials
+ * token (HTTP Basic auth, form-encoded `grant_type=client_credentials`) and, with
+ * `refreshOn401`, refreshes and retries exactly once when a request returns 401.
+ *
+ * Retries: failures classified in `retry.retryOn` (default: rateLimited, server,
+ * network) are retried with exponential backoff and jitter up to `maxAttempts` total
+ * attempts, honoring a parseable Retry-After header. Only idempotent methods
+ * (GET/HEAD/OPTIONS) are retried unless the request sets `retryUnsafe: true`.
+ *
+ * Logging: the client logs retries and token refreshes at debug level only and always
+ * rejects with the original axios error — error-level logging is left to the call site
+ * (typically via withApiErrorHandling) so composed usage logs each failure exactly once.
+ */
+export const createAuthenticatedClient = (
+  options: CreateAuthenticatedClientOptions
+): AuthenticatedClient => {
+  const log = options.logger ?? defaultLogger;
+  const retryPolicy: RetryPolicy = {...DEFAULT_RETRY_POLICY, ...options.retry};
+  let cachedToken: string | undefined;
+
+  const fetchToken = async (): Promise<string> => {
+    const {auth} = options;
+    if (auth.type === "bearer") {
+      return auth.getToken();
+    }
+    if (auth.type === "apiKey") {
+      return auth.getKey();
+    }
+    const response = await axios.post(
+      auth.tokenUrl,
+      new URLSearchParams({grant_type: "client_credentials"}),
+      {
+        auth: {password: auth.credentials.clientSecret, username: auth.credentials.clientId},
+        headers: {"Content-Type": "application/x-www-form-urlencoded"},
+      }
+    );
+    return response.data.access_token;
+  };
+
+  const getCachedToken = async (): Promise<string> => {
+    if (cachedToken === undefined) {
+      cachedToken = await fetchToken();
+    }
+    return cachedToken;
+  };
+
+  const instance = axios.create({baseURL: options.baseURL});
+
+  instance.interceptors.request.use(async (config): Promise<InternalAxiosRequestConfig> => {
+    const token = await getCachedToken();
+    if (options.auth.type === "apiKey") {
+      config.headers.set(options.auth.header, token);
+    } else {
+      config.headers.set("Authorization", `Bearer ${token}`);
+    }
+    return config;
+  });
+
+  instance.interceptors.response.use(undefined, async (error: unknown) => {
+    if (!axios.isAxiosError(error) || !error.config) {
+      throw error;
+    }
+    const config = error.config as InternalAxiosRequestConfig & RetryState;
+    let normalized = normalizeApiError(error, {
+      apiName: options.baseURL,
+      operation: `${config.method ?? "request"} ${config.url ?? ""}`,
+    });
+    if (options.redactError) {
+      normalized = options.redactError(normalized);
+    }
+
+    // One-shot token refresh on 401 for oauth2 strategies.
+    if (
+      options.auth.type === "oauth2" &&
+      options.auth.refreshOn401 &&
+      error.response?.status === 401 &&
+      !config.__httpClientDidAuthRefresh
+    ) {
+      config.__httpClientDidAuthRefresh = true;
+      cachedToken = undefined;
+      log.debug(`[httpClient] ${normalized.operation} got 401, refreshing token and retrying`);
+      return instance.request(config);
+    }
+
+    const method = (config.method ?? "get").toLowerCase();
+    const isRetryableMethod = IDEMPOTENT_METHODS.includes(method) || config.retryUnsafe === true;
+    const attemptsSoFar = (config.__httpClientRetryCount ?? 0) + 1;
+    if (
+      !retryPolicy.retryOn.includes(normalized.classification) ||
+      !isRetryableMethod ||
+      attemptsSoFar >= retryPolicy.maxAttempts
+    ) {
+      throw error;
+    }
+
+    config.__httpClientRetryCount = attemptsSoFar;
+    const backoffMs =
+      retryPolicy.baseDelayMs * 2 ** (attemptsSoFar - 1) * (1 + Math.random() * 0.5);
+    const retryAfterMs = parseRetryAfterMs(error.response?.headers?.["retry-after"]);
+    const delayMs = retryAfterMs ?? backoffMs;
+    log.debug(
+      `[httpClient] ${normalized.operation} failed (${normalized.classification}), ` +
+        `retrying attempt ${attemptsSoFar + 1}/${retryPolicy.maxAttempts} in ${Math.round(delayMs)}ms`
+    );
+    await sleep(delayMs);
+    return instance.request(config);
+  });
+
+  return {
+    axios: instance,
+    invalidateToken: (): void => {
+      cachedToken = undefined;
+    },
+  };
 };

--- a/api/src/httpClient.ts
+++ b/api/src/httpClient.ts
@@ -1,29 +1,35 @@
-import axios, {type AxiosInstance, type InternalAxiosRequestConfig} from "axios";
+import axios, {
+  type AxiosInstance,
+  type AxiosRequestConfig,
+  type InternalAxiosRequestConfig,
+} from "axios";
 
 import {APIError} from "./errors";
 import {logger as defaultLogger} from "./logger";
 
-// Note: this augmentation is global — `retryUnsafe` appears on every axios config type in
-// consumer apps, but it only has an effect on instances created by createAuthenticatedClient.
-// Retried request bodies must be replayable: JSON objects are fine, but streams/FormData are
-// consumed on first send and cannot be retried.
-declare module "axios" {
-  export interface AxiosRequestConfig {
-    // Opts a non-idempotent request (POST/PUT/PATCH/DELETE) into the retry policy.
-    // Callers must be sure the operation is safe to repeat.
-    retryUnsafe?: boolean;
-  }
-}
-
 // Internal per-request state tracked on the axios config across interceptor retries.
 // __httpClientManaged marks configs that passed through this client's request interceptor —
 // errors from foreign configs (e.g. the oauth2 token POST itself) must never be refreshed
-// or retried here, or a failing token endpoint would loop forever.
+// or retried here, or a failing token endpoint would loop forever. retryUnsafe is set by
+// markRetryUnsafe() rather than a global axios module augmentation so the flag stays
+// scoped to this module's API and cannot be silently misapplied to unrelated axios usage.
 interface RetryState {
   __httpClientRetryCount?: number;
   __httpClientDidAuthRefresh?: boolean;
   __httpClientManaged?: boolean;
+  retryUnsafe?: boolean;
 }
+
+/**
+ * Opts a non-idempotent request (POST/PUT/PATCH/DELETE) into the retry policy of a
+ * createAuthenticatedClient instance: `client.axios.post(url, body, markRetryUnsafe())`.
+ * Callers must be sure the operation is safe to repeat, and the request body must be
+ * replayable — JSON objects are fine, but streams/FormData are consumed on first send.
+ * Has no effect on axios instances not created by createAuthenticatedClient.
+ */
+export const markRetryUnsafe = (config: AxiosRequestConfig = {}): AxiosRequestConfig => {
+  return {...config, retryUnsafe: true} as AxiosRequestConfig & RetryState;
+};
 
 /**
  * Minimal logging surface used by the HTTP client utilities so consumers (and tests)
@@ -252,7 +258,7 @@ const DEFAULT_RETRY_POLICY: RetryPolicy = {
   retryOn: ["rateLimited", "server", "network"],
 };
 
-// Retries apply only to these methods unless a request sets `retryUnsafe: true` —
+// Retries apply only to these methods unless a request opts in via markRetryUnsafe() —
 // repeating a failed POST against an external service can duplicate side effects.
 const IDEMPOTENT_METHODS = ["get", "head", "options"];
 
@@ -302,7 +308,7 @@ const parseRetryAfterMs = (headerValue: unknown): number | undefined => {
  * Retries: failures classified in `retry.retryOn` (default: rateLimited, server,
  * network) are retried with exponential backoff and jitter up to `maxAttempts` total
  * attempts, honoring a parseable Retry-After header. Only idempotent methods
- * (GET/HEAD/OPTIONS) are retried unless the request sets `retryUnsafe: true`.
+ * (GET/HEAD/OPTIONS) are retried unless the request opts in via markRetryUnsafe().
  *
  * Logging: the client logs retries and token refreshes at debug level only and always
  * rejects with the original axios error — error-level logging is left to the call site

--- a/api/src/httpClient.ts
+++ b/api/src/httpClient.ts
@@ -3,6 +3,10 @@ import axios, {type AxiosInstance, type InternalAxiosRequestConfig} from "axios"
 import {APIError} from "./errors";
 import {logger as defaultLogger} from "./logger";
 
+// Note: this augmentation is global — `retryUnsafe` appears on every axios config type in
+// consumer apps, but it only has an effect on instances created by createAuthenticatedClient.
+// Retried request bodies must be replayable: JSON objects are fine, but streams/FormData are
+// consumed on first send and cannot be retried.
 declare module "axios" {
   export interface AxiosRequestConfig {
     // Opts a non-idempotent request (POST/PUT/PATCH/DELETE) into the retry policy.
@@ -12,9 +16,13 @@ declare module "axios" {
 }
 
 // Internal per-request state tracked on the axios config across interceptor retries.
+// __httpClientManaged marks configs that passed through this client's request interceptor —
+// errors from foreign configs (e.g. the oauth2 token POST itself) must never be refreshed
+// or retried here, or a failing token endpoint would loop forever.
 interface RetryState {
   __httpClientRetryCount?: number;
   __httpClientDidAuthRefresh?: boolean;
+  __httpClientManaged?: boolean;
 }
 
 /**
@@ -232,11 +240,15 @@ export interface RetryPolicy {
   // Base for exponential backoff with jitter; a Retry-After response header takes
   // precedence when present and parseable.
   baseDelayMs: number;
+  // Ceiling for any single delay, including server-provided Retry-After values, so a
+  // hostile or misconfigured server cannot make the client sleep indefinitely.
+  maxDelayMs: number;
 }
 
 const DEFAULT_RETRY_POLICY: RetryPolicy = {
   baseDelayMs: 250,
   maxAttempts: 3,
+  maxDelayMs: 30_000,
   retryOn: ["rateLimited", "server", "network"],
 };
 
@@ -246,11 +258,15 @@ const IDEMPOTENT_METHODS = ["get", "head", "options"];
 
 export interface CreateAuthenticatedClientOptions {
   baseURL: string;
+  // Service name used in normalized error context and log prefixes (e.g. "fitbit");
+  // defaults to the baseURL.
+  apiName?: string;
   auth: AuthStrategy;
   retry?: Partial<RetryPolicy>;
   logger?: HttpClientLogger;
-  // Rewrites the normalized error before it is logged — for consumers with bespoke
-  // redaction/classification needs.
+  // Rewrites the normalized error before it is logged. Note the returned classification
+  // also feeds the retry decision, so hooks should redact messages rather than rewrite
+  // classifications unless changing retry behavior is intended.
   redactError?: (normalized: NormalizedApiError) => NormalizedApiError;
 }
 
@@ -263,13 +279,14 @@ export interface AuthenticatedClient {
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 const parseRetryAfterMs = (headerValue: unknown): number | undefined => {
-  if (typeof headerValue !== "string") {
+  if (typeof headerValue !== "string" || headerValue.trim() === "") {
     return undefined;
   }
   const seconds = Number(headerValue);
   if (Number.isFinite(seconds) && seconds >= 0) {
     return seconds * 1000;
   }
+  // HTTP-date form falls back to backoff rather than date math.
   return undefined;
 };
 
@@ -295,8 +312,13 @@ export const createAuthenticatedClient = (
   options: CreateAuthenticatedClientOptions
 ): AuthenticatedClient => {
   const log = options.logger ?? defaultLogger;
+  const apiName = options.apiName ?? options.baseURL;
   const retryPolicy: RetryPolicy = {...DEFAULT_RETRY_POLICY, ...options.retry};
-  let cachedToken: string | undefined;
+  // The in-flight promise is cached (not the resolved value) so concurrent first
+  // requests share a single token fetch. resolvedToken tracks the last issued token so
+  // a 401 only invalidates the cache if a newer token hasn't already replaced it.
+  let tokenPromise: Promise<string> | undefined;
+  let resolvedToken: string | undefined;
 
   const fetchToken = async (): Promise<string> => {
     const {auth} = options;
@@ -314,19 +336,46 @@ export const createAuthenticatedClient = (
         headers: {"Content-Type": "application/x-www-form-urlencoded"},
       }
     );
-    return response.data.access_token;
+    const accessToken = response.data?.access_token;
+    if (typeof accessToken !== "string" || accessToken.length === 0) {
+      throw new Error(`[httpClient] ${apiName} token response has no access_token`);
+    }
+    return accessToken;
   };
 
-  const getCachedToken = async (): Promise<string> => {
-    if (cachedToken === undefined) {
-      cachedToken = await fetchToken();
+  const invalidateToken = (): void => {
+    tokenPromise = undefined;
+    resolvedToken = undefined;
+  };
+
+  const getCachedToken = (): Promise<string> => {
+    if (!tokenPromise) {
+      tokenPromise = fetchToken().then(
+        (token) => {
+          resolvedToken = token;
+          return token;
+        },
+        (error) => {
+          // Clear the failed fetch so the next request retries, and wrap the failure in
+          // a plain Error: the raw token-request AxiosError must never reach the response
+          // interceptor's refresh/retry logic (see __httpClientManaged).
+          invalidateToken();
+          const normalized = normalizeApiError(error, {apiName, operation: "token fetch"});
+          const wrapped = new Error(
+            `[httpClient] ${apiName} token fetch failed: ${normalized.messages[0]}`
+          );
+          (wrapped as Error & {cause?: unknown}).cause = error;
+          throw wrapped;
+        }
+      );
     }
-    return cachedToken;
+    return tokenPromise;
   };
 
   const instance = axios.create({baseURL: options.baseURL});
 
   instance.interceptors.request.use(async (config): Promise<InternalAxiosRequestConfig> => {
+    (config as InternalAxiosRequestConfig & RetryState).__httpClientManaged = true;
     const token = await getCachedToken();
     if (options.auth.type === "apiKey") {
       config.headers.set(options.auth.header, token);
@@ -341,8 +390,13 @@ export const createAuthenticatedClient = (
       throw error;
     }
     const config = error.config as InternalAxiosRequestConfig & RetryState;
+    // Errors from configs this client didn't manage (e.g. a failing token POST) must
+    // propagate untouched — refreshing or retrying them can loop forever.
+    if (!config.__httpClientManaged) {
+      throw error;
+    }
     let normalized = normalizeApiError(error, {
-      apiName: options.baseURL,
+      apiName,
       operation: `${config.method ?? "request"} ${config.url ?? ""}`,
     });
     if (options.redactError) {
@@ -357,8 +411,13 @@ export const createAuthenticatedClient = (
       !config.__httpClientDidAuthRefresh
     ) {
       config.__httpClientDidAuthRefresh = true;
-      cachedToken = undefined;
-      log.debug(`[httpClient] ${normalized.operation} got 401, refreshing token and retrying`);
+      // Only invalidate if this request failed with the current token — a concurrent
+      // request may have already refreshed it.
+      const sentAuthorization = config.headers.get("Authorization");
+      if (resolvedToken === undefined || sentAuthorization === `Bearer ${resolvedToken}`) {
+        invalidateToken();
+      }
+      log.debug(`[${apiName}] ${normalized.operation} got 401, refreshing token and retrying`);
       return instance.request(config);
     }
 
@@ -377,19 +436,14 @@ export const createAuthenticatedClient = (
     const backoffMs =
       retryPolicy.baseDelayMs * 2 ** (attemptsSoFar - 1) * (1 + Math.random() * 0.5);
     const retryAfterMs = parseRetryAfterMs(error.response?.headers?.["retry-after"]);
-    const delayMs = retryAfterMs ?? backoffMs;
+    const delayMs = Math.min(retryAfterMs ?? backoffMs, retryPolicy.maxDelayMs);
     log.debug(
-      `[httpClient] ${normalized.operation} failed (${normalized.classification}), ` +
+      `[${apiName}] ${normalized.operation} failed (${normalized.classification}), ` +
         `retrying attempt ${attemptsSoFar + 1}/${retryPolicy.maxAttempts} in ${Math.round(delayMs)}ms`
     );
     await sleep(delayMs);
     return instance.request(config);
   });
 
-  return {
-    axios: instance,
-    invalidateToken: (): void => {
-      cachedToken = undefined;
-    },
-  };
+  return {axios: instance, invalidateToken};
 };

--- a/api/src/httpClient.ts
+++ b/api/src/httpClient.ts
@@ -350,16 +350,24 @@ export const createAuthenticatedClient = (
 
   const getCachedToken = (): Promise<string> => {
     if (!tokenPromise) {
-      tokenPromise = fetchToken().then(
+      // The promise-identity checks below keep an out-of-order resolution (a fetch that
+      // was invalidated and replaced while in flight) from clobbering the newer fetch's
+      // cache state.
+      const thisPromise: Promise<string> = fetchToken().then(
         (token) => {
-          resolvedToken = token;
+          if (tokenPromise === thisPromise) {
+            resolvedToken = token;
+          }
           return token;
         },
         (error) => {
           // Clear the failed fetch so the next request retries, and wrap the failure in
-          // a plain Error: the raw token-request AxiosError must never reach the response
-          // interceptor's refresh/retry logic (see __httpClientManaged).
-          invalidateToken();
+          // a plain Error. The wrapping is what keeps the raw token-request AxiosError
+          // out of the response interceptor's refresh/retry logic (a wrapped error fails
+          // the isAxiosError guard); __httpClientManaged is defense-in-depth behind it.
+          if (tokenPromise === thisPromise) {
+            invalidateToken();
+          }
           const normalized = normalizeApiError(error, {apiName, operation: "token fetch"});
           const wrapped = new Error(
             `[httpClient] ${apiName} token fetch failed: ${normalized.messages[0]}`
@@ -368,6 +376,7 @@ export const createAuthenticatedClient = (
           throw wrapped;
         }
       );
+      tokenPromise = thisPromise;
     }
     return tokenPromise;
   };

--- a/api/src/httpClient.ts
+++ b/api/src/httpClient.ts
@@ -1,0 +1,186 @@
+import axios from "axios";
+
+import {APIError} from "./errors";
+import {logger as defaultLogger} from "./logger";
+
+/**
+ * Minimal logging surface used by the HTTP client utilities so consumers (and tests)
+ * can inject their own logger. Defaults to the terreno logger.
+ */
+export interface HttpClientLogger {
+  debug: (msg: string, ...args: unknown[]) => void;
+  warn: (msg: string, ...args: unknown[]) => void;
+  error: (msg: string, ...args: unknown[]) => void;
+}
+
+/**
+ * Machine-readable classification of an external API failure, used to drive retry
+ * policies and consistent logging across API clients.
+ */
+export type ApiErrorClassification =
+  | "rateLimited"
+  | "unauthorized"
+  | "notFound"
+  | "validation"
+  | "server"
+  | "network"
+  | "unknown";
+
+export interface NormalizedApiError {
+  isAxios: boolean;
+  statusCode: number | undefined;
+  messages: string[];
+  classification: ApiErrorClassification;
+  // Context echoed back for structured logging.
+  apiName: string;
+  operation: string;
+}
+
+const classifyStatusCode = (statusCode: number): ApiErrorClassification => {
+  if (statusCode === 429) {
+    return "rateLimited";
+  }
+  if (statusCode === 401 || statusCode === 403) {
+    return "unauthorized";
+  }
+  if (statusCode === 404) {
+    return "notFound";
+  }
+  if (statusCode >= 400 && statusCode < 500) {
+    return "validation";
+  }
+  if (statusCode >= 500) {
+    return "server";
+  }
+  return "unknown";
+};
+
+/**
+ * Extracts human-readable messages from common API error response body shapes:
+ * plain strings, `{message}`, and JSONAPI-style `{errors: [{title, detail}]}`.
+ * Returns an empty array when the body has no recognizable message.
+ */
+const extractBodyMessages = (data: unknown): string[] => {
+  if (typeof data === "string" && data.length > 0) {
+    return [data];
+  }
+  if (data && typeof data === "object") {
+    const body = data as {message?: unknown; errors?: unknown};
+    if (typeof body.message === "string" && body.message.length > 0) {
+      return [body.message];
+    }
+    if (Array.isArray(body.errors)) {
+      const messages: string[] = [];
+      for (const entry of body.errors) {
+        if (entry && typeof entry === "object") {
+          const {title, detail} = entry as {title?: unknown; detail?: unknown};
+          if (typeof title === "string" && typeof detail === "string") {
+            messages.push(`${title}: ${detail}`);
+          } else if (typeof title === "string") {
+            messages.push(title);
+          } else if (typeof detail === "string") {
+            messages.push(detail);
+          }
+        }
+      }
+      if (messages.length > 0) {
+        return messages;
+      }
+    }
+  }
+  return [];
+};
+
+/**
+ * Normalizes an unknown thrown value from an external API call into a stable shape:
+ * status code, human-readable messages, and a machine classification. Axios errors are
+ * unwrapped (response body messages extracted); axios errors without a response are
+ * classified as "network"; non-axios errors fall through to "unknown" with the error
+ * message preserved.
+ *
+ * The normalized shape intentionally excludes request/response payload bodies so it is
+ * safe to log as-is.
+ */
+export const normalizeApiError = (
+  error: unknown,
+  context: {apiName: string; operation: string}
+): NormalizedApiError => {
+  const base = {apiName: context.apiName, operation: context.operation};
+
+  if (axios.isAxiosError(error)) {
+    const statusCode = error.response?.status;
+    if (statusCode === undefined) {
+      return {
+        ...base,
+        classification: "network",
+        isAxios: true,
+        messages: [error.message],
+        statusCode: undefined,
+      };
+    }
+    const bodyMessages = extractBodyMessages(error.response?.data);
+    return {
+      ...base,
+      classification: classifyStatusCode(statusCode),
+      isAxios: true,
+      messages: bodyMessages.length > 0 ? bodyMessages : [error.message],
+      statusCode,
+    };
+  }
+
+  return {
+    ...base,
+    classification: "unknown",
+    isAxios: false,
+    messages: [error instanceof Error ? error.message : String(error)],
+    statusCode: undefined,
+  };
+};
+
+export interface WithApiErrorHandlingOptions {
+  apiName: string;
+  operation: string;
+  // "apiError" converts the failure to a terreno APIError suitable for route handlers;
+  // "raw" (default) logs the normalized shape and rethrows the original error.
+  rethrowAs?: "apiError" | "raw";
+  // Rewrites the normalized error before it is logged or converted — for consumers that
+  // need to redact service-specific sensitive fields.
+  redactError?: (normalized: NormalizedApiError) => NormalizedApiError;
+  logger?: HttpClientLogger;
+}
+
+/**
+ * Wraps an external API call with standardized error handling: failures are normalized
+ * via normalizeApiError, passed through the optional redactError hook, logged once with
+ * structured context, and rethrown — either as the original error (default) or as a
+ * terreno APIError when `rethrowAs: "apiError"`.
+ *
+ * Only the normalized shape (status code, classification, extracted messages) is logged;
+ * request/response payload bodies never reach the logger.
+ */
+export const withApiErrorHandling = async <T>(
+  fn: () => Promise<T>,
+  options: WithApiErrorHandlingOptions
+): Promise<T> => {
+  const log = options.logger ?? defaultLogger;
+  try {
+    return await fn();
+  } catch (error) {
+    let normalized = normalizeApiError(error, {
+      apiName: options.apiName,
+      operation: options.operation,
+    });
+    if (options.redactError) {
+      normalized = options.redactError(normalized);
+    }
+    log.error(`[${options.apiName}] ${options.operation} failed`, normalized);
+    if (options.rethrowAs === "apiError") {
+      throw new APIError({
+        error,
+        status: normalized.statusCode ?? 500,
+        title: `${options.apiName} ${options.operation} failed: ${normalized.messages[0]}`,
+      });
+    }
+    throw error;
+  }
+};

--- a/api/src/httpClient.ts
+++ b/api/src/httpClient.ts
@@ -55,13 +55,20 @@ const classifyStatusCode = (statusCode: number): ApiErrorClassification => {
   return "unknown";
 };
 
+// Plain-string bodies (HTML error pages, proxy text) are truncated to this length so an
+// unbounded — and potentially sensitive — payload never reaches the logger whole.
+const MAX_STRING_BODY_MESSAGE_LENGTH = 500;
+
 /**
  * Extracts human-readable messages from common API error response body shapes:
- * plain strings, `{message}`, and JSONAPI-style `{errors: [{title, detail}]}`.
+ * plain strings (truncated), `{message}`, and JSONAPI-style `{errors: [{title, detail}]}`.
  * Returns an empty array when the body has no recognizable message.
  */
 const extractBodyMessages = (data: unknown): string[] => {
   if (typeof data === "string" && data.length > 0) {
+    if (data.length > MAX_STRING_BODY_MESSAGE_LENGTH) {
+      return [`${data.slice(0, MAX_STRING_BODY_MESSAGE_LENGTH)}…`];
+    }
     return [data];
   }
   if (data && typeof data === "object") {
@@ -98,8 +105,10 @@ const extractBodyMessages = (data: unknown): string[] => {
  * classified as "network"; non-axios errors fall through to "unknown" with the error
  * message preserved.
  *
- * The normalized shape intentionally excludes request/response payload bodies so it is
- * safe to log as-is.
+ * Raw payload bodies are not carried on the normalized shape — only recognized message
+ * fields are extracted, and plain-string bodies are truncated. Consumers whose services
+ * put sensitive data inside those message fields should additionally use a redactError
+ * hook.
  */
 export const normalizeApiError = (
   error: unknown,
@@ -151,12 +160,14 @@ export interface WithApiErrorHandlingOptions {
 
 /**
  * Wraps an external API call with standardized error handling: failures are normalized
- * via normalizeApiError, passed through the optional redactError hook, logged once with
- * structured context, and rethrown — either as the original error (default) or as a
- * terreno APIError when `rethrowAs: "apiError"`.
+ * via normalizeApiError, passed through the optional redactError hook, logged exactly
+ * once, and rethrown.
  *
- * Only the normalized shape (status code, classification, extracted messages) is logged;
- * request/response payload bodies never reach the logger.
+ * In "raw" mode (default) the wrapper logs the normalized shape via the injected logger
+ * and rethrows the original error. In "apiError" mode the wrapper throws a terreno
+ * APIError — whose constructor already logs — so the wrapper itself stays silent to
+ * preserve the log-once contract. The APIError title is stable per JSONAPI convention;
+ * per-occurrence text goes in `detail`, built from the (redacted) normalized messages.
  */
 export const withApiErrorHandling = async <T>(
   fn: () => Promise<T>,
@@ -173,14 +184,17 @@ export const withApiErrorHandling = async <T>(
     if (options.redactError) {
       normalized = options.redactError(normalized);
     }
-    log.error(`[${options.apiName}] ${options.operation} failed`, normalized);
     if (options.rethrowAs === "apiError") {
+      const statusCode = normalized.statusCode;
       throw new APIError({
+        detail: normalized.messages[0] ?? "unknown error",
         error,
-        status: normalized.statusCode ?? 500,
-        title: `${options.apiName} ${options.operation} failed: ${normalized.messages[0]}`,
+        meta: {classification: normalized.classification},
+        status: statusCode !== undefined && statusCode >= 400 ? statusCode : 500,
+        title: `${options.apiName} ${options.operation} request failed`,
       });
     }
+    log.error(`[${options.apiName}] ${options.operation} failed`, normalized);
     throw error;
   }
 };

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -12,6 +12,7 @@ export * from "./envConfigurationPlugin";
 export * from "./errors";
 export * from "./expressServer";
 export * from "./githubAuth";
+export * from "./httpClient";
 export * from "./logger";
 export * from "./middleware";
 export * from "./models/consentForm";

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -8,6 +8,7 @@ Problem-oriented, practical steps. Use these when you know what you want to do.
 - [Add GitHub OAuth authentication](add-github-oauth.md) — Enable GitHub login for your API
 - [Configure Better Auth](configure-better-auth.md) — Set up Better Auth with social OAuth (Google, GitHub, Apple)
 - [Add WebSocket integration](websocket-integration.md) — Set up real-time Socket.io connections
+- [Call external APIs](call-external-apis.md) — Authenticated HTTP client, retries, and error normalization for third-party integrations
 - [Deploy to Google Cloud Platform](deploy-to-gcp.md) — Deploy demo and example apps to GCS with CDN
 
 ## Coming Soon

--- a/docs/how-to/call-external-apis.md
+++ b/docs/how-to/call-external-apis.md
@@ -1,0 +1,101 @@
+# Call external APIs
+
+How to talk to third-party HTTP APIs (payment processors, health integrations, meeting providers, etc.) from a `@terreno/api` backend using the shared HTTP client utilities, instead of hand-rolling axios setup, token caching, retry, and error handling per integration.
+
+## When to use each piece
+
+| You are... | Use |
+|---|---|
+| Calling a third-party REST API that needs a bearer token, OAuth2 client-credentials, or API-key auth | `createAuthenticatedClient` |
+| Calling an external service through its own SDK (Twilio, Google APIs, Stripe) | `withApiErrorHandling` around the SDK calls — the SDK owns transport, you standardize failures |
+| Logging or classifying a caught error from any external call | `normalizeApiError` |
+| Surfacing an external failure to your API's consumers from a route handler | `withApiErrorHandling` with `rethrowAs: "apiError"` |
+| Making internal requests to your own `@terreno/api` backend | None of these — use `@terreno/rtk` on the frontend or direct function calls on the backend |
+
+**Rule of thumb:** any file that would otherwise contain `axios.create(...)` plus a token variable plus a `try/catch → axios.isAxiosError → log → throw` block should use these utilities instead.
+
+## Create a client
+
+```typescript
+import {createAuthenticatedClient} from "@terreno/api";
+
+const widgetApi = createAuthenticatedClient({
+  apiName: "widgetService", // used in logs and normalized errors; defaults to baseURL
+  auth: {
+    credentials: {clientId: process.env.WIDGET_CLIENT_ID!, clientSecret: process.env.WIDGET_CLIENT_SECRET!},
+    refreshOn401: true,
+    tokenUrl: "https://api.widgets.example/oauth/token",
+    type: "oauth2",
+  },
+  baseURL: "https://api.widgets.example/v2",
+});
+
+const response = await widgetApi.axios.get("/widgets/123");
+```
+
+Auth strategies:
+
+- `{type: "bearer", getToken}` — you supply an async token fetcher; the client caches the result until `invalidateToken()` is called.
+- `{type: "oauth2", tokenUrl, credentials, refreshOn401}` — the client performs the client-credentials grant itself (HTTP Basic auth, form-encoded). With `refreshOn401: true`, a 401 response invalidates the cached token and retries the request exactly once with a fresh one.
+- `{type: "apiKey", header, getKey}` — the key is sent on the header you name.
+
+Tokens are fetched lazily and concurrent first requests share a single fetch. Create the client once per service at module scope — not per request — so the token cache is actually shared.
+
+## What you get for free
+
+- **Retry with backoff** for transient failures (429 rate limits, 5xx, network errors), honoring `Retry-After`, capped by `maxDelayMs`. Defaults: 3 total attempts, 250ms base delay, 30s delay ceiling — override via the `retry` option.
+- **Idempotency safety**: only GET/HEAD/OPTIONS are retried by default. Retrying a failed POST can duplicate side effects (a payment, a prescription, a meeting). If a specific POST/PUT/DELETE is genuinely safe to repeat, opt it in per request:
+
+  ```typescript
+  import {markRetryUnsafe} from "@terreno/api";
+
+  // Safe to repeat: the upstream endpoint is idempotent on externalId.
+  await widgetApi.axios.post("/widgets", {externalId, name}, markRetryUnsafe());
+  ```
+
+  The request body must be replayable — JSON is fine; streams/FormData are consumed on first send.
+- **Quiet transport logging**: the client logs retries and token refreshes at debug level only and always rejects with the original axios error. Error-level logging belongs to the call site (next section) so composed usage logs each failure exactly once.
+
+## Handle failures at the call site
+
+Wrap calls with `withApiErrorHandling` to normalize, log once, and rethrow:
+
+```typescript
+import {withApiErrorHandling} from "@terreno/api";
+
+export const getWidget = async (id: string): Promise<Widget> => {
+  const response = await withApiErrorHandling(() => widgetApi.axios.get(`/widgets/${id}`), {
+    apiName: "widgetService",
+    operation: "getWidget",
+  });
+  return response.data;
+};
+```
+
+- Default (`rethrowAs: "raw"`): logs the normalized shape (status code, classification, extracted messages) and rethrows the original error for callers that need it.
+- `rethrowAs: "apiError"`: throws a terreno `APIError` (stable title, per-occurrence `detail`) so route handlers surface a clean JSONAPI error instead of a raw axios failure. In this mode the `APIError` constructor does the logging.
+
+For SDK-based integrations where `createAuthenticatedClient` doesn't apply, `withApiErrorHandling` still works — `normalizeApiError` classifies non-axios errors as `"unknown"` while preserving the message.
+
+## Sensitive response data
+
+`normalizeApiError` never logs raw payload bodies: it extracts only recognized message fields (`{message}`, JSONAPI `{errors: [{title, detail}]}`, plain strings truncated to 500 chars). If the upstream service puts sensitive data *inside* those message fields, supply a `redactError` hook (available on both `createAuthenticatedClient` and `withApiErrorHandling`):
+
+```typescript
+redactError: (normalized) => ({
+  ...normalized,
+  messages: normalized.messages.map((message) => message.replace(PATIENT_ID_PATTERN, "[redacted]")),
+}),
+```
+
+Note the hook's output classification also feeds the client's retry decision — redact messages, don't rewrite classifications, unless changing retry behavior is intended.
+
+## When not to use this
+
+- **Your own backend's routes** — use the generated `@terreno/rtk` SDK (frontend) or call the function directly (backend).
+- **SDK-managed transport** (Twilio, googleapis) — don't fight the SDK's HTTP layer; adopt only `normalizeApiError`/`withApiErrorHandling` for consistent failure handling.
+- **Webhook notifiers** — `sendSlackMessage`/`sendGoogleChatMessage`/`sendZoomMessage` already exist; see [Webhooks & Notifications](../reference/api.md#webhooks--notifications).
+
+## Related
+
+- [@terreno/api reference — HTTP Client](../reference/api.md#http-client)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -13,6 +13,7 @@ REST API framework built on Express and Mongoose. Provides modelRouter (CRUD end
 - [Logging & Tracing](#logging--tracing)
 - [Extensibility](#extensibility)
 - [Webhooks & Notifications](#webhooks--notifications)
+- [HTTP Client](#http-client)
 - [Utilities](#utilities)
 - [Script Helpers](#script-helpers)
 
@@ -29,6 +30,7 @@ REST API framework built on Express and Mongoose. Provides modelRouter (CRUD end
 - Middleware: `openApiEtagMiddleware`, `sentryAppVersionMiddleware`
 - Extensibility: `TerrenoPlugin` interface
 - Notifiers: `sendSlackMessage`, `sendGoogleChatMessage`, `sendZoomMessage`
+- HTTP client: `createAuthenticatedClient`, `withApiErrorHandling`, `normalizeApiError`, `markRetryUnsafe`
 
 ## Server Setup
 
@@ -969,6 +971,75 @@ await sendZoomMessage({
 - Error alerts
 - Deployment confirmations
 - Health check failures
+
+## HTTP Client
+
+Utilities for calling **external** third-party APIs with consistent auth, retry, and error handling. See the how-to guide: [Call external APIs](../how-to/call-external-apis.md).
+
+### createAuthenticatedClient
+
+Axios instance factory with a pluggable auth strategy, lazy token caching, and a retry policy for transient failures.
+
+``````typescript
+import {createAuthenticatedClient} from "@terreno/api";
+
+const client = createAuthenticatedClient({
+  apiName: "widgetService",
+  auth: {getToken: async () => fetchServiceToken(), type: "bearer"},
+  baseURL: "https://api.widgets.example/v2",
+  retry: {maxAttempts: 3}, // optional; shown with defaults below
+});
+
+const response = await client.axios.get("/widgets/123");
+client.invalidateToken(); // drop the cached token; next request re-authenticates
+``````
+
+**Auth strategies** (`auth` option):
+- `{type: "bearer", getToken}` — caller-supplied async token fetcher, cached until invalidated
+- `{type: "oauth2", tokenUrl, credentials, refreshOn401}` — client-credentials grant handled internally; `refreshOn401: true` refreshes and retries exactly once on a 401
+- `{type: "apiKey", header, getKey}` — key sent on the named header
+
+**Retry policy** (`retry` option, all fields optional):
+
+| Field | Default | Meaning |
+|---|---|---|
+| `maxAttempts` | `3` | Total attempts including the first request |
+| `retryOn` | `["rateLimited", "server", "network"]` | Failure classifications to retry |
+| `baseDelayMs` | `250` | Base for exponential backoff with jitter |
+| `maxDelayMs` | `30000` | Ceiling for any single delay, including `Retry-After` values |
+
+Only idempotent methods (GET/HEAD/OPTIONS) are retried by default. Opt a request in with `markRetryUnsafe(config?)` when the operation is safe to repeat and its body is replayable.
+
+**Why:** external integrations otherwise duplicate token plumbing and diverge on retry behavior; centralizing them makes rate-limit handling and credential rotation consistent, and makes non-idempotent retries an explicit, reviewable choice.
+
+### normalizeApiError
+
+Pure function converting any thrown value into a stable, log-safe shape.
+
+``````typescript
+import {normalizeApiError} from "@terreno/api";
+
+const normalized = normalizeApiError(error, {apiName: "widgetService", operation: "getWidget"});
+// {isAxios, statusCode, messages, classification, apiName, operation}
+``````
+
+`classification` is one of `"rateLimited" | "unauthorized" | "notFound" | "validation" | "server" | "network" | "unknown"`. Messages are extracted only from recognized body fields (`{message}`, JSONAPI `{errors: [{title, detail}]}`, plain strings truncated to 500 chars) — raw payload bodies never reach the normalized shape.
+
+### withApiErrorHandling
+
+Call-site wrapper: normalize → optional `redactError` hook → log exactly once → rethrow.
+
+``````typescript
+import {withApiErrorHandling} from "@terreno/api";
+
+const response = await withApiErrorHandling(() => client.axios.get(`/widgets/${id}`), {
+  apiName: "widgetService",
+  operation: "getWidget",
+  rethrowAs: "apiError", // optional; default "raw" rethrows the original error
+});
+``````
+
+With `rethrowAs: "apiError"` the failure is converted to a terreno `APIError` (stable title, per-occurrence `detail`, classification in `meta`) suitable for route handlers. Works with SDK-based integrations too — it does not require `createAuthenticatedClient`.
 
 ## Utilities
 


### PR DESCRIPTION
## Summary
Adds a shared transport + error-normalization layer to `@terreno/api` so downstream API clients (Fitbit, DoseSpot, Zoom, Retriever, PagerDuty, etc. in consuming apps) stop hand-rolling token caching, retry, and error-classification boilerplate. This is Phase 1 of the Terreno-Http-Client implementation plan (FlourishHealth/flourish#6161); consuming-app migrations follow in later phases after a release + version bump.

New public surface in `api/src/httpClient.ts`:
- `normalizeApiError(error, {apiName, operation})` — stable `{statusCode, messages, classification}` shape from any thrown value; unwraps axios errors, extracts `{message}` / JSONAPI `{errors: [...]}` / string bodies (strings truncated at 500 chars so unbounded payloads never reach logs)
- `withApiErrorHandling(fn, options)` — normalize → optional `redactError` hook → log exactly once → rethrow raw or as `APIError` (stable title, per-occurrence `detail`)
- `createAuthenticatedClient(options)` — axios factory with bearer/oauth2/apiKey auth strategies, in-flight-promise token caching + `invalidateToken()`, one-shot refresh-on-401 for oauth2, and jittered exponential-backoff retry on rateLimited/server/network for idempotent methods only (`retryUnsafe` opts non-idempotent requests in); honors Retry-After capped by `maxDelayMs`

Notable safety properties, each with a regression test:
- A 401 from the oauth2 token endpoint itself (rotated/bad credentials) cannot refresh-loop: token-fetch failures are wrapped in a plain error that can't re-enter the interceptor's refresh/retry logic
- Non-idempotent requests are never retried by default — retrying a failed POST against an external service can duplicate side effects
- Concurrent first requests share a single token fetch; out-of-order fetch resolution can't clobber newer cache state

## Human Testing Steps
- [ ] Review the retry defaults (maxAttempts 3, retryOn rateLimited/server/network, baseDelayMs 250, maxDelayMs 30s) for suitability as library-wide defaults
- [ ] Review the `markRetryUnsafe(config?)` helper — non-idempotent requests opt into retry via this module-scoped helper (no global axios type augmentation)
- [ ] Confirm the log-once split: the client logs retries/refreshes at debug only; error-level logging is left to `withApiErrorHandling` or the call site

## Documentation
- New how-to guide [docs/how-to/call-external-apis.md](https://github.com/FlourishHealth/terreno/blob/http-client/docs/how-to/call-external-apis.md) — when to use `createAuthenticatedClient` vs `withApiErrorHandling` vs the rtk SDK, auth strategies, retry semantics, and redaction guidance
- `HTTP Client` section added to the `@terreno/api` reference (`docs/reference/api.md`) plus index entries in the how-to README and package README

## Automated Tests
- `api/src/httpClient.test.ts` — 43 tests against a real local express server (real OAuth2 client-credentials handshake, no mocks), covering classification, message extraction, truncation, redaction interplay, token caching/invalidation/concurrency, 401 refresh one-shot + token-endpoint-401 loop regression, retry counts, Retry-After precedence/fallback/cap, retryUnsafe, and custom retryOn
- Full `@terreno/api` suite: 1290 pass; `bun tsc --noEmit` and `biome check` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New library surface affects how outbound calls handle credentials, retries, and errors; misconfigured retries on non-idempotent POSTs could duplicate side effects, though defaults and `markRetryUnsafe` are designed to make that explicit.
> 
> **Overview**
> Introduces a shared **HTTP client layer** in `@terreno/api` for third-party integrations, exported from `api/src/httpClient.ts` and documented in a new how-to plus reference sections.
> 
> **`createAuthenticatedClient`** builds an axios instance with bearer, OAuth2 client-credentials, or API-key auth, lazy in-flight token caching, optional one-shot refresh on 401, and retries for rate limits / 5xx / network on idempotent methods only. **`markRetryUnsafe`** opts specific non-idempotent calls into retry. Guards prevent refresh loops when the token endpoint fails.
> 
> **`normalizeApiError`** and **`withApiErrorHandling`** standardize failure classification, log-safe message extraction (truncated bodies, optional `redactError`), and single-shot logging with optional `APIError` conversion for route handlers.
> 
> Coverage is in **`api/src/httpClient.test.ts`** (~43 integration tests against a local Express server).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e218020e7dddc278c24fe89dba5e6e88d8d5400b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


