### PR TITLE
Include run evidence (screenshots/videos) in PRs via submit and pour skills

### DIFF
--- a/.agents/skills/submit/SKILL.md
+++ b/.agents/skills/submit/SKILL.md
@@ -48,6 +48,16 @@ git push origin HEAD
 
 ## Step 4: Create or Update PR
 
+### Include run evidence (screenshots/videos)
+
+If any evidence was captured during this run — screenshots, screen recordings, or videos (e.g. from browser testing, `verify-ui-changes`, Playwright, or emulator sessions) — include it in the PR body under an `## Evidence` section:
+
+- Check for media generated during the session (e.g. `/opt/cursor/artifacts/`, `.cursor/artifacts/`, test output dirs, or files you saved while verifying).
+- In Cursor cloud runs, reference artifacts by absolute path with HTML tags — the PR tool uploads them and rewrites the URLs automatically: `<img alt="Description" src="/opt/cursor/artifacts/screenshots/example.png" />` or `<video src="/opt/cursor/artifacts/demo.mp4"></video>`.
+- With `gh`, only include media you can reference by a stable URL (already-uploaded images); do not commit media files to the repo just to link them.
+- Give each item a one-line caption saying what it demonstrates.
+- Skip the section entirely if no evidence exists — never add placeholders.
+
 ### If no PR exists
 
 Use this template for the **initial** body only:
@@ -69,6 +79,8 @@ EOF
 )" --draft
 ```
 
+Append an `## Evidence` section to the initial body when run evidence exists (see "Include run evidence" above).
+
 ### If a PR already exists
 
 1. Read the current PR title and body, then compare against commits and diff on the branch:
@@ -86,6 +98,7 @@ git diff $(gh pr view --json baseRefName -q .baseRefName)...HEAD --stat
 - Prefer **additive** updates: append bullets under **Changes** for new work; extend **Summary** with a brief "Update:" line (and date if helpful) when scope grows, instead of deleting the original explanation.
 - Refresh **Human Testing Steps** / **Automated Tests** only when verification needs changed; add or adjust bullets rather than wiping sections unless an item is now false.
 - If new work does not fit existing headings, add a **new section at the end** instead of removing unrelated content.
+- If this run produced new evidence (screenshots/videos), add it under the existing `## Evidence` section, or create that section if missing — keep any evidence already in the body.
 - Change the PR **title** only when the overall branch goal changed; otherwise keep the existing title.
 
 3. Compare your merged draft against the `git log` / `git diff` output above. Revise only what is stale.

--- a/.claude/skills/submit/SKILL.md
+++ b/.claude/skills/submit/SKILL.md
@@ -48,6 +48,16 @@ git push origin HEAD
 
 ## Step 4: Create or Update PR
 
+### Include run evidence (screenshots/videos)
+
+If any evidence was captured during this run — screenshots, screen recordings, or videos (e.g. from browser testing, `verify-ui-changes`, Playwright, or emulator sessions) — include it in the PR body under an `## Evidence` section:
+
+- Check for media generated during the session (e.g. `/opt/cursor/artifacts/`, `.cursor/artifacts/`, test output dirs, or files you saved while verifying).
+- In Cursor cloud runs, reference artifacts by absolute path with HTML tags — the PR tool uploads them and rewrites the URLs automatically: `<img alt="Description" src="/opt/cursor/artifacts/screenshots/example.png" />` or `<video src="/opt/cursor/artifacts/demo.mp4"></video>`.
+- With `gh`, only include media you can reference by a stable URL (already-uploaded images); do not commit media files to the repo just to link them.
+- Give each item a one-line caption saying what it demonstrates.
+- Skip the section entirely if no evidence exists — never add placeholders.
+
 ### If no PR exists
 
 Use this template for the **initial** body only:
@@ -69,6 +79,8 @@ EOF
 )" --draft
 ```
 
+Append an `## Evidence` section to the initial body when run evidence exists (see "Include run evidence" above).
+
 ### If a PR already exists
 
 1. Read the current PR title and body, then compare against commits and diff on the branch:
@@ -86,6 +98,7 @@ git diff $(gh pr view --json baseRefName -q .baseRefName)...HEAD --stat
 - Prefer **additive** updates: append bullets under **Changes** for new work; extend **Summary** with a brief "Update:" line (and date if helpful) when scope grows, instead of deleting the original explanation.
 - Refresh **Human Testing Steps** / **Automated Tests** only when verification needs changed; add or adjust bullets rather than wiping sections unless an item is now false.
 - If new work does not fit existing headings, add a **new section at the end** instead of removing unrelated content.
+- If this run produced new evidence (screenshots/videos), add it under the existing `## Evidence` section, or create that section if missing — keep any evidence already in the body.
 - Change the PR **title** only when the overall branch goal changed; otherwise keep the existing title.
 
 3. Compare your merged draft against the `git log` / `git diff` output above. Revise only what is stale.

--- a/.cursor/skills/submit/SKILL.md
+++ b/.cursor/skills/submit/SKILL.md
@@ -45,6 +45,16 @@ git push origin HEAD
 
 ## Step 4: Create or Update PR
 
+### Include run evidence (screenshots/videos)
+
+If any evidence was captured during this run — screenshots, screen recordings, or videos (e.g. from browser testing, `verify-ui-changes`, Playwright, or emulator sessions) — include it in the PR body under an `## Evidence` section:
+
+- Check for media generated during the session (e.g. `/opt/cursor/artifacts/`, `.cursor/artifacts/`, test output dirs, or files you saved while verifying).
+- In Cursor cloud runs, reference artifacts by absolute path with HTML tags — the PR tool uploads them and rewrites the URLs automatically: `<img alt="Description" src="/opt/cursor/artifacts/screenshots/example.png" />` or `<video src="/opt/cursor/artifacts/demo.mp4"></video>`.
+- With `gh`, only include media you can reference by a stable URL (already-uploaded images); do not commit media files to the repo just to link them.
+- Give each item a one-line caption saying what it demonstrates.
+- Skip the section entirely if no evidence exists — never add placeholders.
+
 ### If no PR exists
 
 Use this template for the **initial** body only:
@@ -66,6 +76,8 @@ EOF
 )" --draft
 ```
 
+Append an `## Evidence` section to the initial body when run evidence exists (see "Include run evidence" above).
+
 ### If a PR already exists
 
 1. Read the current PR title and body, then compare against commits and diff on the branch:
@@ -83,6 +95,7 @@ git diff $(gh pr view --json baseRefName -q .baseRefName)...HEAD --stat
 - Prefer **additive** updates: append bullets under **Changes** for new work; extend **Summary** with a brief "Update:" line (and date if helpful) when scope grows, instead of deleting the original explanation.
 - Refresh **Human Testing Steps** / **Automated Tests** only when verification needs changed; add or adjust bullets rather than wiping sections unless an item is now false.
 - If new work does not fit existing headings, add a **new section at the end** instead of removing unrelated content.
+- If this run produced new evidence (screenshots/videos), add it under the existing `## Evidence` section, or create that section if missing — keep any evidence already in the body.
 - Change the PR **title** only when the overall branch goal changed; otherwise keep the existing title.
 
 3. Compare your merged draft against the `git log` / `git diff` output above. Revise only what is stale.

--- a/.github/skills/submit/SKILL.md
+++ b/.github/skills/submit/SKILL.md
@@ -48,6 +48,16 @@ git push origin HEAD
 
 ## Step 4: Create or Update PR
 
+### Include run evidence (screenshots/videos)
+
+If any evidence was captured during this run — screenshots, screen recordings, or videos (e.g. from browser testing, `verify-ui-changes`, Playwright, or emulator sessions) — include it in the PR body under an `## Evidence` section:
+
+- Check for media generated during the session (e.g. `/opt/cursor/artifacts/`, `.cursor/artifacts/`, test output dirs, or files you saved while verifying).
+- In Cursor cloud runs, reference artifacts by absolute path with HTML tags — the PR tool uploads them and rewrites the URLs automatically: `<img alt="Description" src="/opt/cursor/artifacts/screenshots/example.png" />` or `<video src="/opt/cursor/artifacts/demo.mp4"></video>`.
+- With `gh`, only include media you can reference by a stable URL (already-uploaded images); do not commit media files to the repo just to link them.
+- Give each item a one-line caption saying what it demonstrates.
+- Skip the section entirely if no evidence exists — never add placeholders.
+
 ### If no PR exists
 
 Use this template for the **initial** body only:
@@ -69,6 +79,8 @@ EOF
 )" --draft
 ```
 
+Append an `## Evidence` section to the initial body when run evidence exists (see "Include run evidence" above).
+
 ### If a PR already exists
 
 1. Read the current PR title and body, then compare against commits and diff on the branch:
@@ -86,6 +98,7 @@ git diff $(gh pr view --json baseRefName -q .baseRefName)...HEAD --stat
 - Prefer **additive** updates: append bullets under **Changes** for new work; extend **Summary** with a brief "Update:" line (and date if helpful) when scope grows, instead of deleting the original explanation.
 - Refresh **Human Testing Steps** / **Automated Tests** only when verification needs changed; add or adjust bullets rather than wiping sections unless an item is now false.
 - If new work does not fit existing headings, add a **new section at the end** instead of removing unrelated content.
+- If this run produced new evidence (screenshots/videos), add it under the existing `## Evidence` section, or create that section if missing — keep any evidence already in the body.
 - Change the PR **title** only when the overall branch goal changed; otherwise keep the existing title.
 
 3. Compare your merged draft against the `git log` / `git diff` output above. Revise only what is stale.

--- a/.rulesync/skills/submit/SKILL.md
+++ b/.rulesync/skills/submit/SKILL.md
@@ -47,6 +47,16 @@ git push origin HEAD
 
 ## Step 4: Create or Update PR
 
+### Include run evidence (screenshots/videos)
+
+If any evidence was captured during this run — screenshots, screen recordings, or videos (e.g. from browser testing, `verify-ui-changes`, Playwright, or emulator sessions) — include it in the PR body under an `## Evidence` section:
+
+- Check for media generated during the session (e.g. `/opt/cursor/artifacts/`, `.cursor/artifacts/`, test output dirs, or files you saved while verifying).
+- In Cursor cloud runs, reference artifacts by absolute path with HTML tags — the PR tool uploads them and rewrites the URLs automatically: `<img alt="Description" src="/opt/cursor/artifacts/screenshots/example.png" />` or `<video src="/opt/cursor/artifacts/demo.mp4"></video>`.
+- With `gh`, only include media you can reference by a stable URL (already-uploaded images); do not commit media files to the repo just to link them.
+- Give each item a one-line caption saying what it demonstrates.
+- Skip the section entirely if no evidence exists — never add placeholders.
+
 ### If no PR exists
 
 Use this template for the **initial** body only:
@@ -68,6 +78,8 @@ EOF
 )" --draft
 ```
 
+Append an `## Evidence` section to the initial body when run evidence exists (see "Include run evidence" above).
+
 ### If a PR already exists
 
 1. Read the current PR title and body, then compare against commits and diff on the branch:
@@ -85,6 +97,7 @@ git diff $(gh pr view --json baseRefName -q .baseRefName)...HEAD --stat
 - Prefer **additive** updates: append bullets under **Changes** for new work; extend **Summary** with a brief "Update:" line (and date if helpful) when scope grows, instead of deleting the original explanation.
 - Refresh **Human Testing Steps** / **Automated Tests** only when verification needs changed; add or adjust bullets rather than wiping sections unless an item is now false.
 - If new work does not fit existing headings, add a **new section at the end** instead of removing unrelated content.
+- If this run produced new evidence (screenshots/videos), add it under the existing `## Evidence` section, or create that section if missing — keep any evidence already in the body.
 - Change the PR **title** only when the overall branch goal changed; otherwise keep the existing title.
 
 3. Compare your merged draft against the `git log` / `git diff` output above. Revise only what is stale.

--- a/.windsurf/skills/submit/SKILL.md
+++ b/.windsurf/skills/submit/SKILL.md
@@ -48,6 +48,16 @@ git push origin HEAD
 
 ## Step 4: Create or Update PR
 
+### Include run evidence (screenshots/videos)
+
+If any evidence was captured during this run — screenshots, screen recordings, or videos (e.g. from browser testing, `verify-ui-changes`, Playwright, or emulator sessions) — include it in the PR body under an `## Evidence` section:
+
+- Check for media generated during the session (e.g. `/opt/cursor/artifacts/`, `.cursor/artifacts/`, test output dirs, or files you saved while verifying).
+- In Cursor cloud runs, reference artifacts by absolute path with HTML tags — the PR tool uploads them and rewrites the URLs automatically: `<img alt="Description" src="/opt/cursor/artifacts/screenshots/example.png" />` or `<video src="/opt/cursor/artifacts/demo.mp4"></video>`.
+- With `gh`, only include media you can reference by a stable URL (already-uploaded images); do not commit media files to the repo just to link them.
+- Give each item a one-line caption saying what it demonstrates.
+- Skip the section entirely if no evidence exists — never add placeholders.
+
 ### If no PR exists
 
 Use this template for the **initial** body only:
@@ -69,6 +79,8 @@ EOF
 )" --draft
 ```
 
+Append an `## Evidence` section to the initial body when run evidence exists (see "Include run evidence" above).
+
 ### If a PR already exists
 
 1. Read the current PR title and body, then compare against commits and diff on the branch:
@@ -86,6 +98,7 @@ git diff $(gh pr view --json baseRefName -q .baseRefName)...HEAD --stat
 - Prefer **additive** updates: append bullets under **Changes** for new work; extend **Summary** with a brief "Update:" line (and date if helpful) when scope grows, instead of deleting the original explanation.
 - Refresh **Human Testing Steps** / **Automated Tests** only when verification needs changed; add or adjust bullets rather than wiping sections unless an item is now false.
 - If new work does not fit existing headings, add a **new section at the end** instead of removing unrelated content.
+- If this run produced new evidence (screenshots/videos), add it under the existing `## Evidence` section, or create that section if missing — keep any evidence already in the body.
 - Change the PR **title** only when the overall branch goal changed; otherwise keep the existing title.
 
 3. Compare your merged draft against the `git log` / `git diff` output above. Revise only what is stale.

--- a/plugins/terreno-planning/skills/terreno-pour/SKILL.md
+++ b/plugins/terreno-planning/skills/terreno-pour/SKILL.md
@@ -46,7 +46,8 @@ Stop and fix before committing if checks fail.
 - Read and apply PR template if present.
 - Keep PR title/body accurate and concise.
 - Include human testing steps and automated checks sections.
-- Apply PHI minimum-necessary handling in PR text.
+- **Include run evidence:** if any screenshots, screen recordings, or videos were captured during this run (browser testing, Playwright, emulator sessions, UI verification), add them to the PR body under an `## Evidence` section with a one-line caption per item. In Cursor cloud runs, reference artifacts by absolute path with HTML tags (`<img src="/opt/cursor/artifacts/screenshots/example.png" />`, `<video src="/opt/cursor/artifacts/demo.mp4"></video>`) — the PR tool uploads them and rewrites URLs automatically. When updating an existing PR, append new evidence without removing what is already there. Skip the section if no evidence exists.
+- Apply PHI minimum-necessary handling in PR text, including evidence media — do not attach screenshots or recordings containing PHI.
 
 ### 5) Conflict resolution before handoff
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Updates the `/submit` skill and the `terreno-pour` skill so that any evidence captured during an agent run — screenshots, screen recordings, or videos — gets included in the PR body under an `## Evidence` section instead of being lost when the run ends.

## Human Testing Steps
- [ ] Run `/submit` after a session that captured screenshots/videos and confirm the PR body gains an `## Evidence` section with the media embedded
- [ ] Run the pour skill on a branch with captured evidence and confirm the same
- [ ] Confirm neither skill adds an empty/placeholder Evidence section when no media was captured

## Changes
- `.rulesync/skills/submit/SKILL.md`: added an "Include run evidence" subsection to Step 4 (where to look for media, how to embed it — Cursor artifact paths with `<img>`/`<video>` tags vs. stable URLs with `gh`), a note to append `## Evidence` to the initial PR body template, and a merge-policy bullet to append new evidence to existing PRs without dropping prior media
- Regenerated the mirrored skill copies via `bunx rulesync generate` (`.agents`, `.claude`, `.cursor`, `.github`, `.windsurf`)
- `plugins/terreno-planning/skills/terreno-pour/SKILL.md`: added a run-evidence bullet to the PR setup step and extended the PHI minimum-necessary rule to cover evidence media

## Automated Tests
- None (documentation/skill-only change); rulesync regeneration keeps generated copies in sync with the source

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3dbf7969-7bf8-4f26-a5f8-ab9034bca2f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3dbf7969-7bf8-4f26-a5f8-ab9034bca2f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

