### PR TITLE
feat(demo): lock error/warning/success/neutral palette anchors to their tones

### DIFF
--- a/demo/components/palette/AnchorControls.tsx
+++ b/demo/components/palette/AnchorControls.tsx
@@ -3,7 +3,13 @@ import React, {useCallback} from "react";
 import {ColorPicker} from "./ColorPicker";
 import type {PaletteAnchors} from "./colorUtils";
 import {normalizeHex, readableTextColor} from "./colorUtils";
-import {ANCHOR_FAMILIES, FAMILY_LABELS, type MainFamily, type StatusFamily} from "./paletteTypes";
+import {
+  ANCHOR_FAMILIES,
+  FAMILY_LABELS,
+  type MainFamily,
+  type StatusFamily,
+  TONE_LOCK_HINTS,
+} from "./paletteTypes";
 
 /**
  * The manual editing surface: a swatch per anchor family that you tap to select, plus the full
@@ -79,6 +85,8 @@ export const AnchorControls: React.FC<AnchorControlsProps> = ({
     [onChangeAnchor, selectedFamily]
   );
 
+  const toneHint = TONE_LOCK_HINTS[selectedFamily];
+
   return (
     <Box gap={4}>
       <Box direction="row" gap={2} wrap>
@@ -99,6 +107,11 @@ export const AnchorControls: React.FC<AnchorControlsProps> = ({
         onChange={handleColorChange}
         value={anchors[selectedFamily]}
       />
+      {toneHint ? (
+        <Text color="secondaryLight" size="sm">
+          {toneHint}
+        </Text>
+      ) : null}
     </Box>
   );
 };

--- a/demo/components/palette/PaletteGenerator.tsx
+++ b/demo/components/palette/PaletteGenerator.tsx
@@ -9,7 +9,12 @@ import {ChatPanel} from "./ChatPanel";
 import {CodeOutput} from "./CodeOutput";
 import {ComponentPreview} from "./ComponentPreview";
 import {ContrastReport} from "./ContrastReport";
-import {generatePrimitivesFromAnchors, type PaletteAnchors} from "./colorUtils";
+import {
+  constrainAnchorsToFamilyTones,
+  constrainAnchorToFamilyTone,
+  generatePrimitivesFromAnchors,
+  type PaletteAnchors,
+} from "./colorUtils";
 import {DarkModeAudit} from "./DarkModeAudit";
 import {FontControls} from "./FontControls";
 import {buildFontOptions, DEFAULT_FONTS, type FontSelection} from "./fonts";
@@ -62,7 +67,9 @@ export const PaletteGenerator: React.FC = () => {
     decodeShareState(typeof searchParams.s === "string" ? searchParams.s : undefined)
   ).current;
 
-  const [anchors, setAnchors] = useState<PaletteAnchors>(sharedState?.anchors ?? DEFAULT_ANCHORS);
+  const [anchors, setAnchors] = useState<PaletteAnchors>(
+    constrainAnchorsToFamilyTones(sharedState?.anchors ?? DEFAULT_ANCHORS)
+  );
   const [fonts, setFonts] = useState<FontSelection>(sharedState?.fonts ?? DEFAULT_FONTS);
   const [shareCopied, setShareCopied] = useState<boolean>(false);
   const [fontRationale, setFontRationale] = useState<string | undefined>(undefined);
@@ -115,7 +122,9 @@ export const PaletteGenerator: React.FC = () => {
   }, [apiKey]);
 
   const handleChangeAnchor = useCallback((family: Family, hex: string): void => {
-    setAnchors((prev) => ({...prev, [family]: hex}));
+    // Semantic families (error/warning/success/neutral) are locked to their conventional tones so a
+    // manual edit can't turn "error" blue or "success" purple; other families are free brand colors.
+    setAnchors((prev) => ({...prev, [family]: constrainAnchorToFamilyTone(family, hex)}));
   }, []);
 
   const handleSend = useCallback(
@@ -144,7 +153,7 @@ export const PaletteGenerator: React.FC = () => {
           messages: history,
           model: model || DEFAULT_GEMINI_MODEL,
         });
-        setAnchors(result.anchors);
+        setAnchors(constrainAnchorsToFamilyTones(result.anchors));
         setFonts(result.fonts);
         setFontRationale(result.fontRationale);
         const reply = result.fontRationale

--- a/demo/components/palette/colorUtils.test.ts
+++ b/demo/components/palette/colorUtils.test.ts
@@ -2,6 +2,9 @@ import {describe, expect, it} from "bun:test";
 
 import {
   assessContrast,
+  clampHueToBand,
+  constrainAnchorsToFamilyTones,
+  constrainAnchorToFamilyTone,
   contrastRatio,
   generateColorScale,
   generatePrimitivesFromAnchors,
@@ -107,6 +110,118 @@ describe("generatePrimitivesFromAnchors", () => {
     expect(primitives.success000).toBeDefined();
     // 4 families * 11 shades + 3 status families * 3 shades = 53 keys
     expect(Object.keys(primitives).length).toBe(53);
+  });
+});
+
+describe("clampHueToBand", () => {
+  it("leaves an in-band hue unchanged", () => {
+    expect(clampHueToBand(130, 130, 45)).toBe(130);
+    expect(clampHueToBand(100, 130, 45)).toBe(100);
+  });
+
+  it("snaps an out-of-band hue to the nearest edge", () => {
+    expect(clampHueToBand(240, 130, 45)).toBe(175);
+    expect(clampHueToBand(60, 130, 45)).toBe(85);
+  });
+
+  it("wraps correctly around 0/360 for red", () => {
+    expect(clampHueToBand(350, 0, 18)).toBe(350);
+    expect(clampHueToBand(10, 0, 18)).toBe(10);
+    // Blue is far from red on both sides; snaps to the nearer edge (342).
+    expect(clampHueToBand(220, 0, 18)).toBe(342);
+    // Just past the warm edge snaps down to +18.
+    expect(clampHueToBand(90, 0, 18)).toBe(18);
+  });
+});
+
+describe("constrainAnchorToFamilyTone", () => {
+  // Circular distance (degrees) between two hues, tolerant of ±1° hex round-trip rounding.
+  const hueDistance = (hue: number, center: number): number => {
+    const diff = Math.abs((((hue - center) % 360) + 360) % 360);
+    return Math.min(diff, 360 - diff);
+  };
+  const hueOf = (hex: string): number => hexToHsl(hex)!.h;
+
+  it("keeps unlocked families (primary/secondary/accent) unchanged", () => {
+    expect(constrainAnchorToFamilyTone("primary", "#0000ff")).toBe("#0000ff");
+    expect(constrainAnchorToFamilyTone("accent", "#00ff00")).toBe("#00ff00");
+  });
+
+  it("returns an in-tone anchor verbatim", () => {
+    expect(constrainAnchorToFamilyTone("error", "#d33232")).toBe("#d33232");
+    expect(constrainAnchorToFamilyTone("success", "#3ea45c")).toBe("#3ea45c");
+    expect(constrainAnchorToFamilyTone("warning", "#f36719")).toBe("#f36719");
+  });
+
+  it("snaps a blue 'error' back into the red band", () => {
+    const result = constrainAnchorToFamilyTone("error", "#2b6cff");
+    // Red band is centered on 0 with an 18° tolerance (plus rounding slack).
+    expect(hueDistance(hueOf(result), 0)).toBeLessThanOrEqual(20);
+  });
+
+  it("snaps a purple 'success' back into the green band", () => {
+    const result = constrainAnchorToFamilyTone("success", "#8a2be2");
+    expect(hueDistance(hueOf(result), 130)).toBeLessThanOrEqual(47);
+  });
+
+  it("snaps a magenta 'warning' back into the amber band", () => {
+    const result = constrainAnchorToFamilyTone("warning", "#ff00ff");
+    expect(hueDistance(hueOf(result), 35)).toBeLessThanOrEqual(22);
+  });
+
+  it("caps neutral saturation to keep it gray", () => {
+    const result = constrainAnchorToFamilyTone("neutral", "#1e90ff");
+    expect(hexToHsl(result)!.s).toBeLessThanOrEqual(0.12 + 1e-6);
+  });
+
+  it("preserves lightness when snapping the hue", () => {
+    const result = constrainAnchorToFamilyTone("error", "#2b6cff");
+    expect(Math.abs(hexToHsl(result)!.l - hexToHsl("#2b6cff")!.l)).toBeLessThanOrEqual(0.01);
+  });
+
+  it("returns invalid input as-is", () => {
+    expect(constrainAnchorToFamilyTone("error", "nope")).toBe("nope");
+  });
+});
+
+describe("constrainAnchorsToFamilyTones", () => {
+  const hueDistance = (hue: number, center: number): number => {
+    const diff = Math.abs((((hue - center) % 360) + 360) % 360);
+    return Math.min(diff, 360 - diff);
+  };
+
+  it("locks status/neutral families but preserves brand families", () => {
+    const anchors: PaletteAnchors = {
+      accent: "#123456",
+      error: "#3355ff",
+      neutral: "#1e90ff",
+      primary: "#8a2be2",
+      secondary: "#00ffcc",
+      success: "#ff00ff",
+      warning: "#0000ff",
+    };
+    const locked = constrainAnchorsToFamilyTones(anchors);
+    // Brand families are untouched.
+    expect(locked.primary).toBe("#8a2be2");
+    expect(locked.secondary).toBe("#00ffcc");
+    expect(locked.accent).toBe("#123456");
+    // Neutral is desaturated toward gray.
+    expect(hexToHsl(locked.neutral)!.s).toBeLessThanOrEqual(0.12 + 1e-6);
+    // Success is forced into the green band.
+    expect(hueDistance(hexToHsl(locked.success)!.h, 130)).toBeLessThanOrEqual(47);
+  });
+
+  it("leaves the default anchors unchanged", () => {
+    const defaults: PaletteAnchors = {
+      accent: "#d69c0e",
+      error: "#d33232",
+      neutral: "#9a9a9a",
+      primary: "#0086b3",
+      secondary: "#2b6072",
+      success: "#3ea45c",
+      warning: "#f36719",
+    };
+    expect(constrainAnchorsToFamilyTones(defaults)).toEqual(defaults);
   });
 });
 

--- a/demo/components/palette/colorUtils.ts
+++ b/demo/components/palette/colorUtils.ts
@@ -289,6 +289,95 @@ export const generatePrimitivesFromAnchors = (
 };
 
 /**
+ * A tone constraint applied to a semantic family so its meaning stays legible: an optional hue band
+ * (center + max deviation, in degrees) plus optional saturation limits (0-1). Families without a
+ * lock (primary/secondary/accent) are free brand colors.
+ */
+export interface ToneLock {
+  /** Center hue in degrees the family should stay near. */
+  hueCenter?: number;
+  /** Maximum allowed deviation from `hueCenter` in degrees (circular). */
+  hueTolerance?: number;
+  /** Maximum saturation (0-1); values above are clamped down (keeps neutral gray). */
+  maxSaturation?: number;
+  /** Minimum saturation (0-1); values below are clamped up. */
+  minSaturation?: number;
+}
+
+/**
+ * The semantic families whose tone is locked so they keep conveying their meaning: error stays red,
+ * warning orange/amber, success green, and neutral a low-saturation gray. Bands are intentionally
+ * generous so users still have room to pick a specific shade within the correct tone.
+ */
+export const FAMILY_TONE_LOCKS: Partial<Record<MainFamily | StatusFamily, ToneLock>> = {
+  error: {hueCenter: 0, hueTolerance: 18},
+  neutral: {maxSaturation: 0.12},
+  success: {hueCenter: 130, hueTolerance: 45},
+  warning: {hueCenter: 35, hueTolerance: 20},
+};
+
+/**
+ * Snap a hue (degrees) into a band centered on `center` with a maximum deviation of `tolerance`,
+ * taking the shorter way around the color wheel so bands that straddle 0/360 (e.g. red) wrap
+ * correctly. Returns a value in [0, 360).
+ */
+export const clampHueToBand = (hue: number, center: number, tolerance: number): number => {
+  const normalized = ((hue % 360) + 360) % 360;
+  const signedDistance = ((normalized - center + 540) % 360) - 180;
+  if (Math.abs(signedDistance) <= tolerance) {
+    return normalized;
+  }
+  const edge = signedDistance > 0 ? center + tolerance : center - tolerance;
+  return ((edge % 360) + 360) % 360;
+};
+
+/**
+ * Constrain an anchor color to its family's locked tone: status families (error/warning/success)
+ * are snapped into their hue band (red/amber/green) and neutral is pulled toward gray by capping
+ * saturation. Unlocked families (primary/secondary/accent) and invalid input are returned as-is, and
+ * an already-in-tone color is returned verbatim so the exact anchor is preserved at its ramp step.
+ */
+export const constrainAnchorToFamilyTone = (
+  family: MainFamily | StatusFamily,
+  hex: string
+): string => {
+  const normalized = normalizeHex(hex);
+  const lock = FAMILY_TONE_LOCKS[family];
+  if (!normalized || !lock) {
+    return normalized ?? hex;
+  }
+  const hsl = hexToHsl(normalized);
+  if (!hsl) {
+    return normalized;
+  }
+  let hue = hsl.h;
+  let saturation = hsl.s;
+  // A pure gray has a meaningless hue, so only snap the hue when there is real chroma to place.
+  if (lock.hueCenter !== undefined && lock.hueTolerance !== undefined && saturation > 0) {
+    hue = clampHueToBand(hue, lock.hueCenter, lock.hueTolerance);
+  }
+  if (lock.maxSaturation !== undefined) {
+    saturation = Math.min(saturation, lock.maxSaturation);
+  }
+  if (lock.minSaturation !== undefined) {
+    saturation = Math.max(saturation, lock.minSaturation);
+  }
+  if (hue === hsl.h && saturation === hsl.s) {
+    return normalized;
+  }
+  return hslToHex({h: hue, l: hsl.l, s: saturation});
+};
+
+/** Apply {@link constrainAnchorToFamilyTone} to every family in an anchor set. */
+export const constrainAnchorsToFamilyTones = (anchors: PaletteAnchors): PaletteAnchors => {
+  const result = {...anchors};
+  for (const family of [...MAIN_FAMILIES, ...STATUS_FAMILIES]) {
+    result[family] = constrainAnchorToFamilyTone(family, anchors[family]);
+  }
+  return result;
+};
+
+/**
  * Relative luminance of an sRGB color per the WCAG 2.1 definition. Used as the basis for contrast
  * ratio computation.
  */

--- a/demo/components/palette/geminiClient.ts
+++ b/demo/components/palette/geminiClient.ts
@@ -111,9 +111,14 @@ You design palettes for a React Native design system with seven color families:
 - primary: the main brand/action color used for buttons and links.
 - secondary: a supporting brand color for headers and secondary surfaces.
 - accent: a warm highlight color used sparingly for emphasis.
-- error: red-ish, for destructive/error states.
+- error: red, for destructive/error states.
 - warning: orange/amber, for cautionary states.
 - success: green, for positive states.
+
+The error, warning, success, and neutral families are automatically constrained to their
+conventional tones (red, orange/amber, green, and low-saturation gray, respectively), so keep their
+anchors within those tones — any out-of-tone hue you return will be snapped back. primary,
+secondary, and accent are free brand colors with no tone restriction.
 
 For EACH family you return exactly ONE anchor hex color. The design system will automatically
 generate the lighter and darker 000-900 shades from your anchor, so pick a mid-tone (~500 level)

--- a/demo/components/palette/paletteTypes.ts
+++ b/demo/components/palette/paletteTypes.ts
@@ -44,6 +44,17 @@ export const ANCHOR_FAMILIES: (MainFamily | StatusFamily)[] = [
   ...STATUS_FAMILIES,
 ];
 
+/**
+ * Short helper copy shown under the picker for the families whose tone is locked (see
+ * `FAMILY_TONE_LOCKS`), so users understand why an out-of-tone color snaps back.
+ */
+export const TONE_LOCK_HINTS: Partial<Record<MainFamily | StatusFamily, string>> = {
+  error: "Locked to red tones so error states stay recognizable.",
+  neutral: "Locked to low-saturation gray for text, borders, and backgrounds.",
+  success: "Locked to green tones so success states stay recognizable.",
+  warning: "Locked to orange/amber tones so warnings stay recognizable.",
+};
+
 /** The default anchor set, matching the stock Terreno theme so the tool opens on a known-good palette. */
 export const DEFAULT_ANCHORS: PaletteAnchors = {
   accent: "#d69c0e",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follows up on the AI palette generator: the semantic color families are now **locked into their conventional tones** so a manual edit (or an AI suggestion) can't change their meaning.

- **error** → red hues
- **warning** → orange/amber hues
- **success** → green hues
- **neutral** → low-saturation gray

`primary`, `secondary`, and `accent` stay unconstrained brand colors.

When you drag the hue/saturation sliders, type a hex, or the assistant returns an off-tone color, the anchor snaps to the nearest in-tone color (lightness is preserved, so you keep control over how light/dark the shade is). An already-in-tone anchor is returned verbatim, so the exact color you pick is still placed at its ramp step.

## Changes

- **`colorUtils.ts`**: new `FAMILY_TONE_LOCKS`, `clampHueToBand`, `constrainAnchorToFamilyTone`, and `constrainAnchorsToFamilyTones`. Hue bands are intentionally generous (error ±18°, warning ±20°, success ±45°) so there's still room to pick a shade within the correct tone; neutral is capped at ≤0.12 saturation. The red band wraps correctly around 0/360.
- **`PaletteGenerator.tsx`**: applies the constraint on manual anchor edits, on Gemini results, and when restoring a shared palette from the URL.
- **`AnchorControls.tsx`** + **`paletteTypes.ts`**: a short hint under the picker for locked families (e.g. "Locked to red tones so error states stay recognizable").
- **`geminiClient.ts`**: `COLOR_SYSTEM_PROMPT` now tells the model these four families are constrained to their tones.
- **`colorUtils.test.ts`**: unit tests for the new utilities (in-band/out-of-band snapping, red wrap-around, neutral desaturation, lightness preservation, defaults unchanged).

## Verification

- `bun test components/palette/` — 51 pass
- `bun run lint` (demo) — clean
- `bun run compile` (workspace) — `terreno-demo` and all packages compile

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b89f6eb-a356-4b27-b514-31d83797f4e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b89f6eb-a356-4b27-b514-31d83797f4e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

