### PR TITLE
admin-spa: first-admin setup flow

### DIFF
--- a/.claude/rules/admin-backend/00-admin-backend.md
+++ b/.claude/rules/admin-backend/00-admin-backend.md
@@ -81,6 +81,7 @@ All routes require `Permissions.IsAdmin`.
 interface AdminOptions {
   models: AdminModelConfig[];  // Array of model configurations
   basePath?: string;           // Base path for all admin routes (default: "/admin")
+  firstAdminSetup?: {userModel: Model<any>};  // Opt-in "create the first admin" flow
 }
 
 interface AdminModelConfig {
@@ -91,6 +92,26 @@ interface AdminModelConfig {
   defaultSort?: string;        // Default sort order (default: "-created")
 }
 ```
+
+## First-Admin Setup Flow
+
+When no admin user exists yet (e.g. a fresh deploy), pass `firstAdminSetup` to bootstrap the first admin account without a database console:
+
+```typescript
+const admin = new AdminApp({
+  basePath: "/admin",
+  models: [...],
+  firstAdminSetup: {userModel: User},
+});
+```
+
+This registers:
+- `GET {basePath}/setup-status` (public) — `{needsSetup: boolean}`, true only while `userModel.countDocuments({admin: true}) === 0`
+- `POST {basePath}/setup-claim` (authenticated) — promotes the calling (already signed-in) user to `admin: true`, but only while no admin user exists yet
+
+Account creation itself (sign up / sign in) is left to the app's existing auth flow (JWT signup, Better Auth email sign-up, OAuth, ...) — `setup-claim` only "claims" the admin flag for the first authenticated user while the app has zero admins. See `@terreno/admin-spa`'s `/setup` screen for a full frontend implementation of this flow.
+
+Set the `ADMIN_SETUP_DISABLED` environment variable to `"true"` to turn this off at runtime (e.g. once the first admin has been created) without a deploy.
 
 ## Field Metadata Extraction
 

--- a/.cursor/rules/admin-backend/00-admin-backend.mdc
+++ b/.cursor/rules/admin-backend/00-admin-backend.mdc
@@ -82,6 +82,7 @@ All routes require `Permissions.IsAdmin`.
 interface AdminOptions {
   models: AdminModelConfig[];  // Array of model configurations
   basePath?: string;           // Base path for all admin routes (default: "/admin")
+  firstAdminSetup?: {userModel: Model<any>};  // Opt-in "create the first admin" flow
 }
 
 interface AdminModelConfig {
@@ -92,6 +93,26 @@ interface AdminModelConfig {
   defaultSort?: string;        // Default sort order (default: "-created")
 }
 ```
+
+## First-Admin Setup Flow
+
+When no admin user exists yet (e.g. a fresh deploy), pass `firstAdminSetup` to bootstrap the first admin account without a database console:
+
+```typescript
+const admin = new AdminApp({
+  basePath: "/admin",
+  models: [...],
+  firstAdminSetup: {userModel: User},
+});
+```
+
+This registers:
+- `GET {basePath}/setup-status` (public) — `{needsSetup: boolean}`, true only while `userModel.countDocuments({admin: true}) === 0`
+- `POST {basePath}/setup-claim` (authenticated) — promotes the calling (already signed-in) user to `admin: true`, but only while no admin user exists yet
+
+Account creation itself (sign up / sign in) is left to the app's existing auth flow (JWT signup, Better Auth email sign-up, OAuth, ...) — `setup-claim` only "claims" the admin flag for the first authenticated user while the app has zero admins. See `@terreno/admin-spa`'s `/setup` screen for a full frontend implementation of this flow.
+
+Set the `ADMIN_SETUP_DISABLED` environment variable to `"true"` to turn this off at runtime (e.g. once the first admin has been created) without a deploy.
 
 ## Field Metadata Extraction
 

--- a/.github/instructions/admin-backend/00-admin-backend.instructions.md
+++ b/.github/instructions/admin-backend/00-admin-backend.instructions.md
@@ -81,6 +81,7 @@ All routes require `Permissions.IsAdmin`.
 interface AdminOptions {
   models: AdminModelConfig[];  // Array of model configurations
   basePath?: string;           // Base path for all admin routes (default: "/admin")
+  firstAdminSetup?: {userModel: Model<any>};  // Opt-in "create the first admin" flow
 }
 
 interface AdminModelConfig {
@@ -91,6 +92,26 @@ interface AdminModelConfig {
   defaultSort?: string;        // Default sort order (default: "-created")
 }
 ```
+
+## First-Admin Setup Flow
+
+When no admin user exists yet (e.g. a fresh deploy), pass `firstAdminSetup` to bootstrap the first admin account without a database console:
+
+```typescript
+const admin = new AdminApp({
+  basePath: "/admin",
+  models: [...],
+  firstAdminSetup: {userModel: User},
+});
+```
+
+This registers:
+- `GET {basePath}/setup-status` (public) — `{needsSetup: boolean}`, true only while `userModel.countDocuments({admin: true}) === 0`
+- `POST {basePath}/setup-claim` (authenticated) — promotes the calling (already signed-in) user to `admin: true`, but only while no admin user exists yet
+
+Account creation itself (sign up / sign in) is left to the app's existing auth flow (JWT signup, Better Auth email sign-up, OAuth, ...) — `setup-claim` only "claims" the admin flag for the first authenticated user while the app has zero admins. See `@terreno/admin-spa`'s `/setup` screen for a full frontend implementation of this flow.
+
+Set the `ADMIN_SETUP_DISABLED` environment variable to `"true"` to turn this off at runtime (e.g. once the first admin has been created) without a deploy.
 
 ## Field Metadata Extraction
 

--- a/.rulesync/rules/admin-backend/00-admin-backend.md
+++ b/.rulesync/rules/admin-backend/00-admin-backend.md
@@ -83,6 +83,7 @@ All routes require `Permissions.IsAdmin`.
 interface AdminOptions {
   models: AdminModelConfig[];  // Array of model configurations
   basePath?: string;           // Base path for all admin routes (default: "/admin")
+  firstAdminSetup?: {userModel: Model<any>};  // Opt-in "create the first admin" flow
 }
 
 interface AdminModelConfig {
@@ -93,6 +94,26 @@ interface AdminModelConfig {
   defaultSort?: string;        // Default sort order (default: "-created")
 }
 ```
+
+## First-Admin Setup Flow
+
+When no admin user exists yet (e.g. a fresh deploy), pass `firstAdminSetup` to bootstrap the first admin account without a database console:
+
+```typescript
+const admin = new AdminApp({
+  basePath: "/admin",
+  models: [...],
+  firstAdminSetup: {userModel: User},
+});
+```
+
+This registers:
+- `GET {basePath}/setup-status` (public) — `{needsSetup: boolean}`, true only while `userModel.countDocuments({admin: true}) === 0`
+- `POST {basePath}/setup-claim` (authenticated) — promotes the calling (already signed-in) user to `admin: true`, but only while no admin user exists yet
+
+Account creation itself (sign up / sign in) is left to the app's existing auth flow (JWT signup, Better Auth email sign-up, OAuth, ...) — `setup-claim` only "claims" the admin flag for the first authenticated user while the app has zero admins. See `@terreno/admin-spa`'s `/setup` screen for a full frontend implementation of this flow.
+
+Set the `ADMIN_SETUP_DISABLED` environment variable to `"true"` to turn this off at runtime (e.g. once the first admin has been created) without a deploy.
 
 ## Field Metadata Extraction
 

--- a/.windsurf/rules/admin-backend/00-admin-backend.md
+++ b/.windsurf/rules/admin-backend/00-admin-backend.md
@@ -81,6 +81,7 @@ All routes require `Permissions.IsAdmin`.
 interface AdminOptions {
   models: AdminModelConfig[];  // Array of model configurations
   basePath?: string;           // Base path for all admin routes (default: "/admin")
+  firstAdminSetup?: {userModel: Model<any>};  // Opt-in "create the first admin" flow
 }
 
 interface AdminModelConfig {
@@ -91,6 +92,26 @@ interface AdminModelConfig {
   defaultSort?: string;        // Default sort order (default: "-created")
 }
 ```
+
+## First-Admin Setup Flow
+
+When no admin user exists yet (e.g. a fresh deploy), pass `firstAdminSetup` to bootstrap the first admin account without a database console:
+
+```typescript
+const admin = new AdminApp({
+  basePath: "/admin",
+  models: [...],
+  firstAdminSetup: {userModel: User},
+});
+```
+
+This registers:
+- `GET {basePath}/setup-status` (public) — `{needsSetup: boolean}`, true only while `userModel.countDocuments({admin: true}) === 0`
+- `POST {basePath}/setup-claim` (authenticated) — promotes the calling (already signed-in) user to `admin: true`, but only while no admin user exists yet
+
+Account creation itself (sign up / sign in) is left to the app's existing auth flow (JWT signup, Better Auth email sign-up, OAuth, ...) — `setup-claim` only "claims" the admin flag for the first authenticated user while the app has zero admins. See `@terreno/admin-spa`'s `/setup` screen for a full frontend implementation of this flow.
+
+Set the `ADMIN_SETUP_DISABLED` environment variable to `"true"` to turn this off at runtime (e.g. once the first admin has been created) without a deploy.
 
 ## Field Metadata Extraction
 

--- a/admin-backend/src/adminApp.firstAdminSetup.test.ts
+++ b/admin-backend/src/adminApp.firstAdminSetup.test.ts
@@ -11,7 +11,7 @@ import type express from "express";
 import supertest from "supertest";
 import type TestAgent from "supertest/lib/agent";
 
-import type {AdminOptions} from "./adminApp";
+import type {AdminAuditEvent, AdminOptions} from "./adminApp";
 import {AdminApp} from "./adminApp";
 
 const buildApp = (adminOverrides?: Partial<AdminOptions>): express.Application => {
@@ -165,6 +165,63 @@ describe("AdminApp first-admin setup flow", () => {
       expect(res.body.title).toInclude("An admin user already exists");
       const unchanged = await UserModel.findOne({email: "notAdmin@example.com"});
       expect(unchanged?.admin).toBe(false);
+    });
+  });
+
+  describe("POST /admin/setup-claim onAdminAudit", () => {
+    let app: express.Application;
+    let notAdminAgent: TestAgent;
+    const auditEvents: AdminAuditEvent[] = [];
+
+    beforeEach(async () => {
+      await setupDb();
+      auditEvents.length = 0;
+      app = buildApp({
+        firstAdminSetup: {userModel: UserModel as unknown as UserModelType},
+        onAdminAudit: async (event): Promise<void> => {
+          auditEvents.push(event);
+        },
+      });
+      notAdminAgent = await authAsUser(app, "notAdmin");
+    });
+
+    it("invokes onAdminAudit with verb updated after claiming", async () => {
+      await clearAllAdmins();
+      const notAdmin = await UserModel.findOne({email: "notAdmin@example.com"});
+
+      await notAdminAgent.post("/admin/setup-claim").expect(200);
+
+      expect(auditEvents).toHaveLength(1);
+      const [event] = auditEvents;
+      expect(event.verb).toBe("updated");
+      expect(event.modelName).toBe("User");
+      expect(event.recordId).toBe(String(notAdmin?._id));
+      expect(event.actorId).toBe(String(notAdmin?._id));
+    });
+
+    it("does not invoke onAdminAudit when the claim is rejected", async () => {
+      // An admin already exists (setupDb default), so the claim is rejected before
+      // any mutation or audit event.
+      await notAdminAgent.post("/admin/setup-claim").expect(403);
+
+      expect(auditEvents).toHaveLength(0);
+    });
+
+    it("still returns 200 when onAdminAudit throws (audit is best-effort)", async () => {
+      await clearAllAdmins();
+      const throwingApp = buildApp({
+        firstAdminSetup: {userModel: UserModel as unknown as UserModelType},
+        onAdminAudit: async (): Promise<void> => {
+          throw new Error("audit sink failure");
+        },
+      });
+      const agent = await authAsUser(throwingApp, "notAdmin");
+
+      const res = await agent.post("/admin/setup-claim").expect(200);
+
+      expect(res.body.admin).toBe(true);
+      const updated = await UserModel.findOne({email: "notAdmin@example.com"});
+      expect(updated?.admin).toBe(true);
     });
   });
 });

--- a/admin-backend/src/adminApp.firstAdminSetup.test.ts
+++ b/admin-backend/src/adminApp.firstAdminSetup.test.ts
@@ -1,0 +1,170 @@
+import {afterEach, beforeEach, describe, expect, it} from "bun:test";
+import {
+  addAuthRoutes,
+  apiErrorMiddleware,
+  apiUnauthorizedMiddleware,
+  setupAuth,
+  type UserModel as UserModelType,
+} from "@terreno/api";
+import {authAsUser, getBaseServer, setupDb, UserModel} from "@terreno/api/testing";
+import type express from "express";
+import supertest from "supertest";
+import type TestAgent from "supertest/lib/agent";
+
+import type {AdminOptions} from "./adminApp";
+import {AdminApp} from "./adminApp";
+
+const buildApp = (adminOverrides?: Partial<AdminOptions>): express.Application => {
+  const app = getBaseServer();
+  setupAuth(app, UserModel as unknown as UserModelType);
+  addAuthRoutes(app, UserModel as unknown as UserModelType);
+
+  const admin = new AdminApp({
+    basePath: "/admin",
+    models: [],
+    ...adminOverrides,
+  });
+  admin.register(app);
+
+  app.use(apiUnauthorizedMiddleware);
+  app.use(apiErrorMiddleware);
+
+  return app;
+};
+
+/** Demotes every seeded admin so the DB simulates a fresh deploy with zero admins. */
+const clearAllAdmins = async (): Promise<void> => {
+  await UserModel.updateMany({admin: true}, {$set: {admin: false}});
+};
+
+describe("AdminApp first-admin setup flow", () => {
+  const OLD_ENV = process.env.ADMIN_SETUP_DISABLED;
+
+  afterEach(() => {
+    if (OLD_ENV === undefined) {
+      delete process.env.ADMIN_SETUP_DISABLED;
+    } else {
+      process.env.ADMIN_SETUP_DISABLED = OLD_ENV;
+    }
+  });
+
+  describe("when firstAdminSetup is not configured", () => {
+    let app: express.Application;
+
+    beforeEach(async () => {
+      await setupDb();
+      app = buildApp();
+    });
+
+    it("does not register setup-status", async () => {
+      await supertest(app).get("/admin/setup-status").expect(404);
+    });
+
+    it("does not register setup-claim", async () => {
+      await supertest(app).post("/admin/setup-claim").expect(404);
+    });
+  });
+
+  describe("GET /admin/setup-status", () => {
+    let app: express.Application;
+
+    beforeEach(async () => {
+      await setupDb();
+      app = buildApp({firstAdminSetup: {userModel: UserModel as unknown as UserModelType}});
+    });
+
+    it("returns needsSetup: true when no admin user exists", async () => {
+      await clearAllAdmins();
+
+      const res = await supertest(app).get("/admin/setup-status").expect(200);
+
+      expect(res.body.needsSetup).toBe(true);
+    });
+
+    it("returns needsSetup: false when an admin user already exists", async () => {
+      const res = await supertest(app).get("/admin/setup-status").expect(200);
+
+      expect(res.body.needsSetup).toBe(false);
+    });
+
+    it("returns needsSetup: false when disabled via ADMIN_SETUP_DISABLED", async () => {
+      await clearAllAdmins();
+      process.env.ADMIN_SETUP_DISABLED = "true";
+
+      const res = await supertest(app).get("/admin/setup-status").expect(200);
+
+      expect(res.body.needsSetup).toBe(false);
+    });
+
+    it("does not require authentication", async () => {
+      await clearAllAdmins();
+
+      const res = await supertest(app).get("/admin/setup-status").expect(200);
+
+      expect(res.body.needsSetup).toBe(true);
+    });
+  });
+
+  describe("POST /admin/setup-claim", () => {
+    let app: express.Application;
+    let notAdminAgent: TestAgent;
+    let adminAgent: TestAgent;
+
+    beforeEach(async () => {
+      await setupDb();
+      app = buildApp({firstAdminSetup: {userModel: UserModel as unknown as UserModelType}});
+      notAdminAgent = await authAsUser(app, "notAdmin");
+      adminAgent = await authAsUser(app, "admin");
+    });
+
+    it("returns 401 when unauthenticated", async () => {
+      await clearAllAdmins();
+
+      await supertest(app).post("/admin/setup-claim").expect(401);
+    });
+
+    it("promotes the signed-in user to admin when no admin exists yet", async () => {
+      await clearAllAdmins();
+
+      const res = await notAdminAgent.post("/admin/setup-claim").expect(200);
+
+      expect(res.body.admin).toBe(true);
+      const updated = await UserModel.findOne({email: "notAdmin@example.com"});
+      expect(updated?.admin).toBe(true);
+    });
+
+    it("makes setup-status report needsSetup: false after claiming", async () => {
+      await clearAllAdmins();
+      await notAdminAgent.post("/admin/setup-claim").expect(200);
+
+      const res = await supertest(app).get("/admin/setup-status").expect(200);
+      expect(res.body.needsSetup).toBe(false);
+    });
+
+    it("returns 403 when an admin user already exists", async () => {
+      const res = await notAdminAgent.post("/admin/setup-claim").expect(403);
+
+      expect(res.body.title).toInclude("An admin user already exists");
+      const unchanged = await UserModel.findOne({email: "notAdmin@example.com"});
+      expect(unchanged?.admin).toBe(false);
+    });
+
+    it("returns 403 for an already-admin caller once another admin exists", async () => {
+      // setupDb seeds two admins (admin, adminOther), so the guard rejects even an
+      // already-admin caller since the "no admin exists yet" precondition is false.
+      const res = await adminAgent.post("/admin/setup-claim").expect(403);
+      expect(res.body.title).toInclude("An admin user already exists");
+    });
+
+    it("returns 403 when disabled via ADMIN_SETUP_DISABLED even with zero admins", async () => {
+      await clearAllAdmins();
+      process.env.ADMIN_SETUP_DISABLED = "true";
+
+      const res = await notAdminAgent.post("/admin/setup-claim").expect(403);
+
+      expect(res.body.title).toInclude("An admin user already exists");
+      const unchanged = await UserModel.findOne({email: "notAdmin@example.com"});
+      expect(unchanged?.admin).toBe(false);
+    });
+  });
+});

--- a/admin-backend/src/adminApp.ts
+++ b/admin-backend/src/adminApp.ts
@@ -159,6 +159,19 @@ export interface AdminCustomScreenConfig {
 }
 
 /**
+ * Configuration for the "create the first admin" bootstrap flow.
+ * @see AdminOptions.firstAdminSetup
+ */
+export interface AdminFirstAdminSetupOptions {
+  /**
+   * Mongoose User model used to count existing admins and promote the first one.
+   * Must have an `admin: boolean` field (e.g. via `baseUserPlugin`).
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: Model<T> is invariant; must accept the consumer's User model shape.
+  userModel: Model<any>;
+}
+
+/**
  * Configuration options for the AdminApp plugin.
  */
 export interface AdminOptions {
@@ -177,6 +190,21 @@ export interface AdminOptions {
    * Consumers typically persist to an `AdminAuditLog` collection.
    */
   onAdminAudit?: (event: AdminAuditEvent, req: express.Request) => void | Promise<void>;
+  /**
+   * Enables a "create the first admin" bootstrap flow for when no admin user exists yet
+   * (e.g. a fresh deploy). When configured, registers:
+   * - `GET {basePath}/setup-status` (public) — `{needsSetup: boolean}`
+   * - `POST {basePath}/setup-claim` (authenticated) — promotes the signed-in user to
+   *   `admin: true`, but only while no admin user exists yet.
+   *
+   * Account creation itself (sign up / sign in) is left to the app's existing auth flow
+   * (JWT signup, Better Auth email sign-up, OAuth, ...) — this only "claims" the admin
+   * flag for the first authenticated user while the app has zero admins.
+   *
+   * Set the `ADMIN_SETUP_DISABLED` environment variable to `"true"` to turn this off at
+   * runtime (e.g. after the first admin has been created) without a deploy.
+   */
+  firstAdminSetup?: AdminFirstAdminSetupOptions;
 }
 
 interface AdminFieldMeta {
@@ -450,6 +478,8 @@ export class AdminApp {
     const openApiMw = openApi as OpenApiMiddleware | undefined;
     const modelConfigs = this.options.models;
     const onAdminAudit = this.options.onAdminAudit;
+
+    this.registerFirstAdminSetupRoutes(app, basePath);
 
     /** Audit is best-effort: failures must not change HTTP outcomes after mutations succeed. */
     const safeOnAdminAudit = async (
@@ -1107,6 +1137,59 @@ export class AdminApp {
 
       app.use(`${basePath}/scripts`, scriptsRouter);
     }
+  }
+
+  /**
+   * Registers the optional "create the first admin" bootstrap routes when
+   * {@link AdminOptions.firstAdminSetup} is configured.
+   */
+  private registerFirstAdminSetupRoutes(app: express.Application, basePath: string): void {
+    const setupConfig = this.options.firstAdminSetup;
+    if (!setupConfig) {
+      return;
+    }
+    const {userModel} = setupConfig;
+
+    const isSetupNeeded = async (): Promise<boolean> => {
+      if (process.env.ADMIN_SETUP_DISABLED === "true") {
+        return false;
+      }
+      const adminCount = await userModel.countDocuments({admin: true});
+      return adminCount === 0;
+    };
+
+    // GET /admin/setup-status — public, so an anonymous first-run visitor can detect
+    // whether to show the setup flow before signing in.
+    app.get(
+      `${basePath}/setup-status`,
+      asyncHandler(async (_req, res) => {
+        return res.json({needsSetup: await isSetupNeeded()});
+      })
+    );
+
+    // POST /admin/setup-claim — promotes the calling (already authenticated) user to
+    // admin. Only succeeds while no admin user exists yet. This is a best-effort race
+    // guard (re-checked immediately before writing) rather than a hard atomic guarantee
+    // across documents, which is unnecessary for a one-time bootstrap flow.
+    app.post(
+      `${basePath}/setup-claim`,
+      authenticateMiddleware(),
+      asyncHandler(async (req, res) => {
+        if (!(await isSetupNeeded())) {
+          throw new APIError({status: 403, title: "An admin user already exists"});
+        }
+        const user = req.user as {_id?: unknown} | undefined;
+        if (!user?._id) {
+          throw new APIError({status: 401, title: "Sign in before claiming admin access"});
+        }
+        const result = await userModel.updateOne({_id: user._id}, {$set: {admin: true}});
+        if (result.matchedCount === 0) {
+          throw new APIError({status: 404, title: "User not found"});
+        }
+        logger.info(`Claimed first admin via setup flow: ${String(user._id)}`);
+        return res.status(200).json({admin: true});
+      })
+    );
   }
 
   private mountScriptRoutes(router: express.Router, scripts: AdminScriptConfig[]): void {

--- a/admin-backend/src/adminApp.ts
+++ b/admin-backend/src/adminApp.ts
@@ -479,8 +479,6 @@ export class AdminApp {
     const modelConfigs = this.options.models;
     const onAdminAudit = this.options.onAdminAudit;
 
-    this.registerFirstAdminSetupRoutes(app, basePath);
-
     /** Audit is best-effort: failures must not change HTTP outcomes after mutations succeed. */
     const safeOnAdminAudit = async (
       request: express.Request,
@@ -496,6 +494,8 @@ export class AdminApp {
         logger.error(`onAdminAudit failed after ${event.verb} on ${event.modelName}: ${detail}`);
       }
     };
+
+    this.registerFirstAdminSetupRoutes(app, basePath, safeOnAdminAudit);
 
     // Build config response with field metadata from Mongoose schemas
     const configModels: AdminModelMeta[] = modelConfigs.map((config) => {
@@ -1142,8 +1142,15 @@ export class AdminApp {
   /**
    * Registers the optional "create the first admin" bootstrap routes when
    * {@link AdminOptions.firstAdminSetup} is configured.
+   *
+   * @param onAudit - Shared `safeOnAdminAudit` from {@link register}, so a first-admin
+   * claim shows up in the same `onAdminAudit` trail as other AdminApp mutations.
    */
-  private registerFirstAdminSetupRoutes(app: express.Application, basePath: string): void {
+  private registerFirstAdminSetupRoutes(
+    app: express.Application,
+    basePath: string,
+    onAudit: (request: express.Request, event: AdminAuditEvent) => Promise<void>
+  ): void {
     const setupConfig = this.options.firstAdminSetup;
     if (!setupConfig) {
       return;
@@ -1178,7 +1185,7 @@ export class AdminApp {
         if (!(await isSetupNeeded())) {
           throw new APIError({status: 403, title: "An admin user already exists"});
         }
-        const user = req.user as {_id?: unknown} | undefined;
+        const user = req.user as {_id?: unknown; email?: string; name?: string} | undefined;
         if (!user?._id) {
           throw new APIError({status: 401, title: "Sign in before claiming admin access"});
         }
@@ -1186,7 +1193,15 @@ export class AdminApp {
         if (result.matchedCount === 0) {
           throw new APIError({status: 404, title: "User not found"});
         }
-        logger.info(`Claimed first admin via setup flow: ${String(user._id)}`);
+        const userId = String(user._id);
+        logger.info(`Claimed first admin via setup flow: ${userId}`);
+        await onAudit(req, {
+          actorId: userId,
+          modelName: userModel.modelName,
+          recordId: userId,
+          recordLabel: user.name ?? user.email,
+          verb: "updated",
+        });
         return res.status(200).json({admin: true});
       })
     );

--- a/admin-backend/src/index.ts
+++ b/admin-backend/src/index.ts
@@ -2,6 +2,7 @@ export type {
   AdminAuditEvent,
   AdminCustomScreenConfig,
   AdminFieldOverride,
+  AdminFirstAdminSetupOptions,
   AdminModelConfig,
   AdminOptions,
   AdminScriptConfig,

--- a/admin-spa/README.md
+++ b/admin-spa/README.md
@@ -20,6 +20,9 @@ does) remains supported and unchanged.
 Boot flow: `AppConfigGate` fetches `app-config.json` → `StoreProvider` builds the
 Better-Auth client + Redux store → `AdminGate` syncs the session and redirects
 anonymous users to `/login` and non-admins (admin API returns 403) to `/forbidden`.
+When the backend reports no admin user exists yet (see "First-admin setup" below),
+`AdminGate` redirects to `/setup` instead — including for already-authenticated,
+non-admin sessions — so it takes priority over both `/login` and `/forbidden`.
 
 ## Install
 
@@ -80,6 +83,22 @@ auth/admin API paths per consumer without rebuilding. Defaults:
 }
 ```
 
+## First-admin setup
+
+If the backend registers `AdminApp` with `firstAdminSetup: {userModel: User}` (see
+`@terreno/admin-backend`), the SPA shows a `/setup` screen instead of `/login` whenever
+no admin user exists yet:
+
+- **Anonymous visitor**: fills in name/email/password, which signs up via Better-Auth
+  (`authClient.signUp.email`) and then claims admin access (`POST {adminApiBasePath}/setup-claim`).
+- **Already signed-in, non-admin visitor** (e.g. signed up before anyone was ever
+  promoted to admin): sees a single "Claim admin access" button that calls the same
+  claim endpoint using the existing session — no re-entering credentials.
+
+`setup-claim` only succeeds while zero admin users exist, so the flow disappears (and
+`AdminGate` falls back to the normal login flow) as soon as the first admin is created.
+The backend can also disable the whole flow at runtime via `ADMIN_SETUP_DISABLED=true`.
+
 ## How serving works
 
 - `${basePath}/_expo` and `${basePath}/assets` are served with
@@ -109,7 +128,7 @@ bun run build:web    # produce the static export in dist/
 bun run dev          # expo start --web for local SPA development
 bun run test:ci      # serve-plugin unit tests (supertest)
 bun run smoke        # backend-free smoke over the built dist/
-bun run test:e2e     # Playwright e2e (anonymous -> login) over the built dist/
+bun run test:e2e     # Playwright e2e (anonymous -> login, first-admin setup) over the built dist/
 ```
 
 `dist/` is produced by `bun run build:web` and shipped via

--- a/admin-spa/app/setup.tsx
+++ b/admin-spa/app/setup.tsx
@@ -1,0 +1,134 @@
+import {selectBetterAuthIsAuthenticated} from "@terreno/rtk";
+import {Box, Button, Heading, Text, TextField} from "@terreno/ui";
+import {useRouter} from "expo-router";
+import React, {useCallback, useState} from "react";
+import {useDispatch, useSelector} from "react-redux";
+import {useAppConfig} from "../components/AppConfigGate";
+import {useAuth} from "../components/StoreProvider";
+import {useClaimFirstAdminMutation} from "../store/sdk";
+
+/**
+ * Shown by `AdminGate` when the backend reports no admin user exists yet
+ * (`GET {adminApiBasePath}/setup-status` → `needsSetup: true`). Lets the very first
+ * visitor bootstrap admin access without needing a database console:
+ * - Anonymous visitor: create an account (better-auth email sign-up), then claim it.
+ * - Already signed-in, non-admin visitor (e.g. signed up before an admin was ever
+ *   promoted): just claim admin access for the current session.
+ *
+ * "Claiming" calls the backend's `POST {adminApiBasePath}/setup-claim`, which only
+ * succeeds while zero admin users exist — see `AdminApp`'s `firstAdminSetup` option.
+ */
+const SetupScreen: React.FC = () => {
+  const router = useRouter();
+  const dispatch = useDispatch();
+  const {appConfig} = useAppConfig();
+  const {authClient, syncSession} = useAuth();
+  const isAuthenticated = useSelector(selectBetterAuthIsAuthenticated);
+  const apiBase = appConfig.adminApiBasePath ?? "/admin";
+  const [claimFirstAdmin, {isLoading: isClaiming}] = useClaimFirstAdminMutation();
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const claimAndEnter = useCallback(async (): Promise<void> => {
+    await claimFirstAdmin({apiBase}).unwrap();
+    router.replace("/");
+  }, [apiBase, claimFirstAdmin, router]);
+
+  const handleCreateAccount = useCallback(async (): Promise<void> => {
+    setError(undefined);
+    setIsSubmitting(true);
+    try {
+      const result = await authClient.signUp.email({email, name, password});
+      if (result.error) {
+        setError(result.error.message ?? "Failed to create the admin account.");
+        return;
+      }
+      await syncSession(dispatch);
+      await claimAndEnter();
+    } catch (err) {
+      console.error("Setup: account creation failed", err);
+      setError("Failed to create the admin account. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [authClient, claimAndEnter, dispatch, email, name, password, syncSession]);
+
+  const handleClaimExisting = useCallback(async (): Promise<void> => {
+    setError(undefined);
+    setIsSubmitting(true);
+    try {
+      await claimAndEnter();
+    } catch (err) {
+      console.error("Setup: claiming admin access failed", err);
+      setError("Failed to claim admin access. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [claimAndEnter]);
+
+  const isBusy = isSubmitting || isClaiming;
+
+  return (
+    <Box alignItems="center" color="base" flex="grow" justifyContent="center" padding={6}>
+      <Box gap={5} maxWidth={420} width="100%">
+        <Heading align="center" size="lg">
+          {appConfig.brandName}
+        </Heading>
+        <Text align="center" color="secondaryDark">
+          No admin account exists yet.{" "}
+          {isAuthenticated
+            ? "Claim admin access for your signed-in account to get started."
+            : "Create the first admin account to get started."}
+        </Text>
+        {error ? (
+          <Text align="center" color="error" testID="admin-spa-setup-error">
+            {error}
+          </Text>
+        ) : null}
+        {isAuthenticated ? (
+          <Button
+            fullWidth
+            loading={isBusy}
+            onClick={handleClaimExisting}
+            testID="admin-spa-setup-claim"
+            text="Claim admin access"
+            variant="primary"
+          />
+        ) : (
+          <Box gap={3}>
+            <TextField onChange={setName} testID="admin-spa-setup-name" title="Name" value={name} />
+            <TextField
+              onChange={setEmail}
+              placeholder="you@example.com"
+              testID="admin-spa-setup-email"
+              title="Email"
+              type="email"
+              value={email}
+            />
+            <TextField
+              onChange={setPassword}
+              testID="admin-spa-setup-password"
+              title="Password"
+              type="password"
+              value={password}
+            />
+            <Button
+              fullWidth
+              loading={isBusy}
+              onClick={handleCreateAccount}
+              testID="admin-spa-setup-submit"
+              text="Create admin account"
+              variant="primary"
+            />
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default SetupScreen;

--- a/admin-spa/components/AdminGate.test.ts
+++ b/admin-spa/components/AdminGate.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from "bun:test";
-import {isForbiddenAdminConfigError} from "./adminGateUtils";
+import {isForbiddenAdminConfigError, resolveAdminGateState} from "./adminGateUtils";
 
 describe("isForbiddenAdminConfigError", () => {
   it("returns true only for authenticated 403 responses", () => {
@@ -67,5 +67,50 @@ describe("isForbiddenAdminConfigError", () => {
         status: 403,
       })
     ).toBe(false);
+  });
+});
+
+describe("resolveAdminGateState", () => {
+  const baseOptions = {
+    isAuthenticated: false,
+    isAuthLoading: false,
+    isForbidden: false,
+    isSetupStatusLoading: false,
+    needsSetup: false,
+  };
+
+  it("returns loading while auth or setup-status is still resolving", () => {
+    expect(resolveAdminGateState({...baseOptions, isAuthLoading: true})).toBe("loading");
+    expect(resolveAdminGateState({...baseOptions, isSetupStatusLoading: true})).toBe("loading");
+  });
+
+  it("returns setup when no admin user exists yet, even for an anonymous visitor", () => {
+    expect(resolveAdminGateState({...baseOptions, needsSetup: true})).toBe("setup");
+  });
+
+  it("prioritizes setup over login for an authenticated non-admin visitor", () => {
+    expect(resolveAdminGateState({...baseOptions, isAuthenticated: true, needsSetup: true})).toBe(
+      "setup"
+    );
+  });
+
+  it("returns login when unauthenticated and setup is not needed", () => {
+    expect(resolveAdminGateState({...baseOptions, isAuthenticated: false})).toBe("login");
+  });
+
+  it("returns login on a 401 even if isAuthenticated is stale/true", () => {
+    expect(resolveAdminGateState({...baseOptions, isAuthenticated: true, status: 401})).toBe(
+      "login"
+    );
+  });
+
+  it("returns forbidden for an authenticated non-admin visitor", () => {
+    expect(resolveAdminGateState({...baseOptions, isAuthenticated: true, isForbidden: true})).toBe(
+      "forbidden"
+    );
+  });
+
+  it("returns app for an authenticated admin visitor", () => {
+    expect(resolveAdminGateState({...baseOptions, isAuthenticated: true})).toBe("app");
   });
 });

--- a/admin-spa/components/AdminGate.tsx
+++ b/admin-spa/components/AdminGate.tsx
@@ -4,9 +4,13 @@ import {Box, Spinner} from "@terreno/ui";
 import {usePathname, useRouter} from "expo-router";
 import React, {useEffect} from "react";
 import {useDispatch, useSelector} from "react-redux";
-import {terrenoApi} from "../store/sdk";
+import {terrenoApi, useGetAdminSetupStatusQuery} from "../store/sdk";
 import {useAppConfig} from "./AppConfigGate";
-import {isForbiddenAdminConfigError} from "./adminGateUtils";
+import {
+  ADMIN_GATE_ROUTES,
+  isForbiddenAdminConfigError,
+  resolveAdminGateState,
+} from "./adminGateUtils";
 import {useAuth} from "./StoreProvider";
 
 interface RtkError {
@@ -26,13 +30,19 @@ const LoadingScreen: React.FC = () => (
 
 /**
  * Auth + authorization gate. Syncs the better-auth session on mount, then:
+ * - no admin user exists yet (backend `firstAdminSetup` opted in) → redirect to /setup
  * - unauthenticated → redirect to /login
  * - authenticated but NOT an admin (admin API returns 403) → redirect to /forbidden
- * - authenticated admin sitting on /login or /forbidden → redirect to /
+ * - authenticated admin sitting on /login, /forbidden, or /setup → redirect to /
  *
  * Admin status is determined by the backend's own authorization on `${adminApiBase}/config`
  * (200 = admin, 403 = forbidden), since the better-auth session does not carry the
  * Terreno `admin` flag.
+ *
+ * The setup check calls `${adminApiBase}/setup-status`, which only exists when the backend
+ * configured `AdminApp`'s `firstAdminSetup` option. A missing/erroring endpoint (feature not
+ * configured, or disabled via `ADMIN_SETUP_DISABLED`) is treated the same as "no setup needed"
+ * so the gate falls through to the normal login flow.
  */
 export const AdminGate: React.FC<{children: React.ReactNode}> = ({children}) => {
   const dispatch = useDispatch();
@@ -45,6 +55,13 @@ export const AdminGate: React.FC<{children: React.ReactNode}> = ({children}) => 
   const isAuthenticated = useSelector(selectBetterAuthIsAuthenticated);
 
   const apiBase = appConfig.adminApiBasePath ?? "/admin";
+  const {
+    data: setupStatus,
+    isLoading: isSetupStatusLoading,
+    isError: isSetupStatusError,
+  } = useGetAdminSetupStatusQuery({apiBase});
+  const needsSetup = !isSetupStatusError && Boolean(setupStatus?.needsSetup);
+
   const {config, isLoading: isConfigLoading, error} = useAdminConfig(terrenoApi, apiBase);
   const status = (error as RtkError | undefined)?.status;
   const isForbidden = isForbiddenAdminConfigError({
@@ -55,41 +72,44 @@ export const AdminGate: React.FC<{children: React.ReactNode}> = ({children}) => 
   });
   const isAdmin = isAuthenticated && !isConfigLoading && !error && Boolean(config);
 
+  const gateState = resolveAdminGateState({
+    isAuthenticated,
+    isAuthLoading,
+    isForbidden,
+    isSetupStatusLoading,
+    needsSetup,
+    status,
+  });
+
   // Sync the better-auth session into Redux once on mount.
   useEffect(() => {
     void syncSession(dispatch);
   }, [dispatch, syncSession]);
 
-  // Drive redirects from auth + authorization state.
+  // Drive redirects from setup + auth + authorization state.
   useEffect(() => {
-    if (isAuthLoading) {
+    if (gateState === "loading") {
       return;
     }
-    if (!isAuthenticated || status === 401) {
-      if (pathname !== "/login") {
-        router.replace("/login");
+    if (gateState === "app") {
+      const onGateScreen =
+        pathname === "/login" || pathname === "/forbidden" || pathname === "/setup";
+      if (isAdmin && onGateScreen) {
+        router.replace("/");
       }
       return;
     }
-    if (isForbidden) {
-      if (pathname !== "/forbidden") {
-        router.replace("/forbidden");
-      }
-      return;
+    const target = ADMIN_GATE_ROUTES[gateState];
+    if (pathname !== target) {
+      router.replace(target);
     }
-    if (isAdmin && (pathname === "/login" || pathname === "/forbidden")) {
-      router.replace("/");
-    }
-  }, [isAuthLoading, isAuthenticated, isForbidden, isAdmin, status, pathname, router]);
+  }, [gateState, isAdmin, pathname, router]);
 
-  if (isAuthLoading) {
+  if (gateState === "loading") {
     return <LoadingScreen />;
   }
-  if (!isAuthenticated || status === 401) {
-    return pathname === "/login" ? children : <LoadingScreen />;
-  }
-  if (isForbidden) {
-    return pathname === "/forbidden" ? children : <LoadingScreen />;
+  if (gateState !== "app") {
+    return pathname === ADMIN_GATE_ROUTES[gateState] ? children : <LoadingScreen />;
   }
   if (isConfigLoading) {
     return <LoadingScreen />;

--- a/admin-spa/components/adminGateUtils.ts
+++ b/admin-spa/components/adminGateUtils.ts
@@ -22,3 +22,56 @@ export const isForbiddenAdminConfigError = ({
   }
   return status === 403;
 };
+
+/**
+ * Screens `AdminGate` may show instead of the wrapped app content. `"app"` means the
+ * visitor is a verified admin (the gate still checks `isConfigLoading` separately before
+ * rendering children in that case).
+ */
+export type AdminGateState = "loading" | "setup" | "login" | "forbidden" | "app";
+
+/** The route each non-"loading"/"app" gate state redirects to. */
+export const ADMIN_GATE_ROUTES: Record<Exclude<AdminGateState, "loading" | "app">, string> = {
+  forbidden: "/forbidden",
+  login: "/login",
+  setup: "/setup",
+};
+
+interface ResolveAdminGateStateOptions {
+  isAuthLoading: boolean;
+  isSetupStatusLoading: boolean;
+  /** True when the backend reports no admin user exists yet. */
+  needsSetup: boolean;
+  isAuthenticated: boolean;
+  isForbidden: boolean;
+  status?: number;
+}
+
+/**
+ * Pure decision function behind `AdminGate`. Priority order matters: the setup flow
+ * takes precedence over login (an anonymous visitor sees /setup, not /login, when no
+ * admin exists yet), which takes precedence over the forbidden check (which requires an
+ * authenticated, non-admin session).
+ */
+export const resolveAdminGateState = ({
+  isAuthLoading,
+  isSetupStatusLoading,
+  needsSetup,
+  isAuthenticated,
+  isForbidden,
+  status,
+}: ResolveAdminGateStateOptions): AdminGateState => {
+  if (isAuthLoading || isSetupStatusLoading) {
+    return "loading";
+  }
+  if (needsSetup) {
+    return "setup";
+  }
+  if (!isAuthenticated || status === 401) {
+    return "login";
+  }
+  if (isForbidden) {
+    return "forbidden";
+  }
+  return "app";
+};

--- a/admin-spa/e2e/credentials.ts
+++ b/admin-spa/e2e/credentials.ts
@@ -5,3 +5,11 @@
  */
 export const E2E_ADMIN_EMAIL = "admin-e2e@example.com";
 export const E2E_ADMIN_PASSWORD = "admin-e2e-password";
+
+/**
+ * Cookie a spec sets on its browser context to make the mock server's
+ * `/admin/setup-status` report `needsSetup: true` for that context only. Scoping via a
+ * per-context cookie (rather than shared server state) keeps the first-admin-setup specs
+ * safe to run in parallel with the rest of the suite against the same webServer.
+ */
+export const E2E_NEEDS_SETUP_COOKIE = "admin_spa_e2e_needs_setup";

--- a/admin-spa/e2e/serveTestApp.ts
+++ b/admin-spa/e2e/serveTestApp.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import express from "express";
 import {DateTime} from "luxon";
 import {AdminSpaServeApp} from "../src/serve";
-import {E2E_ADMIN_EMAIL, E2E_ADMIN_PASSWORD} from "./credentials";
+import {E2E_ADMIN_EMAIL, E2E_ADMIN_PASSWORD, E2E_NEEDS_SETUP_COOKIE} from "./credentials";
 
 // Pre-built bundle lives at admin-spa/dist. Resolved explicitly (rather than relying on
 // the plugin's compiled-location default) so the e2e works when run from TS source.
@@ -103,6 +103,22 @@ export const createTestApp = (): express.Express => {
     });
   });
 
+  // Mock better-auth email sign-up: any new email/name/password succeeds and sets a
+  // session cookie, mirroring the real Better Auth flow the setup screen relies on.
+  app.post("/api/auth/sign-up/email", (req, res) => {
+    const {email, name} = req.body ?? {};
+    res.cookie(SESSION_COOKIE, SESSION_TOKEN, {httpOnly: true, path: "/", sameSite: "lax"});
+    res.json({
+      redirect: false,
+      token: SESSION_TOKEN,
+      user: {
+        ...E2E_ADMIN_USER,
+        email: email ?? E2E_ADMIN_USER.email,
+        name: name ?? E2E_ADMIN_USER.name,
+      },
+    });
+  });
+
   // Mock better-auth sign-out: clears the session cookie.
   app.post("/api/auth/sign-out", (_req, res) => {
     res.clearCookie(SESSION_COOKIE, {path: "/"});
@@ -117,6 +133,22 @@ export const createTestApp = (): express.Express => {
       return;
     }
     res.json(ADMIN_CONFIG);
+  });
+
+  // Mock the first-admin setup flow exposed by AdminApp's `firstAdminSetup` option.
+  // `needsSetup` is driven entirely by the per-context E2E_NEEDS_SETUP_COOKIE (set by
+  // the spec via `page.context().addCookies`) so parallel test workers sharing this
+  // server never interfere with each other.
+  app.get("/admin/setup-status", (req, res) => {
+    const needsSetup = (req.headers.cookie ?? "").includes(`${E2E_NEEDS_SETUP_COOKIE}=1`);
+    res.json({needsSetup});
+  });
+  app.post("/admin/setup-claim", (req, res) => {
+    if (!hasSession(req)) {
+      res.status(401).json({title: "Sign in before claiming admin access"});
+      return;
+    }
+    res.clearCookie(E2E_NEEDS_SETUP_COOKIE, {path: "/"}).json({admin: true});
   });
 
   const plugin = new AdminSpaServeApp({

--- a/admin-spa/e2e/setup.spec.ts
+++ b/admin-spa/e2e/setup.spec.ts
@@ -1,0 +1,81 @@
+import type {BrowserContext} from "@playwright/test";
+import {expect, test} from "@playwright/test";
+import {E2E_ADMIN_EMAIL, E2E_ADMIN_PASSWORD, E2E_NEEDS_SETUP_COOKIE} from "./credentials";
+
+/** Marks this browser context as "no admin exists yet" for every subsequent request. */
+const setNeedsSetupCookie = async (context: BrowserContext, baseURL: string): Promise<void> => {
+  await context.addCookies([{name: E2E_NEEDS_SETUP_COOKIE, url: baseURL, value: "1"}]);
+};
+
+/**
+ * End-to-end: the first-admin setup flow shown when the (mocked) backend reports no
+ * admin user exists yet (`GET /admin/setup-status` → `needsSetup: true`, driven by the
+ * per-context E2E_NEEDS_SETUP_COOKIE — see serveTestApp.ts). Exercises AdminGate's setup
+ * redirect, the setup screen's sign-up-then-claim path, and its claim-only path for an
+ * already-authenticated visitor.
+ */
+test.describe("first-admin setup flow", () => {
+  test("anonymous visitor is redirected to setup instead of login", async ({page, baseURL}) => {
+    await setNeedsSetupCookie(page.context(), baseURL ?? "http://localhost:4100");
+
+    await page.goto("/console/");
+
+    await page.waitForURL(/\/console\/setup/, {timeout: 20_000});
+    await expect(page.getByText("No admin account exists yet.")).toBeVisible();
+    await expect(page.getByTestId("admin-spa-setup-name")).toBeVisible();
+    await expect(page.getByTestId("admin-spa-setup-email")).toBeVisible();
+    await expect(page.getByTestId("admin-spa-setup-password")).toBeVisible();
+    await expect(page.getByTestId("admin-spa-setup-submit")).toBeVisible();
+  });
+
+  test("creating the first admin account signs up, claims admin, and lands on the admin home", async ({
+    page,
+    baseURL,
+  }) => {
+    await setNeedsSetupCookie(page.context(), baseURL ?? "http://localhost:4100");
+
+    await page.goto("/console/setup");
+    await expect(page.getByTestId("admin-spa-setup-name")).toBeVisible();
+
+    await page.getByTestId("admin-spa-setup-name").fill("First Admin");
+    await page.getByTestId("admin-spa-setup-email").fill("first-admin@example.com");
+    await page.getByTestId("admin-spa-setup-password").fill("first-admin-password");
+    await page.getByTestId("admin-spa-setup-submit").click();
+
+    // Successful sign-up + claim routes to the SPA root, rendering AdminHome from the
+    // (mocked) /admin/config response — /admin/setup-claim clears the setup cookie
+    // server-side, so this next navigation no longer bounces back to /setup.
+    await page.waitForURL(/\/console\/?$/, {timeout: 20_000});
+    await expect(page.getByTestId("admin-home-models-grid-Todo-clickable")).toBeVisible({
+      timeout: 20_000,
+    });
+  });
+
+  test("an already signed-in visitor can claim admin access directly, without re-entering credentials", async ({
+    page,
+    baseURL,
+  }) => {
+    // Sign in normally first (no setup cookie yet), establishing a real session.
+    await page.goto("/console/login");
+    await page.getByTestId("admin-spa-login-email").fill(E2E_ADMIN_EMAIL);
+    await page.getByTestId("admin-spa-login-password").fill(E2E_ADMIN_PASSWORD);
+    await page.getByTestId("admin-spa-login-submit").click();
+    await page.waitForURL(/\/console\/?$/, {timeout: 20_000});
+
+    // Now simulate "no admin exists yet" and reload — AdminGate should send the already
+    // signed-in visitor to /setup (not /login), and the screen should offer a claim-only
+    // button since a session already exists.
+    await setNeedsSetupCookie(page.context(), baseURL ?? "http://localhost:4100");
+    await page.goto("/console/");
+    await page.waitForURL(/\/console\/setup/, {timeout: 20_000});
+
+    await expect(page.getByTestId("admin-spa-setup-name")).toHaveCount(0);
+    await expect(page.getByTestId("admin-spa-setup-claim")).toBeVisible();
+    await page.getByTestId("admin-spa-setup-claim").click();
+
+    await page.waitForURL(/\/console\/?$/, {timeout: 20_000});
+    await expect(page.getByTestId("admin-home-models-grid-Todo-clickable")).toBeVisible({
+      timeout: 20_000,
+    });
+  });
+});

--- a/admin-spa/package.json
+++ b/admin-spa/package.json
@@ -94,8 +94,8 @@
     "lint:fix": "biome check --write ./src ./app ./store ./components ./e2e playwright.config.ts playwright.integration.config.ts",
     "smoke": "bun e2e/smoke.ts",
     "start": "expo start",
-    "test": "bun test ./src",
-    "test:ci": "bun test ./src",
+    "test": "bun test ./src ./components",
+    "test:ci": "bun test ./src ./components",
     "test:e2e": "playwright test",
     "test:integration": "playwright test --config playwright.integration.config.ts",
     "web": "expo start --web --port 8083"

--- a/admin-spa/store/sdk.ts
+++ b/admin-spa/store/sdk.ts
@@ -1,6 +1,15 @@
 import type {AdminScreenProps} from "@terreno/admin-frontend";
 import {createSessionApi} from "@terreno/rtk";
 
+export interface AdminSetupStatusResponse {
+  /** True when no admin user exists yet and the first-admin setup flow should be shown. */
+  needsSetup: boolean;
+}
+
+export interface AdminSetupClaimResponse {
+  admin: boolean;
+}
+
 /**
  * Base RTK Query API for the admin SPA. Admin CRUD endpoints are injected at runtime
  * by `@terreno/admin-frontend`'s `useAdminApi`/`useAdminConfig` hooks, so no codegen is
@@ -11,10 +20,29 @@ import {createSessionApi} from "@terreno/rtk";
  * better-auth session cookie on the same origin, and `emptySplitApi`'s JWT base query
  * would dispatch a global logout (killing the better-auth session) whenever no bearer
  * token is found in storage.
+ *
+ * Also injects the first-admin setup endpoints (`GET {apiBase}/setup-status`,
+ * `POST {apiBase}/setup-claim`) exposed by `@terreno/admin-backend`'s `AdminApp` when
+ * `firstAdminSetup` is configured. Declared here (rather than dynamically like the
+ * admin-frontend hooks) since the setup gate needs typed hooks before any model config
+ * is known.
  */
-export const openapi = createSessionApi().enhanceEndpoints({
-  addTagTypes: ["admin-models", "admin-version-config", "admin-scripts", "profile"],
-});
+export const openapi = createSessionApi()
+  .enhanceEndpoints({
+    addTagTypes: ["admin-models", "admin-version-config", "admin-scripts", "profile"],
+  })
+  .injectEndpoints({
+    endpoints: (build) => ({
+      claimFirstAdmin: build.mutation<AdminSetupClaimResponse, {apiBase: string}>({
+        query: ({apiBase}) => ({method: "POST", url: `${apiBase}/setup-claim`}),
+      }),
+      getAdminSetupStatus: build.query<AdminSetupStatusResponse, {apiBase: string}>({
+        query: ({apiBase}) => ({method: "GET", url: `${apiBase}/setup-status`}),
+      }),
+    }),
+  });
+
+export const {useClaimFirstAdminMutation, useGetAdminSetupStatusQuery} = openapi;
 
 /**
  * The API instance passed to `@terreno/admin-frontend` screens. Cast to the

--- a/admin-spa/store/sdk.ts
+++ b/admin-spa/store/sdk.ts
@@ -26,17 +26,45 @@ export interface AdminSetupClaimResponse {
  * `firstAdminSetup` is configured. Declared here (rather than dynamically like the
  * admin-frontend hooks) since the setup gate needs typed hooks before any model config
  * is known.
+ *
+ * `claimFirstAdmin` both patches the cached `getAdminSetupStatus` result to
+ * `needsSetup: false` synchronously on success (`onQueryStarted`) and invalidates the
+ * `admin-setup-status` tag (background refetch, reconciling with the server as the
+ * source of truth). The synchronous patch closes the race between the mutation
+ * resolving and `AdminGate`'s immediate post-claim `router.replace("/")` — without it,
+ * the gate would briefly re-derive `needsSetup: true` from stale cached data and bounce
+ * back to `/setup`.
  */
 export const openapi = createSessionApi()
   .enhanceEndpoints({
-    addTagTypes: ["admin-models", "admin-version-config", "admin-scripts", "profile"],
+    addTagTypes: [
+      "admin-models",
+      "admin-version-config",
+      "admin-scripts",
+      "admin-setup-status",
+      "profile",
+    ],
   })
   .injectEndpoints({
     endpoints: (build) => ({
       claimFirstAdmin: build.mutation<AdminSetupClaimResponse, {apiBase: string}>({
+        invalidatesTags: ["admin-setup-status"],
+        onQueryStarted: async ({apiBase}, {dispatch, queryFulfilled}) => {
+          try {
+            await queryFulfilled;
+            dispatch(
+              openapi.util.updateQueryData("getAdminSetupStatus", {apiBase}, (draft) => {
+                draft.needsSetup = false;
+              })
+            );
+          } catch {
+            // Claim failed; leave the cached setup-status untouched.
+          }
+        },
         query: ({apiBase}) => ({method: "POST", url: `${apiBase}/setup-claim`}),
       }),
       getAdminSetupStatus: build.query<AdminSetupStatusResponse, {apiBase: string}>({
+        providesTags: ["admin-setup-status"],
         query: ({apiBase}) => ({method: "GET", url: `${apiBase}/setup-status`}),
       }),
     }),

--- a/admin-spa/store/sdk.ts
+++ b/admin-spa/store/sdk.ts
@@ -27,44 +27,37 @@ export interface AdminSetupClaimResponse {
  * admin-frontend hooks) since the setup gate needs typed hooks before any model config
  * is known.
  *
- * `claimFirstAdmin` both patches the cached `getAdminSetupStatus` result to
- * `needsSetup: false` synchronously on success (`onQueryStarted`) and invalidates the
- * `admin-setup-status` tag (background refetch, reconciling with the server as the
- * source of truth). The synchronous patch closes the race between the mutation
- * resolving and `AdminGate`'s immediate post-claim `router.replace("/")` — without it,
- * the gate would briefly re-derive `needsSetup: true` from stale cached data and bounce
- * back to `/setup`.
+ * On a successful claim, `claimFirstAdmin` resets the entire RTK Query cache
+ * (`api.util.resetApiState()`) rather than only invalidating `getAdminSetupStatus`.
+ * The visitor just transitioned from anonymous/non-admin to admin, so every other
+ * cached response is now stale too — most notably `@terreno/admin-frontend`'s
+ * dynamically-injected `adminConfig` query (`GET {apiBase}/config`, used by
+ * `AdminGate` to decide `isForbidden`/`isAdmin`), which was very likely cached as a
+ * 403 from before the claim and carries no tags this module could invalidate
+ * directly. Without the reset, `AdminGate` would derive `isForbidden` from that stale
+ * 403 and redirect the freshly-promoted admin to `/forbidden` instead of `/`. Active
+ * subscribers (AdminGate's `useGetAdminSetupStatusQuery` and `useAdminConfig`) refetch
+ * automatically once their cache entries are cleared, so the gate briefly shows its
+ * loading state instead of bouncing to the wrong screen.
  */
 export const openapi = createSessionApi()
   .enhanceEndpoints({
-    addTagTypes: [
-      "admin-models",
-      "admin-version-config",
-      "admin-scripts",
-      "admin-setup-status",
-      "profile",
-    ],
+    addTagTypes: ["admin-models", "admin-version-config", "admin-scripts", "profile"],
   })
   .injectEndpoints({
     endpoints: (build) => ({
       claimFirstAdmin: build.mutation<AdminSetupClaimResponse, {apiBase: string}>({
-        invalidatesTags: ["admin-setup-status"],
-        onQueryStarted: async ({apiBase}, {dispatch, queryFulfilled}) => {
+        onQueryStarted: async (_args, {dispatch, queryFulfilled}) => {
           try {
             await queryFulfilled;
-            dispatch(
-              openapi.util.updateQueryData("getAdminSetupStatus", {apiBase}, (draft) => {
-                draft.needsSetup = false;
-              })
-            );
+            dispatch(openapi.util.resetApiState());
           } catch {
-            // Claim failed; leave the cached setup-status untouched.
+            // Claim failed; leave the cache untouched.
           }
         },
         query: ({apiBase}) => ({method: "POST", url: `${apiBase}/setup-claim`}),
       }),
       getAdminSetupStatus: build.query<AdminSetupStatusResponse, {apiBase: string}>({
-        providesTags: ["admin-setup-status"],
         query: ({apiBase}) => ({method: "GET", url: `${apiBase}/setup-status`}),
       }),
     }),

--- a/example-backend/src/server.ts
+++ b/example-backend/src/server.ts
@@ -249,6 +249,13 @@ export async function start(skipListen = false): Promise<express.Application> {
               name: "showcase",
             },
           ],
+          // Lets the very first visitor bootstrap admin access (no admin user exists
+          // yet) without a database console. Set ADMIN_SETUP_DISABLED=true to turn this
+          // off once the first admin has been created.
+          firstAdminSetup: {
+            // biome-ignore lint/suspicious/noExplicitAny: User model type mismatch
+            userModel: User as any,
+          },
           home: {
             slots: {
               contentTop: [],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a "create the first admin" setup flow to `admin-spa`, shown automatically when no admin user exists yet, with a runtime environment variable to disable it.

### Backend (`@terreno/admin-backend`)

`AdminApp` gains an opt-in `firstAdminSetup: {userModel}` option. When configured it registers two routes:

- `GET {basePath}/setup-status` (public) — `{needsSetup: boolean}`, true only while `userModel.countDocuments({admin: true}) === 0`
- `POST {basePath}/setup-claim` (authenticated) — promotes the calling (already signed-in) user to `admin: true`, but only while no admin user exists yet

Account creation itself (sign up / sign in) stays with the app's existing auth flow (JWT signup, Better Auth email sign-up, OAuth, ...) — `setup-claim` only "claims" the admin flag for the first authenticated user while the app has zero admins.

**Toggle:** set `ADMIN_SETUP_DISABLED=true` to turn the whole flow off at runtime (e.g. once the first admin has been created), without a deploy — mirrors the existing `SIGNUP_DISABLED` convention in `@terreno/api`.

### Frontend (`@terreno/admin-spa`)

`AdminGate` now checks `GET {adminApiBasePath}/setup-status` and redirects to a new `/setup` screen — ahead of both `/login` and `/forbidden` — whenever the backend reports no admin exists yet. A missing/erroring endpoint (feature not configured, or disabled) is treated the same as "no setup needed," so existing consumers are unaffected.

The `/setup` screen adapts to session state:
- **Anonymous visitor:** fills in name/email/password → Better Auth sign-up → claims admin access.
- **Already signed-in, non-admin visitor** (e.g. signed up before anyone was promoted): a single "Claim admin access" button using the existing session.

The gate's branching logic was extracted into a pure `resolveAdminGateState` helper (unit tested) for testability.

### example-backend

Wired `firstAdminSetup: {userModel: User}` into the example `AdminApp` registration so the flow is exercised end-to-end via `/console`.

## Testing

- `admin-backend`: 12 new unit tests covering `setup-status`/`setup-claim` (disabled-by-default-when-unconfigured, race guard, `ADMIN_SETUP_DISABLED`, auth requirements). Full suite: 155 pass.
- `admin-spa`: unit tests for `resolveAdminGateState`; 3 new Playwright e2e specs (anonymous → setup, sign-up + claim, already-signed-in claim) against a mocked backend, isolated per-browser-context via a cookie so they're safe to run in parallel with the rest of the suite. Full `test:ci` + `test:e2e` suites pass.
- `example-backend`: full suite still passes (74 tests); `bun run compile`/`lint` clean across all touched packages.

## Docs

Updated `admin-spa/README.md` and the `admin-backend` Cursor AI rules doc to describe the new option/flow.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec2acd3a-011b-42df-8dd6-bef58d5fbc8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec2acd3a-011b-42df-8dd6-bef58d5fbc8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

