### PR TITLE
fix(ui): consistent SelectField placeholder size across searchable toggle

### DIFF
--- a/ui/src/PickerSelect.tsx
+++ b/ui/src/PickerSelect.tsx
@@ -714,7 +714,7 @@ export const RNPickerSelect = ({
       color: disabled ? theme.text.secondaryLight : theme.text.primary,
       flex: 1,
       fontFamily: "text" as const,
-      fontSize: 14,
+      fontSize: 16,
       paddingLeft: 0,
       paddingRight: 8,
       paddingVertical: 0,
@@ -793,6 +793,8 @@ export const RNPickerSelect = ({
               style={{
                 color: disabled ? theme.text.secondaryLight : theme.text.primary,
                 flex: 1,
+                fontFamily: "text",
+                fontSize: 16,
                 paddingRight: 8,
               }}
               testID="text_input"

--- a/ui/src/__snapshots__/AddressField.test.tsx.snap
+++ b/ui/src/__snapshots__/AddressField.test.tsx.snap
@@ -396,6 +396,8 @@ exports[`AddressField renders correctly with default props 1`] = `
                           "style": {
                             "color": "#1C1C1C",
                             "flex": 1,
+                            "fontFamily": "text",
+                            "fontSize": 16,
                             "paddingRight": 8,
                           },
                           "testID": "text_input",

--- a/ui/src/__snapshots__/CustomSelectField.test.tsx.snap
+++ b/ui/src/__snapshots__/CustomSelectField.test.tsx.snap
@@ -29,6 +29,8 @@ exports[`CustomSelectField renders correctly with default props 1`] = `
                             "style": {
                               "color": "#1C1C1C",
                               "flex": 1,
+                              "fontFamily": "text",
+                              "fontSize": 16,
                               "paddingRight": 8,
                             },
                             "testID": "text_input",
@@ -467,6 +469,8 @@ exports[`CustomSelectField renders with title 1`] = `
                             "style": {
                               "color": "#1C1C1C",
                               "flex": 1,
+                              "fontFamily": "text",
+                              "fontSize": 16,
                               "paddingRight": 8,
                             },
                             "testID": "text_input",
@@ -890,6 +894,8 @@ exports[`CustomSelectField renders with placeholder 1`] = `
                             "style": {
                               "color": "#1C1C1C",
                               "flex": 1,
+                              "fontFamily": "text",
+                              "fontSize": 16,
                               "paddingRight": 8,
                             },
                             "testID": "text_input",
@@ -1313,6 +1319,8 @@ exports[`CustomSelectField renders with selected value 1`] = `
                             "style": {
                               "color": "#1C1C1C",
                               "flex": 1,
+                              "fontFamily": "text",
+                              "fontSize": 16,
                               "paddingRight": 8,
                             },
                             "testID": "text_input",
@@ -1736,6 +1744,8 @@ exports[`CustomSelectField renders with custom value (not in options) 1`] = `
                             "style": {
                               "color": "#1C1C1C",
                               "flex": 1,
+                              "fontFamily": "text",
+                              "fontSize": 16,
                               "paddingRight": 8,
                             },
                             "testID": "text_input",
@@ -2263,6 +2273,8 @@ exports[`CustomSelectField renders disabled state 1`] = `
                             "style": {
                               "color": "#686868",
                               "flex": 1,
+                              "fontFamily": "text",
+                              "fontSize": 16,
                               "paddingRight": 8,
                             },
                             "testID": "text_input",
@@ -2688,6 +2700,8 @@ exports[`CustomSelectField includes custom option in dropdown 1`] = `
                             "style": {
                               "color": "#1C1C1C",
                               "flex": 1,
+                              "fontFamily": "text",
+                              "fontSize": 16,
                               "paddingRight": 8,
                             },
                             "testID": "text_input",

--- a/ui/src/__snapshots__/Field.test.tsx.snap
+++ b/ui/src/__snapshots__/Field.test.tsx.snap
@@ -1198,6 +1198,8 @@ exports[`Field renders time field 1`] = `
                                 "style": {
                                   "color": "#1C1C1C",
                                   "flex": 1,
+                                  "fontFamily": "text",
+                                  "fontSize": 16,
                                   "paddingRight": 8,
                                 },
                                 "testID": "text_input",
@@ -1494,6 +1496,8 @@ exports[`Field renders time field 1`] = `
                                 "style": {
                                   "color": "#1C1C1C",
                                   "flex": 1,
+                                  "fontFamily": "text",
+                                  "fontSize": 16,
                                   "paddingRight": 8,
                                 },
                                 "testID": "text_input",
@@ -2414,6 +2418,8 @@ exports[`Field renders datetime field 1`] = `
                                 "style": {
                                   "color": "#1C1C1C",
                                   "flex": 1,
+                                  "fontFamily": "text",
+                                  "fontSize": 16,
                                   "paddingRight": 8,
                                 },
                                 "testID": "text_input",
@@ -2710,6 +2716,8 @@ exports[`Field renders datetime field 1`] = `
                                 "style": {
                                   "color": "#1C1C1C",
                                   "flex": 1,
+                                  "fontFamily": "text",
+                                  "fontSize": 16,
                                   "paddingRight": 8,
                                 },
                                 "testID": "text_input",
@@ -3276,6 +3284,8 @@ exports[`Field renders select field 1`] = `
                     "style": {
                       "color": "#1C1C1C",
                       "flex": 1,
+                      "fontFamily": "text",
+                      "fontSize": 16,
                       "paddingRight": 8,
                     },
                     "testID": "text_input",
@@ -4210,6 +4220,8 @@ exports[`Field renders address field 1`] = `
                           "style": {
                             "color": "#1C1C1C",
                             "flex": 1,
+                            "fontFamily": "text",
+                            "fontSize": 16,
                             "paddingRight": 8,
                           },
                           "testID": "text_input",
@@ -6618,6 +6630,8 @@ exports[`Field renders customSelect field 1`] = `
                             "style": {
                               "color": "#1C1C1C",
                               "flex": 1,
+                              "fontFamily": "text",
+                              "fontSize": 16,
                               "paddingRight": 8,
                             },
                             "testID": "text_input",

--- a/ui/src/__snapshots__/SelectField.test.tsx.snap
+++ b/ui/src/__snapshots__/SelectField.test.tsx.snap
@@ -23,6 +23,8 @@ exports[`SelectField renders correctly with default props 1`] = `
                     "style": {
                       "color": "#1C1C1C",
                       "flex": 1,
+                      "fontFamily": "text",
+                      "fontSize": 16,
                       "paddingRight": 8,
                     },
                     "testID": "text_input",
@@ -395,6 +397,8 @@ exports[`SelectField renders with title 1`] = `
                     "style": {
                       "color": "#1C1C1C",
                       "flex": 1,
+                      "fontFamily": "text",
+                      "fontSize": 16,
                       "paddingRight": 8,
                     },
                     "testID": "text_input",
@@ -752,6 +756,8 @@ exports[`SelectField renders with selected value 1`] = `
                     "style": {
                       "color": "#1C1C1C",
                       "flex": 1,
+                      "fontFamily": "text",
+                      "fontSize": 16,
                       "paddingRight": 8,
                     },
                     "testID": "text_input",
@@ -1109,6 +1115,8 @@ exports[`SelectField renders with custom placeholder 1`] = `
                     "style": {
                       "color": "#1C1C1C",
                       "flex": 1,
+                      "fontFamily": "text",
+                      "fontSize": 16,
                       "paddingRight": 8,
                     },
                     "testID": "text_input",
@@ -1466,6 +1474,8 @@ exports[`SelectField renders disabled state 1`] = `
                     "style": {
                       "color": "#686868",
                       "flex": 1,
+                      "fontFamily": "text",
+                      "fontSize": 16,
                       "paddingRight": 8,
                     },
                     "testID": "text_input",
@@ -1825,6 +1835,8 @@ exports[`SelectField renders with requireValue (no clear option) 1`] = `
                     "style": {
                       "color": "#1C1C1C",
                       "flex": 1,
+                      "fontFamily": "text",
+                      "fontSize": 16,
                       "paddingRight": 8,
                     },
                     "testID": "text_input",

--- a/ui/src/__snapshots__/TimezonePicker.test.tsx.snap
+++ b/ui/src/__snapshots__/TimezonePicker.test.tsx.snap
@@ -38,6 +38,8 @@ exports[`TimezonePicker renders correctly with default props 1`] = `
                     "style": {
                       "color": "#1C1C1C",
                       "flex": 1,
+                      "fontFamily": "text",
+                      "fontSize": 16,
                       "paddingRight": 8,
                     },
                     "testID": "text_input",
@@ -547,6 +549,8 @@ exports[`TimezonePicker hides title when hideTitle is true 1`] = `
                     "style": {
                       "color": "#1C1C1C",
                       "flex": 1,
+                      "fontFamily": "text",
+                      "fontSize": 16,
                       "paddingRight": 8,
                     },
                     "testID": "text_input",
@@ -1071,6 +1075,8 @@ exports[`TimezonePicker renders with selected timezone 1`] = `
                     "style": {
                       "color": "#1C1C1C",
                       "flex": 1,
+                      "fontFamily": "text",
+                      "fontSize": 16,
                       "paddingRight": 8,
                     },
                     "testID": "text_input",
@@ -1595,6 +1601,8 @@ exports[`TimezonePicker renders USA timezones by default 1`] = `
                     "style": {
                       "color": "#1C1C1C",
                       "flex": 1,
+                      "fontFamily": "text",
+                      "fontSize": 16,
                       "paddingRight": 8,
                     },
                     "testID": "text_input",
@@ -2119,6 +2127,8 @@ exports[`TimezonePicker renders with short timezone labels 1`] = `
                     "style": {
                       "color": "#1C1C1C",
                       "flex": 1,
+                      "fontFamily": "text",
+                      "fontSize": 16,
                       "paddingRight": 8,
                     },
                     "testID": "text_input",
@@ -2643,6 +2653,8 @@ exports[`TimezonePicker calls onChange when timezone is selected 1`] = `
                     "style": {
                       "color": "#1C1C1C",
                       "flex": 1,
+                      "fontFamily": "text",
+                      "fontSize": 16,
                       "paddingRight": 8,
                     },
                     "testID": "text_input",

--- a/ui/src/table/__snapshots__/TableBadge.test.tsx.snap
+++ b/ui/src/table/__snapshots__/TableBadge.test.tsx.snap
@@ -457,6 +457,8 @@ exports[`TableBadge renders select field when editing 1`] = `
                         "style": {
                           "color": "#1C1C1C",
                           "flex": 1,
+                          "fontFamily": "text",
+                          "fontSize": 16,
                           "paddingRight": 8,
                         },
                         "testID": "text_input",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Toggling `searchable` on/off on a `SelectField` changed the size of the placeholder/label text. On web, the picker trigger rendered:

- **searchable mode**: a `TextInput` styled at `fontSize: 14`
- **non-searchable mode**: a plain React Native `Text` with no explicit `fontSize` (falling back to the default) and no `fontFamily`

This mismatch also meant neither state matched `TextField`, whose input/placeholder uses `fontSize: 16` / `fontFamily: "text"`.

## Fix

In `ui/src/PickerSelect.tsx` (`renderCustomDropdown`):

- Bumped the searchable trigger `triggerTextStyle.fontSize` from `14` → `16`.
- Added `fontFamily: "text"` and `fontSize: 16` to the non-searchable trigger `Text`.

Both trigger variants now render the placeholder at the same size, matching `TextField`'s placeholder.

## Testing

- `bun run ui:test` — all pass; snapshots regenerated to include the new `fontFamily`/`fontSize` on affected components (`SelectField`, `CustomSelectField`, `AddressField`, `Field`, `TimezonePicker`, `TableBadge`).
- `bun run lint` (ui) — clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0742bd2-64c3-4b3d-9a15-0faf41df7b3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0742bd2-64c3-4b3d-9a15-0faf41df7b3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

