### PR TITLE
feat(ui): add active state to IconButton [PRO-312]

### DIFF
--- a/demo/stories/IconButton.stories.tsx
+++ b/demo/stories/IconButton.stories.tsx
@@ -261,3 +261,47 @@ export const AllButtonIconVariants = (props: Partial<IconButtonProps>) => {
     </Box>
   );
 };
+
+const ICON_BUTTON_STATE_VARIANTS: {label: string; variant: IconButtonProps["variant"]}[] = [
+  {label: "Primary", variant: "primary"},
+  {label: "Secondary", variant: "secondary"},
+  {label: "Muted", variant: "muted"},
+  {label: "Destructive", variant: "destructive"},
+  {label: "Ghost", variant: "ghost"},
+];
+
+export const IconButtonStates = (props: Partial<IconButtonProps>) => {
+  return (
+    <Box direction="column" gap={4}>
+      {ICON_BUTTON_STATE_VARIANTS.map(({label, variant}) => (
+        <Box alignItems="center" direction="row" gap={4} key={variant}>
+          <Box width={100}>
+            <Text>{label}</Text>
+          </Box>
+          <Box alignItems="center" gap={1}>
+            <Text>Default</Text>
+            <IconButton
+              accessibilityLabel={`${label} default`}
+              iconName="plus"
+              onClick={() => console.info("clicked")}
+              state="default"
+              variant={variant}
+              {...props}
+            />
+          </Box>
+          <Box alignItems="center" gap={1}>
+            <Text>Active</Text>
+            <IconButton
+              accessibilityLabel={`${label} active`}
+              iconName="plus"
+              onClick={() => console.info("clicked")}
+              state="active"
+              variant={variant}
+              {...props}
+            />
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+};

--- a/demo/story-config/IconButton.config.tsx
+++ b/demo/story-config/IconButton.config.tsx
@@ -4,6 +4,7 @@ import {
   ConfirmationIconButton,
   IconButtonDemo,
   IconButtonSizes,
+  IconButtonStates,
   IndicatorIconButton,
   LoadingIconButton,
   NavigationIconButton,
@@ -62,6 +63,14 @@ export const IconButtonConfiguration: DemoConfiguration = {
           {label: "Disabled", value: "disabled"},
         ],
       },
+      state: {
+        type: "select",
+        defaultValue: "default",
+        options: [
+          {label: "Default", value: "default"},
+          {label: "Active", value: "active"},
+        ],
+      },
       iconName: {
         type: "select",
         defaultValue: "plus",
@@ -94,6 +103,7 @@ export const IconButtonConfiguration: DemoConfiguration = {
   },
   stories: {
     Variants: {render: () => AllButtonIconVariants({})},
+    States: {render: () => IconButtonStates({})},
     Sizes: {render: () => IconButtonSizes({})},
     Confirmation: {render: () => ConfirmationIconButton({})},
     WithToolTip: {render: () => ToolTipIconButton({})},

--- a/ui/src/Common.ts
+++ b/ui/src/Common.ts
@@ -1958,9 +1958,8 @@ export interface IconButtonProps extends WithTestID {
   size?: "default" | "sm";
 
   /**
-   * The interaction state of the button. "active" applies the pressed/selected styling:
-   * the primary variant darkens its background, while all other variants adopt a
-   * surface-primary background with an inverted icon.
+   * Controls the button's interaction state. Use Default for standard button appearance
+   * and Active to indicate a selected or currently engaged state.
    * @default "default"
    */
   state?: "default" | "active";

--- a/ui/src/Common.ts
+++ b/ui/src/Common.ts
@@ -1958,6 +1958,14 @@ export interface IconButtonProps extends WithTestID {
   size?: "default" | "sm";
 
   /**
+   * The interaction state of the button. "active" applies the pressed/selected styling:
+   * the primary variant darkens its background, while all other variants adopt a
+   * surface-primary background with an inverted icon.
+   * @default "default"
+   */
+  state?: "default" | "active";
+
+  /**
    * The ideal position of the tooltip.
    */
   tooltipIdealPosition?: TooltipPosition;

--- a/ui/src/IconButton.test.tsx
+++ b/ui/src/IconButton.test.tsx
@@ -157,6 +157,32 @@ describe("IconButton", () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
+  it("renders primary variant in active state", () => {
+    const {toJSON} = renderWithTheme(
+      <IconButton
+        accessibilityLabel="Test"
+        iconName="check"
+        onClick={() => {}}
+        state="active"
+        variant="primary"
+      />
+    );
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it("renders ghost variant in active state", () => {
+    const {toJSON} = renderWithTheme(
+      <IconButton
+        accessibilityLabel="Test"
+        iconName="check"
+        onClick={() => {}}
+        state="active"
+        variant="ghost"
+      />
+    );
+    expect(toJSON()).toMatchSnapshot();
+  });
+
   describe("custom icons", () => {
     // IconButton renders `null` under the bun/react-test-renderer harness (all of
     // its snapshots are null), so we verify the custom-icon code path renders

--- a/ui/src/IconButton.tsx
+++ b/ui/src/IconButton.tsx
@@ -57,6 +57,7 @@ const IconButtonComponent: FC<IconButtonProps> = ({
   indicatorText,
   loading: propsLoading = false,
   size = "default",
+  state = "default",
   testID,
   variant = "primary",
   withConfirmation = false,
@@ -97,6 +98,15 @@ const IconButtonComponent: FC<IconButtonProps> = ({
   } else if (variant === "ghost") {
     backgroundColor = "transparent";
     color = theme.surface.secondaryDark;
+  }
+
+  if (!disabled && state === "active") {
+    if (variant === "primary") {
+      backgroundColor = theme.primitives.primary600;
+    } else {
+      backgroundColor = theme.surface.primary;
+      color = theme.text.inverted;
+    }
   }
 
   const indicatorColor = indicator ? theme.surface[indicator] : undefined;

--- a/ui/src/__snapshots__/IconButton.test.tsx.snap
+++ b/ui/src/__snapshots__/IconButton.test.tsx.snap
@@ -31,3 +31,7 @@ exports[`IconButton renders with confirmation props 1`] = `null`;
 exports[`IconButton renders ghost variant 1`] = `null`;
 
 exports[`IconButton renders sm size 1`] = `null`;
+
+exports[`IconButton renders primary variant in active state 1`] = `null`;
+
+exports[`IconButton renders ghost variant in active state 1`] = `null`;


### PR DESCRIPTION
## Summary
Adds an `active` interaction state to `IconButton` (per Figma), on top of the existing variants. A new `state?: "default" | "active"` prop drives it:

- `variant="primary"` + `state="active"` → darker background (`theme.primitives.primary600`, aka color/primary-blue/600); icon stays inverted.
- all other variants (incl. `ghost`) + `state="active"` → `surface.primary` background with an inverted (`text.inverted`) icon.
- `disabled` still wins over `state`.

```tsx
if (!disabled && state === "active") {
  if (variant === "primary") {
    backgroundColor = theme.primitives.primary600;
  } else {
    backgroundColor = theme.surface.primary;
    color = theme.text.inverted;
  }
}
```

Docs/demo: adds a **State** dropdown (Default / Active) to the interactive IconButton demo controls and a new **States** story showing every variant in both states, so the state is documented alongside variants on the demo page.

## Notes
- `state` defaults to `"default"`, so existing usages are unchanged.
- Snapshot tests for primary/ghost active states added; like the rest of this component's suite they render `null` under the bun test harness (documented in the test file), so they guard against render-time throws rather than asserting pixels.
- Verified: `bun run ui:test` (1796 pass), `@terreno/ui` + `demo` typecheck, and Biome lint all clean.

Link to Devin session: https://app.devin.ai/sessions/6a2e4b4e10b0468b9c010ec68e551fea
Requested by: @jo-hutchison

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in visual prop defaulting to unchanged behavior; scoped to IconButton styling and demo/docs.
> 
> **Overview**
> Adds an optional **`state`** prop (`"default"` | `"active"`) to **`IconButton`** so toggles and selected toolbar actions can match Figma.
> 
> When **`state="active"`** and the button is not disabled, styling overrides the variant: **primary** uses a darker fill (`primary600`); **all other variants** (including ghost) use **`surface.primary`** with an inverted icon. **`disabled`** still takes precedence.
> 
> The public API is documented on **`IconButtonProps`**, the demo gains a **State** control and a **States** story across variants, and snapshot tests cover primary/ghost active renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7fa926878cba759503a8851c22d3ab0ea0e2698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->