### PR TITLE
Add implementation plan for @terreno/syncdb-codegen

### DIFF
--- a/docs/implementationPlans/PLAN_INDEX.md
+++ b/docs/implementationPlans/PLAN_INDEX.md
@@ -7,6 +7,7 @@ Tracks active and completed implementation plans (IP) for Terreno. File paths ar
 | Plan | Status | Created | Tasks |
 |------|--------|---------|-------|
 | [Admin UI v2 — Django-parity admin](admin-ui-v2-django-parity.md) | Approved | 2026-06-15 | [tasks](../tasks/admin-ui-v2-django-parity.md) |
+| [@terreno/syncdb-codegen](syncdb-codegen.md) | Draft | 2026-07-08 | [tasks](../tasks/syncdb-codegen.md) |
 
 ## Completed
 

--- a/docs/implementationPlans/syncdb-codegen.md
+++ b/docs/implementationPlans/syncdb-codegen.md
@@ -18,11 +18,12 @@ const todos = useQuery<SyncTodo>("todos", {sort: sortByCreatedDesc});
 const {update, remove} = useMutate("todos"); // update/remove payloads are Record<string, unknown>
 ```
 
-After this IP, a generated `store/syncDbSdk.ts` provides `useTodosQuery()`, `useTodosEntity(id)`, and `useTodosMutate()` with payload types derived from the same OpenAPI schemas RTK codegen uses (`Todo`, `CreateTodoBody`, `UpdateTodoBody`), plus a `SYNC_COLLECTIONS` constant that feeds `createSyncDb`. Custom hooks are supported the same way RTK supports custom endpoints: the generated file is never edited, and consumers extend it in a sibling file using the same public factory the generated code uses.
+After this IP, a generated `store/syncDbSdk.ts` provides one hook per operation with the exact names RTK codegen would produce for the same routes — `useGetTodosQuery` (list query), `useGetTodosByIdQuery` (read), `usePostTodosMutation` (create), `usePatchTodosByIdMutation` (update/patch), `useDeleteTodosByIdMutation` (delete) — with payload types derived from the same OpenAPI schemas RTK codegen uses (`Todo`, `CreateTodoBody`, `UpdateTodoBody`), plus a `SYNC_COLLECTIONS` constant that feeds `createSyncDb`. Migrating a screen from RTK to syncdb becomes (mostly) an import-path change. Custom hooks are supported the same way RTK supports custom endpoints: the generated file is never edited, and consumers extend it in a sibling file using the same public factory the generated code uses.
 
 ## Non-Goals
 
-- Covering the whole syncdb surface. Only `useEntity` / `useQuery` / `useMutate` get generated per-collection wrappers. `useSyncStatus`, `useConflicts`, `useSyncDbClient`, and `SyncDbProvider` are global (not per-collection) and stay as direct imports from `@terreno/syncdb/react`.
+- Covering the whole syncdb surface. Only the five CRUD operations (list query, read, create, update/patch, delete) get generated per-collection hooks. `useSyncStatus`, `useConflicts`, `useSyncDbClient`, and `SyncDbProvider` are global (not per-collection) and stay as direct imports from `@terreno/syncdb/react`.
+- Full RTK return-shape emulation. Hook **names and call sites** match RTK; return shapes are syncdb-native where the semantics differ (no `isLoading`/`error` async state on mutations — writes are synchronous local applies plus a durable outbox; sync state lives in `useSyncStatus`). The mapping is documented in the generated file header and the migration guide.
 - Runtime schema validation of mutation payloads (types are compile-time only, matching RTK codegen).
 - Publishing per-platform compiled binaries to npm or GitHub releases (the compiled binary is a local/CI build target for now; `@terreno/syncdb` itself is not in `publish-on-tag.yml` yet either).
 - Watch mode, incremental generation, or multi-output-file support.
@@ -39,7 +40,8 @@ Options were considered where the design was genuinely open; each row records th
 | **Config surface: flags only, or a config file?** The binary should "take a few args", but per-collection overrides (retries, exclusions) don't map well to flags. | **Flags for the common path, optional JSON config for overrides.** `--schema`, `--out`, `--collections` cover the RTK-equivalent happy path. `--config ./syncdb-codegen.json` adds `{overrides: {<collection>: {retries?: boolean \| number}}, exportName?, sdkImportPath?}`. JSON (not TS) because a compiled bun binary cannot reliably import arbitrary consumer TypeScript at runtime; RTK's TS `ConfigFile` needs the `tsx`/`TS_NODE_PROJECT` dance we currently work around in `example-frontend/scripts/generate-sdk.ts`. |
 | **How are TS types emitted from OpenAPI schemas?** Options: (a) a small hand-rolled emitter for the subset `mongoose-to-swagger` actually produces (objects, primitives, enums as string unions, arrays, `$ref`); (b) depend on `openapi-typescript` or oazapfts. | **(a).** The @terreno/api spec is a narrow, known dialect; a ~150-line emitter with snapshot tests keeps the binary dependency-free and small. If the emitter grows past that dialect, revisit (b). |
 | **Where does the shared hook factory live?** Generated code and custom hooks must be built the same way (the RTK parallel: generated `injectEndpoints` and app `sdk.ts` both build on `emptySplitApi`). Options: (a) new `createCollectionHooks` export in `@terreno/syncdb/react`; (b) inline the factory into every generated file; (c) a runtime export of `@terreno/syncdb-codegen`. | **(a).** One implementation, versioned with the hooks it wraps, and consumers already depend on `@terreno/syncdb`. (b) duplicates logic into generated output; (c) would make the codegen package a runtime dependency of apps, which it should never be. |
-| **Hook naming.** Singularizing collection tags (`todos` → `useTodoEntity`) requires inflection rules that break on words like `statuses`. | **No singularization.** Deterministic pascal-case of the collection tag: `useTodosQuery`, `useTodosEntity`, `useTodosMutate`. Entity/type names come from the OpenAPI component schema names, which are already singular model names (`Todo`, `CreateTodoBody`, `UpdateTodoBody`). |
+| **Hook granularity and naming.** Options: (a) one grouped `useTodosMutate()` returning `{create, update, remove}`; (b) one hook per operation with RTK codegen's exact naming scheme (`use{Method}{Path}Query/Mutation`); (c) per-operation hooks with friendlier names (`useCreateTodo`). | **(b) — per-operation, RTK names.** Generated per collection: `useGetTodosQuery`, `useGetTodosByIdQuery`, `usePostTodosMutation`, `usePatchTodosByIdMutation`, `useDeleteTodosByIdMutation`. Name derivation is the same deterministic pascal-case of the route path RTK uses (no singularization heuristics). This makes RTK→syncdb migration an import swap. Two consequences are accepted: (1) name **collisions with `openApiSdk.ts`** are intentional — during migration both files export e.g. `useGetTodosQuery`, and the import path picks the data source; imports must never be mixed via a barrel that re-exports both. (2) "update" and "patch" are the **same hook**: modelRouter only exposes PATCH (merge semantics) and syncdb's update is a merge, so `usePatchTodosByIdMutation` is the update hook — there is no separate PUT/replace hook to generate. |
+| **Mutation hook return shape.** RTK mutation hooks return `[trigger, {isLoading, error, ...}]` and triggers return promises with `.unwrap()`. syncdb writes are synchronous local applies; there is no per-call async state. | **One-element tuple `[trigger]`.** Keeps the RTK call site (`const [createTodo] = usePostTodosMutation()`) working unchanged; the trigger returns `{mutationId, id}` synchronously instead of a promise, so `.unwrap()`/`isLoading` usages are deleted during migration (the compiler flags them). Pending/conflict state is per-entity (`isPending` on reads) and global (`useSyncStatus`), not per-call. |
 | **Distribution.** "Compiled bun binary" vs npm reality. | **Both, npm-bin first.** The package ships `"bin": {"terreno-syncdb-codegen": "./dist/cli.js"}` with a `#!/usr/bin/env bun` shebang (the `@terreno/mcp` pattern), plus a `build:binary` script running `bun build --compile src/cli.ts --outfile dist/terreno-syncdb-codegen` (the `example-backend/Dockerfile` pattern) for standalone use. Publishing platform binaries is future work. |
 
 ## Architecture
@@ -57,9 +59,10 @@ example-backend                                example-frontend
                                               store/syncDbSdk.ts   (generated, never edited)
                                                 ├─ interface Todo / CreateTodoBody / UpdateTodoBody
                                                 ├─ export const SYNC_COLLECTIONS = ["todos"] as const
-                                                └─ export const {useTodosQuery, useTodosEntity,
-                                                     useTodosMutate} = createCollectionHooks<...>({
-                                                       collection: "todos", retries: ...})
+                                                └─ export const {useGetTodosQuery, useGetTodosByIdQuery,
+                                                     usePostTodosMutation, usePatchTodosByIdMutation,
+                                                     useDeleteTodosByIdMutation} =
+                                                       createCollectionHooks<...>({collection: "todos"})
                                                              │ extended by (custom hooks)
                                                              ▼
                                               store/syncSdk.ts    (hand-written, optional)
@@ -81,14 +84,19 @@ export interface CollectionHooksConfig {
   retries?: boolean | number;
 }
 
+export type MutationTrigger<TArgs> = (args: TArgs) => {mutationId: string; id: string};
+
 export interface CollectionHooks<TData, TCreate, TUpdate> {
-  useQuery: (options?: UseQueryOptions<TData>) => TData[];
-  useEntity: (id: string) => UseEntityResult<TData>;
-  useMutate: () => {
-    create: (args: {data: TCreate}) => {mutationId: string; id: string};
-    update: (args: {id: string; data: TUpdate}) => {mutationId: string; id: string};
-    remove: (args: {id: string}) => {mutationId: string; id: string};
-  };
+  /** List query (RTK: useGet{Path}Query). */
+  useListQuery: (options?: UseQueryOptions<TData>) => {data: TData[]};
+  /** Single-entity read (RTK: useGet{Path}ByIdQuery). */
+  useReadQuery: (id: string) => UseEntityResult<TData>;
+  /** Create (RTK: usePost{Path}Mutation). */
+  useCreateMutation: () => [MutationTrigger<{data: TCreate}>];
+  /** Update via merge — patch semantics (RTK: usePatch{Path}ByIdMutation). */
+  useUpdateMutation: () => [MutationTrigger<{id: string; data: TUpdate}>];
+  /** Soft delete (RTK: useDelete{Path}ByIdMutation). */
+  useDeleteMutation: () => [MutationTrigger<{id: string}>];
 }
 
 export const createCollectionHooks = <
@@ -98,7 +106,7 @@ export const createCollectionHooks = <
 >(config: CollectionHooksConfig): CollectionHooks<TData, TCreate, TUpdate> => { ... };
 ```
 
-It delegates to the existing `useQuery`/`useEntity`/`useMutate` (no listener logic duplicated) and threads `retries` into `client.mutate` as `maxAttempts`. This is the `emptySplitApi` of the syncdb world: generated code calls it, and custom hooks call it directly — that is the whole "custom hooks the same way RTK does" story.
+The factory returns **operation-named keys** (`useListQuery`, `useReadQuery`, `useCreateMutation`, `useUpdateMutation`, `useDeleteMutation`); the generated file renames them to the RTK-style collection-specific names via destructuring (`useListQuery: useGetTodosQuery`, ...). Custom hooks can keep the generic names or rename the same way. Each hook delegates to the existing `useQuery`/`useEntity`/`useMutate` internals (no listener logic duplicated) and threads `retries` into `client.mutate` as `maxAttempts`. This is the `emptySplitApi` of the syncdb world: generated code calls it, and custom hooks call it directly — that is the whole "custom hooks the same way RTK does" story.
 
 ### Generated file shape
 
@@ -114,10 +122,24 @@ export type UpdateTodoBody = Partial<CreateTodoBody>;
 export const SYNC_COLLECTIONS = ["todos"] as const;
 
 export const {
-  useQuery: useTodosQuery,
-  useEntity: useTodosEntity,
-  useMutate: useTodosMutate,
+  useListQuery: useGetTodosQuery,
+  useReadQuery: useGetTodosByIdQuery,
+  useCreateMutation: usePostTodosMutation,
+  useUpdateMutation: usePatchTodosByIdMutation,
+  useDeleteMutation: useDeleteTodosByIdMutation,
 } = createCollectionHooks<Todo, CreateTodoBody, UpdateTodoBody>({collection: "todos"});
+```
+
+Call-site comparison for migration:
+
+```typescript
+// RTK                                              // syncdb (generated)
+const {data} = useGetTodosQuery({});                 const {data} = useGetTodosQuery();
+const {data} = useGetTodosByIdQuery({id});           const {data, isPending} = useGetTodosByIdQuery(id);
+const [createTodo] = usePostTodosMutation();         const [createTodo] = usePostTodosMutation();
+await createTodo({body}).unwrap();                   createTodo({data}); // sync, returns {mutationId, id}
+const [patchTodo] = usePatchTodosByIdMutation();     const [patchTodo] = usePatchTodosByIdMutation();
+const [deleteTodo] = useDeleteTodosByIdMutation();   const [deleteTodo] = useDeleteTodosByIdMutation();
 ```
 
 `SYNC_COLLECTIONS` replaces the hand-maintained list in `example-frontend/store/syncdb.ts`, closing the "client string must match backend route" gap.
@@ -154,7 +176,7 @@ None needed.
 
 ## UI
 
-No new screens. `example-frontend/components/SyncTodosScreen.tsx` swaps its hand-rolled `SyncTodo` interface and string-based hooks for the generated `useTodosQuery`/`useTodosMutate`, and `store/syncdb.ts` imports `SYNC_COLLECTIONS` from the generated file. Behavior is unchanged; the existing syncdb Playwright e2e suite is the regression net.
+No new screens. `example-frontend/components/SyncTodosScreen.tsx` swaps its hand-rolled `SyncTodo` interface and string-based hooks for the generated `useGetTodosQuery`/`usePostTodosMutation`/`usePatchTodosByIdMutation`/`useDeleteTodosByIdMutation`, and `store/syncdb.ts` imports `SYNC_COLLECTIONS` from the generated file. Behavior is unchanged; the existing syncdb Playwright e2e suite is the regression net.
 
 ## Phases
 
@@ -182,7 +204,8 @@ None — developer tooling only.
 - Generated wrappers for `useSyncStatus`/`useConflicts` (no per-collection typing to add).
 - Server-driven filters/sorts in `useQuery` options (syncdb filters run client-side in JS; nothing for codegen to type beyond `TData`).
 - Zod/AJV runtime validation of mutation payloads against the OpenAPI schema.
-- Singular/custom hook naming via config (`overrides.todos.hookName`), if the pascal-case default proves awkward.
+- Custom hook naming via config (`overrides.todos.hookPrefix`), for apps that need to avoid the intentional name overlap with RTK-generated hooks.
+- RTK-compatible async mutation state (`isLoading`, promise-returning triggers with `.unwrap()`), should a drop-in compatibility mode ever be wanted.
 - A `--watch` mode.
 
 ## Files to Create / Modify
@@ -218,10 +241,10 @@ See [docs/tasks/syncdb-codegen.md](../tasks/syncdb-codegen.md).
 
 ## Acceptance Criteria
 
-- [ ] `createCollectionHooks<Todo>({collection: "todos"})` returns hooks whose behavior matches direct `useQuery`/`useEntity`/`useMutate` calls (covered by unit tests in `syncdb/src/react/`).
+- [ ] `createCollectionHooks<Todo>({collection: "todos"})` returns the five per-operation hooks (`useListQuery`, `useReadQuery`, `useCreateMutation`, `useUpdateMutation`, `useDeleteMutation`) whose behavior matches direct `useQuery`/`useEntity`/`useMutate` calls; mutation hooks return `[trigger]` tuples so RTK-style destructuring compiles (unit tests in `syncdb/src/react/`).
 - [ ] `createCollectionHooks({collection: "todos", retries: false})` produces mutations whose outbox rows fail terminally after a single `error` nack; `retries: 3` fails after three attempts; omitted keeps the current 5-attempt backoff (replay coordinator tests).
 - [ ] `GET /openapi.json` from a backend with `sync: {scope: {type: "owner"}}` on `/todos` includes `x-terreno-sync: {collection: "todos", scope: "owner"}` on the list operation; non-synced routes have no extension (api test).
-- [ ] `terreno-syncdb-codegen --schema <fixture> --out out.ts` emits a file that type-checks under the example-frontend tsconfig, contains `SYNC_COLLECTIONS`, typed interfaces, and one `createCollectionHooks` block per synced collection (snapshot test).
+- [ ] `terreno-syncdb-codegen --schema <fixture> --out out.ts` emits a file that type-checks under the example-frontend tsconfig and contains `SYNC_COLLECTIONS`, typed interfaces, and per synced collection the five RTK-named hooks (`useGetTodosQuery`, `useGetTodosByIdQuery`, `usePostTodosMutation`, `usePatchTodosByIdMutation`, `useDeleteTodosByIdMutation`) — names byte-identical to what `@rtk-query/codegen-openapi` derives for the same routes (snapshot test).
 - [ ] `--collections todos` filters output to that collection; a spec without extensions and no `--collections` flag exits non-zero with an actionable message.
 - [ ] A config file with `{overrides: {todos: {retries: false}}}` produces `createCollectionHooks<...>({collection: "todos", retries: false})` in the output.
 - [ ] `bun run build:binary` in `syncdb-codegen/` produces a standalone executable that generates identical output to the bin entry.

--- a/docs/implementationPlans/syncdb-codegen.md
+++ b/docs/implementationPlans/syncdb-codegen.md
@@ -1,0 +1,229 @@
+# Implementation Plan: @terreno/syncdb-codegen
+
+**Status:** Draft
+**Branch:** cursor/ip-syncdb-codegen-41d6
+**Owner:**
+**Created:** 2026-07-08
+
+## Goal
+
+Ship `@terreno/syncdb-codegen`: a small CLI (runnable as an npm bin under bun and buildable as a standalone compiled bun binary) that reads a backend OpenAPI spec and generates a static, typed set of syncdb hooks — the local-first analogue of the existing `@rtk-query/codegen-openapi` flow (`bun run sdk` → `store/openApiSdk.ts`).
+
+Today syncdb consumers hand-write both the entity types and the collection strings:
+
+```typescript
+// example-frontend/components/SyncTodosScreen.tsx — all manual today
+interface SyncTodo { _id: string; title?: string; completed?: boolean; created?: string; }
+const todos = useQuery<SyncTodo>("todos", {sort: sortByCreatedDesc});
+const {update, remove} = useMutate("todos"); // update/remove payloads are Record<string, unknown>
+```
+
+After this IP, a generated `store/syncDbSdk.ts` provides `useTodosQuery()`, `useTodosEntity(id)`, and `useTodosMutate()` with payload types derived from the same OpenAPI schemas RTK codegen uses (`Todo`, `CreateTodoBody`, `UpdateTodoBody`), plus a `SYNC_COLLECTIONS` constant that feeds `createSyncDb`. Custom hooks are supported the same way RTK supports custom endpoints: the generated file is never edited, and consumers extend it in a sibling file using the same public factory the generated code uses.
+
+## Non-Goals
+
+- Covering the whole syncdb surface. Only `useEntity` / `useQuery` / `useMutate` get generated per-collection wrappers. `useSyncStatus`, `useConflicts`, `useSyncDbClient`, and `SyncDbProvider` are global (not per-collection) and stay as direct imports from `@terreno/syncdb/react`.
+- Runtime schema validation of mutation payloads (types are compile-time only, matching RTK codegen).
+- Publishing per-platform compiled binaries to npm or GitHub releases (the compiled binary is a local/CI build target for now; `@terreno/syncdb` itself is not in `publish-on-tag.yml` yet either).
+- Watch mode, incremental generation, or multi-output-file support.
+- Generating Redux integration or migrating non-synced endpoints — per `docs/how-to/migrate-rtk-to-syncdb.md`, custom routes stay on RTK.
+
+## Decisions
+
+Options were considered where the design was genuinely open; each row records the recommendation this plan is built on. Rejected alternatives are listed so review can overrule them cheaply.
+
+| Question | Decision |
+|----------|----------|
+| **How does codegen know which collections are synced?** OpenAPI does not mark sync today; the server-side `syncRegistry` (`api/src/sync/registry.ts`) is in-memory only. Options: (a) emit an `x-terreno-sync` vendor extension on the list path from `modelRouter` when `options.sync` is set; (b) require an explicit `--collections` CLI arg; (c) add a `GET /sync/config` manifest endpoint. | **(a) with (b) as override.** The extension is a ~10-line change in `@terreno/api`'s list OpenAPI middleware, keeps the spec the single input (same as RTK codegen), and can't drift from the backend. `--collections` remains as an explicit filter/override for apps that sync a subset. (c) adds server surface for no extra information and is rejected. |
+| **How is "retries vs not" expressed?** RTK disables retries per-endpoint via `extraOptions: {maxRetries: 0}` (see `rtk/src/authSlice.ts`). syncdb retries live in the replay engine: `MAX_ERROR_NACK_ATTEMPTS = 5` with exponential backoff in `syncdb/src/sync/replayCoordinator.ts`, not configurable per mutation. Options: (a) plumb an optional per-mutation `maxAttempts` through `client.mutate` → outbox row → replay coordinator, and expose `retries` in the codegen config; (b) codegen-only option that is silently ignored until the engine supports it. | **(a).** Small, contained change: `MutateArgs.maxAttempts?`, one optional outbox cell, one `??` in the replay coordinator's error-nack branch. `retries: false` maps to `maxAttempts: 1` (fail fast, like RTK's `maxRetries: 0`), a number maps directly, and omitted keeps the engine default of 5. (b) would generate config that lies. Note syncdb mutations are idempotent via `mutationId`, so unlike RTK the motivation is fail-fast UX (surface a terminal failure immediately), not duplicate-write safety. |
+| **Config surface: flags only, or a config file?** The binary should "take a few args", but per-collection overrides (retries, exclusions) don't map well to flags. | **Flags for the common path, optional JSON config for overrides.** `--schema`, `--out`, `--collections` cover the RTK-equivalent happy path. `--config ./syncdb-codegen.json` adds `{overrides: {<collection>: {retries?: boolean \| number}}, exportName?, sdkImportPath?}`. JSON (not TS) because a compiled bun binary cannot reliably import arbitrary consumer TypeScript at runtime; RTK's TS `ConfigFile` needs the `tsx`/`TS_NODE_PROJECT` dance we currently work around in `example-frontend/scripts/generate-sdk.ts`. |
+| **How are TS types emitted from OpenAPI schemas?** Options: (a) a small hand-rolled emitter for the subset `mongoose-to-swagger` actually produces (objects, primitives, enums as string unions, arrays, `$ref`); (b) depend on `openapi-typescript` or oazapfts. | **(a).** The @terreno/api spec is a narrow, known dialect; a ~150-line emitter with snapshot tests keeps the binary dependency-free and small. If the emitter grows past that dialect, revisit (b). |
+| **Where does the shared hook factory live?** Generated code and custom hooks must be built the same way (the RTK parallel: generated `injectEndpoints` and app `sdk.ts` both build on `emptySplitApi`). Options: (a) new `createCollectionHooks` export in `@terreno/syncdb/react`; (b) inline the factory into every generated file; (c) a runtime export of `@terreno/syncdb-codegen`. | **(a).** One implementation, versioned with the hooks it wraps, and consumers already depend on `@terreno/syncdb`. (b) duplicates logic into generated output; (c) would make the codegen package a runtime dependency of apps, which it should never be. |
+| **Hook naming.** Singularizing collection tags (`todos` → `useTodoEntity`) requires inflection rules that break on words like `statuses`. | **No singularization.** Deterministic pascal-case of the collection tag: `useTodosQuery`, `useTodosEntity`, `useTodosMutate`. Entity/type names come from the OpenAPI component schema names, which are already singular model names (`Todo`, `CreateTodoBody`, `UpdateTodoBody`). |
+| **Distribution.** "Compiled bun binary" vs npm reality. | **Both, npm-bin first.** The package ships `"bin": {"terreno-syncdb-codegen": "./dist/cli.js"}` with a `#!/usr/bin/env bun` shebang (the `@terreno/mcp` pattern), plus a `build:binary` script running `bun build --compile src/cli.ts --outfile dist/terreno-syncdb-codegen` (the `example-backend/Dockerfile` pattern) for standalone use. Publishing platform binaries is future work. |
+
+## Architecture
+
+```
+example-backend                                example-frontend
+  modelRouter("/todos", Todo, {sync: {...}})     bun run sync-sdk
+    └─ list OpenAPI middleware emits               └─ terreno-syncdb-codegen
+       x-terreno-sync on GET /todos                     --schema http://localhost:4000/openapi.json
+            │                                           --out ./store/syncDbSdk.ts
+            ▼                                                │
+      /openapi.json  ──── fetch/read ────────────────────────┘
+                                                             │ emits
+                                                             ▼
+                                              store/syncDbSdk.ts   (generated, never edited)
+                                                ├─ interface Todo / CreateTodoBody / UpdateTodoBody
+                                                ├─ export const SYNC_COLLECTIONS = ["todos"] as const
+                                                └─ export const {useTodosQuery, useTodosEntity,
+                                                     useTodosMutate} = createCollectionHooks<...>({
+                                                       collection: "todos", retries: ...})
+                                                             │ extended by (custom hooks)
+                                                             ▼
+                                              store/syncSdk.ts    (hand-written, optional)
+                                                └─ createCollectionHooks<LocalNote>({collection: "notes"})
+```
+
+Three packages change:
+
+1. **`@terreno/syncdb`** (runtime): `createCollectionHooks` factory in `src/react/`, plus per-mutation `maxAttempts` plumbing through `client.mutate` → outbox → replay coordinator.
+2. **`@terreno/api`**: `listOpenApiMiddleware` (or the shared path-building step in `api/src/openApi.ts`) adds `"x-terreno-sync": {collection, scope}` to the list operation when `options.sync` is present.
+3. **`@terreno/syncdb-codegen`** (new): CLI that parses the spec, discovers synced collections, and emits the SDK file.
+
+### Runtime factory (`@terreno/syncdb/react`)
+
+```typescript
+export interface CollectionHooksConfig {
+  collection: string;
+  /** false → 1 attempt (fail fast); number → max replay attempts; omitted → engine default (5). */
+  retries?: boolean | number;
+}
+
+export interface CollectionHooks<TData, TCreate, TUpdate> {
+  useQuery: (options?: UseQueryOptions<TData>) => TData[];
+  useEntity: (id: string) => UseEntityResult<TData>;
+  useMutate: () => {
+    create: (args: {data: TCreate}) => {mutationId: string; id: string};
+    update: (args: {id: string; data: TUpdate}) => {mutationId: string; id: string};
+    remove: (args: {id: string}) => {mutationId: string; id: string};
+  };
+}
+
+export const createCollectionHooks = <
+  TData = Record<string, unknown>,
+  TCreate = Record<string, unknown>,
+  TUpdate = Partial<TCreate>,
+>(config: CollectionHooksConfig): CollectionHooks<TData, TCreate, TUpdate> => { ... };
+```
+
+It delegates to the existing `useQuery`/`useEntity`/`useMutate` (no listener logic duplicated) and threads `retries` into `client.mutate` as `maxAttempts`. This is the `emptySplitApi` of the syncdb world: generated code calls it, and custom hooks call it directly — that is the whole "custom hooks the same way RTK does" story.
+
+### Generated file shape
+
+```typescript
+// store/syncDbSdk.ts — GENERATED by @terreno/syncdb-codegen. Do not edit.
+import {createCollectionHooks} from "@terreno/syncdb/react";
+
+export interface Todo { _id: string; title: string; completed: boolean; ownerId: string; created: string; updated: string; }
+export interface CreateTodoBody { title: string; completed?: boolean; }
+export type UpdateTodoBody = Partial<CreateTodoBody>;
+
+/** Collections with sync enabled on the backend; pass to createSyncDb. */
+export const SYNC_COLLECTIONS = ["todos"] as const;
+
+export const {
+  useQuery: useTodosQuery,
+  useEntity: useTodosEntity,
+  useMutate: useTodosMutate,
+} = createCollectionHooks<Todo, CreateTodoBody, UpdateTodoBody>({collection: "todos"});
+```
+
+`SYNC_COLLECTIONS` replaces the hand-maintained list in `example-frontend/store/syncdb.ts`, closing the "client string must match backend route" gap.
+
+### CLI
+
+```
+terreno-syncdb-codegen --schema <url|path> --out <file> [--collections a,b] [--config <json>] [--no-format]
+```
+
+- `--schema` (required): OpenAPI URL or local JSON file (same source as `openapi-config.ts`'s `schemaFile`).
+- `--out` (required): output `.ts` path.
+- `--collections` (optional): comma-separated allowlist; also the fallback when the spec has no `x-terreno-sync` extensions (older backends). Errors clearly if neither extensions nor the flag identify any collection.
+- `--config` (optional): JSON file with `{overrides: {todos: {retries: false}}}` per-collection settings.
+- `--no-format` (optional): skip the biome/prettier formatting pass (codegen formats output via `Bun.spawn`-ed `bunx biome check --write` when available, mirroring `generate-sdk.ts`; falls back to raw emit).
+
+## Models
+
+No Mongoose model changes. One local-storage schema change in syncdb: the `_outbox` reserved table gains an optional `maxAttempts` numeric cell (`syncdb/src/storage/schema.ts`, `syncdb/src/mutations/outbox.ts`). Missing cell means engine default, so existing persisted stores need no migration.
+
+## APIs
+
+No new HTTP endpoints. One OpenAPI spec addition in `@terreno/api`: list operations of sync-enabled model routers gain
+
+```json
+"x-terreno-sync": {"collection": "todos", "scope": "owner"}
+```
+
+Vendor extensions are legal OpenAPI and ignored by the RTK codegen, Swagger UI, and the AJV validator, so this is backward-compatible.
+
+## Notifications
+
+None needed.
+
+## UI
+
+No new screens. `example-frontend/components/SyncTodosScreen.tsx` swaps its hand-rolled `SyncTodo` interface and string-based hooks for the generated `useTodosQuery`/`useTodosMutate`, and `store/syncdb.ts` imports `SYNC_COLLECTIONS` from the generated file. Behavior is unchanged; the existing syncdb Playwright e2e suite is the regression net.
+
+## Phases
+
+Single PR is plausible but the work splits cleanly into four phases if review prefers smaller units:
+
+1. **syncdb runtime** — `createCollectionHooks` + `maxAttempts` plumbing (mutate → outbox → replay coordinator), with unit tests. No consumer-visible breaking changes.
+2. **api spec extension** — `x-terreno-sync` on list operations, with an OpenAPI generation test asserting the extension appears for `example-backend`-style sync configs and is absent otherwise.
+3. **codegen package** — new `syncdb-codegen/` workspace package: arg parsing, spec loading, collection discovery, type emitter, file emitter, snapshot tests against a fixture spec captured from `example-backend`, `build:binary` script.
+4. **integration + docs** — `example-frontend` `sync-sdk` script and screen migration; README updates (`syncdb/README.md`, new `syncdb-codegen/README.md`, `docs/how-to/migrate-rtk-to-syncdb.md` note); root `package.json` convenience scripts.
+
+## Feature Flags & Migrations
+
+- No new feature flags. The existing `use-syncdb` flag continues to gate the syncdb path in `example-frontend`.
+- No data migrations. The new `_outbox.maxAttempts` cell is optional and defaulted.
+- Publishing: not wired into `publish-on-tag.yml` in this IP (neither is `@terreno/syncdb` yet); tracked in Future Work so both are added together.
+
+## Activity Log & User Updates
+
+None — developer tooling only.
+
+## Not Included / Future Work
+
+- Publishing `@terreno/syncdb` and `@terreno/syncdb-codegen` to npm (add `publish-syncdb` + `publish-syncdb-codegen` jobs to `publish-on-tag.yml`).
+- Per-platform prebuilt binaries as release artifacts.
+- Generated wrappers for `useSyncStatus`/`useConflicts` (no per-collection typing to add).
+- Server-driven filters/sorts in `useQuery` options (syncdb filters run client-side in JS; nothing for codegen to type beyond `TData`).
+- Zod/AJV runtime validation of mutation payloads against the OpenAPI schema.
+- Singular/custom hook naming via config (`overrides.todos.hookName`), if the pascal-case default proves awkward.
+- A `--watch` mode.
+
+## Files to Create / Modify
+
+**Create**
+- `syncdb-codegen/package.json` — name `@terreno/syncdb-codegen`, `bin`, `build:binary`, catalog deps (dev-only: typescript, biome).
+- `syncdb-codegen/tsconfig.json`, `syncdb-codegen/biome.jsonc` — copied from `syncdb/` siblings.
+- `syncdb-codegen/src/cli.ts` — `#!/usr/bin/env bun` entry; arg parsing (`Bun.argv` + `util.parseArgs`), exit codes, error messages.
+- `syncdb-codegen/src/loadSpec.ts` — fetch/read + JSON parse of the OpenAPI document.
+- `syncdb-codegen/src/discoverCollections.ts` — walk `paths`, collect `x-terreno-sync` operations, resolve entity/create/update schema refs from the list/create/patch operations; apply `--collections` filter/fallback.
+- `syncdb-codegen/src/emitTypes.ts` — OpenAPI schema subset → TS interfaces.
+- `syncdb-codegen/src/emitSdk.ts` — assemble the output file (header, types, `SYNC_COLLECTIONS`, `createCollectionHooks` calls with overrides applied).
+- `syncdb-codegen/src/*.test.ts` — unit + snapshot tests against `syncdb-codegen/src/fixtures/openapi.example.json`.
+- `syncdb-codegen/README.md` — usage, args, config format, custom-hooks pattern.
+- `example-frontend/syncdb-codegen.json` — per-collection overrides example (todos with default retries).
+
+**Modify**
+- `syncdb/src/react/collectionHooks.ts` (new file in existing package) + `syncdb/src/react/index.ts` — `createCollectionHooks` export.
+- `syncdb/src/client.ts` — `MutateArgs.maxAttempts?`, pass-through to outbox.
+- `syncdb/src/mutations/outbox.ts`, `syncdb/src/storage/schema.ts` — optional `maxAttempts` cell.
+- `syncdb/src/sync/replayCoordinator.ts` — `row.maxAttempts ?? MAX_ERROR_NACK_ATTEMPTS` in the error-nack branch.
+- `api/src/openApi.ts` (`listOpenApiMiddleware`) — emit `x-terreno-sync` when `options.sync` is set.
+- `example-frontend/package.json` — `"sync-sdk": "terreno-syncdb-codegen --schema ... --out ./store/syncDbSdk.ts --config ./syncdb-codegen.json"` script; add `@terreno/syncdb-codegen` as a workspace dev dependency.
+- `example-frontend/store/syncDbSdk.ts` — generated output (checked in, like `openApiSdk.ts`).
+- `example-frontend/store/syncdb.ts` — import `SYNC_COLLECTIONS` from the generated file.
+- `example-frontend/components/SyncTodosScreen.tsx` — use generated hooks; delete the local `SyncTodo` interface.
+- Root `package.json` — workspace entry + `syncdb-codegen:compile` / `syncdb-codegen:test` scripts.
+- `syncdb/README.md`, `docs/how-to/migrate-rtk-to-syncdb.md` — codegen sections.
+
+## Task List
+
+See [docs/tasks/syncdb-codegen.md](../tasks/syncdb-codegen.md).
+
+## Acceptance Criteria
+
+- [ ] `createCollectionHooks<Todo>({collection: "todos"})` returns hooks whose behavior matches direct `useQuery`/`useEntity`/`useMutate` calls (covered by unit tests in `syncdb/src/react/`).
+- [ ] `createCollectionHooks({collection: "todos", retries: false})` produces mutations whose outbox rows fail terminally after a single `error` nack; `retries: 3` fails after three attempts; omitted keeps the current 5-attempt backoff (replay coordinator tests).
+- [ ] `GET /openapi.json` from a backend with `sync: {scope: {type: "owner"}}` on `/todos` includes `x-terreno-sync: {collection: "todos", scope: "owner"}` on the list operation; non-synced routes have no extension (api test).
+- [ ] `terreno-syncdb-codegen --schema <fixture> --out out.ts` emits a file that type-checks under the example-frontend tsconfig, contains `SYNC_COLLECTIONS`, typed interfaces, and one `createCollectionHooks` block per synced collection (snapshot test).
+- [ ] `--collections todos` filters output to that collection; a spec without extensions and no `--collections` flag exits non-zero with an actionable message.
+- [ ] A config file with `{overrides: {todos: {retries: false}}}` produces `createCollectionHooks<...>({collection: "todos", retries: false})` in the output.
+- [ ] `bun run build:binary` in `syncdb-codegen/` produces a standalone executable that generates identical output to the bin entry.
+- [ ] `bun run sync-sdk` in `example-frontend` (backend running) regenerates `store/syncDbSdk.ts` with no diff when the backend is unchanged; SyncTodosScreen works against the generated hooks (existing syncdb e2e suite passes).
+- [ ] `bun run lint`, `bun run syncdb:test`, `bun run api:test`, and the new `syncdb-codegen:test` pass.

--- a/docs/tasks/syncdb-codegen.md
+++ b/docs/tasks/syncdb-codegen.md
@@ -11,10 +11,10 @@ Paired with [docs/implementationPlans/syncdb-codegen.md](../implementationPlans/
   - Acceptance: `maxAttempts: 1` fails terminally after one error nack; omitted preserves 5-attempt exponential backoff; existing tests unchanged.
 
 - [ ] **Task 1.2**: `createCollectionHooks` factory
-  - Description: New `createCollectionHooks<TData, TCreate, TUpdate>({collection, retries})` in `@terreno/syncdb/react` returning `{useQuery, useEntity, useMutate}` that delegate to the existing hooks and map `retries` (false → 1, number → n, omitted → undefined) to `maxAttempts`.
+  - Description: New `createCollectionHooks<TData, TCreate, TUpdate>({collection, retries})` in `@terreno/syncdb/react` returning the five per-operation hooks `{useListQuery, useReadQuery, useCreateMutation, useUpdateMutation, useDeleteMutation}`. Read hooks delegate to the existing `useQuery`/`useEntity`; mutation hooks return one-element `[trigger]` tuples (RTK call-site parity) whose triggers wrap `client.mutate`, mapping `retries` (false → 1, number → n, omitted → undefined) to `maxAttempts`.
   - Files: `syncdb/src/react/collectionHooks.ts` (new), `syncdb/src/react/collectionHooks.test.tsx` (new), `syncdb/src/react/index.ts`
   - Depends on: Task 1.1
-  - Acceptance: factory hooks behave identically to direct hook calls; typed create/update payloads compile; `retries` reaches the outbox row.
+  - Acceptance: factory hooks behave identically to direct hook calls; `const [create] = useCreateMutation()` destructuring compiles and works; typed create/update payloads compile; `retries` reaches the outbox row.
 
 ## Phase 2: OpenAPI extension in @terreno/api
 
@@ -39,10 +39,10 @@ Paired with [docs/implementationPlans/syncdb-codegen.md](../implementationPlans/
   - Acceptance: fixture spec yields `[{collection: "todos", entityRef, createRef, updateRef}]`; missing extensions + no flag exits non-zero.
 
 - [ ] **Task 3.3**: Type and SDK emitters
-  - Description: Emit TS interfaces from the OpenAPI schema subset produced by `mongoose-to-swagger` (objects, primitives, string-union enums, arrays, `$ref`, required lists), then assemble the output file: generated header, interfaces, `SYNC_COLLECTIONS as const`, and one destructured `createCollectionHooks` block per collection with per-collection `retries` overrides from `--config` JSON applied. Format via `bunx biome check --write` when available; `--no-format` skips.
+  - Description: Emit TS interfaces from the OpenAPI schema subset produced by `mongoose-to-swagger` (objects, primitives, string-union enums, arrays, `$ref`, required lists), then assemble the output file: generated header, interfaces, `SYNC_COLLECTIONS as const`, and one destructured `createCollectionHooks` block per collection renaming the factory keys to RTK-style hook names (`useListQuery: useGetTodosQuery`, `useReadQuery: useGetTodosByIdQuery`, `useCreateMutation: usePostTodosMutation`, `useUpdateMutation: usePatchTodosByIdMutation`, `useDeleteMutation: useDeleteTodosByIdMutation`), with per-collection `retries` overrides from `--config` JSON applied. Name derivation must match `@rtk-query/codegen-openapi`'s pascal-case of the route path. Format via `bunx biome check --write` when available; `--no-format` skips.
   - Files: `syncdb-codegen/src/emitTypes.ts` (new), `syncdb-codegen/src/emitSdk.ts` (new), snapshot tests
   - Depends on: Task 3.2
-  - Acceptance: snapshot output type-checks; `{overrides: {todos: {retries: false}}}` appears as `retries: false` in the emitted factory call.
+  - Acceptance: snapshot output type-checks; emitted hook names for the todos fixture are byte-identical to the RTK-generated names in `example-frontend/store/openApiSdk.ts`; `{overrides: {todos: {retries: false}}}` appears as `retries: false` in the emitted factory call.
 
 - [ ] **Task 3.4**: CLI entry and binary build
   - Description: `cli.ts` wires arg parsing (`util.parseArgs`) → load → discover → emit → write, with clear usage/error output and non-zero exit codes. Verify `build:binary` produces a standalone executable with identical output.
@@ -53,7 +53,7 @@ Paired with [docs/implementationPlans/syncdb-codegen.md](../implementationPlans/
 ## Phase 4: Integration and docs
 
 - [ ] **Task 4.1**: example-frontend integration
-  - Description: Add `sync-sdk` script and `syncdb-codegen.json`, check in generated `store/syncDbSdk.ts`, source `SYNC_COLLECTIONS` from it in `store/syncdb.ts`, and migrate `SyncTodosScreen` to the generated hooks (delete the local `SyncTodo` interface).
+  - Description: Add `sync-sdk` script and `syncdb-codegen.json`, check in generated `store/syncDbSdk.ts`, source `SYNC_COLLECTIONS` from it in `store/syncdb.ts`, and migrate `SyncTodosScreen` to the generated hooks (`useGetTodosQuery`, `usePostTodosMutation`, `usePatchTodosByIdMutation`, `useDeleteTodosByIdMutation`; delete the local `SyncTodo` interface). Imports come from `@/store/syncDbSdk` — never re-export these alongside `openApiSdk.ts` from a shared barrel, since the names intentionally collide.
   - Files: `example-frontend/package.json`, `example-frontend/syncdb-codegen.json` (new), `example-frontend/store/syncDbSdk.ts` (generated), `example-frontend/store/syncdb.ts`, `example-frontend/components/SyncTodosScreen.tsx`
   - Depends on: Task 1.2, Task 3.4
   - Acceptance: `bun run sync-sdk` regenerates with no diff against an unchanged backend; syncdb Playwright e2e suite passes; `compile` passes.

--- a/docs/tasks/syncdb-codegen.md
+++ b/docs/tasks/syncdb-codegen.md
@@ -1,0 +1,65 @@
+# Task List: @terreno/syncdb-codegen
+
+Paired with [docs/implementationPlans/syncdb-codegen.md](../implementationPlans/syncdb-codegen.md). Each task is independently implementable and testable.
+
+## Phase 1: syncdb runtime
+
+- [ ] **Task 1.1**: Per-mutation `maxAttempts` plumbing
+  - Description: Add optional `maxAttempts` to `MutateArgs`, store it as an optional cell on the outbox row, and have the replay coordinator's `error`-nack branch use `row.maxAttempts ?? MAX_ERROR_NACK_ATTEMPTS` when deciding terminal failure. Missing cell keeps current behavior.
+  - Files: `syncdb/src/client.ts`, `syncdb/src/mutations/outbox.ts`, `syncdb/src/storage/schema.ts`, `syncdb/src/sync/replayCoordinator.ts`, `syncdb/src/sync/replayCoordinator.test.ts`, `syncdb/src/mutations/outbox.test.ts`
+  - Depends on: none
+  - Acceptance: `maxAttempts: 1` fails terminally after one error nack; omitted preserves 5-attempt exponential backoff; existing tests unchanged.
+
+- [ ] **Task 1.2**: `createCollectionHooks` factory
+  - Description: New `createCollectionHooks<TData, TCreate, TUpdate>({collection, retries})` in `@terreno/syncdb/react` returning `{useQuery, useEntity, useMutate}` that delegate to the existing hooks and map `retries` (false → 1, number → n, omitted → undefined) to `maxAttempts`.
+  - Files: `syncdb/src/react/collectionHooks.ts` (new), `syncdb/src/react/collectionHooks.test.tsx` (new), `syncdb/src/react/index.ts`
+  - Depends on: Task 1.1
+  - Acceptance: factory hooks behave identically to direct hook calls; typed create/update payloads compile; `retries` reaches the outbox row.
+
+## Phase 2: OpenAPI extension in @terreno/api
+
+- [ ] **Task 2.1**: Emit `x-terreno-sync` on list operations
+  - Description: When `modelRouter` options include `sync`, the list operation's OpenAPI object gains `"x-terreno-sync": {collection, scope}` where `collection` is the route path without the leading slash and `scope` is the scope type ("owner" | "tenant" | "broadcast" | "custom").
+  - Files: `api/src/openApi.ts`, `api/src/openApi.test.ts` (or the existing spec-generation test file)
+  - Depends on: none
+  - Acceptance: spec for a synced model contains the extension with correct collection tag and scope; non-synced routes contain no extension; RTK codegen output for example-frontend is unchanged.
+
+## Phase 3: codegen package
+
+- [ ] **Task 3.1**: Package scaffold
+  - Description: New `syncdb-codegen/` workspace package (`@terreno/syncdb-codegen`) with bin `terreno-syncdb-codegen` (`#!/usr/bin/env bun`), `compile`, `test`, `lint`, and `build:binary` (`bun build --compile src/cli.ts --outfile dist/terreno-syncdb-codegen`) scripts, modeled on `syncdb/` + the `mcp-server` bin pattern.
+  - Files: `syncdb-codegen/package.json` (new), `syncdb-codegen/tsconfig.json` (new), `syncdb-codegen/biome.jsonc` (new), root `package.json` (workspaces + `syncdb-codegen:compile`/`syncdb-codegen:test` scripts)
+  - Depends on: none
+  - Acceptance: `bun run syncdb-codegen:compile` and `bun run lint` pass from the repo root.
+
+- [ ] **Task 3.2**: Spec loading and collection discovery
+  - Description: Load the OpenAPI document from a URL or file path; walk `paths` for `x-terreno-sync` extensions; resolve each collection's entity schema (list response `data` items ref), create body, and update body schema refs; apply `--collections` as filter or fallback; fail with an actionable error when no collections resolve.
+  - Files: `syncdb-codegen/src/loadSpec.ts` (new), `syncdb-codegen/src/discoverCollections.ts` (new), tests, `syncdb-codegen/src/fixtures/openapi.example.json` (new, captured from example-backend)
+  - Depends on: Task 2.1, Task 3.1
+  - Acceptance: fixture spec yields `[{collection: "todos", entityRef, createRef, updateRef}]`; missing extensions + no flag exits non-zero.
+
+- [ ] **Task 3.3**: Type and SDK emitters
+  - Description: Emit TS interfaces from the OpenAPI schema subset produced by `mongoose-to-swagger` (objects, primitives, string-union enums, arrays, `$ref`, required lists), then assemble the output file: generated header, interfaces, `SYNC_COLLECTIONS as const`, and one destructured `createCollectionHooks` block per collection with per-collection `retries` overrides from `--config` JSON applied. Format via `bunx biome check --write` when available; `--no-format` skips.
+  - Files: `syncdb-codegen/src/emitTypes.ts` (new), `syncdb-codegen/src/emitSdk.ts` (new), snapshot tests
+  - Depends on: Task 3.2
+  - Acceptance: snapshot output type-checks; `{overrides: {todos: {retries: false}}}` appears as `retries: false` in the emitted factory call.
+
+- [ ] **Task 3.4**: CLI entry and binary build
+  - Description: `cli.ts` wires arg parsing (`util.parseArgs`) → load → discover → emit → write, with clear usage/error output and non-zero exit codes. Verify `build:binary` produces a standalone executable with identical output.
+  - Files: `syncdb-codegen/src/cli.ts` (new), `syncdb-codegen/src/cli.test.ts` (new)
+  - Depends on: Task 3.3
+  - Acceptance: `terreno-syncdb-codegen --schema fixtures/openapi.example.json --out /tmp/out.ts` succeeds; missing required args print usage and exit 1; compiled binary output matches bin output byte-for-byte.
+
+## Phase 4: Integration and docs
+
+- [ ] **Task 4.1**: example-frontend integration
+  - Description: Add `sync-sdk` script and `syncdb-codegen.json`, check in generated `store/syncDbSdk.ts`, source `SYNC_COLLECTIONS` from it in `store/syncdb.ts`, and migrate `SyncTodosScreen` to the generated hooks (delete the local `SyncTodo` interface).
+  - Files: `example-frontend/package.json`, `example-frontend/syncdb-codegen.json` (new), `example-frontend/store/syncDbSdk.ts` (generated), `example-frontend/store/syncdb.ts`, `example-frontend/components/SyncTodosScreen.tsx`
+  - Depends on: Task 1.2, Task 3.4
+  - Acceptance: `bun run sync-sdk` regenerates with no diff against an unchanged backend; syncdb Playwright e2e suite passes; `compile` passes.
+
+- [ ] **Task 4.2**: Documentation
+  - Description: Codegen section in `syncdb/README.md`, new `syncdb-codegen/README.md` (args, config format, custom-hooks pattern via `createCollectionHooks`), and a note in the RTK migration guide pointing at generated hooks.
+  - Files: `syncdb/README.md`, `syncdb-codegen/README.md` (new), `docs/how-to/migrate-rtk-to-syncdb.md`
+  - Depends on: Task 4.1
+  - Acceptance: docs cover install, generation, custom hooks, and retries overrides; examples compile as written.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an implementation plan (plus paired task list) for `@terreno/syncdb-codegen` — a small CLI (npm bin under bun + `bun build --compile` standalone binary) that generates static typed syncdb hooks from a backend OpenAPI spec, mirroring the existing RTK Query codegen flow.

## Key design points

- **Per-operation hooks with RTK's exact names**: for each synced collection the generator emits `useGetTodosQuery` (list), `useGetTodosByIdQuery` (read), `usePostTodosMutation` (create), `usePatchTodosByIdMutation` (update/patch — modelRouter only exposes PATCH and syncdb updates are merges, so these are one hook), and `useDeleteTodosByIdMutation` (delete). Names are derived the same way `@rtk-query/codegen-openapi` derives them, so migrating a screen from RTK to syncdb is mostly an import-path swap. Mutation hooks return `[trigger]` tuples so RTK destructuring call sites compile unchanged (triggers are synchronous, returning `{mutationId, id}`).
- **Sync discovery**: `modelRouter` emits an `x-terreno-sync` vendor extension on list operations when `sync` is configured, so the OpenAPI spec stays the single codegen input (with a `--collections` CLI override/fallback). Rejected alternatives (manifest endpoint, flag-only) are documented in the Decisions table.
- **Custom hooks, RTK-style**: a new `createCollectionHooks<TData, TCreate, TUpdate>` factory in `@terreno/syncdb/react` is the shared building block — generated code destructure-renames its operation keys to the RTK-style names, and consumers use the same factory in a sibling file for custom collections (the `emptySplitApi` + `sdk.ts` parallel).
- **Retries option**: `retries: false | number` per collection (analogue of RTK's `extraOptions.maxRetries: 0`), backed by a small per-mutation `maxAttempts` plumb through `client.mutate` → outbox row → replay coordinator (default stays 5 attempts with backoff).
- **Deliberately small scope**: only the five CRUD hooks are generated; status/conflicts hooks, lazy queries, async mutation state emulation, npm publishing, watch mode, and runtime validation are explicitly deferred.

## Files

- `docs/implementationPlans/syncdb-codegen.md` — the IP (goal, decisions with options considered, architecture, phases, acceptance criteria)
- `docs/tasks/syncdb-codegen.md` — 4-phase task breakdown (syncdb runtime, api extension, codegen package, example integration + docs)
- `docs/implementationPlans/PLAN_INDEX.md` — registered as an active Draft plan

No code changes — planning docs only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45be77af-5032-4a08-92b2-2937e40241d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45be77af-5032-4a08-92b2-2937e40241d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

