### PR TITLE
Harden syncdb: ordered batching, auth-pause, protocol correctness, load/chaos tests

### DIFF
--- a/.github/workflows/e2e-load-nightly.yml
+++ b/.github/workflows/e2e-load-nightly.yml
@@ -1,53 +1,24 @@
-name: E2E Tests
+name: E2E Load Tests (nightly)
 
+# Dedicated, non-PR-blocking job for the syncdb-loadlab spec (Phase F4): generates
+# 2000 todos + churn rounds against the admin-guarded /loadtest routes, which is much
+# heavier than the rest of the syncdb-*.spec.ts suite and does not belong in the
+# PR-blocking matrix in e2e-ci.yml. Runs nightly on a schedule, on manual dispatch, or
+# on a PR carrying the `load-test` label — never unconditionally on every PR push.
 on:
-  push:
-    paths:
-      - "example-frontend/app/**"
-      - "example-frontend/constants/**"
-      - "example-frontend/hooks/**"
-      - "example-frontend/lib/**"
-      - "example-frontend/store/**"
-      - "example-frontend/utils/**"
-      - "example-frontend/e2e/**"
-      - "example-frontend/playwright.config.ts"
-      - "example-frontend/package.json"
-      - "example-backend/src/**"
-      - "bun.lock"
-      - "ui/src/**"
-      - "rtk/src/**"
-      - "api/src/**"
-      - "ai/src/**"
-      - "admin-backend/src/**"
-      - "admin-frontend/src/**"
-      - "feature-flags/src/**"
-      - "api-health/src/**"
-      - ".github/workflows/e2e-ci.yml"
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch: {}
+  pull_request:
+    types: [labeled]
 
 jobs:
-  e2e:
-    name: "E2E · ${{ matrix.spec }}"
+  e2e-load:
+    name: "E2E Load · syncdb-loadlab"
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        # One shard per spec file. Keep this list in sync with example-frontend/e2e/
-        # so every spec runs in CI; a shard's playwright step should stay under ~2
-        # minutes — split the spec file if it grows past that.
-        spec:
-          - login
-          - signup
-          - todos
-          - profile
-          - admin
-          - consents
-          - ai-chat
-          - realtime
-          - syncdb-load-delta
-          - syncdb-offline
-          - syncdb-conflicts
-          - syncdb-storage
-          - syncdb-chaos
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.label.name == 'load-test'
     steps:
       - uses: actions/checkout@v6.0.3
 
@@ -132,8 +103,8 @@ jobs:
         run: bunx playwright install --with-deps chromium
         working-directory: example-frontend
 
-      - name: Run Playwright tests — ${{ matrix.spec }}
-        run: bunx playwright test ${{ matrix.spec }}.spec.ts
+      - name: Run Playwright tests — syncdb-loadlab
+        run: bunx playwright test syncdb-loadlab.spec.ts
         working-directory: example-frontend
         env:
           AUTH_PROVIDER: better-auth
@@ -150,7 +121,7 @@ jobs:
         uses: actions/upload-artifact@v7.0.1
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report-${{ matrix.spec }}
+          name: playwright-report-syncdb-loadlab
           path: example-frontend/playwright-report/
           if-no-files-found: ignore
           retention-days: 30
@@ -159,7 +130,7 @@ jobs:
         uses: actions/upload-artifact@v7.0.1
         if: ${{ !cancelled() }}
         with:
-          name: playwright-test-results-${{ matrix.spec }}
+          name: playwright-test-results-syncdb-loadlab
           path: example-frontend/test-results/
           if-no-files-found: ignore
           retention-days: 30

--- a/api/package.json
+++ b/api/package.json
@@ -115,6 +115,7 @@
     "lint": "biome check ./src",
     "lint:fix": "biome check --write ./src",
     "lint:unsafefix": "biome check --fix --unsafe ./src",
+    "load": "bun src/sync/loadHarness.ts",
     "test": "bun test --update-snapshots",
     "test:ci": "bun test",
     "test:coverage": "bun run ../scripts/check-coverage.ts",

--- a/api/src/auth.test.ts
+++ b/api/src/auth.test.ts
@@ -1,5 +1,5 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: test mock typing
-import {afterEach, beforeEach, describe, expect, it, setSystemTime} from "bun:test";
+import {afterEach, beforeEach, describe, expect, it, setSystemTime, spyOn} from "bun:test";
 import type express from "express";
 import type jwt from "jsonwebtoken";
 import supertest from "supertest";
@@ -11,9 +11,11 @@ import {
   addMeRoutes,
   generateTokens,
   type HasSetPassword,
+  MAX_PASSWORD_LENGTH,
   setPasswordForUser,
   setupAuth,
 } from "./auth";
+import {logger} from "./logger";
 import {Permissions} from "./permissions";
 import {getCurrentRequestContext} from "./requestContext";
 import {TerrenoApp} from "./terrenoApp";
@@ -1287,6 +1289,40 @@ describe("JWT cookie extraction", () => {
     const res = await agent.get("/food").set("authorization", "Bearer undefined").expect(200);
     expect(res.body.data).toBeDefined();
   });
+
+  // D1: the JWT-vs-non-JWT fallthrough now decodes the token's header/payload
+  // structure (jwt.decode with complete: true) instead of counting dots, so it is
+  // robust to opaque tokens that coincidentally contain two dots and to malformed
+  // strings that happen to have three dot-delimited segments without real JWT
+  // structure.
+  it("falls through (200, no 401) for an opaque non-JWT bearer token with two dots", async () => {
+    // An opaque token shaped like a Better Auth session id — has exactly two dots
+    // but is not base64url-encoded JSON in any segment.
+    const res = await agent
+      .get("/food")
+      .set("authorization", "Bearer not.a.jwt-at-all")
+      .expect(200);
+    expect(res.body.data).toBeDefined();
+  });
+
+  it("falls through (200, no 401) for a three-dot string with no real JWT header/payload structure", async () => {
+    // Exactly three dot-delimited segments (would have been treated as "a JWT" by
+    // the old dot-counting check) but none are valid base64url JSON.
+    const res = await agent.get("/food").set("authorization", "Bearer abc.def.ghi").expect(200);
+    expect(res.body.data).toBeDefined();
+  });
+
+  it("returns 401 for a genuinely malformed JWT-shaped token (decodable header, bad signature)", async () => {
+    const jwtLib = await import("jsonwebtoken");
+    // A well-formed JWT (decodable header/payload) but signed with the wrong
+    // secret — jwt.verify throws, and jwt.decode succeeds (it is a real JWT), so
+    // this must still 401 rather than fall through.
+    const badToken = jwtLib.sign({id: "someone"}, "wrong-secret", {
+      issuer: process.env.TOKEN_ISSUER,
+    });
+    const res = await agent.get("/food").set("authorization", `Bearer ${badToken}`);
+    expect(res.status).toBe(401);
+  });
 });
 
 describe("signup disabled", () => {
@@ -1374,5 +1410,66 @@ describe("setPasswordForUser", () => {
     await expect(setPasswordForUser(user, "pw", 10)).rejects.toThrow(
       "Timed out while setting password"
     );
+  });
+
+  it("rejects passwords longer than MAX_PASSWORD_LENGTH without calling setPassword", async () => {
+    let called = false;
+    const user: HasSetPassword = {
+      setPassword: (_password, callback) => {
+        called = true;
+        callback?.();
+      },
+    };
+    const tooLong = "x".repeat(MAX_PASSWORD_LENGTH + 1);
+
+    await expect(setPasswordForUser(user, tooLong)).rejects.toThrow(
+      `Password must be at most ${MAX_PASSWORD_LENGTH} characters`
+    );
+    expect(called).toBe(false);
+  });
+
+  it("accepts a password exactly at MAX_PASSWORD_LENGTH", async () => {
+    let receivedPassword: string | undefined;
+    const user: HasSetPassword = {
+      setPassword: (password, callback) => {
+        receivedPassword = password;
+        callback?.();
+      },
+    };
+    const atLimit = "x".repeat(MAX_PASSWORD_LENGTH);
+
+    await setPasswordForUser(user, atLimit);
+    expect(receivedPassword).toBe(atLimit);
+  });
+
+  it("logs an audit line with the admin id and target user id when audit context is provided", async () => {
+    const infoSpy = spyOn(logger, "info");
+    infoSpy.mockClear();
+    const user: HasSetPassword = {
+      _id: "target-user-id",
+      setPassword: (_password, callback) => callback?.(),
+    };
+
+    await setPasswordForUser(user, "new-password", undefined, {adminId: "admin-id-123"});
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const [message] = infoSpy.mock.calls[0] as [string];
+    expect(message).toContain("admin-id-123");
+    expect(message).toContain("target-user-id");
+    expect(message).not.toContain("new-password");
+    infoSpy.mockRestore();
+  });
+
+  it("does not log an audit line when no audit context is provided", async () => {
+    const infoSpy = spyOn(logger, "info");
+    infoSpy.mockClear();
+    const user: HasSetPassword = {
+      setPassword: (_password, callback) => callback?.(),
+    };
+
+    await setPasswordForUser(user, "new-password");
+
+    expect(infoSpy).not.toHaveBeenCalled();
+    infoSpy.mockRestore();
   });
 });

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -105,10 +105,21 @@ export const signupUser = async (
 
 /** A user document exposing passport-local-mongoose's `setPassword`. */
 export interface HasSetPassword {
+  _id?: unknown;
+  id?: string;
   setPassword: (
     password: string,
     callback?: (error?: unknown) => void
   ) => Promise<unknown> | unknown;
+}
+
+/** Upper bound on password length accepted by {@link setPasswordForUser} (D5). */
+export const MAX_PASSWORD_LENGTH = 256;
+
+/** Optional audit context for {@link setPasswordForUser} — never includes the password itself. */
+export interface SetPasswordAuditContext {
+  /** The admin performing the change, when set via an admin-only route. */
+  adminId?: unknown;
 }
 
 /**
@@ -117,12 +128,31 @@ export interface HasSetPassword {
  * return a promise while older ones only invoke the callback; this helper normalizes both and
  * rejects after `timeoutMs` (default 15s) if neither settles. Call `user.save()` afterwards to
  * persist the new hash/salt.
+ *
+ * Rejects synchronously (before touching `setPassword`) when `password` exceeds
+ * {@link MAX_PASSWORD_LENGTH} characters. When `audit.adminId` is provided (an admin-initiated
+ * password change), logs a `logger.info` audit line with the admin id, target user id, and
+ * timestamp — NEVER the password itself.
  */
 export const setPasswordForUser = async (
   user: HasSetPassword,
   password: string,
-  timeoutMs = 15_000
+  timeoutMs = 15_000,
+  audit?: SetPasswordAuditContext
 ): Promise<void> => {
+  if (password.length > MAX_PASSWORD_LENGTH) {
+    throw new APIError({
+      status: 400,
+      title: `Password must be at most ${MAX_PASSWORD_LENGTH} characters`,
+    });
+  }
+  if (audit?.adminId !== undefined) {
+    const targetUserId = user._id ?? user.id ?? "unknown";
+    logger.info(
+      `[auth] Admin ${String(audit.adminId)} set password for user ${String(targetUserId)} ` +
+        `at ${DateTime.now().toISO()}`
+    );
+  }
   await new Promise<void>((resolve, reject) => {
     let isSettled = false;
     const timeout = setTimeout(() => {
@@ -360,12 +390,17 @@ export const setupAuth = (app: express.Application, userModel: UserModel): void 
         issuer: process.env.TOKEN_ISSUER,
       }) as jwt.JwtPayload;
     } catch (error: unknown) {
-      // A bearer token that is not a JWT (three dot-delimited segments) is not ours to
-      // reject — e.g. a Better Auth session token. Fall through so a later auth layer
-      // (Better Auth session middleware) or the route's own permissions can handle it.
+      // A bearer token that is not a JWT at all (e.g. a Better Auth opaque session
+      // token) is not ours to reject — fall through so a later auth layer (Better
+      // Auth session middleware) or the route's own permissions can handle it.
+      // Detect this by decoding the token's header/payload structure (D1) rather
+      // than counting dot-delimited segments: an opaque token can coincidentally
+      // contain exactly two dots, and a malformed-but-JWT-shaped string can fail
+      // this same check for the wrong reason — `jwt.decode` parses the actual
+      // base64url JSON structure of each segment, which dot-counting cannot.
       // Genuine JWTs that fail verification (malformed/expired) still return 401 so the
       // client's token-refresh flow is preserved.
-      if (token.split(".").length !== 3) {
+      if (jwt.decode(token, {complete: true}) === null) {
         return next();
       }
       const userText = req.user?._id ? ` for user ${req.user._id} ` : "";

--- a/api/src/realtime/changeStreamWatcher.ts
+++ b/api/src/realtime/changeStreamWatcher.ts
@@ -22,6 +22,7 @@ import type {User} from "../auth";
 import {APIError} from "../errors";
 import {logger} from "../logger";
 import {checkPermissions, type PermissionMethod} from "../permissions";
+import {computeStableFrontier, SyncScopeMove} from "../sync/models";
 import {findSyncEntryByCollectionName, type SyncRegistryEntry} from "../sync/registry";
 import {serializeSyncPayload} from "../sync/serialize";
 import {syncRoomForStream} from "../sync/socketHandlers";
@@ -35,7 +36,41 @@ import type {ChangeStreamConfig, RealtimeEvent} from "./types";
 
 let changeWatcher: ChangeStream | null = null;
 
-const DEFAULT_IGNORED_COLLECTIONS = ["socketio", "sessions"];
+/**
+ * C8: per-entity serialized dispatch. The change-stream `"change"` handler is async and
+ * multiple events can be in flight at once; without ordering, two events for the SAME
+ * document could emit their deltas out of order (a client would then see LWW-by-seq
+ * violated within an entity). This keeps a promise chain PER entity key
+ * (`{collection}:{docId}`) so same-entity deltas dispatch strictly in change-stream
+ * order, while different entities still run concurrently. Chains self-clean when idle.
+ */
+const entityDispatchChains = new Map<string, Promise<void>>();
+
+const serializePerEntity = (key: string, task: () => Promise<void>): void => {
+  const prior = entityDispatchChains.get(key) ?? Promise.resolve();
+  const next = prior.then(task, task);
+  entityDispatchChains.set(key, next);
+  void next.finally(() => {
+    // Drop the chain once this was the last queued task, so the map does not grow.
+    if (entityDispatchChains.get(key) === next) {
+      entityDispatchChains.delete(key);
+    }
+  });
+};
+
+/**
+ * C7: the sync bookkeeping collections must never drive fan-out — their own change
+ * events are internal (counters/ledger/markers/keys), and processing them would emit
+ * spurious deltas or reprocess scope-move markers. Exported for testing.
+ */
+export const DEFAULT_IGNORED_COLLECTIONS = [
+  "socketio",
+  "sessions",
+  "synccounters",
+  "syncmutations",
+  "syncscopemoves",
+  "synckeys",
+];
 
 /**
  * Map MongoDB change stream operation types to our method names.
@@ -520,11 +555,18 @@ const processRealtimeChange = async ({
  * Soft deletes (an update setting `deleted: true`, reclassified by `mapOperationType`)
  * produce a `method: "delete"` delta with `deleted: true` and the tombstone data intact.
  *
- * Scope moves: when the post-image carries a `_syncPrevStream` differing from the current
- * stream (stamped by `syncPlugin` at write time — change streams run with
- * `fullDocumentBeforeChange: "off"`, so the old scope is not otherwise available), a
- * data-less tombstone delta is emitted to the previous stream and the delta to the new
- * stream is reported as `method: "create"` so new-stream subscribers materialize the doc.
+ * Scope moves (C4): the old-stream tombstone is derived from durable `SyncScopeMove`
+ * markers (written by `syncPlugin` in the same op-scope as the move), NOT from the racy
+ * `_syncPrevStream` post-image — a second write racing this event's processing can reset
+ * `_syncPrevStream`, but it cannot erase the durable marker. For each marker on this
+ * document, a data-less tombstone is emitted to the marker's `fromStream` (carrying the
+ * marker's old-stream seq), and the new-stream delta is reported as `method: "create"`.
+ * Client tombstone application is idempotent by seq, so re-emitting a marker on a later
+ * change of the same doc is harmless.
+ *
+ * Every emitted delta carries `frontierSeq` (the emitting stream's stable frontier at
+ * emit time, C1); the client advances its cursor to `min(delta.seq, delta.frontierSeq)`
+ * so a delta observed out of commit order never advances a cursor past an uncommitted hole.
  *
  * A model with both `realtime` and `sync` configs emits both the legacy "sync" event and
  * "sync:delta" — distinct event names, no interference (documented as transitional).
@@ -573,20 +615,26 @@ export const emitSyncDeltaForChange = async ({
     scope: entry.config.scope,
   });
 
-  const prevStreamRaw = fullDocument._syncPrevStream;
-  const prevStream =
-    typeof prevStreamRaw === "string" && prevStreamRaw.length > 0 && prevStreamRaw !== stream
-      ? prevStreamRaw
-      : null;
-  if (prevStream) {
-    // Scope move: tombstone the old stream (no data) so its subscribers drop the doc...
+  // C4: emit old-stream tombstones from durable markers, not the racy _syncPrevStream.
+  const markers = await SyncScopeMove.find({
+    collectionTag: entry.collectionTag,
+    entityId: docId,
+  }).lean();
+  let movedAway = false;
+  for (const marker of markers) {
+    if (marker.fromStream === stream) {
+      continue;
+    }
+    movedAway = true;
+    const markerFrontier = await computeStableFrontier({stream: marker.fromStream});
     const tombstone: SyncDelta = {
       collection: entry.collectionTag,
       deleted: true,
+      frontierSeq: markerFrontier,
       id: docId,
       method: "delete",
-      seq,
-      stream: prevStream,
+      seq: marker.seq,
+      stream: marker.fromStream,
     };
     await emitPayloadToAuthorizedRoom({
       buildPayload: () => tombstone,
@@ -595,20 +643,22 @@ export const emitSyncDeltaForChange = async ({
       fullDocument,
       io,
       logDebug,
-      room: syncRoomForStream(prevStream),
+      room: syncRoomForStream(marker.fromStream),
     });
     logDebug(
-      `[sync] Emitted scope-move tombstone for ${entry.collectionTag}/${docId} to ${prevStream}`
+      `[sync] Emitted scope-move tombstone for ${entry.collectionTag}/${docId} to ${marker.fromStream} seq=${marker.seq}`
     );
-    // ...and the new stream sees the doc for the first time: report it as a create
-    // (unless the same write also soft-deleted the doc, in which case the tombstone wins).
-    if (method !== "delete") {
-      method = "create";
-    }
+  }
+  // The new stream sees a moved-away doc for the first time: report it as a create
+  // (unless the same write also soft-deleted the doc, in which case the tombstone wins).
+  if (movedAway && method !== "delete") {
+    method = "create";
   }
 
+  const frontierSeq = await computeStableFrontier({stream});
   const delta: SyncDelta = {
     collection: entry.collectionTag,
+    frontierSeq,
     id: docId,
     method,
     seq,
@@ -616,13 +666,16 @@ export const emitSyncDeltaForChange = async ({
     ...(deleted ? {deleted: true} : {}),
   };
   await emitPayloadToAuthorizedRoom({
-    buildPayload: async (user) => {
-      const syntheticReq = {params: {}, query: {}, user} as unknown as express.Request;
-      const data = ensureApiId(
-        await serializeSyncPayload({doc: fullDocument, entry, method, req: syntheticReq})
-      );
-      return {...delta, data};
-    },
+    // C7: tombstone deltas carry no data (only id/seq/deleted); live deltas serialize.
+    buildPayload: deleted
+      ? () => delta
+      : async (user) => {
+          const syntheticReq = {params: {}, query: {}, user} as unknown as express.Request;
+          const data = ensureApiId(
+            await serializeSyncPayload({doc: fullDocument, entry, method, req: syntheticReq})
+          );
+          return {...delta, data};
+        },
     entry,
     eventName: "sync:delta",
     fullDocument,
@@ -631,7 +684,7 @@ export const emitSyncDeltaForChange = async ({
     room: syncRoomForStream(stream),
   });
   logDebug(
-    `[sync] Emitted sync:delta ${method} for ${entry.collectionTag}/${docId} seq=${seq} stream=${stream}`
+    `[sync] Emitted sync:delta ${method} for ${entry.collectionTag}/${docId} seq=${seq} stream=${stream} frontier=${frontierSeq}`
   );
 };
 
@@ -745,12 +798,17 @@ export const startChangeStreamWatcher = (
         }
 
         if (syncEntry) {
-          try {
-            await emitSyncDeltaForChange({change, docId, entry: syncEntry, io, logDebug});
-          } catch (error) {
-            logger.error(`[sync] Error emitting sync delta: ${error}`);
-            Sentry.captureException(error);
-          }
+          // C8: serialize per entity so same-doc deltas emit in change-stream order;
+          // different docs still dispatch concurrently. See serializePerEntity + the
+          // per-entity LWW-by-seq contract documented in sync/types.ts (SyncDelta).
+          serializePerEntity(`${collectionName}:${docId}`, async () => {
+            try {
+              await emitSyncDeltaForChange({change, docId, entry: syncEntry, io, logDebug});
+            } catch (error) {
+              logger.error(`[sync] Error emitting sync delta: ${error}`);
+              Sentry.captureException(error);
+            }
+          });
         }
       } catch (error) {
         logger.error(`[realtime] Error processing change event: ${error}`);

--- a/api/src/realtime/index.ts
+++ b/api/src/realtime/index.ts
@@ -31,6 +31,18 @@ export {
   registerRealtime,
 } from "./registry";
 export {
+  DEFAULT_SESSION_REVALIDATION_INTERVAL_MS,
+  loadFullUserForSocket,
+  type RevalidatableSocket,
+  type RevalidationOutcome,
+  reresolveSyncRoomsForSocket,
+  revalidateSocketSession,
+  runSessionRevalidationSweep,
+  type SessionRevalidationHandle,
+  type SessionRevalidationOptions,
+  startSessionRevalidationSweep,
+} from "./sessionRevalidation";
+export {
   type AuthenticatableSocket,
   type BetterAuthSocketOptions,
   createBetterAuthValidator,
@@ -38,6 +50,12 @@ export {
   createSocketAuthMiddleware,
   type SocketAuthValidator,
 } from "./socketAuth";
+export {
+  type DecodedRealtimeToken,
+  getSocketUser,
+  type SocketDataBag,
+  type SocketWithDecodedToken,
+} from "./socketUser";
 export type {
   ChangeStreamConfig,
   DocumentSubscription,

--- a/api/src/realtime/realtimeApp.ts
+++ b/api/src/realtime/realtimeApp.ts
@@ -17,8 +17,13 @@ import {
   removeQuerySubscription,
 } from "./queryStore";
 import {findRegistryEntryByRoutePath, type RealtimeRegistryEntry} from "./registry";
+import {
+  loadFullUserForSocket,
+  type SessionRevalidationHandle,
+  startSessionRevalidationSweep,
+} from "./sessionRevalidation";
 import {createSocketAuthMiddleware} from "./socketAuth";
-import {getSocketUser, type SocketWithDecodedToken} from "./socketUser";
+import {getSocketUser, type SocketDataBag, type SocketWithDecodedToken} from "./socketUser";
 import type {DocumentSubscription, QuerySubscription, RealtimeAppOptions} from "./types";
 
 /**
@@ -122,7 +127,9 @@ export const installRealtimeSocketHandlers = (
   const logInfo = options.logInfo ?? ((): void => {});
   const userId = socket.decodedToken?.id;
   const isAdmin = socket.decodedToken?.admin === true;
-  const user = getSocketUser(socket);
+  // D2: re-derive per event rather than capturing once at install time, so a
+  // handshake-time-loaded full user (or one refreshed by D1's sweep) is always used.
+  const currentUser = (): User | undefined => getSocketUser(socket);
 
   const counts = {document: 0, model: 0, query: 0};
 
@@ -169,7 +176,7 @@ export const installRealtimeSocketHandlers = (
       return;
     }
 
-    if (!(await canSubscribe(entry, "list", user))) {
+    if (!(await canSubscribe(entry, "list", currentUser()))) {
       logInfo(
         `[realtime] User ${userId} denied model subscription for ${modelName}: list permission denied`
       );
@@ -212,7 +219,7 @@ export const installRealtimeSocketHandlers = (
       return;
     }
 
-    if (!(await canSubscribe(entry, "read", user))) {
+    if (!(await canSubscribe(entry, "read", currentUser()))) {
       logInfo(
         `[realtime] User ${userId} denied document subscription for ` +
           `${payload.collection}/${payload.id}: read permission denied`
@@ -267,7 +274,7 @@ export const installRealtimeSocketHandlers = (
       return;
     }
 
-    let query = await getAuthorizedQuery(entry, {...payload.query}, user);
+    let query = await getAuthorizedQuery(entry, {...payload.query}, currentUser());
     if (!query) {
       logInfo(
         `[realtime] User ${userId} denied query subscription for ${payload.collection}: ` +
@@ -338,6 +345,7 @@ export const installRealtimeSocketHandlers = (
 export class RealtimeApp implements TerrenoPlugin {
   private io: Server | null = null;
   private config: RealtimeAppOptions;
+  private sessionRevalidation: SessionRevalidationHandle | null = null;
 
   constructor(config: RealtimeAppOptions = {}) {
     this.config = config;
@@ -389,9 +397,19 @@ export class RealtimeApp implements TerrenoPlugin {
         );
       }
 
+      // D1: pass the issuer through for parity with the HTTP JWT path
+      // (jwt.verify(token, secret, {issuer})) — without it a validly-signed token
+      // issued for a different TOKEN_ISSUER was silently accepted over sockets. A
+      // thunk (not a value captured once here) so a later change to
+      // process.env.TOKEN_ISSUER — or to an explicitly configured tokenIssuer — is
+      // honored on every handshake, matching the HTTP path's per-request env read.
+      const resolveTokenIssuer = (): string | undefined =>
+        this.config.tokenIssuer ?? process.env.TOKEN_ISSUER;
+
       this.io.use(
         createSocketAuthMiddleware({
           betterAuth: this.config.betterAuth,
+          issuer: resolveTokenIssuer,
           tokenSecret,
         })
       );
@@ -406,6 +424,15 @@ export class RealtimeApp implements TerrenoPlugin {
       // Connection handling
       this.io.on("connection", (socket: Socket): void => {
         try {
+          // D2: load the full user document once at handshake (by the decoded
+          // token's id) and cache it on socket.data.fullUser — getSocketUser prefers
+          // it over the synthetic {_id, admin, id} shape for every authorization
+          // check below. Fire-and-forget: handlers install synchronously and fall
+          // back to the synthetic shape until this resolves.
+          void loadFullUserForSocket(
+            socket as unknown as Socket & {data: SocketDataBag},
+            this.config.userModel
+          );
           // The auth middleware adds `decodedToken` at runtime; cast through
           // RealtimeSocketLike (a structural subset) to keep socket handler logic testable.
           installRealtimeSocketHandlers(socket as unknown as RealtimeSocketLike, {logInfo});
@@ -432,6 +459,21 @@ export class RealtimeApp implements TerrenoPlugin {
       // Start the change stream watcher
       startChangeStreamWatcher(this.io, this.config.changeStream, debug);
 
+      // D1: periodic session re-validation sweep — disconnects sockets whose JWT has
+      // expired, whose Better Auth session is no longer valid, or whose user has
+      // since been disabled; also refreshes socket.data.fullUser (D2) and
+      // re-resolves sync room membership (D4) for sockets that remain valid.
+      // A thunk (not a snapshot) so `sync` — the SyncApp plugin's published options,
+      // read by the connection handler fresh per socket too — never goes stale if
+      // SyncApp registers after RealtimeApp.onServerCreated() runs.
+      this.sessionRevalidation = startSessionRevalidationSweep(this.io, () => ({
+        betterAuth: this.config.betterAuth,
+        intervalMs: this.config.sessionRevalidationIntervalMs,
+        logInfo,
+        sync: this.config.sync ?? getActiveSyncAppOptions() ?? undefined,
+        userModel: this.config.userModel,
+      }));
+
       logInfo("[realtime] Socket.io server setup complete");
     } catch (error) {
       logger.error(`[realtime] Failed to set up Socket.io: ${error}`);
@@ -452,6 +494,8 @@ export class RealtimeApp implements TerrenoPlugin {
    */
   async close(): Promise<void> {
     try {
+      this.sessionRevalidation?.stop();
+      this.sessionRevalidation = null;
       await stopChangeStreamWatcher();
       if (this.io) {
         await this.io.close();

--- a/api/src/realtime/sessionRevalidation.test.ts
+++ b/api/src/realtime/sessionRevalidation.test.ts
@@ -1,0 +1,422 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: test mocks use dynamic shapes for sockets, io, and models
+/**
+ * D1: socket session re-validation sweep.
+ *   - revalidateSocketSession: expired/disabled/invalid-session detection per auth kind
+ *   - reresolveSyncRoomsForSocket: D4 room membership diffing (leave revoked, join granted)
+ *   - runSessionRevalidationSweep: disconnects failing sockets with sync:auth-expired
+ *   - loadFullUserForSocket: D2 handshake full-user load
+ */
+import {afterEach, describe, expect, it, mock} from "bun:test";
+import {DateTime} from "luxon";
+import mongoose, {model, Schema} from "mongoose";
+
+import {createdUpdatedPlugin, isDeletedPlugin} from "../plugins";
+import {clearSyncRegistry, registerSync} from "../sync/registry";
+import {syncPlugin} from "../sync/syncSeqPlugin";
+import {
+  loadFullUserForSocket,
+  type RevalidatableSocket,
+  reresolveSyncRoomsForSocket,
+  revalidateSocketSession,
+  runSessionRevalidationSweep,
+  startSessionRevalidationSweep,
+} from "./sessionRevalidation";
+
+/** Minimal fake Mongoose model: findOneOrNoneFor falls back to `.find()` without the plugin. */
+const fakeUserModel = (users: Record<string, unknown>): any => ({
+  find: async (query: {_id: string}) => {
+    const user = users[query._id];
+    return user ? [user] : [];
+  },
+});
+
+/**
+ * Real (but never persisted — no test DB round-trip needed) Mongoose models satisfying
+ * `registerSync`'s schema contract (soft delete + syncPlugin + scope field present), so
+ * D4's room-resolution tests can register genuine sync registry entries.
+ */
+const revalTenantSchema = new Schema({
+  organizationId: {type: String},
+  title: {type: String},
+});
+revalTenantSchema.plugin(isDeletedPlugin);
+revalTenantSchema.plugin(createdUpdatedPlugin);
+revalTenantSchema.plugin(syncPlugin);
+const RevalTenantModel =
+  (mongoose.models.RevalSessionProject as mongoose.Model<any>) ||
+  model("RevalSessionProject", revalTenantSchema);
+
+const revalOwnerSchema = new Schema({
+  ownerId: {type: String},
+  title: {type: String},
+});
+revalOwnerSchema.plugin(isDeletedPlugin);
+revalOwnerSchema.plugin(createdUpdatedPlugin);
+revalOwnerSchema.plugin(syncPlugin);
+const RevalOwnerModel =
+  (mongoose.models.RevalSessionTodo as mongoose.Model<any>) ||
+  model("RevalSessionTodo", revalOwnerSchema);
+
+const makeSocket = (overrides: Partial<RevalidatableSocket> = {}): RevalidatableSocket => ({
+  data: {},
+  disconnect: mock(() => {}),
+  emit: mock(() => {}),
+  id: "socket-1",
+  join: mock(async () => {}),
+  leave: mock(async () => {}),
+  ...overrides,
+});
+
+describe("revalidateSocketSession", () => {
+  it("returns valid for a JWT socket whose exp is in the future", async () => {
+    const socket = makeSocket({
+      decodedToken: {
+        authKind: "jwt",
+        exp: DateTime.now().plus({minutes: 10}).toSeconds(),
+        id: "u1",
+      },
+    });
+    const outcome = await revalidateSocketSession(socket, {});
+    expect(outcome).toBe("valid");
+  });
+
+  it("returns expired for a JWT socket whose exp has passed", async () => {
+    const socket = makeSocket({
+      decodedToken: {
+        authKind: "jwt",
+        exp: DateTime.now().minus({minutes: 1}).toSeconds(),
+        id: "u1",
+      },
+    });
+    const outcome = await revalidateSocketSession(socket, {});
+    expect(outcome).toBe("expired");
+  });
+
+  it("treats a JWT socket with no exp claim as valid (nothing to check locally)", async () => {
+    const socket = makeSocket({decodedToken: {authKind: "jwt", id: "u1"}});
+    const outcome = await revalidateSocketSession(socket, {});
+    expect(outcome).toBe("valid");
+  });
+
+  it("returns valid for a Better Auth socket whose session lookup still resolves", async () => {
+    const socket = makeSocket({
+      decodedToken: {authKind: "better-auth", id: "u1"},
+      encodedToken: "session-token",
+    });
+    const outcome = await revalidateSocketSession(socket, {
+      betterAuth: {
+        auth: {api: {getSession: async () => ({user: {id: "u1"}})}} as any,
+      },
+    });
+    expect(outcome).toBe("valid");
+  });
+
+  it("returns invalid-session for a Better Auth socket whose session no longer resolves", async () => {
+    const socket = makeSocket({
+      decodedToken: {authKind: "better-auth", id: "u1"},
+      encodedToken: "revoked-session-token",
+    });
+    const outcome = await revalidateSocketSession(socket, {
+      betterAuth: {auth: {api: {getSession: async () => null}} as any},
+    });
+    expect(outcome).toBe("invalid-session");
+  });
+
+  it("returns invalid-session for a Better Auth socket when no betterAuth options are configured", async () => {
+    const socket = makeSocket({
+      decodedToken: {authKind: "better-auth", id: "u1"},
+      encodedToken: "session-token",
+    });
+    const outcome = await revalidateSocketSession(socket, {});
+    expect(outcome).toBe("invalid-session");
+  });
+
+  it("returns disabled when the reloaded full user has disabled: true", async () => {
+    const socket = makeSocket({decodedToken: {authKind: "jwt", id: "u1"}});
+    const outcome = await revalidateSocketSession(socket, {
+      userModel: fakeUserModel({u1: {_id: "u1", disabled: true}}),
+    });
+    expect(outcome).toBe("disabled");
+  });
+
+  it("returns invalid-session when the user no longer exists", async () => {
+    const socket = makeSocket({decodedToken: {authKind: "jwt", id: "gone"}});
+    const outcome = await revalidateSocketSession(socket, {userModel: fakeUserModel({})});
+    expect(outcome).toBe("invalid-session");
+  });
+
+  it("refreshes socket.data.fullUser on success (D2)", async () => {
+    const user = {_id: "u1", disabled: false, organizationIds: ["org-a"]};
+    const socket = makeSocket({decodedToken: {authKind: "jwt", id: "u1"}});
+    const outcome = await revalidateSocketSession(socket, {userModel: fakeUserModel({u1: user})});
+    expect(outcome).toBe("valid");
+    expect(socket.data?.fullUser).toEqual(user);
+  });
+
+  it("returns valid when no userModel is configured (no disabled check possible)", async () => {
+    const socket = makeSocket({decodedToken: {authKind: "jwt", id: "u1"}});
+    const outcome = await revalidateSocketSession(socket, {});
+    expect(outcome).toBe("valid");
+  });
+});
+
+describe("reresolveSyncRoomsForSocket (D4)", () => {
+  afterEach(() => {
+    clearSyncRegistry();
+  });
+
+  it("leaves a room for a tenant the user no longer belongs to and joins a newly granted one", async () => {
+    registerSync({
+      config: {scope: {field: "organizationId", type: "tenant"}},
+      model: RevalTenantModel,
+      options: {permissions: {create: [], delete: [], list: [], read: [], update: []}} as any,
+      routePath: "/projects",
+    });
+
+    const subscriptions = new Map<string, Set<string>>([
+      ["projects", new Set(["sync:projects|tenant:org-old"])],
+    ]);
+    const socket = makeSocket({
+      data: {fullUser: {id: "u1"}, syncSubscriptions: subscriptions},
+      decodedToken: {authKind: "jwt", id: "u1"},
+    });
+
+    await reresolveSyncRoomsForSocket(socket, {
+      sync: {getUserScopes: () => ["org-new"]},
+    });
+
+    expect(socket.leave).toHaveBeenCalledWith("sync:projects|tenant:org-old");
+    expect(socket.join).toHaveBeenCalledWith("sync:projects|tenant:org-new");
+    expect(subscriptions.get("projects")).toEqual(new Set(["sync:projects|tenant:org-new"]));
+  });
+
+  it("does nothing when the socket has no sync subscriptions", async () => {
+    const socket = makeSocket({decodedToken: {authKind: "jwt", id: "u1"}});
+    await reresolveSyncRoomsForSocket(socket, {});
+    expect(socket.leave).not.toHaveBeenCalled();
+    expect(socket.join).not.toHaveBeenCalled();
+  });
+
+  it("leaves all rooms when getUserScopes returns no memberships (full revocation)", async () => {
+    registerSync({
+      config: {scope: {field: "organizationId", type: "tenant"}},
+      model: RevalTenantModel,
+      options: {permissions: {create: [], delete: [], list: [], read: [], update: []}} as any,
+      routePath: "/projects",
+    });
+    const subscriptions = new Map<string, Set<string>>([
+      ["projects", new Set(["sync:projects|tenant:org-a"])],
+    ]);
+    const socket = makeSocket({
+      data: {fullUser: {id: "u1"}, syncSubscriptions: subscriptions},
+      decodedToken: {authKind: "jwt", id: "u1"},
+    });
+
+    await reresolveSyncRoomsForSocket(socket, {sync: {getUserScopes: () => []}});
+
+    expect(socket.leave).toHaveBeenCalledWith("sync:projects|tenant:org-a");
+    expect(socket.join).not.toHaveBeenCalled();
+    expect(subscriptions.get("projects")).toEqual(new Set());
+  });
+
+  it("keeps an owner-scoped room untouched (always the socket's own userId)", async () => {
+    registerSync({
+      config: {scope: {type: "owner"}},
+      model: RevalOwnerModel,
+      options: {permissions: {create: [], delete: [], list: [], read: [], update: []}} as any,
+      routePath: "/todos",
+    });
+    const subscriptions = new Map<string, Set<string>>([
+      ["todos", new Set(["sync:todos|owner:u1"])],
+    ]);
+    const socket = makeSocket({
+      data: {fullUser: {id: "u1"}, syncSubscriptions: subscriptions},
+      decodedToken: {authKind: "jwt", id: "u1"},
+    });
+
+    await reresolveSyncRoomsForSocket(socket, {});
+
+    expect(socket.leave).not.toHaveBeenCalled();
+    expect(socket.join).not.toHaveBeenCalled();
+  });
+});
+
+describe("runSessionRevalidationSweep", () => {
+  it("disconnects an expired socket, emitting sync:auth-expired first", async () => {
+    const socket = makeSocket({
+      decodedToken: {
+        authKind: "jwt",
+        exp: DateTime.now().minus({minutes: 1}).toSeconds(),
+        id: "u1",
+      },
+    });
+    const io = {sockets: {sockets: new Map([["socket-1", socket]])}} as any;
+
+    await runSessionRevalidationSweep(io, {});
+
+    expect(socket.emit).toHaveBeenCalledWith("sync:auth-expired", {reason: "expired"});
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
+  });
+
+  it("disconnects a disabled user's socket", async () => {
+    const socket = makeSocket({decodedToken: {authKind: "jwt", id: "u1"}});
+    const io = {sockets: {sockets: new Map([["socket-1", socket]])}} as any;
+
+    await runSessionRevalidationSweep(io, {
+      userModel: fakeUserModel({u1: {_id: "u1", disabled: true}}),
+    });
+
+    expect(socket.emit).toHaveBeenCalledWith("sync:auth-expired", {reason: "disabled"});
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
+  });
+
+  it("leaves a valid socket connected and does not emit sync:auth-expired", async () => {
+    const socket = makeSocket({
+      decodedToken: {
+        authKind: "jwt",
+        exp: DateTime.now().plus({minutes: 10}).toSeconds(),
+        id: "u1",
+      },
+    });
+    const io = {sockets: {sockets: new Map([["socket-1", socket]])}} as any;
+
+    await runSessionRevalidationSweep(io, {});
+
+    expect(socket.emit).not.toHaveBeenCalled();
+    expect(socket.disconnect).not.toHaveBeenCalled();
+  });
+
+  it("continues sweeping other sockets when one throws", async () => {
+    const throwing = makeSocket({
+      decodedToken: {authKind: "jwt", id: "throws"},
+      id: "socket-throws",
+    });
+    const expired = makeSocket({
+      decodedToken: {
+        authKind: "jwt",
+        exp: DateTime.now().minus({minutes: 1}).toSeconds(),
+        id: "u2",
+      },
+      id: "socket-expired",
+    });
+    const throwingUserModel = {
+      find: async () => {
+        throw new Error("db unavailable");
+      },
+    };
+    const io = {
+      sockets: {
+        sockets: new Map([
+          ["socket-throws", throwing],
+          ["socket-expired", expired],
+        ]),
+      },
+    } as any;
+
+    await runSessionRevalidationSweep(io, {userModel: throwingUserModel as any});
+
+    // The throwing socket's error is caught and logged; it is left connected rather
+    // than disconnected on an ambiguous internal failure.
+    expect(throwing.disconnect).not.toHaveBeenCalled();
+    expect(expired.disconnect).toHaveBeenCalledWith(true);
+  });
+});
+
+describe("startSessionRevalidationSweep", () => {
+  it("does not arm a timer when intervalMs is 0", () => {
+    const io = {sockets: {sockets: new Map()}} as any;
+    const handle = startSessionRevalidationSweep(io, {intervalMs: 0});
+    // No assertion beyond "does not throw" is possible without reaching into timer
+    // internals; stop() must be a safe no-op either way.
+    expect(() => handle.stop()).not.toThrow();
+  });
+
+  it("returns a handle whose stop() clears the interval", () => {
+    const io = {sockets: {sockets: new Map()}} as any;
+    const handle = startSessionRevalidationSweep(io, {intervalMs: 60_000});
+    expect(() => handle.stop()).not.toThrow();
+    // Calling stop() twice must also be safe.
+    expect(() => handle.stop()).not.toThrow();
+  });
+
+  it("resolves an options thunk fresh on every tick (no staleness from a captured snapshot)", async () => {
+    // Regression for the same staleness bug fixed for the JWT issuer thunk: a
+    // static options object captured once at RealtimeApp.onServerCreated() time
+    // would use whatever `sync.getUserScopes` was published at that instant,
+    // even if SyncApp registers (or its options change) afterwards.
+    registerSync({
+      config: {scope: {field: "organizationId", type: "tenant"}},
+      model: RevalTenantModel,
+      options: {permissions: {create: [], delete: [], list: [], read: [], update: []}} as any,
+      routePath: "/projects",
+    });
+    const user = {_id: "u1", disabled: false};
+    let scopesAtLastTick: string[] = [];
+    const socket = makeSocket({
+      data: {
+        fullUser: user,
+        syncSubscriptions: new Map([["projects", new Set(["sync:projects|tenant:org-v1"])]]),
+      },
+      decodedToken: {authKind: "jwt", id: "u1"},
+    });
+    const io = {sockets: {sockets: new Map([["socket-1", socket]])}} as any;
+    let currentScopes = ["org-v1"];
+
+    const handle = startSessionRevalidationSweep(io, () => ({
+      intervalMs: 20,
+      sync: {
+        getUserScopes: () => {
+          scopesAtLastTick = currentScopes;
+          return currentScopes;
+        },
+      },
+      userModel: fakeUserModel({u1: user}),
+    }));
+
+    await settleFor(60);
+    expect(scopesAtLastTick).toEqual(["org-v1"]);
+
+    currentScopes = ["org-v2"];
+    await settleFor(60);
+    expect(scopesAtLastTick).toEqual(["org-v2"]);
+
+    handle.stop();
+    clearSyncRegistry();
+  });
+});
+
+const settleFor = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("loadFullUserForSocket (D2)", () => {
+  it("populates socket.data.fullUser from the decoded token's id", async () => {
+    const user = {_id: "u1", organizationIds: ["org-a"]};
+    const socket: any = {data: {}, decodedToken: {id: "u1"}, id: "socket-1"};
+
+    await loadFullUserForSocket(socket, fakeUserModel({u1: user}));
+
+    expect(socket.data.fullUser).toEqual(user);
+  });
+
+  it("is a no-op when no userModel is configured", async () => {
+    const socket: any = {data: {}, decodedToken: {id: "u1"}, id: "socket-1"};
+    await loadFullUserForSocket(socket, undefined);
+    expect(socket.data.fullUser).toBeUndefined();
+  });
+
+  it("is a no-op when the decoded token has no id", async () => {
+    const socket: any = {data: {}, decodedToken: {}, id: "socket-1"};
+    await loadFullUserForSocket(socket, fakeUserModel({u1: {_id: "u1"}}));
+    expect(socket.data.fullUser).toBeUndefined();
+  });
+
+  it("swallows a lookup error and leaves fullUser unset", async () => {
+    const throwingModel = {
+      find: async () => {
+        throw new Error("db down");
+      },
+    };
+    const socket: any = {data: {}, decodedToken: {id: "u1"}, id: "socket-1"};
+    await loadFullUserForSocket(socket, throwingModel as any);
+    expect(socket.data.fullUser).toBeUndefined();
+  });
+});

--- a/api/src/realtime/sessionRevalidation.ts
+++ b/api/src/realtime/sessionRevalidation.ts
@@ -1,0 +1,257 @@
+import {DateTime} from "luxon";
+import type {Server, Socket} from "socket.io";
+
+import type {UserModel} from "../auth";
+import {logger} from "../logger";
+import {findOneOrNoneFor} from "../plugins";
+import {findSyncEntryByCollectionTag} from "../sync/registry";
+import type {SyncAppOptions} from "../sync/routes";
+import {syncRoomForStream} from "../sync/socketHandlers";
+import {streamForScopeValue} from "../sync/streams";
+import type {BetterAuthSocketOptions} from "./socketAuth";
+import {getSocketUser, type SocketDataBag, type SocketWithDecodedToken} from "./socketUser";
+
+/**
+ * Default interval for the periodic socket session re-validation sweep (D1): 60
+ * seconds. Sockets authenticate once at handshake; without a sweep, a revoked
+ * session, an expired token, or a user subsequently disabled keeps streaming deltas
+ * (including PHI) indefinitely.
+ */
+export const DEFAULT_SESSION_REVALIDATION_INTERVAL_MS = 60_000;
+
+/** Minimal socket shape the sweep needs. Lets tests drive it with a mock. */
+export interface RevalidatableSocket extends SocketWithDecodedToken {
+  id: string;
+  encodedToken?: string;
+  data?: SocketDataBag;
+  emit: (event: string, payload?: unknown) => void;
+  disconnect: (close?: boolean) => void;
+  join: (room: string) => Promise<void> | void;
+  leave: (room: string) => Promise<void> | void;
+}
+
+export interface SessionRevalidationOptions {
+  /** Application user model, for reloading the full user and its `disabled` flag. */
+  userModel?: UserModel;
+  /** Enables re-validating Better Auth-authenticated sockets. */
+  betterAuth?: BetterAuthSocketOptions;
+  /** Active SyncAppOptions (for `getUserScopes`), used by D4's room re-resolution. */
+  sync?: SyncAppOptions;
+  logInfo?: (message: string) => void;
+}
+
+/** Result of re-validating a single socket, for tests/observability. */
+export type RevalidationOutcome = "valid" | "expired" | "disabled" | "invalid-session";
+
+/**
+ * Re-run the cheap parts of the auth validator for an already-connected socket:
+ * - JWT sockets (`decodedToken.authKind === "jwt"`): verify `exp` locally (no
+ *   signature re-check — a stolen-but-still-valid token is not this sweep's job;
+ *   revocation-by-expiry and disablement are).
+ * - Better Auth sockets (`decodedToken.authKind === "better-auth"`): re-run
+ *   `auth.api.getSession` for the retained session token.
+ * Also reloads the user's `disabled` flag (and the full user document, refreshing
+ * `socket.data.fullUser` for D2) when a `userModel` is configured.
+ */
+export const revalidateSocketSession = async (
+  socket: RevalidatableSocket,
+  options: SessionRevalidationOptions
+): Promise<RevalidationOutcome> => {
+  const {authKind, id: userId, exp} = socket.decodedToken ?? {};
+
+  if (authKind === "jwt") {
+    if (typeof exp === "number" && exp <= DateTime.now().toSeconds()) {
+      return "expired";
+    }
+  } else if (authKind === "better-auth") {
+    if (!options.betterAuth || !socket.encodedToken) {
+      return "invalid-session";
+    }
+    const session = await options.betterAuth.auth.api.getSession({
+      headers: {authorization: `Bearer ${socket.encodedToken}`} as Record<string, string>,
+    });
+    if (!session?.user?.id) {
+      return "invalid-session";
+    }
+  }
+
+  if (options.userModel && userId) {
+    const fullUser = await findOneOrNoneFor(options.userModel, {_id: userId});
+    if (!fullUser) {
+      return "invalid-session";
+    }
+    if ((fullUser as unknown as {disabled?: boolean}).disabled === true) {
+      return "disabled";
+    }
+    // D2: refresh the cached full user so subsequent authorization checks (and the
+    // next sweep tick's stream re-resolution below) see current fields — e.g. a
+    // membership change to `organizationIds` takes effect without a reconnect.
+    if (socket.data) {
+      socket.data.fullUser = fullUser;
+    }
+  }
+
+  return "valid";
+};
+
+/**
+ * D4: re-resolve the streams the socket's user currently belongs to for every
+ * subscribed collection, and `socket.leave()` any previously-joined sync room the
+ * user no longer holds (e.g. a revoked organization membership). Joins any newly
+ * granted rooms too, mirroring what a fresh `sync:subscribe` would do, so a
+ * membership grant also takes effect without a reconnect.
+ */
+export const reresolveSyncRoomsForSocket = async (
+  socket: RevalidatableSocket,
+  options: SessionRevalidationOptions
+): Promise<void> => {
+  const subscriptions = socket.data?.syncSubscriptions;
+  if (!subscriptions || subscriptions.size === 0) {
+    return;
+  }
+  const user = getSocketUser(socket);
+  if (!user) {
+    return;
+  }
+
+  for (const [collection, currentRooms] of subscriptions) {
+    const entry = findSyncEntryByCollectionTag(collection);
+    if (!entry) {
+      continue;
+    }
+    const {scope} = entry.config;
+    let streams: string[];
+    if (typeof scope !== "function" && scope.type === "broadcast") {
+      streams = [streamForScopeValue({collectionTag: collection, scope, scopeValue: null})];
+    } else if (typeof scope !== "function" && scope.type === "owner") {
+      streams = [streamForScopeValue({collectionTag: collection, scope, scopeValue: user.id})];
+    } else if (options.sync?.getUserScopes) {
+      let scopeValues: string[];
+      try {
+        scopeValues = await options.sync.getUserScopes(user, entry);
+      } catch (error: unknown) {
+        logger.error(`[realtime] getUserScopes threw during session revalidation: ${error}`);
+        continue;
+      }
+      streams = scopeValues.map((scopeValue) =>
+        streamForScopeValue({collectionTag: collection, scope, scopeValue})
+      );
+    } else {
+      continue;
+    }
+
+    const nextRooms = new Set(streams.map(syncRoomForStream));
+    for (const room of currentRooms) {
+      if (!nextRooms.has(room)) {
+        await socket.leave(room);
+      }
+    }
+    for (const room of nextRooms) {
+      if (!currentRooms.has(room)) {
+        await socket.join(room);
+      }
+    }
+    subscriptions.set(collection, nextRooms);
+  }
+};
+
+/**
+ * Run one sweep pass over every connected socket: re-validate the session (D1),
+ * disconnecting (`sync:auth-expired` then `disconnect(true)`) any socket that fails,
+ * and re-resolve sync room membership (D4) for sockets that remain valid.
+ */
+export const runSessionRevalidationSweep = async (
+  io: Server,
+  options: SessionRevalidationOptions = {}
+): Promise<void> => {
+  const logInfo = options.logInfo ?? ((): void => {});
+  const sockets = [...io.sockets.sockets.values()] as unknown as RevalidatableSocket[];
+
+  await Promise.all(
+    sockets.map(async (socket) => {
+      try {
+        const outcome = await revalidateSocketSession(socket, options);
+        if (outcome !== "valid") {
+          logInfo(
+            `[realtime] Session revalidation sweep disconnecting socket ${socket.id}: ${outcome}`
+          );
+          socket.emit("sync:auth-expired", {reason: outcome});
+          socket.disconnect(true);
+          return;
+        }
+        await reresolveSyncRoomsForSocket(socket, options);
+      } catch (error: unknown) {
+        logger.error(
+          `[realtime] Session revalidation sweep failed for socket ${socket.id}: ${error}`
+        );
+      }
+    })
+  );
+};
+
+/** Handle returned by {@link startSessionRevalidationSweep}; call to stop the timer. */
+export type SessionRevalidationHandle = {stop: () => void};
+
+/**
+ * Start the periodic sweep (D1). Returns a handle to stop it (called from
+ * `RealtimeApp.close()`). A `intervalMs` of 0 disables the sweep (useful for tests
+ * that don't want a background timer).
+ *
+ * `options` may be a plain object or a thunk resolved fresh on EVERY tick — pass a
+ * thunk when any field (notably `sync`, whose `getUserScopes` resolver is published
+ * by the `SyncApp` plugin and may not be registered yet, or may change, at the time
+ * `RealtimeApp.onServerCreated()` runs) must never go stale for the lifetime of the
+ * sweep, mirroring the per-handshake freshness `createLegacyJwtValidator`'s issuer
+ * thunk already provides.
+ */
+export const startSessionRevalidationSweep = (
+  io: Server,
+  optionsOrThunk:
+    | (SessionRevalidationOptions & {intervalMs?: number})
+    | (() => SessionRevalidationOptions & {intervalMs?: number}) = {}
+): SessionRevalidationHandle => {
+  const resolveOptions = (): SessionRevalidationOptions & {intervalMs?: number} =>
+    typeof optionsOrThunk === "function" ? optionsOrThunk() : optionsOrThunk;
+  const intervalMs = resolveOptions().intervalMs ?? DEFAULT_SESSION_REVALIDATION_INTERVAL_MS;
+  if (intervalMs <= 0) {
+    return {stop: (): void => {}};
+  }
+  const timer = setInterval(() => {
+    void runSessionRevalidationSweep(io, resolveOptions()).catch((error: unknown) => {
+      logger.error(`[realtime] Session revalidation sweep tick failed: ${error}`);
+    });
+  }, intervalMs);
+  return {
+    stop: (): void => {
+      clearInterval(timer);
+    },
+  };
+};
+
+/**
+ * Load the full user document for a just-authenticated socket and cache it on
+ * `socket.data.fullUser` (D2). Called once at handshake, right after the auth
+ * middleware succeeds; the periodic sweep (D1) refreshes it afterwards. A no-op when
+ * no `userModel` is configured (falls back to the synthetic decoded-token shape via
+ * `getSocketUser`) or the decoded token carries no id (should not happen for a
+ * socket that passed auth, but guarded defensively).
+ */
+export const loadFullUserForSocket = async (
+  socket: Socket & {data: SocketDataBag},
+  userModel?: UserModel
+): Promise<void> => {
+  const userId = (socket as unknown as SocketWithDecodedToken).decodedToken?.id;
+  if (!userModel || !userId) {
+    return;
+  }
+  try {
+    const fullUser = await findOneOrNoneFor(userModel, {_id: userId});
+    if (fullUser) {
+      socket.data.fullUser = fullUser;
+    }
+  } catch (error: unknown) {
+    logger.error(
+      `[realtime] Failed to load full user at handshake for socket ${socket.id}: ${error}`
+    );
+  }
+};

--- a/api/src/realtime/socketAuth.test.ts
+++ b/api/src/realtime/socketAuth.test.ts
@@ -1,0 +1,354 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: test mocks use dynamic shapes for sockets and auth stubs
+/**
+ * Full validator matrix for the socket authentication chain (D1):
+ *   - Legacy JWT validator (valid / expired / wrong-secret / wrong-issuer / missing token)
+ *   - Better Auth session validator (valid / invalid session / missing token)
+ *   - Chain fall-through and precedence
+ *   - Bearer-prefix stripping
+ *   - Issuer parity with the HTTP JWT path (D1), including per-handshake freshness
+ *
+ * Moved out of sync/syncSocket.test.ts (which still covers the higher-level
+ * subscribe/mutate socket handlers) into its own file per the syncdb hardening plan.
+ */
+import {describe, expect, it} from "bun:test";
+import jwt from "jsonwebtoken";
+
+import {
+  type AuthenticatableSocket,
+  createBetterAuthValidator,
+  createLegacyJwtValidator,
+  createSocketAuthMiddleware,
+} from "./socketAuth";
+
+describe("socketAuth", () => {
+  const tokenSecret = "socket-auth-test-secret";
+
+  const makeAuthSocket = (token?: string): AuthenticatableSocket & {decodedToken?: any} => ({
+    handshake: {auth: token === undefined ? {} : {token}},
+  });
+
+  const runMiddleware = (
+    middleware: (socket: any, next: (error?: Error) => void) => void,
+    socket: AuthenticatableSocket
+  ): Promise<Error | undefined> =>
+    new Promise((resolve) => {
+      middleware(socket, (error?: Error) => resolve(error));
+    });
+
+  describe("createLegacyJwtValidator", () => {
+    it("accepts a valid Bearer JWT and populates decodedToken", async () => {
+      const validator = createLegacyJwtValidator(tokenSecret);
+      const token = jwt.sign({admin: true, id: "jwt-user"}, tokenSecret);
+      const socket = makeAuthSocket(`Bearer ${token}`);
+      await validator(socket);
+      expect(socket.decodedToken?.id).toBe("jwt-user");
+      expect(socket.decodedToken?.admin).toBe(true);
+    });
+
+    it("stamps authKind: 'jwt' on a successful validation (D1 sweep discriminator)", async () => {
+      const validator = createLegacyJwtValidator(tokenSecret);
+      const token = jwt.sign({id: "jwt-user"}, tokenSecret);
+      const socket = makeAuthSocket(`Bearer ${token}`);
+      await validator(socket);
+      expect(socket.decodedToken?.authKind).toBe("jwt");
+    });
+
+    it("rejects an expired JWT", async () => {
+      const validator = createLegacyJwtValidator(tokenSecret);
+      const token = jwt.sign({id: "jwt-user"}, tokenSecret, {expiresIn: -10});
+      await expect(validator(makeAuthSocket(`Bearer ${token}`))).rejects.toThrow(
+        "Token is missing or invalid Bearer"
+      );
+    });
+
+    it("rejects a token signed with the wrong secret", async () => {
+      const validator = createLegacyJwtValidator(tokenSecret);
+      const token = jwt.sign({id: "jwt-user"}, "wrong-secret");
+      await expect(validator(makeAuthSocket(`Bearer ${token}`))).rejects.toThrow(
+        "Token is missing or invalid Bearer"
+      );
+    });
+
+    it("rejects a token without the Bearer prefix", async () => {
+      const validator = createLegacyJwtValidator(tokenSecret);
+      const token = jwt.sign({id: "jwt-user"}, tokenSecret);
+      await expect(validator(makeAuthSocket(token))).rejects.toThrow(
+        "Format is Authorization: Bearer [token]"
+      );
+    });
+
+    it("rejects when no token is provided", async () => {
+      const validator = createLegacyJwtValidator(tokenSecret);
+      await expect(validator(makeAuthSocket(undefined))).rejects.toThrow("no token provided");
+    });
+
+    // D1: parity with the HTTP JWT path's jwt.verify(token, secret, {issuer}).
+    describe("issuer parity (D1)", () => {
+      it("accepts a token whose iss matches the required issuer", async () => {
+        const validator = createLegacyJwtValidator(tokenSecret, "expected-issuer");
+        const token = jwt.sign({id: "jwt-user"}, tokenSecret, {issuer: "expected-issuer"});
+        const socket = makeAuthSocket(`Bearer ${token}`);
+        await validator(socket);
+        expect(socket.decodedToken?.id).toBe("jwt-user");
+      });
+
+      it("rejects a validly-signed token issued for a different issuer", async () => {
+        const validator = createLegacyJwtValidator(tokenSecret, "expected-issuer");
+        const token = jwt.sign({id: "jwt-user"}, tokenSecret, {issuer: "some-other-issuer"});
+        await expect(validator(makeAuthSocket(`Bearer ${token}`))).rejects.toThrow(
+          "Token is missing or invalid Bearer"
+        );
+      });
+
+      it("rejects a token with no iss claim when an issuer is required", async () => {
+        const validator = createLegacyJwtValidator(tokenSecret, "expected-issuer");
+        const token = jwt.sign({id: "jwt-user"}, tokenSecret);
+        await expect(validator(makeAuthSocket(`Bearer ${token}`))).rejects.toThrow(
+          "Token is missing or invalid Bearer"
+        );
+      });
+
+      it("does not check issuer when none is configured (pre-D1 behavior preserved)", async () => {
+        const validator = createLegacyJwtValidator(tokenSecret);
+        const token = jwt.sign({id: "jwt-user"}, tokenSecret, {issuer: "whatever"});
+        const socket = makeAuthSocket(`Bearer ${token}`);
+        await validator(socket);
+        expect(socket.decodedToken?.id).toBe("jwt-user");
+      });
+
+      it("resolves a thunk issuer fresh on every handshake (no staleness from a captured value)", async () => {
+        let currentIssuer = "issuer-v1";
+        const validator = createLegacyJwtValidator(tokenSecret, () => currentIssuer);
+
+        const tokenV1 = jwt.sign({id: "user-1"}, tokenSecret, {issuer: "issuer-v1"});
+        await validator(makeAuthSocket(`Bearer ${tokenV1}`));
+
+        // Simulate the issuer changing after the validator was constructed (the real
+        // bug this guards: RealtimeApp used to capture process.env.TOKEN_ISSUER once
+        // at onServerCreated() time instead of reading it fresh per handshake).
+        currentIssuer = "issuer-v2";
+        const tokenV1Again = jwt.sign({id: "user-1"}, tokenSecret, {issuer: "issuer-v1"});
+        await expect(validator(makeAuthSocket(`Bearer ${tokenV1Again}`))).rejects.toThrow(
+          "Token is missing or invalid Bearer"
+        );
+
+        const tokenV2 = jwt.sign({id: "user-2"}, tokenSecret, {issuer: "issuer-v2"});
+        const socket = makeAuthSocket(`Bearer ${tokenV2}`);
+        await validator(socket);
+        expect(socket.decodedToken?.id).toBe("user-2");
+      });
+    });
+  });
+
+  describe("createBetterAuthValidator", () => {
+    const stubAuth = (session: unknown, capture?: {headers?: unknown}): any => ({
+      api: {
+        getSession: async ({headers}: {headers: unknown}) => {
+          if (capture) {
+            capture.headers = headers;
+          }
+          return session;
+        },
+      },
+    });
+
+    it("populates decodedToken from a valid Better Auth session", async () => {
+      const validator = createBetterAuthValidator({
+        auth: stubAuth({session: {id: "sess-1"}, user: {id: "ba-user-1"}}),
+      });
+      const socket = makeAuthSocket("session-token-abc");
+      await validator(socket);
+      expect(socket.decodedToken).toEqual({
+        admin: false,
+        authKind: "better-auth",
+        id: "ba-user-1",
+        isAnonymous: false,
+      });
+    });
+
+    it("retains the raw session token on socket.encodedToken (for D1's sweep re-check)", async () => {
+      const validator = createBetterAuthValidator({
+        auth: stubAuth({session: {id: "sess-1"}, user: {id: "ba-user-1"}}),
+      });
+      const socket = makeAuthSocket("Bearer session-token-abc");
+      await validator(socket);
+      expect(socket.encodedToken).toBe("session-token-abc");
+    });
+
+    it("passes the token as a bearer authorization header only", async () => {
+      const capture: {headers?: any} = {};
+      const validator = createBetterAuthValidator({
+        auth: stubAuth({session: {id: "s"}, user: {id: "u"}}, capture),
+      });
+      await validator(makeAuthSocket("Bearer session-token-xyz"));
+      expect(capture.headers.authorization).toBe("Bearer session-token-xyz");
+      // A raw (unsigned) token cookie fails signature verification and can shadow the
+      // bearer path, so the validator must not send one.
+      expect(capture.headers.cookie).toBeUndefined();
+    });
+
+    it("rejects when the session lookup returns null", async () => {
+      const validator = createBetterAuthValidator({auth: stubAuth(null)});
+      await expect(validator(makeAuthSocket("bad-session"))).rejects.toThrow(
+        "Better Auth session is missing or invalid"
+      );
+    });
+
+    it("rejects when no token is provided", async () => {
+      const validator = createBetterAuthValidator({auth: stubAuth(null)});
+      await expect(validator(makeAuthSocket(undefined))).rejects.toThrow("no token provided");
+    });
+
+    it("resolves the app user for id and admin when a userModel is provided", async () => {
+      const userModel = {
+        find: () => {
+          throw new Error("unused");
+        },
+      };
+      const appUser = {_id: "app-user-1", admin: true};
+      const findOneOrNone = async (query: Record<string, unknown>) =>
+        query.betterAuthId === "ba-user-1" ? appUser : null;
+      const validator = createBetterAuthValidator({
+        auth: stubAuth({session: {id: "s"}, user: {id: "ba-user-1"}}),
+        userModel: {...userModel, findOneOrNone} as any,
+      });
+      const socket = makeAuthSocket("session-token");
+      await validator(socket);
+      expect(socket.decodedToken).toEqual({
+        admin: true,
+        authKind: "better-auth",
+        id: "app-user-1",
+        isAnonymous: false,
+      });
+    });
+
+    it("rejects when the Better Auth user has no application user", async () => {
+      const validator = createBetterAuthValidator({
+        auth: stubAuth({session: {id: "s"}, user: {id: "ba-orphan"}}),
+        userModel: {findOneOrNone: async () => null} as any,
+      });
+      await expect(validator(makeAuthSocket("session-token"))).rejects.toThrow(
+        "no application user"
+      );
+    });
+  });
+
+  describe("createSocketAuthMiddleware — validator chain", () => {
+    it("accepts a legacy JWT with the default chain", async () => {
+      const middleware = createSocketAuthMiddleware({tokenSecret});
+      const token = jwt.sign({admin: false, id: "chain-user"}, tokenSecret);
+      const socket = makeAuthSocket(`Bearer ${token}`);
+      const error = await runMiddleware(middleware, socket);
+      expect(error).toBeUndefined();
+      expect(socket.decodedToken?.id).toBe("chain-user");
+    });
+
+    it("rejects an invalid token with the default chain", async () => {
+      const middleware = createSocketAuthMiddleware({tokenSecret});
+      const socket = makeAuthSocket("Bearer not-a-jwt");
+      const error = await runMiddleware(middleware, socket);
+      expect(error).toBeDefined();
+      expect(error?.message).toContain("invalid");
+      expect(socket.decodedToken).toBeUndefined();
+    });
+
+    it("falls through to the Better Auth validator when the JWT validator fails", async () => {
+      const middleware = createSocketAuthMiddleware({
+        betterAuth: {
+          auth: {
+            api: {getSession: async () => ({session: {id: "s"}, user: {id: "ba-user-2"}})},
+          } as any,
+        },
+        tokenSecret,
+      });
+      const socket = makeAuthSocket("better-auth-session-token");
+      const error = await runMiddleware(middleware, socket);
+      expect(error).toBeUndefined();
+      expect(socket.decodedToken).toEqual({
+        admin: false,
+        authKind: "better-auth",
+        id: "ba-user-2",
+        isAnonymous: false,
+      });
+    });
+
+    it("falls through to Better Auth when the JWT is expired", async () => {
+      const middleware = createSocketAuthMiddleware({
+        betterAuth: {
+          auth: {
+            api: {getSession: async () => ({session: {id: "s"}, user: {id: "ba-fallback"}})},
+          } as any,
+        },
+        tokenSecret,
+      });
+      const expiredToken = jwt.sign({id: "expired-jwt-user"}, tokenSecret, {expiresIn: -10});
+      const socket = makeAuthSocket(`Bearer ${expiredToken}`);
+      const error = await runMiddleware(middleware, socket);
+      expect(error).toBeUndefined();
+      expect(socket.decodedToken?.id).toBe("ba-fallback");
+    });
+
+    it("prefers the legacy JWT validator when both would work", async () => {
+      const middleware = createSocketAuthMiddleware({
+        betterAuth: {
+          auth: {
+            api: {
+              getSession: async () => {
+                throw new Error("should not be called for a valid JWT");
+              },
+            },
+          } as any,
+        },
+        tokenSecret,
+      });
+      const token = jwt.sign({admin: true, id: "jwt-first"}, tokenSecret);
+      const socket = makeAuthSocket(`Bearer ${token}`);
+      const error = await runMiddleware(middleware, socket);
+      expect(error).toBeUndefined();
+      expect(socket.decodedToken?.id).toBe("jwt-first");
+      expect(socket.decodedToken?.admin).toBe(true);
+    });
+
+    it("rejects with the last validator's error when every validator fails", async () => {
+      const middleware = createSocketAuthMiddleware({
+        betterAuth: {auth: {api: {getSession: async () => null}} as any},
+        tokenSecret,
+      });
+      const socket = makeAuthSocket("neither-jwt-nor-session");
+      const error = await runMiddleware(middleware, socket);
+      expect(error?.message).toContain("Better Auth session is missing or invalid");
+    });
+
+    it("passes the configured issuer through to the JWT validator", async () => {
+      const middleware = createSocketAuthMiddleware({issuer: "chain-issuer", tokenSecret});
+      const wrongIssuerToken = jwt.sign({id: "u"}, tokenSecret, {issuer: "not-chain-issuer"});
+      const socket = makeAuthSocket(`Bearer ${wrongIssuerToken}`);
+      const error = await runMiddleware(middleware, socket);
+      expect(error).toBeDefined();
+      expect(error?.message).toContain("invalid");
+      // The wrapped socketio-jwt middleware sets decodedToken from the raw JWT payload
+      // before the post-verify onAuthentication issuer check runs, so the property is
+      // present (but never stamped with authKind, since that only happens on success)
+      // — the connection is still rejected via the returned error either way.
+      expect(socket.decodedToken?.authKind).toBeUndefined();
+    });
+
+    it("supports extra validators appended to the chain", async () => {
+      const middleware = createSocketAuthMiddleware({
+        extraValidators: [
+          async (socket) => {
+            if (socket.handshake.auth.token !== "magic") {
+              throw new Error("not magic");
+            }
+            socket.decodedToken = {admin: false, id: "magic-user", isAnonymous: false};
+          },
+        ],
+        tokenSecret,
+      });
+      const socket = makeAuthSocket("magic");
+      const error = await runMiddleware(middleware, socket);
+      expect(error).toBeUndefined();
+      expect(socket.decodedToken?.id).toBe("magic-user");
+    });
+  });
+});

--- a/api/src/realtime/socketAuth.ts
+++ b/api/src/realtime/socketAuth.ts
@@ -54,9 +54,42 @@ export interface BetterAuthSocketOptions {
  * Legacy JWT validator: wraps the `@thream/socketio-jwt` middleware so its observable
  * behavior (token format requirements, secret verification, `decodedToken` payload,
  * `UnauthorizedError` shapes) is identical to the previous direct `io.use(authorize(...))`.
+ *
+ * D1: `@thream/socketio-jwt`'s `authorize()` has no `issuer` option — it only verifies
+ * the signature/algorithm — so without this the socket path silently accepted a
+ * validly-signed token issued for a DIFFERENT `TOKEN_ISSUER` (e.g. a token from another
+ * environment sharing the same `TOKEN_SECRET`), unlike the HTTP path's
+ * `jwt.verify(token, secret, {issuer})`. When `issuer` is provided, the post-verify
+ * `onAuthentication` hook checks `decodedToken.iss` and rejects a mismatch with the
+ * same `UnauthorizedError` shape the signature-verification failure path uses, so
+ * callers cannot distinguish "bad signature" from "wrong issuer" from the error alone
+ * (matching the non-disclosure posture the HTTP path also has).
+ *
+ * `issuer` may be a plain string or a thunk (`() => string | undefined`) resolved on
+ * EVERY handshake — the HTTP path's `jwt.verify` reads `process.env.TOKEN_ISSUER` fresh
+ * per request rather than once at server startup, and a static string captured once at
+ * `RealtimeApp.onServerCreated()` time would go stale if `TOKEN_ISSUER` changes later
+ * (e.g. test suites that mutate it between fixtures). Pass a thunk to preserve that
+ * per-request freshness; a plain string is still supported for callers who intentionally
+ * want a fixed value.
  */
-export const createLegacyJwtValidator = (tokenSecret: string): SocketAuthValidator => {
-  const middleware = authorize({secret: tokenSecret});
+export const createLegacyJwtValidator = (
+  tokenSecret: string,
+  issuer?: string | (() => string | undefined)
+): SocketAuthValidator => {
+  const resolveIssuer = (): string | undefined =>
+    typeof issuer === "function" ? issuer() : issuer;
+  const middleware = authorize({
+    onAuthentication: (decodedToken: {iss?: string}) => {
+      const expectedIssuer = resolveIssuer();
+      if (expectedIssuer && decodedToken?.iss !== expectedIssuer) {
+        throw new UnauthorizedError("invalid_token", {
+          message: "Unauthorized: Token is missing or invalid Bearer",
+        });
+      }
+    },
+    secret: tokenSecret,
+  });
   return (socket) =>
     new Promise<void>((resolve, reject) => {
       // The socketio-jwt middleware types demand a full Socket; it only reads
@@ -65,6 +98,13 @@ export const createLegacyJwtValidator = (tokenSecret: string): SocketAuthValidat
         if (error) {
           reject(error);
           return;
+        }
+        // D1: stamp which validator authenticated this socket so the periodic
+        // re-validation sweep knows to re-check local JWT expiry (not a Better Auth
+        // session lookup) for it. The library already populated decodedToken with the
+        // full JWT payload (exp/iss included), so this only adds the discriminator.
+        if (socket.decodedToken) {
+          socket.decodedToken.authKind = "jwt";
         }
         resolve();
       });
@@ -130,7 +170,11 @@ export const createBetterAuthValidator = (
       admin = appUser.admin === true;
     }
 
-    socket.decodedToken = {admin, id, isAnonymous: false};
+    socket.decodedToken = {admin, authKind: "better-auth", id, isAnonymous: false};
+    // D1: retain the raw session token so the periodic re-validation sweep can re-run
+    // `auth.api.getSession` for this socket without re-deriving it from the handshake
+    // (which may have since changed if the client reconnected with a new token).
+    socket.encodedToken = rawToken;
   };
 };
 
@@ -140,17 +184,24 @@ export const createBetterAuthValidator = (
  */
 export const createSocketAuthMiddleware = ({
   tokenSecret,
+  issuer,
   betterAuth,
   extraValidators = [],
 }: {
   /** Secret for the legacy JWT validator (same handling as before the refactor). */
   tokenSecret: string;
+  /**
+   * JWT issuer to require (D1 parity with the HTTP path's `jwt.verify(token, secret,
+   * {issuer})`). Omitted means no issuer check, matching pre-D1 behavior. A thunk is
+   * resolved fresh on every handshake (see {@link createLegacyJwtValidator}).
+   */
+  issuer?: string | (() => string | undefined);
   /** Enables the Better Auth session validator after the legacy JWT validator. */
   betterAuth?: BetterAuthSocketOptions;
   /** Additional validators appended to the chain (after JWT and Better Auth). */
   extraValidators?: SocketAuthValidator[];
 }): ((socket: Socket, next: (error?: Error) => void) => void) => {
-  const validators: SocketAuthValidator[] = [createLegacyJwtValidator(tokenSecret)];
+  const validators: SocketAuthValidator[] = [createLegacyJwtValidator(tokenSecret, issuer)];
   if (betterAuth) {
     validators.push(createBetterAuthValidator(betterAuth));
   }

--- a/api/src/realtime/socketUser.ts
+++ b/api/src/realtime/socketUser.ts
@@ -4,13 +4,60 @@ export interface DecodedRealtimeToken {
   admin?: boolean;
   id?: string;
   isAnonymous?: boolean;
+  /** JWT `exp` claim (seconds since epoch) — present for the legacy JWT validator only. */
+  exp?: number;
+  /** JWT `iss` claim — present for the legacy JWT validator only. */
+  iss?: string;
+  /**
+   * Which validator in the chain authenticated this socket (D1: the periodic
+   * re-validation sweep uses this to pick the matching cheap re-check — local JWT
+   * expiry verification vs. a Better Auth session lookup). Undefined for handshakes
+   * that predate this field (never actually observable at runtime — set by every
+   * validator — but kept optional so structural test doubles compile without it).
+   */
+  authKind?: "jwt" | "better-auth";
+}
+
+/**
+ * Per-socket data bag. `fullUser` is populated once at handshake (see
+ * `loadFullUserForSocket` / `RealtimeApp`'s connection handler) by loading the full
+ * Mongoose user document for `decodedToken.id`, and refreshed by D1's periodic
+ * re-validation sweep. When present it is authoritative for authorization (permits
+ * fields like `organizationIds` that the synthetic decoded-token shape never carries
+ * — see D2); the synthetic shape remains a fallback for setups with no `userModel`
+ * configured, or while the handshake load is still in flight.
+ */
+export interface SocketDataBag {
+  // biome-ignore lint/suspicious/noExplicitAny: the full user is a consumer Mongoose document with app-specific fields
+  fullUser?: any;
+  /**
+   * Sync collection tag -> joined `sync:{stream}` rooms (see `socketHandlers.ts`).
+   * Lives on the data bag (not the handler closure) so D1's sweep can re-resolve
+   * stream membership and `socket.leave()` rooms no longer held (D4) without needing
+   * access to `installSyncSocketHandlers`'s internal state.
+   */
+  syncSubscriptions?: Map<string, Set<string>>;
 }
 
 export interface SocketWithDecodedToken {
   decodedToken?: DecodedRealtimeToken;
+  data?: SocketDataBag;
 }
 
+/**
+ * Resolve the authorization-ready user for a socket: the full user document loaded at
+ * handshake (`socket.data.fullUser`, see D2) when available, otherwise the synthetic
+ * `{_id, admin, id, isAnonymous}` shape derived from the decoded token alone. Consumers
+ * (permission checks, `getUserScopes`, delta filters) should always go through this
+ * function rather than reading `decodedToken` directly, so they transparently benefit
+ * once a `userModel` is configured.
+ */
 export const getSocketUser = (socket: SocketWithDecodedToken): User | undefined => {
+  const fullUser = socket.data?.fullUser as User | undefined;
+  if (fullUser) {
+    return fullUser;
+  }
+
   const userId = socket.decodedToken?.id;
   if (!userId) {
     return undefined;

--- a/api/src/realtime/types.ts
+++ b/api/src/realtime/types.ts
@@ -1,4 +1,5 @@
 import type express from "express";
+import type {UserModel} from "../auth";
 import type {SyncAppOptions} from "../sync/routes";
 import type {BetterAuthSocketOptions} from "./socketAuth";
 
@@ -84,6 +85,12 @@ export interface RealtimeAppOptions {
   /** JWT secret for socket authentication (default: process.env.TOKEN_SECRET) */
   tokenSecret?: string;
   /**
+   * JWT issuer required for socket authentication (default: process.env.TOKEN_ISSUER),
+   * for parity with the HTTP JWT path's `jwt.verify(token, secret, {issuer})` (D1).
+   * Omit (and leave `TOKEN_ISSUER` unset) to skip the issuer check.
+   */
+  tokenIssuer?: string;
+  /**
    * Enables the Better Auth session validator for socket authentication, tried after the
    * legacy JWT validator. Pass the instance returned by `createBetterAuth` (and optionally
    * the app user model so `decodedToken.id`/`admin` match the REST identity).
@@ -94,6 +101,26 @@ export interface RealtimeAppOptions {
    * the options registered by the SyncApp plugin are used automatically.
    */
   sync?: SyncAppOptions;
+  /**
+   * The application's Mongoose user model. When provided, the full user document is
+   * loaded once at handshake (by the decoded token's id) and cached on
+   * `socket.data.fullUser`, then refreshed by the periodic session re-validation sweep
+   * (D1). Authorization for realtime/sync subscriptions and mutations uses this full
+   * document instead of the synthetic `{_id, admin, id}` shape derived from the token
+   * alone — required for any permission check or `getUserScopes` resolver that reads
+   * fields beyond `admin` (e.g. `organizationIds` for tenant-scoped sync). Without it,
+   * socket-side authorization falls back to the synthetic shape (pre-D2 behavior).
+   */
+  userModel?: UserModel;
+  /**
+   * Interval in ms for the periodic socket session re-validation sweep (D1): re-checks
+   * JWT expiry / Better Auth session validity and the user's `disabled` flag for every
+   * connected socket, disconnecting (`sync:auth-expired` then `disconnect(true)`) any
+   * socket that fails. Also refreshes `socket.data.fullUser` (D2) and re-resolves sync
+   * stream membership, leaving rooms for streams no longer held (D4). Default 60_000ms;
+   * set to 0 to disable the sweep entirely (e.g. in tests).
+   */
+  sessionRevalidationIntervalMs?: number;
   /** Enable debug logging */
   debug?: boolean;
 }

--- a/api/src/sync/ensureSyncIndexes.test.ts
+++ b/api/src/sync/ensureSyncIndexes.test.ts
@@ -1,0 +1,80 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: test model typing
+import {beforeEach, describe, expect, it} from "bun:test";
+import {model, Schema} from "mongoose";
+import type {ModelRouterOptions} from "../api";
+import {Permissions} from "../permissions";
+import {createdUpdatedPlugin, type IsDeleted, isDeletedPlugin} from "../plugins";
+import {clearSyncRegistry, ensureSyncIndexes, registerSync} from "./registry";
+import {syncPlugin} from "./syncSeqPlugin";
+
+/**
+ * C8: `ensureSyncIndexes()` must fail server startup loudly when a snapshot-index
+ * createIndex rejects (a missing index table-scans the snapshot/catch-up query under
+ * load), and resolve quietly otherwise. Wired into TerrenoApp.start() before listen.
+ */
+
+interface IndexTodo extends IsDeleted {
+  _id: string;
+  title: string;
+  ownerId: string;
+  _syncSeq?: number;
+}
+
+const buildModel = (name: string) => {
+  const schema = new Schema<IndexTodo>({
+    ownerId: {description: "The owner", type: String},
+    title: {description: "The title", required: true, type: String},
+  });
+  schema.plugin(isDeletedPlugin);
+  schema.plugin(createdUpdatedPlugin);
+  schema.plugin(syncPlugin);
+  return model<IndexTodo>(name, schema);
+};
+
+const authedOptions = {
+  permissions: {
+    create: [Permissions.IsAuthenticated],
+    delete: [Permissions.IsAuthenticated],
+    list: [Permissions.IsAuthenticated],
+    read: [Permissions.IsAuthenticated],
+    update: [Permissions.IsAuthenticated],
+  },
+} as unknown as ModelRouterOptions<any>;
+
+describe("ensureSyncIndexes (C8)", () => {
+  beforeEach(() => {
+    clearSyncRegistry();
+  });
+
+  it("resolves when there are no registered sync models", async () => {
+    await expect(ensureSyncIndexes()).resolves.toBeUndefined();
+  });
+
+  it("resolves once a registered model's snapshot index is created", async () => {
+    const IndexTodoModel = buildModel("EnsureIndexTodoOk");
+    registerSync({
+      config: {scope: {type: "owner"}},
+      model: IndexTodoModel as any,
+      options: authedOptions,
+      routePath: "/ensureIndexTodosOk",
+    });
+    await expect(ensureSyncIndexes()).resolves.toBeUndefined();
+  });
+
+  it("rejects with an actionable error when createIndex fails, so startup fails loudly", async () => {
+    const IndexTodoModel = buildModel("EnsureIndexTodoFail");
+    // Force the collection's createIndex to reject, simulating a DB/schema failure.
+    (IndexTodoModel.collection as any).createIndex = async () => {
+      throw new Error("boom: index build failed");
+    };
+    registerSync({
+      config: {scope: {type: "owner"}},
+      model: IndexTodoModel as any,
+      options: authedOptions,
+      routePath: "/ensureIndexTodosFail",
+    });
+    await expect(ensureSyncIndexes()).rejects.toThrow(
+      /Failed to create sync snapshot index for EnsureIndexTodoFail/
+    );
+  });
+});

--- a/api/src/sync/executors.ts
+++ b/api/src/sync/executors.ts
@@ -43,6 +43,18 @@ export interface ExecutorResult<T> {
    * `options.populatePaths` for create/update, matching the REST handlers.
    */
   doc: ExecutorDoc<T>;
+  /**
+   * C5 (FIX 6): present only when `executeUpdate` was called with
+   * `skipPostHooks: true` — the cleaned/transformed update body, needed to
+   * run `postUpdate` later via `runPostUpdate`.
+   */
+  cleanedBody?: Partial<T>;
+  /**
+   * C5 (FIX 6): present only when `executeUpdate` was called with
+   * `skipPostHooks: true` — the pre-update document snapshot, needed to
+   * run `postUpdate` later via `runPostUpdate`.
+   */
+  prevDoc?: T;
 }
 
 /**
@@ -140,6 +152,7 @@ export const executeCreate = async <T>({
   user,
   body,
   req,
+  skipPostHooks,
 }: {
   model: Model<T>;
   options: ModelRouterOptions<T>;
@@ -147,6 +160,13 @@ export const executeCreate = async <T>({
   body: unknown;
   /** The real Express request when called over HTTP; hooks receive a `{user}` stub otherwise. */
   req?: express.Request;
+  /**
+   * C5 (FIX 6): when true, skip the built-in `postCreate` call — the caller
+   * (the sync mutation handler) runs it manually AFTER finalizing the
+   * idempotency ledger `applied`, so a post-hook throw can never make a
+   * committed write look like a failure. REST handlers never set this.
+   */
+  skipPostHooks?: boolean;
 }): Promise<ExecutorResult<T>> => {
   const request = req ?? stubRequest(user);
 
@@ -235,7 +255,7 @@ export const executeCreate = async <T>({
     }
   }
 
-  if (options.postCreate) {
+  if (options.postCreate && !skipPostHooks) {
     try {
       await options.postCreate(data, request);
     } catch (error: unknown) {
@@ -248,6 +268,27 @@ export const executeCreate = async <T>({
     }
   }
   return {doc: data};
+};
+
+/**
+ * C5 (FIX 6): run `postCreate` outside the write transaction/ledger-finalize
+ * window. Errors are the caller's responsibility to catch — the sync mutation
+ * handler logs them and reports a warning, never converting them into a nack
+ * (the document write already committed and the ledger already finalized
+ * `applied`).
+ */
+export const runPostCreate = async <T>({
+  doc,
+  options,
+  request,
+}: {
+  doc: ExecutorDoc<T>;
+  options: ModelRouterOptions<T>;
+  request: express.Request;
+}): Promise<void> => {
+  if (options.postCreate) {
+    await options.postCreate(doc, request);
+  }
 };
 
 /**
@@ -266,6 +307,7 @@ export const executeUpdate = async <T>({
   concurrencyCheck,
   existingDoc,
   req,
+  skipPostHooks,
 }: {
   model: Model<T>;
   options: ModelRouterOptions<T>;
@@ -280,6 +322,8 @@ export const executeUpdate = async <T>({
   existingDoc?: ExecutorDoc<T>;
   /** The real Express request when called over HTTP; hooks receive a `{user}` stub otherwise. */
   req?: express.Request;
+  /** C5 (FIX 6): see `executeCreate`'s `skipPostHooks` doc comment. */
+  skipPostHooks?: boolean;
 }): Promise<ExecutorResult<T>> => {
   const request = req ?? stubRequest(user);
 
@@ -434,7 +478,7 @@ export const executeUpdate = async <T>({
     doc = await populateQuery.exec();
   }
 
-  if (options.postUpdate) {
+  if (options.postUpdate && !skipPostHooks) {
     try {
       await options.postUpdate(doc, cleanedBody as Partial<T>, request, prevDoc as T);
     } catch (error: unknown) {
@@ -447,7 +491,26 @@ export const executeUpdate = async <T>({
     }
   }
 
-  return {doc};
+  return {cleanedBody: cleanedBody as Partial<T>, doc, prevDoc: prevDoc as T};
+};
+
+/** C5 (FIX 6): run `postUpdate` outside the write/ledger-finalize window — see `runPostCreate`. */
+export const runPostUpdate = async <T>({
+  doc,
+  cleanedBody,
+  prevDoc,
+  options,
+  request,
+}: {
+  doc: ExecutorDoc<T>;
+  cleanedBody: Partial<T>;
+  prevDoc: T;
+  options: ModelRouterOptions<T>;
+  request: express.Request;
+}): Promise<void> => {
+  if (options.postUpdate) {
+    await options.postUpdate(doc, cleanedBody, request, prevDoc);
+  }
 };
 
 /**
@@ -463,6 +526,7 @@ export const executeDelete = async <T>({
   id,
   existingDoc,
   req,
+  skipPostHooks,
 }: {
   model: Model<T>;
   options: ModelRouterOptions<T>;
@@ -475,6 +539,8 @@ export const executeDelete = async <T>({
   existingDoc?: ExecutorDoc<T> & {deleted?: boolean};
   /** The real Express request when called over HTTP; hooks receive a `{user}` stub otherwise. */
   req?: express.Request;
+  /** C5 (FIX 6): see `executeCreate`'s `skipPostHooks` doc comment. */
+  skipPostHooks?: boolean;
 }): Promise<ExecutorResult<T>> => {
   const request = req ?? stubRequest(user);
 
@@ -550,7 +616,7 @@ export const executeDelete = async <T>({
     }
   }
 
-  if (options.postDelete) {
+  if (options.postDelete && !skipPostHooks) {
     try {
       await options.postDelete(request, doc);
     } catch (error: unknown) {
@@ -564,4 +630,19 @@ export const executeDelete = async <T>({
   }
 
   return {doc};
+};
+
+/** C5 (FIX 6): run `postDelete` outside the write/ledger-finalize window — see `runPostCreate`. */
+export const runPostDelete = async <T>({
+  doc,
+  options,
+  request,
+}: {
+  doc: ExecutorDoc<T>;
+  options: ModelRouterOptions<T>;
+  request: express.Request;
+}): Promise<void> => {
+  if (options.postDelete) {
+    await options.postDelete(request, doc);
+  }
 };

--- a/api/src/sync/executors.ts
+++ b/api/src/sync/executors.ts
@@ -17,7 +17,7 @@
 import type express from "express";
 import cloneDeep from "lodash/cloneDeep";
 import {DateTime} from "luxon";
-import type {Document, Model} from "mongoose";
+import mongoose, {type Document, type Model} from "mongoose";
 
 import {addPopulateToQuery, type ModelRouterOptions} from "../api";
 import type {User} from "../auth";
@@ -551,11 +551,31 @@ export const executeDelete = async <T>({
     });
   }
 
-  const doc =
-    existingDoc ??
-    ((await loadDocOr404<T>(model, id, options.populatePaths)) as ExecutorDoc<T> & {
-      deleted?: boolean;
-    });
+  // C8: delete of an already-deleted doc is idempotent — loadDocOr404 auto-filters
+  // soft-deleted docs and would 404 (a `validation` nack over sync). Load the tombstone
+  // directly and return it as an idempotent success (its existing seq) instead.
+  let doc = existingDoc;
+  if (!doc) {
+    try {
+      doc = (await loadDocOr404<T>(model, id, options.populatePaths)) as ExecutorDoc<T> & {
+        deleted?: boolean;
+      };
+    } catch (error: unknown) {
+      const alreadyDeleted =
+        isAPIError(error) &&
+        error.status === 404 &&
+        (error.meta as {deleted?: string} | undefined)?.deleted === "true";
+      if (alreadyDeleted) {
+        // Hydrate the tombstone bypassing the isDeletedPlugin find filter.
+        const tombstone = await model
+          .find({_id: new mongoose.Types.ObjectId(id), deleted: {$in: [true, false]}})
+          .limit(1);
+        const resolved = tombstone[0] as ExecutorDoc<T> & {deleted?: boolean};
+        return {doc: resolved};
+      }
+      throw error;
+    }
+  }
 
   if (!(await checkPermissions("delete", options.permissions.delete, user, doc))) {
     throw new APIError({

--- a/api/src/sync/index.ts
+++ b/api/src/sync/index.ts
@@ -3,6 +3,7 @@ export * from "./models";
 export * from "./mutationHandler";
 export * from "./registry";
 export * from "./routes";
+export * from "./scripts/compactTombstones";
 export * from "./serialize";
 export * from "./socketHandlers";
 export * from "./streams";

--- a/api/src/sync/integration.test.ts
+++ b/api/src/sync/integration.test.ts
@@ -288,8 +288,9 @@ describe("syncdb end-to-end integration", () => {
     expect(status.isOnline).toBe(true);
     expect(status.queuedCount).toBe(0);
     expect(status.conflictCount).toBe(0);
-    // The snapshot cursor advanced to the highest applied seq.
-    expect(status.streams[`snapshot:${COLLECTION}`]).toBe(3);
+    // C2: the per-stream cursor (keyed by the REAL stream key, not the old
+    // snapshot:{collection} pseudo-cursor) advanced to the highest applied seq.
+    expect(status.streams[`${COLLECTION}|owner:${userAId}`]).toBe(3);
   }, 15_000);
 
   it("2. applies a live change-stream delta without reconcile", async () => {

--- a/api/src/sync/integration.test.ts
+++ b/api/src/sync/integration.test.ts
@@ -492,6 +492,53 @@ describe("syncdb end-to-end integration", () => {
     expect(entity?.pendingMutationId).toBeUndefined();
   }, 20_000);
 
+  it("4c. offline create + update to the same entity never self-conflicts on reconnect (A2)", async () => {
+    await goOffline(a);
+    const {id, mutationId: createMutationId} = a.client.mutate({
+      collection: COLLECTION,
+      data: {title: "v1"},
+      operation: "create",
+    });
+    const {mutationId: updateMutationId} = a.client.mutate({
+      collection: COLLECTION,
+      data: {title: "v2"},
+      id,
+      operation: "update",
+    });
+    // Both mutations were enqueued against the same (pre-create) baseVersion —
+    // without A2's send-time refresh, the update would ship the create's stale
+    // base and manufacture a conflict against the server's strict equality
+    // check the instant the create acks.
+    await waitFor(
+      () => {
+        const create = a.client.outbox.getMutation({mutationId: createMutationId});
+        const update = a.client.outbox.getMutation({mutationId: updateMutationId});
+        return (
+          create?.status === "queued" &&
+          create.attemptCount >= 1 &&
+          update?.status === "queued" &&
+          update.attemptCount >= 1
+        );
+      },
+      {label: "offline create+update queued"}
+    );
+
+    a.setOffline(false);
+    await a.transport.connect();
+    await waitFor(() => a.client.outbox.getMutation({mutationId: updateMutationId}) === undefined, {
+      label: "update acked and pruned",
+    });
+
+    expect(a.client.getSyncStatus().conflictCount).toBe(0);
+    expect(a.client.getSyncStatus().queuedCount).toBe(0);
+    const saved = await IntTodoModel.findById(id);
+    expect(saved?.title).toBe("v2");
+    const entity = a.client.store.getEntity<{title?: string}>({collection: COLLECTION, id});
+    expect(entity?.data?.title).toBe("v2");
+    expect(entity?.pendingMutationId).toBeUndefined();
+    expect(entity?.seq).toBe(saved?._syncSeq ?? -1);
+  }, 20_000);
+
   it("5. returns the identical ack for a duplicate mutationId over POST /sync/mutate", async () => {
     const request: SyncMutateRequest = {
       collection: COLLECTION,

--- a/api/src/sync/integration.test.ts
+++ b/api/src/sync/integration.test.ts
@@ -37,12 +37,13 @@ import {
 import mongoose, {model, Schema} from "mongoose";
 
 import {modelRouter} from "../api";
-import {addAuthRoutes, generateTokens, setupAuth} from "../auth";
+import {addAuthRoutes, generateTokens, setupAuth, type User} from "../auth";
 import {Permissions} from "../permissions";
 import {createdUpdatedPlugin, findOneOrNoneFor, type IsDeleted, isDeletedPlugin} from "../plugins";
 import {RealtimeApp} from "../realtime/realtimeApp";
 import {getBaseServer, setupDb, UserModel} from "../tests";
 import {SyncCounter, SyncMutation} from "./models";
+import {applySyncMutation} from "./mutationHandler";
 import {clearSyncRegistry} from "./registry";
 import {clearActiveSyncAppOptions} from "./socketHandlers";
 import {SyncApp} from "./syncApp";
@@ -346,18 +347,38 @@ describe("syncdb end-to-end integration", () => {
     expect(a.client.getSyncStatus().queuedCount).toBe(1);
     expect(await IntTodoModel.countDocuments({title: "offline create"})).toBe(0);
 
-    // Reconnect: the outbox drains over the socket and the ack finalizes the entity.
+    // Reconnect: the outbox drains over the socket and the ack finalizes the
+    // entity. Acked rows are pruned automatically right after each successful
+    // drain pass (A5), so polling for the row to read back status "acked" is
+    // a genuine race: the prune can remove the row before the next poll tick
+    // ever observes it, and `getMutation` returns `undefined` forever after —
+    // NOT a replica-set-availability issue, a real (and previously unfixed)
+    // test bug. `queuedCount` alone is not a sufficient "settled" signal
+    // either: it only counts rows with status "queued" (see outbox.ts
+    // `listQueued`), so it reads back 0 the instant the mutation is SENT and
+    // transitions to "inFlight" — well before the server has acked/nacked it.
+    // The robust condition is "left the queued+inFlight window", i.e. the row
+    // reached a terminal status (acked/conflicted/failed) or was pruned.
     a.setOffline(false);
     await a.transport.connect();
-    await waitFor(() => a.client.outbox.getMutation({mutationId})?.status === "acked", {
-      label: "mutation acked",
-    });
+    await waitFor(
+      () => {
+        const status = a.client.outbox.getMutation({mutationId})?.status;
+        return status !== "queued" && status !== "inFlight";
+      },
+      {label: "mutation settled (acked, pruned, or a terminal outcome)"}
+    );
 
     const saved = await IntTodoModel.findById(id);
     expect(saved?.title).toBe("offline create");
     // The server honored the client-generated id and stamped ownership via preCreate.
     expect(String(saved?._id)).toBe(id);
     expect(saved?.ownerId).toBe(userAId);
+
+    // The row is either still readable as "acked" (about to be pruned) or
+    // already pruned (`undefined`) — both are the successful outcome.
+    const mutation = a.client.outbox.getMutation({mutationId});
+    expect(["acked", undefined]).toContain(mutation?.status);
 
     const entity = a.client.store.getEntity<{title?: string}>({collection: COLLECTION, id});
     expect(entity?.pendingMutationId).toBeUndefined();
@@ -510,18 +531,26 @@ describe("syncdb end-to-end integration", () => {
     // without A2's send-time refresh, the update would ship the create's stale
     // base and manufacture a conflict against the server's strict equality
     // check the instant the create acks.
+    //
+    // Only the CREATE is asserted to have attempted (and failed) at least once
+    // here. Per INV-1 (global FIFO / stop-the-line), the replay coordinator
+    // never dispatches a later mutation for the SAME entity until the earlier
+    // one resolves — so while offline (where the create can never resolve),
+    // the update's attemptCount deterministically stays 0 forever. Waiting on
+    // both mutations reaching attemptCount >= 1 here was a genuine test bug
+    // (not replica-set-related, not timing-flaky): it asserted an outcome the
+    // scheduler's documented ordering guarantee makes impossible. The update
+    // gets its first attempt only after reconnect, once create's ack releases
+    // the entity — covered by the waits below.
     await waitFor(
       () => {
         const create = a.client.outbox.getMutation({mutationId: createMutationId});
         const update = a.client.outbox.getMutation({mutationId: updateMutationId});
         return (
-          create?.status === "queued" &&
-          create.attemptCount >= 1 &&
-          update?.status === "queued" &&
-          update.attemptCount >= 1
+          create?.status === "queued" && create.attemptCount >= 1 && update?.status === "queued"
         );
       },
-      {label: "offline create+update queued"}
+      {label: "offline create queued, update enqueued behind it"}
     );
 
     a.setOffline(false);
@@ -582,8 +611,51 @@ describe("syncdb end-to-end integration", () => {
   // ───────────────────────────────────────────────────────────────────────────
   // FIX 7: batch-protocol integration coverage over the REAL socket. Each test
   // below uses its OWN dedicated client(s) (never the shared `a`/`conflictDocId`
-  // chain) so they are independent of the documented flaky cluster (tests 3,
-  // 4c, 5 above intermittently fail in this environment).
+  // chain) so they are independent of the rest of the file.
+  //
+  // Investigation note (Phase F, F-scope item 6): tests 3, 4c, and 5 above
+  // were previously flagged as an intermittently-flaky cluster tied to
+  // replica-set availability. Root-caused: it was NOT a replica-set issue.
+  // Test 3 had a genuine wait-condition bug — it polled `getSyncStatus().
+  // queuedCount === 0` as its "mutation settled" signal, but `queuedCount`
+  // only counts outbox rows with status "queued" (see `outbox.ts`
+  // `listQueued`), so it reads back 0 the instant a mutation is SENT and
+  // transitions to "inFlight" — well before the server acks/nacks it. Under
+  // any real network/scheduling latency this raced the subsequent
+  // `IntTodoModel.findById` assertion against a write that hadn't landed yet.
+  // Fixed by waiting for the mutation to actually leave the queued+inFlight
+  // window (`status !== "queued" && status !== "inFlight"`) before asserting
+  // server state. Test 4c had a similar bug: it waited for BOTH the create
+  // AND the update mutations to reach `attemptCount >= 1` while offline, but
+  // per INV-1 (global FIFO / stop-the-line) the replay coordinator never
+  // attempts a later mutation for the same entity until the earlier one
+  // resolves — so while offline (where the create can never resolve) the
+  // update's attemptCount deterministically stays 0 forever, and the test's
+  // own wait condition could never become true except by chance/timeout
+  // flukes. Fixed by only waiting on the update to be enqueued (not
+  // attempted) behind the create. Test 5 was not touched — it is a pure
+  // HTTP-only idempotency check (`POST /sync/mutate` duplicate mutationId)
+  // with no replica-set or timing dependency, and was not observed to fail
+  // in any of >10 full-file runs during this investigation (with and without
+  // a replica set available).
+  //
+  // A DIFFERENT, separate flake was observed in this environment during the
+  // same investigation, entirely within the FIX 7 block itself: under heavy
+  // CPU/IO contention (this sandbox, not necessarily CI), test "7a. 120
+  // queued mutations..." occasionally overran its own 30s timeout (observed
+  // once at ~65s, once at ~400s+) — the in-memory-Mongo-backed rig's writes
+  // slow down under scheduling pressure faster than the batch drain's own
+  // timeouts do. When bun kills that test at its timeout, the shared
+  // `beforeAll` rig (one HTTP/Socket.io server + one Mongo connection for the
+  // whole file) can be torn down mid-request, cascading into
+  // `MongoTopologyClosedError`/`MongoClientClosedError` failures in "7b" and
+  // "7c" that run afterward in the same process. This is a resource/timeout
+  // budget issue specific to the batch-of-120 test under contention, not a
+  // logic bug in the batch protocol or in 7b/7c themselves (both pass
+  // cleanly whenever 7a completes within its budget) — it is out of the
+  // F-scope item 6 remit (that item names tests 3, 4c, 5 specifically) and is
+  // left here, documented rather than masked, for a follow-up to raise 7a's
+  // timeout or reduce its mutation count under contention if it recurs in CI.
   // ───────────────────────────────────────────────────────────────────────────
 
   describe("FIX 7: batch protocol over the real socket", () => {
@@ -883,5 +955,207 @@ describe("syncdb end-to-end integration", () => {
         await client7c.stop();
       }
     }, 30_000);
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // F1: two remaining integration scenarios from the Phase F test/load
+  // infrastructure plan. Each uses its OWN dedicated client(s)/mutations —
+  // never the shared `a`/`conflictDocId` chain — so they are independent of
+  // the rest of the file and of each other.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe("F1: concurrent devices and lost acks", () => {
+    /** `userA` cast to the shape `applySyncMutation` requires. */
+    const asFullUser = (user: {_id: unknown}): User =>
+      ({
+        _id: user._id,
+        admin: false,
+        id: String(user._id),
+      }) as User;
+
+    it("B1. two syncdb clients for the SAME user on two devices converge on a concurrent edit, no lost update", async () => {
+      const device1 = makeClient({name: "integration-device-1", user: userA});
+      const device2 = makeClient({name: "integration-device-2", user: userA});
+      try {
+        await Promise.all([device1.client.start(), device2.client.start()]);
+        await waitFor(
+          () => device1.client.getSyncStatus().isOnline && device2.client.getSyncStatus().isOnline,
+          {label: "both devices online"}
+        );
+
+        // Seed a doc both devices will converge on. Created directly via the
+        // model (like test 1's bootstrap docs) so it is visible to both
+        // devices' owner stream regardless of which one "wins" the race to
+        // see it first.
+        const doc = await IntTodoModel.create({ownerId: userAId, title: "shared v0"});
+        const id = String(doc._id);
+        // Reconcile (snapshot catch-up) works with or without a replica set,
+        // unlike waiting on a live change-stream delta — keeps this scenario
+        // independent of replica-set availability, matching test 4a's
+        // bootstrap-a-conflict-base pattern.
+        await Promise.all([device1.client.reconcile(), device2.client.reconcile()]);
+        await waitFor(
+          () =>
+            device1.client.store.getEntity({collection: COLLECTION, id}) !== undefined &&
+            device2.client.store.getEntity({collection: COLLECTION, id}) !== undefined,
+          {label: "both devices see the seeded doc"}
+        );
+
+        // Both devices are online and connected. Issue concurrent updates
+        // back-to-back (no await between them) so device 2's mutate() is
+        // enqueued/sent while device 1's write is genuinely in flight or
+        // freshly acked — exercising the delta-vs-pending interleaving: one
+        // device's write can arrive at the OTHER device as an inbound
+        // `sync:delta` while that other device also has its own pending
+        // outbox mutation for the very same entity.
+        const {mutationId: m1} = device1.client.mutate({
+          collection: COLLECTION,
+          data: {title: "device-1 edit"},
+          id,
+          operation: "update",
+        });
+        const {mutationId: m2} = device2.client.mutate({
+          collection: COLLECTION,
+          data: {title: "device-2 edit"},
+          id,
+          operation: "update",
+        });
+
+        // Wait for both mutations to leave the queued+inFlight window (see
+        // the F-scope-item-6 investigation note above for why `queuedCount`
+        // alone is not a sufficient "settled" signal).
+        await waitFor(
+          () => {
+            const s1 = device1.client.outbox.getMutation({mutationId: m1})?.status;
+            const s2 = device2.client.outbox.getMutation({mutationId: m2})?.status;
+            const settled1 = s1 !== "queued" && s1 !== "inFlight";
+            const settled2 = s2 !== "queued" && s2 !== "inFlight";
+            return settled1 && settled2;
+          },
+          {label: "both concurrent updates settled", timeoutMs: 15_000}
+        );
+
+        // Resolve any conflict that landed (documented LWW: the losing
+        // device's edit is nacked as a conflict rather than silently
+        // dropped — this asserts it surfaced, then converges it onto the
+        // canonical server value). Each device only needs to check its OWN
+        // mutation: the loser's own outbox row (not the winner's) is the one
+        // that would carry status "conflicted".
+        if (device1.client.outbox.getMutation({mutationId: m1})?.status === "conflicted") {
+          device1.client.resolveConflict({mutationId: m1, strategy: "useServer"});
+        }
+        if (device2.client.outbox.getMutation({mutationId: m2})?.status === "conflicted") {
+          device2.client.resolveConflict({mutationId: m2, strategy: "useServer"});
+        }
+
+        // Without a live change-stream delta (replica set unavailable in
+        // some environments — see the F-scope-item-6 investigation note),
+        // the device whose write did NOT win the race only learns of the
+        // other device's acked write through a snapshot catch-up. Reconcile
+        // both devices explicitly so convergence does not depend on
+        // replica-set availability — this models "eventually consistent"
+        // correctly under either transport path (live delta or reconcile).
+        await Promise.all([device1.client.reconcile(), device2.client.reconcile()]);
+
+        // Convergence: both devices land on the SAME final state, and that
+        // state matches the server's ground truth — i.e. one of the two
+        // writes won (LWW by seq), never a lost update (neither title) and
+        // never a corrupted merge.
+        await waitFor(
+          async () => {
+            const serverDoc = await IntTodoModel.findById(id);
+            const e1 = device1.client.store.getEntity<{title?: string}>({
+              collection: COLLECTION,
+              id,
+            });
+            const e2 = device2.client.store.getEntity<{title?: string}>({
+              collection: COLLECTION,
+              id,
+            });
+            return (
+              e1?.data?.title === serverDoc?.title &&
+              e2?.data?.title === serverDoc?.title &&
+              e1?.seq === (serverDoc?._syncSeq ?? -1) &&
+              e2?.seq === (serverDoc?._syncSeq ?? -1) &&
+              e1?.pendingMutationId === undefined &&
+              e2?.pendingMutationId === undefined
+            );
+          },
+          {label: "both devices converge on the server's canonical state", timeoutMs: 15_000}
+        );
+
+        const serverDoc = await IntTodoModel.findById(id);
+        expect(["device-1 edit", "device-2 edit"]).toContain(serverDoc?.title ?? "");
+        expect(device1.client.getSyncStatus().conflictCount).toBe(0);
+        expect(device2.client.getSyncStatus().conflictCount).toBe(0);
+        // No duplicate documents were created by the race — still exactly
+        // one doc with this id.
+        expect(await IntTodoModel.countDocuments({_id: id})).toBe(1);
+      } finally {
+        await Promise.all([device1.client.stop(), device2.client.stop()]);
+      }
+    }, 30_000);
+
+    it("B2. a lost ack (response dropped, not the request) is recovered by resending the same mutationId", async () => {
+      const device = makeClient({name: "integration-lost-ack", user: userA});
+      try {
+        await device.client.start();
+        await waitFor(() => device.client.getSyncStatus().isOnline, {label: "device online"});
+
+        // Apply the mutation directly server-side via the SAME code path the
+        // real transports call (`applySyncMutation`) — this simulates "the
+        // server received the request, applied it, and generated an ack" but
+        // that ack response is then simply never forwarded anywhere (a lost
+        // response, not a lost/never-sent request — the distinguishing
+        // scenario the plan calls out: `sendMutation`'s HTTP round trip below
+        // is a genuinely SEPARATE delivery of the identical mutationId, not a
+        // continuation of this one).
+        const mutationRequest: SyncMutateRequest = {
+          collection: COLLECTION,
+          data: {title: "lost-ack create"},
+          mutationId: "integration-lost-ack-1",
+          operation: "create",
+        };
+        const firstOutcome = await applySyncMutation({
+          mutation: mutationRequest,
+          user: asFullUser(userA),
+        });
+        expect(firstOutcome.type).toBe("ack");
+        const firstAck = firstOutcome.type === "ack" ? firstOutcome.ack : undefined;
+        expect(firstAck?.id).toBeTruthy();
+
+        // Ground truth: the write landed exactly once server-side, and the
+        // ledger recorded it as applied — this is the state a client would
+        // be in after sending the request but never receiving the response.
+        expect(await IntTodoModel.countDocuments({title: "lost-ack create"})).toBe(1);
+        const ledgerRow = await findOneOrNoneFor(SyncMutation, {
+          mutationId: mutationRequest.mutationId,
+        });
+        expect(ledgerRow?.status).toBe("applied");
+
+        // The client "resends" the identical mutationId (its outbox never
+        // saw the first ack, so from its perspective this mutation is still
+        // outstanding) via the SAME transport channel the real client uses.
+        // The idempotency ledger must return the IDENTICAL recorded ack
+        // rather than re-executing or erroring, and the resend must NOT
+        // double-apply the write.
+        const secondOutcome = await device.httpChannel.sendMutation(mutationRequest);
+        expect(secondOutcome.type).toBe("ack");
+        expect(secondOutcome).toEqual(firstOutcome);
+        expect(await IntTodoModel.countDocuments({title: "lost-ack create"})).toBe(1);
+
+        // Full round trip: drive the REAL client's outbox through the exact
+        // same resend, proving the client itself ends up in a converged,
+        // acked, non-duplicate-conflict state despite "never having seen"
+        // the first ack — not just that two raw HTTP responses are equal
+        // (which the pre-existing test 5 already covers).
+        const thirdOutcome = await device.httpChannel.sendMutation(mutationRequest);
+        expect(thirdOutcome).toEqual(firstOutcome);
+        expect(await IntTodoModel.countDocuments({title: "lost-ack create"})).toBe(1);
+        expect(device.client.getSyncStatus().conflictCount).toBe(0);
+      } finally {
+        await device.client.stop();
+      }
+    }, 20_000);
   });
 });

--- a/api/src/sync/integration.test.ts
+++ b/api/src/sync/integration.test.ts
@@ -837,6 +837,19 @@ describe("syncdb end-to-end integration", () => {
         // in flight at the exact moment offline toggled false) — the load-
         // bearing assertion is that whatever remains queued burned ZERO
         // error-nack budget and is genuinely queued, not failed/conflicted.
+        //
+        // The pause can arrive via the direct socket auth-expired path while
+        // a send is still awaiting its transport timeout; that mutation
+        // settles and requeues (transport path, zero budget) on its own —
+        // wait for the transient "inFlight" window to drain before asserting.
+        await waitFor(
+          () =>
+            mutationIds.every((mutationId) => {
+              const status = client7c.outbox.getMutation({mutationId})?.status;
+              return status === undefined || status === "acked" || status === "queued";
+            }),
+          {label: "in-flight sends settled while paused", timeoutMs: 10_000}
+        );
         expect(client7c.getSyncStatus().queuedCount).toBeGreaterThan(0);
         expect(client7c.getSyncStatus().queuedCount).toBeLessThanOrEqual(5);
         for (const mutationId of mutationIds) {

--- a/api/src/sync/integration.test.ts
+++ b/api/src/sync/integration.test.ts
@@ -577,4 +577,297 @@ describe("syncdb end-to-end integration", () => {
 
     await b.client.stop();
   }, 20_000);
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // FIX 7: batch-protocol integration coverage over the REAL socket. Each test
+  // below uses its OWN dedicated client(s) (never the shared `a`/`conflictDocId`
+  // chain) so they are independent of the documented flaky cluster (tests 3,
+  // 4c, 5 above intermittently fail in this environment).
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe("FIX 7: batch protocol over the real socket", () => {
+    /** Count `sync:mutateBatch` sends on the server side for one connected socket. */
+    /**
+     * Count `sync:mutateBatch` sends on the server side for one connected
+     * socket, deduped by the set of mutationIds carried (a batch that gets
+     * rate-limited or hits a transient error is resent byte-for-byte with
+     * the SAME mutationIds per INV-3 — that's a retry of the same logical
+     * round-trip, not a new one).
+     *
+     * Under heavy scheduling contention the batch-capability probe (FIX 5)
+     * can genuinely observe two consecutive "unsupported" results (the grace
+     * timer elapses before a receipt lands purely because the process is
+     * starved for CPU, not because the server lacks a handler) and latch
+     * `batchUnsupported` for the rest of that drain, falling back to
+     * per-mutation `sync:mutate` sends for everything after the latch trips.
+     * That's the batch protocol's designed, safe degradation (mirrors a
+     * genuinely-unsupported server) — a real production timeout would
+     * trigger exactly the same fallback. Because of that, this test does not
+     * pin an exact chunk count or assert every mutationId rode in a batch;
+     * it only asserts the chunking contract (≤ batchSize per chunk) and that
+     * batching is exercised at all, leaving delivery correctness (exactly
+     * once, in order) to the doc-count and seq-order assertions below.
+     */
+    const countServerBatchSends = (): {
+      distinctGroups: () => number;
+      groupSizes: () => number[];
+      stop: () => void;
+    } => {
+      const seenGroups = new Set<string>();
+      const io = realtimeApp.getIo();
+      const onConnection = (socket: {
+        onAny: (listener: (event: string, ...args: unknown[]) => void) => void;
+      }): void => {
+        socket.onAny((event: string, ...args: unknown[]) => {
+          if (event === "sync:mutateBatch") {
+            const payload = args[0] as {mutations?: {mutationId: string}[]} | undefined;
+            const ids = (payload?.mutations ?? []).map((m) => m.mutationId);
+            seenGroups.add(ids.join(","));
+          }
+        });
+      };
+      io?.on("connection", onConnection);
+      return {
+        distinctGroups: () => seenGroups.size,
+        groupSizes: () => [...seenGroups].map((group) => group.split(",").length),
+        stop: () => io?.off("connection", onConnection),
+      };
+    };
+
+    it("7a. 120 queued mutations drain in batches of at most 50, server-side seq order matches enqueue order", async () => {
+      const client7a = makeClient({name: "integration-batch-count", user: userA});
+      const tracker = countServerBatchSends();
+      try {
+        await client7a.client.start();
+        await waitFor(() => client7a.client.getSyncStatus().isOnline, {label: "client7a online"});
+
+        await goOffline(client7a);
+        const mutationIds: string[] = [];
+        const titles: string[] = [];
+        for (let i = 0; i < 120; i++) {
+          const title = `batch-count-${i}`;
+          titles.push(title);
+          const {mutationId} = client7a.client.mutate({
+            collection: COLLECTION,
+            data: {title},
+            operation: "create",
+          });
+          mutationIds.push(mutationId);
+        }
+
+        client7a.setOffline(false);
+        await client7a.transport.connect();
+        // Acked rows are pruned automatically after each successful drain
+        // pass (A5), so a mutationId can read back `undefined` well before
+        // the whole queue finishes — queuedCount (backed by a live scan of
+        // remaining `queued` rows) is the robust "fully drained" signal, not
+        // per-mutation status polling.
+        await waitFor(() => client7a.client.getSyncStatus().queuedCount === 0, {
+          label: "all 120 mutations drained",
+          timeoutMs: 20_000,
+        });
+        await waitFor(
+          async () => (await IntTodoModel.countDocuments({title: {$in: titles}})) === 120,
+          {label: "all 120 documents persisted", timeoutMs: 20_000}
+        );
+
+        // Every batch chunk observed on the wire must respect the
+        // DEFAULT_BATCH_SIZE = 50 cap (the chunking contract itself).
+        for (const size of tracker.groupSizes()) {
+          expect(size).toBeLessThanOrEqual(50);
+        }
+        // At least one real sync:mutateBatch round-trip must have happened —
+        // batching must actually be exercised for a 120-mutation queue, not
+        // silently skipped from the very first send. (We don't assert an
+        // exact chunk count or full per-mutationId wire coverage: under
+        // heavy scheduling contention the batch-capability probe can latch
+        // "unsupported" on a false-positive grace-timer expiry — the server
+        // was simply slow, not incapable — falling back to single-sends for
+        // the remainder, which is FIX 5's documented, safe degradation. What
+        // must hold regardless of that mix is delivery: every mutation lands
+        // exactly once, in order.)
+        expect(tracker.distinctGroups()).toBeGreaterThanOrEqual(1);
+        // Every applied mutation landed exactly once regardless of any
+        // retries — the idempotency ledger is what makes a rate-limited
+        // resend, or a lease-takeover after a slow ack, safe (INV-3).
+        expect(await IntTodoModel.countDocuments({title: {$in: titles}})).toBe(120);
+
+        // Server-side seq order matches enqueue order (INV-1, global FIFO).
+        const docs = await IntTodoModel.find({title: {$in: titles}}).sort({_syncSeq: 1});
+        expect(docs.map((doc) => doc.title)).toEqual(titles);
+      } finally {
+        tracker.stop();
+        await client7a.client.stop();
+      }
+    }, 30_000);
+
+    it("7b. socket drop after k-of-n acked applies the remainder exactly once, zero duplicates", async () => {
+      const client7b = makeClient({name: "integration-socket-drop", user: userA});
+      try {
+        await client7b.client.start();
+        await waitFor(() => client7b.client.getSyncStatus().isOnline, {label: "client7b online"});
+
+        await goOffline(client7b);
+        // 60 mutations = 2 batch round-trips (DEFAULT_BATCH_SIZE 50) so the
+        // drop below lands genuinely mid-drain (after the first batch, before
+        // the second), not after the whole thing already completed.
+        const n = 60;
+        const mutationIds: string[] = [];
+        const titles: string[] = [];
+        for (let i = 0; i < n; i++) {
+          const title = `socket-drop-${i}`;
+          titles.push(title);
+          const {mutationId} = client7b.client.mutate({
+            collection: COLLECTION,
+            data: {title},
+            operation: "create",
+          });
+          mutationIds.push(mutationId);
+        }
+
+        client7b.setOffline(false);
+        await client7b.transport.connect();
+        // Wait for the first batch (the first 50, in FIFO order) to land —
+        // queuedCount drops to 10 (the second chunk) — then drop the socket
+        // before the second batch completes. Acked rows are pruned right
+        // after each successful pass (A5), so queuedCount (a live scan of
+        // remaining `queued` rows) is the robust signal here, not
+        // per-mutation status polling which can read back `undefined` for an
+        // already-pruned row.
+        await waitFor(() => client7b.client.getSyncStatus().queuedCount <= 10, {
+          label: "first batch drained before drop",
+          timeoutMs: 10_000,
+        });
+        client7b.transport.disconnect();
+        await waitFor(() => !client7b.client.getSyncStatus().isOnline, {
+          label: "client7b offline after drop",
+        });
+
+        // Reconnect exactly like the existing offline-create scenario (test 3).
+        await client7b.transport.connect();
+        await waitFor(() => client7b.client.getSyncStatus().queuedCount === 0, {
+          label: "all mutations drained after reconnect",
+          timeoutMs: 20_000,
+        });
+        await waitFor(
+          async () => (await IntTodoModel.countDocuments({title: {$in: titles}})) === n,
+          {
+            label: "all documents persisted after reconnect",
+            timeoutMs: 20_000,
+          }
+        );
+
+        // Zero duplicates: exactly one document per title, exactly n documents total.
+        const docs = await IntTodoModel.find({title: {$in: titles}});
+        expect(docs).toHaveLength(n);
+        for (const title of titles) {
+          expect(docs.filter((doc) => doc.title === title)).toHaveLength(1);
+        }
+      } finally {
+        await client7b.client.stop();
+      }
+    }, 30_000);
+
+    it("7c. token expiry mid-batch pauses for auth, then resumes fully on same-user re-auth with the outbox intact", async () => {
+      let tokenIsValid = true;
+      const authChangeListeners = new Set<() => void>();
+      const authProvider: AuthProvider = {
+        getToken: async () =>
+          tokenIsValid ? ((await generateTokens(userA)).token ?? null) : "invalid-expired-token",
+        getUserId: async () => String(userA._id),
+        onAuthChange: (callback) => {
+          authChangeListeners.add(callback);
+          return () => authChangeListeners.delete(callback);
+        },
+      };
+      let offline = false;
+      const fetchImpl: FetchLike = (input, init) => {
+        if (offline) {
+          return Promise.reject(new Error("Simulated network outage"));
+        }
+        return fetch(input, init);
+      };
+      const httpChannel = createHttpChannel({authProvider, baseUrl, fetchImpl});
+      const transport = createSocketTransport({authProvider, baseUrl, timeoutMs: 4_000});
+      clearMemoryPersisterData({databaseName: "integration-token-expiry"});
+      const client7c = createSyncDb({
+        authProvider,
+        collections: [COLLECTION],
+        httpChannel,
+        name: "integration-token-expiry",
+        persisterFactory: memoryPersisterFactory,
+        reconcileIntervalMs: 0,
+        transport,
+      });
+      clients.push(client7c);
+
+      try {
+        await client7c.start();
+        await waitFor(() => client7c.getSyncStatus().isOnline, {label: "client7c online"});
+
+        // Go offline, queue mutations, then flip the token invalid BEFORE
+        // reconnecting — simulating the token expiring while mutations are
+        // queued for the next drain (mid-batch from the server's viewpoint:
+        // the auth middleware rejects the socket handshake/HTTP request).
+        offline = true;
+        transport.disconnect();
+        await waitFor(() => !client7c.getSyncStatus().isOnline, {label: "client7c offline"});
+
+        const mutationIds: string[] = [];
+        for (let i = 0; i < 5; i++) {
+          const {mutationId} = client7c.mutate({
+            collection: COLLECTION,
+            data: {title: `token-expiry-${i}`},
+            operation: "create",
+          });
+          mutationIds.push(mutationId);
+        }
+
+        tokenIsValid = false;
+        offline = false;
+        await transport.connect().catch(() => {});
+
+        // Auth-pause: outbox intact, zero budget consumed, paused visibly.
+        await waitFor(() => client7c.getSyncStatus().paused === "auth", {
+          label: "client7c auth-paused",
+          timeoutMs: 10_000,
+        });
+        // Some of the 5 may have raced onto the wire and already acked
+        // before the token flip took effect (HTTP fallback / a socket send
+        // in flight at the exact moment offline toggled false) — the load-
+        // bearing assertion is that whatever remains queued burned ZERO
+        // error-nack budget and is genuinely queued, not failed/conflicted.
+        expect(client7c.getSyncStatus().queuedCount).toBeGreaterThan(0);
+        expect(client7c.getSyncStatus().queuedCount).toBeLessThanOrEqual(5);
+        for (const mutationId of mutationIds) {
+          const mutation = client7c.outbox.getMutation({mutationId});
+          expect(["acked", "queued", undefined]).toContain(mutation?.status);
+          expect(mutation?.errorNackCount ?? 0).toBe(0);
+        }
+
+        // Same-user re-auth: the pause clears and the queue drains fully
+        // from the halt point, outbox intact throughout.
+        tokenIsValid = true;
+        for (const listener of authChangeListeners) {
+          listener();
+        }
+        await waitFor(() => client7c.getSyncStatus().paused === undefined, {
+          label: "client7c auth-resumed",
+          timeoutMs: 10_000,
+        });
+        await waitFor(() => client7c.getSyncStatus().queuedCount === 0, {
+          label: "all mutations drained after re-auth",
+          timeoutMs: 20_000,
+        });
+        const expectedTitles = Array.from({length: 5}, (_v, i) => `token-expiry-${i}`);
+        await waitFor(
+          async () => (await IntTodoModel.countDocuments({title: {$in: expectedTitles}})) === 5,
+          {label: "all documents persisted after re-auth", timeoutMs: 20_000}
+        );
+        expect(client7c.getSyncStatus().queuedCount).toBe(0);
+      } finally {
+        await client7c.stop();
+      }
+    }, 30_000);
+  });
 });

--- a/api/src/sync/loadHarness.ts
+++ b/api/src/sync/loadHarness.ts
@@ -1,0 +1,619 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: the harness bridges generic model/router/client types, mirroring integration.test.ts
+/**
+ * This is a manual load-generation script — NOT run by `bun test`. Invoke via
+ * `bun run api:load` (see root package.json) or directly:
+ *   `bun run api/src/sync/loadHarness.ts [--clients=20] [--seedDocs=5000] [--targetRate=200] [--durationSec=30] [--mongoUri=...] [--port=0]`
+ * Requires a real MongoDB replica set (change streams power live delta fan-out).
+ *
+ * Stands up one in-process Express + Socket.io server with a synced Mongoose model
+ * (mirroring `IntTodo` from `sync/integration.test.ts`), then drives N real
+ * `@terreno/syncdb` clients (each a distinct owner) against it over real HTTP/socket
+ * transports: seeds documents, bootstraps all clients, then issues a mixed
+ * create/update/delete mutation load — including deliberate duplicate mutationIds
+ * and deliberate update/update conflicts — while measuring:
+ *   - mutate round-trip latency (p50/p95/p99)
+ *   - change-stream -> sync:delta fan-out lag across all connected sockets
+ *   - bootstrap wall time at the seeded doc count
+ *   - final-state convergence (each client's local store vs. what Mongo holds)
+ *
+ * This is a load/perf tool, not a correctness test suite — assertions are logged as
+ * pass/fail lines rather than thrown, so a single divergent client doesn't abort the
+ * report. The process exits non-zero if any client fails to converge.
+ */
+import {createServer, type Server as HttpServer} from "node:http";
+import type {AddressInfo} from "node:net";
+import {
+  type AuthProvider,
+  clearMemoryPersisterData,
+  createHttpChannel,
+  createSocketTransport,
+  createSyncDb,
+  type FetchLike,
+  type HttpChannel,
+  listConflicts,
+  memoryPersisterFactory,
+  type SyncDb,
+  type SyncMutateRequest,
+  type SyncTransport,
+} from "@terreno/syncdb";
+import express from "express";
+import mongoose, {model, Schema} from "mongoose";
+import passportLocalMongoose from "passport-local-mongoose";
+
+import {modelRouter} from "../api";
+import {addAuthRoutes, generateTokens, setupAuth} from "../auth";
+import {logger} from "../logger";
+import {Permissions} from "../permissions";
+import {createdUpdatedPlugin, type IsDeleted, isDeletedPlugin} from "../plugins";
+import {RealtimeApp} from "../realtime/realtimeApp";
+import {clearSyncRegistry} from "./registry";
+import {clearActiveSyncAppOptions} from "./socketHandlers";
+import {SyncApp} from "./syncApp";
+import {syncPlugin} from "./syncSeqPlugin";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLI flags
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface HarnessConfig {
+  clients: number;
+  seedDocs: number;
+  targetRate: number;
+  durationSec: number;
+  mongoUri: string;
+  port: number;
+}
+
+/** Simple `--flag=value` argv parser; no CLI framework needed for a one-off script. */
+const parseFlags = (argv: string[]): HarnessConfig => {
+  const flags = new Map<string, string>();
+  for (const arg of argv) {
+    const match = /^--([^=]+)=(.*)$/.exec(arg);
+    if (match) {
+      flags.set(match[1], match[2]);
+    }
+  }
+  const num = (key: string, fallback: number): number => {
+    const raw = flags.get(key);
+    if (raw === undefined) {
+      return fallback;
+    }
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  };
+  return {
+    clients: num("clients", 20),
+    durationSec: num("durationSec", 30),
+    mongoUri:
+      flags.get("mongoUri") ??
+      process.env.MONGO_URI ??
+      "mongodb://127.0.0.1:27017/terreno-sync-load?replicaSet=rs0",
+    port: num("port", 0),
+    seedDocs: num("seedDocs", 5_000),
+    targetRate: num("targetRate", 200),
+  };
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Synced load-test model (mirrors IntTodo from integration.test.ts)
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface LoadTodo extends IsDeleted {
+  _id: string;
+  title: string;
+  completed: boolean;
+  ownerId: string;
+  created: Date;
+  _syncSeq?: number;
+}
+
+const loadTodoSchema = new Schema<LoadTodo>({
+  _id: {
+    default: (): string => new mongoose.Types.ObjectId().toHexString(),
+    description: "The document id (string so offline clients can mint ids)",
+    type: String,
+  },
+  completed: {
+    default: false,
+    description: "Whether the load-test todo has been completed",
+    type: Boolean,
+  },
+  ownerId: {description: "The user who owns this load-test todo", type: String},
+  title: {description: "The title of the load-test todo", required: true, type: String},
+});
+loadTodoSchema.plugin(isDeletedPlugin);
+loadTodoSchema.plugin(createdUpdatedPlugin);
+loadTodoSchema.plugin(syncPlugin);
+const LoadTodoModel = model<LoadTodo>("LoadHarnessTodo", loadTodoSchema);
+
+const COLLECTION = "loadHarnessTodos";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Percentile helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+const percentile = (samples: number[], p: number): number => {
+  if (samples.length === 0) {
+    return 0;
+  }
+  const sorted = [...samples].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[index];
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rig helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Poll until the predicate holds, or throw naming the failed wait. */
+const waitFor = async (
+  predicate: () => boolean | Promise<boolean>,
+  {
+    label = "condition",
+    timeoutMs = 30_000,
+    intervalMs = 25,
+  }: {
+    label?: string;
+    timeoutMs?: number;
+    intervalMs?: number;
+  } = {}
+): Promise<void> => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for ${label}`);
+};
+
+interface HarnessClient {
+  name: string;
+  user: {_id: unknown};
+  ownerId: string;
+  client: SyncDb;
+  httpChannel: HttpChannel;
+  transport: SyncTransport;
+}
+
+const makeAuthProvider = (user: {_id: unknown}): AuthProvider => ({
+  getToken: async () => (await generateTokens(user)).token ?? null,
+  getUserId: async () => String(user._id),
+  onAuthChange: () => () => {},
+});
+
+const makeHarnessClient = ({
+  name,
+  user,
+  baseUrl,
+}: {
+  name: string;
+  user: {_id: unknown};
+  baseUrl: string;
+}): HarnessClient => {
+  const authProvider = makeAuthProvider(user);
+  const fetchImpl: FetchLike = (input, init) => fetch(input, init);
+  const httpChannel = createHttpChannel({authProvider, baseUrl, fetchImpl});
+  const transport = createSocketTransport({authProvider, baseUrl, timeoutMs: 8_000});
+  clearMemoryPersisterData({databaseName: name});
+  const client = createSyncDb({
+    authProvider,
+    collections: [COLLECTION],
+    httpChannel,
+    name,
+    persisterFactory: memoryPersisterFactory,
+    reconcileIntervalMs: 0,
+    transport,
+  });
+  return {client, httpChannel, name, ownerId: String(user._id), transport, user};
+};
+
+/** Build the Express + Socket.io rig: synced model, SyncApp, RealtimeApp, listening server. */
+const buildRig = async (
+  config: HarnessConfig
+): Promise<{httpServer: HttpServer; realtimeApp: RealtimeApp; baseUrl: string}> => {
+  process.env.TOKEN_SECRET = process.env.TOKEN_SECRET ?? "load-harness-token-secret";
+  process.env.TOKEN_ISSUER = process.env.TOKEN_ISSUER ?? "terreno-load-harness";
+  process.env.REFRESH_TOKEN_SECRET =
+    process.env.REFRESH_TOKEN_SECRET ?? "load-harness-refresh-secret";
+  process.env.SESSION_SECRET = process.env.SESSION_SECRET ?? "load-harness-session-secret";
+
+  clearSyncRegistry();
+
+  // Fresh User model bound to this script's own mongoose connection. setupAuth requires
+  // a passport-local-mongoose-backed model (createStrategy/serializeUser/deserializeUser),
+  // even though the harness only ever mints JWTs directly via generateTokens and never
+  // exercises the password login route.
+  const userSchema = new Schema<{email: string; admin: boolean}>({
+    admin: {default: false, description: "Whether the user has admin privileges", type: Boolean},
+    email: {description: "The user's email", type: String},
+  });
+  userSchema.plugin(
+    passportLocalMongoose as unknown as (schema: Schema, options?: Record<string, unknown>) => void,
+    {usernameField: "email"}
+  );
+  const UserModel = mongoose.models.LoadHarnessUser ?? model("LoadHarnessUser", userSchema);
+
+  // modelRouter's 3-argument form both registers the sync entry AND returns the
+  // Express router to mount, so a single call does both — no need to call it twice.
+  const registration = modelRouter<LoadTodo>("/loadHarnessTodos", LoadTodoModel, {
+    permissions: {
+      create: [Permissions.IsAuthenticated],
+      delete: [Permissions.IsOwner],
+      list: [Permissions.IsAuthenticated],
+      read: [Permissions.IsOwner],
+      update: [Permissions.IsOwner],
+    },
+    preCreate: (body, req) => {
+      const user = req.user as unknown as {_id?: unknown; id?: unknown} | undefined;
+      return {...body, ownerId: String(user?._id ?? user?.id ?? "")} as LoadTodo;
+    },
+    sync: {scope: {type: "owner"}},
+  });
+
+  const app = express();
+  app.use(express.json());
+  setupAuth(app as any, UserModel as any);
+  addAuthRoutes(app as any, UserModel as any);
+  new SyncApp({}).register(app as any);
+  app.use(registration.path, registration.router);
+
+  const realtimeApp = new RealtimeApp({});
+  realtimeApp.register(app as any);
+
+  const httpServer = createServer(app);
+  await new Promise<void>((resolve) => {
+    httpServer.listen(config.port, () => resolve());
+  });
+  const {port} = httpServer.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  realtimeApp.onServerCreated(httpServer);
+  // Give the change-stream cursor a moment to open before any writes happen.
+  await new Promise((resolve) => setTimeout(resolve, 300));
+
+  return {baseUrl, httpServer, realtimeApp};
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────────────────
+
+const main = async (): Promise<void> => {
+  const config = parseFlags(process.argv.slice(2));
+  logger.info("[loadHarness] starting", config as unknown as Record<string, unknown>);
+
+  await mongoose.connect(config.mongoUri);
+
+  await Promise.all([
+    LoadTodoModel.collection.deleteMany({}),
+    mongoose.connection.db?.collection("syncmutations").deleteMany({}),
+    mongoose.connection.db?.collection("synccounters").deleteMany({}),
+  ]);
+
+  const {httpServer, realtimeApp, baseUrl} = await buildRig(config);
+
+  let exitCode = 0;
+  const harnessClients: HarnessClient[] = [];
+
+  try {
+    // ── N users, one owner stream each ──────────────────────────────────────
+    const UserModel = mongoose.models.LoadHarnessUser;
+    const users: {_id: unknown}[] = [];
+    for (let i = 0; i < config.clients; i++) {
+      const user = await UserModel.create({admin: false, email: `load-client-${i}@example.com`});
+      users.push(user as unknown as {_id: unknown});
+    }
+
+    for (let i = 0; i < config.clients; i++) {
+      harnessClients.push(makeHarnessClient({baseUrl, name: `load-client-${i}`, user: users[i]}));
+    }
+
+    // ── Start all clients, wait for online ──────────────────────────────────
+    await Promise.all(harnessClients.map((hc) => hc.client.start()));
+    await waitFor(() => harnessClients.every((hc) => hc.client.getSyncStatus().isOnline), {
+      label: "all clients online",
+      timeoutMs: 30_000,
+    });
+    logger.info(`[loadHarness] ${harnessClients.length} clients online`);
+
+    // ── Seed docs round-robin across owners; measure bootstrap wall time ────
+    const perOwnerCount = new Map<string, number>();
+    const seeds = Array.from({length: config.seedDocs}, (_, i) => {
+      const owner = harnessClients[i % harnessClients.length];
+      perOwnerCount.set(owner.ownerId, (perOwnerCount.get(owner.ownerId) ?? 0) + 1);
+      return {ownerId: owner.ownerId, title: `seed-${i}`};
+    });
+
+    const bootstrapStart = Date.now();
+    if (seeds.length > 0) {
+      await LoadTodoModel.insertMany(seeds);
+    }
+
+    await waitFor(
+      () =>
+        harnessClients.every((hc) => {
+          const expected = perOwnerCount.get(hc.ownerId) ?? 0;
+          return hc.client.store.listEntities({collection: COLLECTION}).length >= expected;
+        }),
+      {label: `bootstrap convergence at ${config.seedDocs} docs`, timeoutMs: 120_000}
+    );
+    const bootstrapWallMs = Date.now() - bootstrapStart;
+    logger.info(`[loadHarness] bootstrap converged in ${bootstrapWallMs}ms`);
+
+    // ── Driven mutation load ─────────────────────────────────────────────────
+    const mutateLatenciesMs: number[] = [];
+    const fanoutLagsMs: number[] = [];
+    let conflictCount = 0;
+    let ackCount = 0;
+    let nackCount = 0;
+    let duplicateCount = 0;
+
+    /** Poll the outbox for a mutation to reach a terminal status, recording latency. */
+    const trackMutation = async (
+      hc: HarnessClient,
+      mutationId: string,
+      startedAt: number
+    ): Promise<void> => {
+      try {
+        await waitFor(
+          () => {
+            const mutation = hc.client.outbox.getMutation({mutationId});
+            return (
+              mutation === undefined ||
+              mutation.status === "acked" ||
+              mutation.status === "conflicted" ||
+              mutation.status === "failed"
+            );
+          },
+          {intervalMs: 8, label: `mutation ${mutationId} terminal`, timeoutMs: 15_000}
+        );
+        mutateLatenciesMs.push(Date.now() - startedAt);
+        const mutation = hc.client.outbox.getMutation({mutationId});
+        if (mutation?.status === "conflicted") {
+          conflictCount += 1;
+        } else if (mutation?.status === "failed") {
+          nackCount += 1;
+        } else {
+          ackCount += 1;
+        }
+      } catch {
+        // Timed out waiting; still record whatever elapsed so the report reflects it.
+        mutateLatenciesMs.push(Date.now() - startedAt);
+      }
+    };
+
+    const randomClient = (): HarnessClient =>
+      harnessClients[Math.floor(Math.random() * harnessClients.length)];
+
+    const knownEntityIds: {clientIndex: number; id: string}[] = [];
+    for (const [i, hc] of harnessClients.entries()) {
+      for (const entity of hc.client.store.listEntities({collection: COLLECTION})) {
+        knownEntityIds.push({clientIndex: i, id: entity.id});
+      }
+    }
+
+    const loadPromises: Promise<void>[] = [];
+    const intervalMs = 1000 / config.targetRate;
+    const loadEnd = Date.now() + config.durationSec * 1000;
+
+    while (Date.now() < loadEnd) {
+      const hc = randomClient();
+      const opRoll = Math.random();
+
+      if (opRoll < 0.5 || knownEntityIds.length === 0) {
+        // Create.
+        const startedAt = Date.now();
+        const {mutationId} = hc.client.mutate({
+          collection: COLLECTION,
+          data: {title: `load-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`},
+          operation: "create",
+        });
+        loadPromises.push(trackMutation(hc, mutationId, startedAt));
+      } else if (opRoll < 0.85) {
+        // Update.
+        const target = knownEntityIds[Math.floor(Math.random() * knownEntityIds.length)];
+        const owner = harnessClients[target.clientIndex];
+        const startedAt = Date.now();
+        const {mutationId} = owner.client.mutate({
+          collection: COLLECTION,
+          data: {title: `updated-${Date.now()}`},
+          id: target.id,
+          operation: "update",
+        });
+        loadPromises.push(trackMutation(owner, mutationId, startedAt));
+
+        // Deliberate mid-batch conflict: race a second, server-side write against the
+        // SAME entity underneath this client's just-queued optimistic edit, mirroring
+        // integration.test.ts's 4a/4b conflict scenarios (server moves on while the
+        // client's mutation is still in flight/queued).
+        if (Math.random() < 0.1) {
+          void LoadTodoModel.findById(target.id)
+            .then((doc) => {
+              if (!doc) {
+                return;
+              }
+              doc.title = `server-race-${Date.now()}`;
+              return doc.save();
+            })
+            .catch(() => {});
+        }
+
+        // Deliberate duplicate mutationId resend: replay the exact same request via the
+        // lower-level httpChannel.sendMutation (mutate() always mints a fresh id, so a
+        // real duplicate delivery must go through the transport-level API directly, per
+        // integration.test.ts test "5.").
+        if (Math.random() < 0.05) {
+          const dupRequest: SyncMutateRequest = {
+            collection: COLLECTION,
+            data: {title: `dup-${Date.now()}`},
+            mutationId: `load-dup-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            operation: "create",
+          };
+          loadPromises.push(
+            owner.httpChannel
+              .sendMutation(dupRequest)
+              .then(() => owner.httpChannel.sendMutation(dupRequest))
+              .then(() => {
+                duplicateCount += 1;
+              })
+              .catch(() => {})
+          );
+        }
+      } else {
+        // Delete.
+        const idx = Math.floor(Math.random() * knownEntityIds.length);
+        const target = knownEntityIds[idx];
+        const owner = harnessClients[target.clientIndex];
+        const startedAt = Date.now();
+        const {mutationId} = owner.client.mutate({
+          collection: COLLECTION,
+          id: target.id,
+          operation: "delete",
+        });
+        loadPromises.push(trackMutation(owner, mutationId, startedAt));
+        knownEntityIds.splice(idx, 1);
+      }
+
+      // ── Fan-out lag sample: an out-of-band server write, measured against every
+      // connected client's local store reflecting it ─────────────────────────────
+      if (Math.random() < 0.02) {
+        const anyOwner = randomClient();
+        const writeStart = Date.now();
+        const doc = await LoadTodoModel.create({
+          ownerId: anyOwner.ownerId,
+          title: `fanout-${writeStart}`,
+        });
+        const id = String(doc._id);
+        knownEntityIds.push({clientIndex: harnessClients.indexOf(anyOwner), id});
+        loadPromises.push(
+          waitFor(
+            () =>
+              harnessClients.every(
+                (hc2) => hc2.client.store.getEntity({collection: COLLECTION, id}) !== undefined
+              ),
+            {
+              intervalMs: 8,
+              label: `fanout delta for ${id}`,
+              timeoutMs: 15_000,
+            }
+          )
+            .then(() => {
+              fanoutLagsMs.push(Date.now() - writeStart);
+            })
+            .catch(() => {})
+        );
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+
+    await Promise.all(loadPromises);
+
+    // Resolve any conflicts left over from the deliberate server-race scenario the load
+    // phase injects (useServer: the canonical server doc wins) — exactly what a real
+    // client eventually does, either via user action or an auto-resolve policy. Without
+    // this, a conflicted mutation sits in the outbox forever and both `queuedCount` and
+    // the final convergence check would spuriously never settle.
+    for (const hc of harnessClients) {
+      for (const conflict of listConflicts({store: hc.client.store})) {
+        hc.client.resolveConflict({mutationId: conflict.mutationId, strategy: "useServer"});
+      }
+    }
+
+    // Drain any outstanding queued mutations before checking convergence.
+    await waitFor(() => harnessClients.every((hc) => hc.client.getSyncStatus().queuedCount === 0), {
+      label: "all clients drained",
+      timeoutMs: 60_000,
+    }).catch((error: unknown) => {
+      logger.warn(`[loadHarness] drain wait: ${String(error)}`);
+    });
+
+    // ── Final-state convergence check ───────────────────────────────────────
+    let convergenceFailures = 0;
+    for (const hc of harnessClients) {
+      const localEntities = new Map(
+        hc.client.store
+          .listEntities<{title?: string}>({collection: COLLECTION})
+          .map((entity) => [entity.id, {data: entity.data, seq: entity.seq}])
+      );
+      const serverDocs = await LoadTodoModel.find({deleted: {$ne: true}, ownerId: hc.ownerId});
+      const serverMap = new Map(
+        serverDocs.map((doc) => [
+          String(doc._id),
+          {seq: (doc as unknown as {_syncSeq?: number})._syncSeq ?? 0, title: doc.title},
+        ])
+      );
+
+      let matches = localEntities.size === serverMap.size;
+      if (matches) {
+        for (const [id, local] of localEntities) {
+          const server = serverMap.get(id);
+          const localData = local.data as {title?: string} | undefined;
+          if (!server || server.seq !== local.seq || server.title !== localData?.title) {
+            matches = false;
+            break;
+          }
+        }
+      }
+      if (!matches) {
+        convergenceFailures += 1;
+      }
+      logger.info(
+        `[loadHarness] convergence ${matches ? "PASS" : "FAIL"} for ${hc.name} (local=${localEntities.size}, server=${serverMap.size})`
+      );
+    }
+
+    // ── Report ───────────────────────────────────────────────────────────────
+    const report = [
+      "",
+      "==================== SyncDB Load Harness Report ====================",
+      `clients=${config.clients} seedDocs=${config.seedDocs} targetRate=${config.targetRate}/s durationSec=${config.durationSec}`,
+      "",
+      `Bootstrap wall time @ ${config.seedDocs} docs: ${bootstrapWallMs}ms`,
+      "",
+      "Mutate round-trip latency (ms):",
+      `  p50=${percentile(mutateLatenciesMs, 50).toFixed(1)} p95=${percentile(mutateLatenciesMs, 95).toFixed(1)} p99=${percentile(mutateLatenciesMs, 99).toFixed(1)} (n=${mutateLatenciesMs.length})`,
+      `  acked=${ackCount} conflicted=${conflictCount} failed=${nackCount} duplicateResends=${duplicateCount}`,
+      "",
+      "Change-stream -> sync:delta fan-out lag across all sockets (ms):",
+      fanoutLagsMs.length > 0
+        ? `  min=${Math.min(...fanoutLagsMs).toFixed(1)} p50=${percentile(fanoutLagsMs, 50).toFixed(1)} p95=${percentile(fanoutLagsMs, 95).toFixed(1)} max=${Math.max(...fanoutLagsMs).toFixed(1)} (n=${fanoutLagsMs.length})`
+        : "  (no samples collected)",
+      "",
+      `Final-state convergence: ${harnessClients.length - convergenceFailures}/${harnessClients.length} clients PASS`,
+      "======================================================================",
+      "",
+    ].join("\n");
+    // Deliberately plain stdout output for a load report — not a structured log line.
+    process.stdout.write(report);
+
+    if (convergenceFailures > 0) {
+      exitCode = 1;
+    }
+  } catch (error: unknown) {
+    logger.error(`[loadHarness] fatal error: ${String(error)}`);
+    exitCode = 1;
+  } finally {
+    for (const hc of harnessClients) {
+      await hc.client.stop().catch(() => {});
+    }
+    realtimeApp.getIo()?.disconnectSockets(true);
+    httpServer.closeAllConnections?.();
+    await realtimeApp.close().catch(() => {});
+    await new Promise<void>((resolve) => {
+      httpServer.close(() => resolve());
+    });
+    clearSyncRegistry();
+    clearActiveSyncAppOptions();
+    await mongoose.disconnect();
+  }
+
+  process.exit(exitCode);
+};
+
+main().catch((error: unknown) => {
+  logger.error(`[loadHarness] unhandled error: ${String(error)}`);
+  process.exit(1);
+});

--- a/api/src/sync/models.ts
+++ b/api/src/sync/models.ts
@@ -6,14 +6,58 @@ import mongoose, {type ClientSession, type Model, Schema} from "mongoose";
  * and the per-user encryption key material.
  */
 
+/** An uncommitted seq claim recorded on the counter's in-flight registry (C1). */
+export interface SyncPendingClaim {
+  /** The claimed seq (or, for a batch, one entry per claimed seq). */
+  seq: number;
+  /** When the claim was registered; a claim older than the lease is reclaimable. */
+  claimedAt: Date;
+}
+
 export interface SyncCounterDocument {
   _id: mongoose.Types.ObjectId;
   stream: string;
   seq: number;
+  /**
+   * C1: seqs claimed but not yet confirmed committed. The stable frontier is
+   * `min(pending.seq) - 1`, or `seq` (the head) when empty, so a cursor never
+   * advances past a seq whose owning write has not yet landed.
+   */
+  pending: SyncPendingClaim[];
 }
+
+/**
+ * C1: a `pending` claim older than this is treated as abandoned (the writer
+ * crashed between claiming and confirming) and excluded from the frontier — a
+ * crashed writer must never freeze the frontier forever. Default 60s.
+ */
+export const PENDING_CLAIM_LEASE_MS = 60 * 1_000;
+
+const syncPendingClaimSchema = new Schema<SyncPendingClaim>(
+  {
+    claimedAt: {
+      default: () => new Date(),
+      description: "When this seq was claimed; a claim older than PENDING_CLAIM_LEASE_MS is stale",
+      type: Date,
+    },
+    seq: {
+      description: "A claimed-but-uncommitted sequence number",
+      required: true,
+      type: Number,
+    },
+  },
+  {_id: false}
+);
 
 const syncCounterSchema = new Schema<SyncCounterDocument>(
   {
+    pending: {
+      default: [],
+      description:
+        "C1 in-flight registry: seqs claimed but not yet confirmed committed; the stable " +
+        "frontier is min(pending.seq) - 1 (or the head when empty)",
+      type: [syncPendingClaimSchema],
+    },
     seq: {
       default: 0,
       description: "The last sequence number claimed for this stream",
@@ -35,9 +79,35 @@ export const SyncCounter: Model<SyncCounterDocument> =
   mongoose.model<SyncCounterDocument>("SyncCounter", syncCounterSchema);
 
 /**
- * Atomically claim `count` sequence numbers for a stream. Returns the last seq
- * claimed; a batch of N owns the range [result - N + 1, result]. Retries once on
- * the upsert race (two concurrent first claims for a new stream).
+ * Result of a seq claim: the last seq claimed (range [lastSeq - count + 1, lastSeq])
+ * and whether the claim registered a pending entry that a later `confirmSyncSeqs`
+ * must clear. A session-backed claim skips the pending registry entirely (the write
+ * and the `$inc` commit atomically), so `registered` is false and no confirm is due.
+ */
+export interface SyncSeqClaim {
+  /** The last (highest) seq claimed; the range is [lastSeq - count + 1, lastSeq]. */
+  lastSeq: number;
+  /** Every seq claimed, in ascending order (the range materialized). */
+  seqs: number[];
+  /** True when a pending registry entry was recorded and `confirmSyncSeqs` must clear it. */
+  registered: boolean;
+}
+
+/**
+ * C1: atomically claim `count` sequence numbers for a stream AND register them on
+ * the in-flight registry so the stable frontier can exclude them until committed.
+ *
+ * Two modes:
+ * - **No caller session (the hot path):** one `findOneAndUpdate` does `$inc: {seq}`
+ *   plus `$push` of a `pending` entry per claimed seq. The write commits separately,
+ *   so `confirmSyncSeqs` must `$pull` the entries once it lands. Until then the
+ *   frontier holds below the lowest pending seq.
+ * - **Caller session present:** the `$inc` and the document write commit atomically
+ *   in the caller's transaction, so there is no window where a claimed seq is
+ *   uncommitted — the pending registry is skipped (`registered: false`, nothing to
+ *   confirm). Frontier logic treats a session-backed claim as already committed.
+ *
+ * Retries once on the upsert race (two concurrent first claims for a new stream).
  */
 export const claimSyncSeqs = async ({
   stream,
@@ -47,14 +117,59 @@ export const claimSyncSeqs = async ({
   stream: string;
   count?: number;
   session?: ClientSession | null;
-}): Promise<number> => {
-  const claim = async (): Promise<number> => {
+}): Promise<SyncSeqClaim> => {
+  const materialize = (lastSeq: number): number[] => {
+    const seqs: number[] = [];
+    for (let s = lastSeq - count + 1; s <= lastSeq; s++) {
+      seqs.push(s);
+    }
+    return seqs;
+  };
+
+  // Session-backed fast path: the write and the $inc are already atomic, so we skip
+  // the pending registry — there is never an uncommitted-but-claimed window to fence.
+  if (session) {
     const doc = await SyncCounter.findOneAndUpdate(
       {stream},
       {$inc: {seq: count}},
-      {new: true, session: session ?? undefined, upsert: true}
+      {new: true, session, upsert: true}
     );
-    return doc.seq;
+    return {lastSeq: doc.seq, registered: false, seqs: materialize(doc.seq)};
+  }
+
+  const claim = async (): Promise<SyncSeqClaim> => {
+    const now = new Date();
+    // Claim (`$inc`) AND register the pending entries in ONE atomic aggregation-pipeline
+    // update, so there is never a window where the incremented head is visible without
+    // its pending claims (which would let `computeStableFrontier` transiently report a
+    // frontier above an about-to-be-pending seq). `$range(oldSeq+1, newSeq+1)` materializes
+    // the claimed range from the just-incremented value; `$map` turns it into pending docs.
+    const doc = await SyncCounter.findOneAndUpdate(
+      {stream},
+      [
+        {$set: {_syncOldSeq: {$ifNull: ["$seq", 0]}}},
+        {$set: {seq: {$add: ["$_syncOldSeq", count]}}},
+        {
+          $set: {
+            pending: {
+              $concatArrays: [
+                {$ifNull: ["$pending", []]},
+                {
+                  $map: {
+                    as: "s",
+                    in: {claimedAt: now, seq: "$$s"},
+                    input: {$range: [{$add: ["$_syncOldSeq", 1]}, {$add: ["$seq", 1]}]},
+                  },
+                },
+              ],
+            },
+          },
+        },
+        {$unset: "_syncOldSeq"},
+      ],
+      {new: true, upsert: true}
+    );
+    return {lastSeq: doc.seq, registered: true, seqs: materialize(doc.seq)};
   };
   try {
     return await claim();
@@ -67,6 +182,139 @@ export const claimSyncSeqs = async ({
     throw error;
   }
 };
+
+/**
+ * C1: confirm that the writes owning `seqs` on `stream` have committed, clearing
+ * their pending registry entries so the stable frontier can advance past them.
+ * A no-op when `seqs` is empty (a session-backed claim registered nothing). Runs
+ * after the document write commits (`post("save")` / query-write post hook); a
+ * `$pull` failure is logged by the caller and left to age out via the lease.
+ */
+export const confirmSyncSeqs = async ({
+  stream,
+  seqs,
+  session,
+}: {
+  stream: string;
+  seqs: number[];
+  session?: ClientSession | null;
+}): Promise<void> => {
+  if (seqs.length === 0) {
+    return;
+  }
+  await SyncCounter.updateOne(
+    {stream},
+    {$pull: {pending: {seq: {$in: seqs}}}},
+    session ? {session} : {}
+  );
+};
+
+/**
+ * C1: the stable frontier for a stream — the highest seq below which no claim is
+ * uncommitted. A cursor (snapshot or delta) may advance to seq N only when N is at
+ * or below this value, so no committed document is ever permanently skipped.
+ *
+ * frontier = `min(live pending.seq) - 1`, or the head `seq` when no live pending
+ * entries remain. A pending entry older than {@link PENDING_CLAIM_LEASE_MS} is
+ * considered abandoned (crashed writer): it is excluded from the min AND `$pull`ed
+ * opportunistically so a crash cannot freeze the frontier forever.
+ */
+export const computeStableFrontier = async ({stream}: {stream: string}): Promise<number> => {
+  const counter = await SyncCounter.findOne({stream});
+  if (!counter) {
+    return 0;
+  }
+  const pending = counter.pending ?? [];
+  if (pending.length === 0) {
+    return counter.seq;
+  }
+  const cutoff = Date.now() - PENDING_CLAIM_LEASE_MS;
+  const staleSeqs: number[] = [];
+  let minLiveSeq = Number.POSITIVE_INFINITY;
+  for (const claim of pending) {
+    const claimedAtMs = new Date(claim.claimedAt).getTime();
+    if (claimedAtMs < cutoff) {
+      staleSeqs.push(claim.seq);
+      continue;
+    }
+    if (claim.seq < minLiveSeq) {
+      minLiveSeq = claim.seq;
+    }
+  }
+  if (staleSeqs.length > 0) {
+    // Opportunistic cleanup: a crashed writer's claim must not freeze the frontier.
+    await SyncCounter.updateOne({stream}, {$pull: {pending: {seq: {$in: staleSeqs}}}}).catch(
+      () => {}
+    );
+  }
+  // All pending entries were stale → frontier is the head; otherwise one below the
+  // lowest live (uncommitted) claim.
+  return minLiveSeq === Number.POSITIVE_INFINITY ? counter.seq : minLiveSeq - 1;
+};
+
+export interface SyncScopeMoveDocument {
+  _id: mongoose.Types.ObjectId;
+  collectionTag: string;
+  entityId: string;
+  fromStream: string;
+  toStream: string;
+  seq: number;
+  created: Date;
+}
+
+/** C4: scope-move markers share the tombstone retention window (default 90 days). */
+const SYNC_SCOPE_MOVE_TTL_SECONDS = 90 * 24 * 60 * 60;
+
+const syncScopeMoveSchema = new Schema<SyncScopeMoveDocument>(
+  {
+    collectionTag: {
+      description: "The collection tag of the moved document",
+      required: true,
+      type: String,
+    },
+    created: {
+      default: () => new Date(),
+      description: "When the move was recorded; TTL-indexed to the tombstone retention window",
+      type: Date,
+    },
+    entityId: {
+      description: "The _id of the document that moved between streams",
+      required: true,
+      type: String,
+    },
+    fromStream: {
+      description: "The stream the document left (the one to tombstone)",
+      required: true,
+      type: String,
+    },
+    seq: {
+      description: "Seq claimed from the OLD stream's counter; orders the tombstone in that stream",
+      required: true,
+      type: Number,
+    },
+    toStream: {
+      description: "The stream the document moved into",
+      required: true,
+      type: String,
+    },
+  },
+  // Consumer apps run checkModelsStrict() at startup; framework models must comply.
+  {strict: "throw", toJSON: {virtuals: true}, toObject: {virtuals: true}}
+);
+// Old-stream snapshot catch-up pages markers by {fromStream, seq}.
+syncScopeMoveSchema.index({fromStream: 1, seq: 1});
+syncScopeMoveSchema.index({collectionTag: 1, entityId: 1});
+syncScopeMoveSchema.index({created: 1}, {expireAfterSeconds: SYNC_SCOPE_MOVE_TTL_SECONDS});
+
+/**
+ * C4: durable marker written in the same op-scope as a scope move, replacing the
+ * racy `_syncPrevStream` post-image read. The old stream tombstones the document
+ * from this marker (change-stream fan-out + snapshot catch-up), so a racing second
+ * write that overwrites `_syncPrevStream` can no longer erase the tombstone.
+ */
+export const SyncScopeMove: Model<SyncScopeMoveDocument> =
+  (mongoose.models.SyncScopeMove as Model<SyncScopeMoveDocument>) ??
+  mongoose.model<SyncScopeMoveDocument>("SyncScopeMove", syncScopeMoveSchema);
 
 /** Lifecycle status of a sync mutation ledger row. */
 export type SyncMutationStatus = "pending" | "applied" | "conflicted" | "failed";

--- a/api/src/sync/models.ts
+++ b/api/src/sync/models.ts
@@ -82,13 +82,28 @@ export interface SyncMutationDocument {
   serverDoc?: unknown;
   error?: string;
   created: Date;
+  claimedAt: Date;
 }
 
 /** Ledger rows are only needed while a client could still replay a mutation. */
 const SYNC_MUTATION_TTL_SECONDS = 30 * 24 * 60 * 60;
 
+/**
+ * C5 (FIX 6): a `pending` row older than this may be taken over by a fresh
+ * delivery — the original claimant is assumed to have crashed between the
+ * claim and finalizing the ledger row.
+ */
+export const SYNC_MUTATION_LEASE_MS = 60 * 1_000;
+
 const syncMutationSchema = new Schema<SyncMutationDocument>(
   {
+    claimedAt: {
+      default: () => new Date(),
+      description:
+        "When this delivery claimed the mutation (lease); a pending row older than " +
+        "SYNC_MUTATION_LEASE_MS may be taken over by a fresh delivery via findOneAndUpdate",
+      type: Date,
+    },
     created: {
       default: () => new Date(),
       description: "When the mutation was first claimed; TTL-indexed so rows expire after 30 days",

--- a/api/src/sync/mutationHandler.test.ts
+++ b/api/src/sync/mutationHandler.test.ts
@@ -288,6 +288,249 @@ describe("applySyncMutation", () => {
     });
   });
 
+  describe("C5 lease takeover (FIX 6)", () => {
+    /** Simulate a crash: a `pending` row whose claimedAt is older than the lease. */
+    const createStalePendingRow = async (mutationId: string, staleForMs: number): Promise<void> => {
+      await SyncMutation.create({
+        claimedAt: new Date(Date.now() - staleForMs),
+        mutationId,
+        status: "pending",
+        userId: String(owner.id),
+      });
+    };
+
+    it("retries and succeeds after the lease expires when the write never landed (create)", async () => {
+      await createStalePendingRow("m-lease-create", 90_000);
+      const ack = expectAck(
+        await applySyncMutation({
+          mutation: {
+            collection: "mutStuff",
+            data: {name: "recovered", ownerId: owner.id},
+            mutationId: "m-lease-create",
+            operation: "create",
+          },
+          user: owner,
+        })
+      );
+      expect(ack.seq).toBe(1);
+      expect(await MutStuffModel.countDocuments({name: "recovered"})).toBe(1);
+      const row = await SyncMutation.findOne({mutationId: "m-lease-create"});
+      expect(row?.status).toBe("applied");
+    });
+
+    it("does NOT take over a pending row within the lease window (regression guard)", async () => {
+      await createStalePendingRow("m-lease-fresh", 5_000); // well under SYNC_MUTATION_LEASE_MS
+      const nack = expectNack(
+        await applySyncMutation({
+          mutation: {
+            collection: "mutStuff",
+            data: {name: "should not apply", ownerId: owner.id},
+            mutationId: "m-lease-fresh",
+            operation: "create",
+          },
+          user: owner,
+        })
+      );
+      expect(nack.code).toBe("error");
+      expect(nack.message).toContain("still in flight");
+      expect(await MutStuffModel.countDocuments({name: "should not apply"})).toBe(0);
+    });
+
+    it("create: tolerates the write having already landed (E11000 on the same _id) and reads back the doc as the ack", async () => {
+      const entityId = new mongoose.Types.ObjectId().toHexString();
+      // Simulate the crash: the doc write from the FIRST attempt landed, but
+      // the process died before finalizing the ledger row `applied`.
+      await MutStuffModel.create({_id: entityId, name: "already written", ownerId: owner.id});
+      await createStalePendingRow("m-lease-create-e11000", 90_000);
+
+      const ack = expectAck(
+        await applySyncMutation({
+          mutation: {
+            collection: "mutStuff",
+            data: {name: "already written", ownerId: owner.id},
+            id: entityId,
+            mutationId: "m-lease-create-e11000",
+            operation: "create",
+          },
+          user: owner,
+        })
+      );
+      expect(ack.id).toBe(entityId);
+      expect(ack.seq).toBe(1);
+      // Exactly one document — the retry did not double-create.
+      expect(await MutStuffModel.countDocuments({_id: entityId})).toBe(1);
+      const row = await SyncMutation.findOne({mutationId: "m-lease-create-e11000"});
+      expect(row?.status).toBe("applied");
+      expect(row?.resultId).toBe(entityId);
+    });
+
+    it("update: tolerates the write having already landed (seq already advanced by exactly this mutation) and reads back the doc as the ack", async () => {
+      const doc = await MutStuffModel.create({name: "v1", ownerId: owner.id});
+      // Simulate the crash: the update write from the FIRST attempt landed
+      // (seq advanced 1 -> 2 with the new name), but the ledger row was
+      // never finalized.
+      doc.name = "v2 (already written)";
+      await doc.save();
+      expect(doc._syncSeq).toBe(2);
+      await createStalePendingRow("m-lease-update", 90_000);
+
+      const ack = expectAck(
+        await applySyncMutation({
+          mutation: {
+            baseVersion: 1, // the client's original (pre-write) baseVersion
+            collection: "mutStuff",
+            data: {name: "v2 (already written)"},
+            id: doc._id.toString(),
+            mutationId: "m-lease-update",
+            operation: "update",
+          },
+          user: owner,
+        })
+      );
+      expect(ack.seq).toBe(2);
+      const saved = await MutStuffModel.findById(doc._id);
+      expect(saved?.name).toBe("v2 (already written)");
+      expect(saved?._syncSeq).toBe(2); // not bumped again
+      const row = await SyncMutation.findOne({mutationId: "m-lease-update"});
+      expect(row?.status).toBe("applied");
+    });
+
+    it("update: a GENUINE conflict (someone else wrote, not this mutation) still nacks even via lease takeover", async () => {
+      const doc = await MutStuffModel.create({name: "v1", ownerId: owner.id});
+      doc.name = "someone else's edit";
+      await doc.save(); // seq 2, but NOT from this mutation
+      await createStalePendingRow("m-lease-genuine-conflict", 90_000);
+
+      const nack = expectNack(
+        await applySyncMutation({
+          mutation: {
+            baseVersion: 1,
+            collection: "mutStuff",
+            data: {name: "my conflicting edit"},
+            id: doc._id.toString(),
+            mutationId: "m-lease-genuine-conflict",
+            operation: "update",
+          },
+          user: owner,
+        })
+      );
+      expect(nack.code).toBe("conflict");
+      expect(nack.serverSeq).toBe(2);
+    });
+
+    it("replay after lease expiry returns the recorded ack for a subsequent duplicate delivery", async () => {
+      await createStalePendingRow("m-lease-replay", 90_000);
+      const first = expectAck(
+        await applySyncMutation({
+          mutation: {
+            collection: "mutStuff",
+            data: {name: "replay me", ownerId: owner.id},
+            mutationId: "m-lease-replay",
+            operation: "create",
+          },
+          user: owner,
+        })
+      );
+      // A later duplicate delivery of the SAME mutationId (e.g. the
+      // original client's transport retry finally reaches the server) reads
+      // back the exact recorded outcome instead of double-applying.
+      const second = expectAck(
+        await applySyncMutation({
+          mutation: {
+            collection: "mutStuff",
+            data: {name: "replay me", ownerId: owner.id},
+            mutationId: "m-lease-replay",
+            operation: "create",
+          },
+          user: owner,
+        })
+      );
+      expect(second).toEqual(first);
+      expect(await MutStuffModel.countDocuments({name: "replay me"})).toBe(1);
+    });
+
+    it("post-hook throw after a committed write: doc changed AND ack returned AND ledger applied (M5)", async () => {
+      registerMutStuff({
+        options: {
+          ...ownerOptions,
+          postCreate: () => {
+            throw new Error("webhook unreachable");
+          },
+        },
+      });
+      const outcome = await applySyncMutation({
+        mutation: {
+          collection: "mutStuff",
+          data: {name: "post-hook throws", ownerId: owner.id},
+          mutationId: "m-posthook-throw",
+          operation: "create",
+        },
+        user: owner,
+      });
+      // Still a full ack, not a nack — the write committed regardless of the
+      // post-hook's fate.
+      const ack = expectAck(outcome);
+      expect(ack.warning).toContain("webhook unreachable");
+      expect(await MutStuffModel.countDocuments({name: "post-hook throws"})).toBe(1);
+      const row = await SyncMutation.findOne({mutationId: "m-posthook-throw"});
+      expect(row?.status).toBe("applied");
+    });
+
+    it("post-hook throw on update also returns ack+warning with the ledger applied", async () => {
+      const doc = await MutStuffModel.create({name: "before", ownerId: owner.id});
+      registerMutStuff({
+        options: {
+          ...ownerOptions,
+          postUpdate: () => {
+            throw new Error("notification failed");
+          },
+        },
+      });
+      const outcome = await applySyncMutation({
+        mutation: {
+          baseVersion: 1,
+          collection: "mutStuff",
+          data: {name: "after"},
+          id: doc._id.toString(),
+          mutationId: "m-posthook-update-throw",
+          operation: "update",
+        },
+        user: owner,
+      });
+      const ack = expectAck(outcome);
+      expect(ack.warning).toContain("notification failed");
+      const saved = await MutStuffModel.findById(doc._id);
+      expect(saved?.name).toBe("after");
+      const row = await SyncMutation.findOne({mutationId: "m-posthook-update-throw"});
+      expect(row?.status).toBe("applied");
+    });
+
+    it("no warning field when the post-hook succeeds", async () => {
+      let called = false;
+      registerMutStuff({
+        options: {
+          ...ownerOptions,
+          postCreate: () => {
+            called = true;
+          },
+        },
+      });
+      const ack = expectAck(
+        await applySyncMutation({
+          mutation: {
+            collection: "mutStuff",
+            data: {name: "clean post-hook", ownerId: owner.id},
+            mutationId: "m-posthook-ok",
+            operation: "create",
+          },
+          user: owner,
+        })
+      );
+      expect(called).toBe(true);
+      expect(ack.warning).toBeUndefined();
+    });
+  });
+
   describe("conflicts", () => {
     it("nacks conflict with the canonical server doc on a stale baseVersion", async () => {
       const doc = await MutStuffModel.create({name: "v1", ownerId: owner.id});

--- a/api/src/sync/mutationHandler.test.ts
+++ b/api/src/sync/mutationHandler.test.ts
@@ -8,10 +8,16 @@ import {Permissions} from "../permissions";
 import {createdUpdatedPlugin, type IsDeleted, isDeletedPlugin} from "../plugins";
 import {setupDb} from "../tests";
 import {SyncCounter, SyncMutation} from "./models";
-import {applySyncMutation, type SyncMutationOutcome} from "./mutationHandler";
+import {
+  applySyncMutation,
+  applySyncMutationBatch,
+  MAX_SYNC_MUTATIONS_PER_BATCH,
+  type SyncMutationOutcome,
+  validateSyncMutationBatch,
+} from "./mutationHandler";
 import {clearSyncRegistry, registerSync} from "./registry";
 import {syncPlugin} from "./syncSeqPlugin";
-import type {SyncMutateRequest} from "./types";
+import type {SyncMutateBatchResponse, SyncMutateRequest} from "./types";
 
 interface MutStuff extends IsDeleted {
   _id: string;
@@ -607,5 +613,253 @@ describe("applySyncMutation", () => {
       expect(row?.status).toBe("failed");
       expect(row?.nackCode).toBe("error");
     });
+  });
+});
+
+describe("validateSyncMutationBatch", () => {
+  it("accepts a batch within the size limit with no duplicate ids", () => {
+    const mutations: SyncMutateRequest[] = Array.from({length: 10}, (_v, i) => ({
+      collection: "mutStuff",
+      data: {name: `item ${i}`},
+      mutationId: `batch-ok-${i}`,
+      operation: "create",
+    }));
+    expect(validateSyncMutationBatch(mutations)).toEqual({ok: true});
+  });
+
+  it("rejects a batch exceeding the maximum size", () => {
+    const mutations: SyncMutateRequest[] = Array.from(
+      {length: MAX_SYNC_MUTATIONS_PER_BATCH + 1},
+      (_v, i) => ({
+        collection: "mutStuff",
+        data: {},
+        mutationId: `batch-oversized-${i}`,
+        operation: "create",
+      })
+    );
+    const outcome = validateSyncMutationBatch(mutations);
+    expect(outcome.ok).toBe(false);
+    if (outcome.ok) {
+      throw new Error("expected rejection");
+    }
+    expect(outcome.response.results).toHaveLength(1);
+    const [result] = outcome.response.results;
+    expect(result.type).toBe("nack");
+    if (result.type !== "nack") {
+      throw new Error("expected nack");
+    }
+    expect(result.nack.code).toBe("validation");
+    expect(result.nack.message).toContain(String(MAX_SYNC_MUTATIONS_PER_BATCH));
+  });
+
+  it("rejects a batch with an intra-batch duplicate mutationId", () => {
+    const mutations: SyncMutateRequest[] = [
+      {collection: "mutStuff", data: {}, mutationId: "dup-1", operation: "create"},
+      {collection: "mutStuff", data: {}, mutationId: "dup-2", operation: "create"},
+      {collection: "mutStuff", data: {}, mutationId: "dup-1", operation: "create"},
+    ];
+    const outcome = validateSyncMutationBatch(mutations);
+    expect(outcome.ok).toBe(false);
+    if (outcome.ok) {
+      throw new Error("expected rejection");
+    }
+    const [result] = outcome.response.results;
+    expect(result.type).toBe("nack");
+    if (result.type !== "nack") {
+      throw new Error("expected nack");
+    }
+    expect(result.nack.code).toBe("validation");
+    expect(result.nack.mutationId).toBe("dup-1");
+  });
+});
+
+describe("applySyncMutationBatch", () => {
+  beforeAll(async () => {
+    await setupDb();
+    await Promise.all([SyncCounter.ensureIndexes(), SyncMutation.ensureIndexes()]);
+  });
+
+  beforeEach(async () => {
+    registerMutStuff();
+    await Promise.all([
+      MutStuffModel.collection.deleteMany({}),
+      SyncCounter.deleteMany({}),
+      SyncMutation.deleteMany({}),
+    ]);
+  });
+
+  const create = (mutationId: string, name: string): SyncMutateRequest => ({
+    collection: "mutStuff",
+    data: {name, ownerId: owner.id},
+    mutationId,
+    operation: "create",
+  });
+
+  it("applies every mutation strictly serially and returns one result per mutation", async () => {
+    const mutations = Array.from({length: 10}, (_v, i) => create(`batch-serial-${i}`, `item ${i}`));
+    const response = await applySyncMutationBatch({mutations, user: owner});
+    expect(response.results).toHaveLength(10);
+    expect(response.results.every((r) => r.type === "ack")).toBe(true);
+    // Order proof: seqs are strictly increasing in request order (strictly serial,
+    // no parallelism).
+    const seqs = response.results.map((r) => (r.type === "ack" ? r.ack.seq : -1));
+    expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+    expect(new Set(seqs).size).toBe(10);
+  });
+
+  it("stops at the first conflict: results shorter than the request, later mutations unledgered", async () => {
+    const doc = await MutStuffModel.create({name: "server v1", ownerId: owner.id});
+    doc.name = "server v2";
+    await doc.save(); // seq 2
+
+    const mutations: SyncMutateRequest[] = [
+      create("batch-conflict-1", "item 1"),
+      create("batch-conflict-2", "item 2"),
+      create("batch-conflict-3", "item 3"),
+      {
+        baseVersion: 1, // stale — server is at seq 2
+        collection: "mutStuff",
+        data: {name: "stale write"},
+        id: String(doc._id),
+        mutationId: "batch-conflict-4",
+        operation: "update",
+      },
+      create("batch-conflict-5", "item 5"),
+      create("batch-conflict-6", "item 6"),
+      create("batch-conflict-7", "item 7"),
+      create("batch-conflict-8", "item 8"),
+      create("batch-conflict-9", "item 9"),
+      create("batch-conflict-10", "item 10"),
+    ];
+
+    const response = await applySyncMutationBatch({mutations, user: owner});
+    expect(response.results).toHaveLength(4);
+    expect(response.results.slice(0, 3).every((r) => r.type === "ack")).toBe(true);
+    const fourth = response.results[3];
+    expect(fourth.type).toBe("nack");
+    if (fourth.type !== "nack") {
+      throw new Error("expected nack");
+    }
+    expect(fourth.nack.code).toBe("conflict");
+
+    // Mutations 5-10 were never attempted: no ledger row exists for them, and no
+    // document was created for them.
+    for (const mutationId of [
+      "batch-conflict-5",
+      "batch-conflict-6",
+      "batch-conflict-7",
+      "batch-conflict-8",
+      "batch-conflict-9",
+      "batch-conflict-10",
+    ]) {
+      expect(await SyncMutation.findOne({mutationId})).toBeNull();
+    }
+    expect(await MutStuffModel.countDocuments({name: {$in: ["item 5", "item 6", "item 10"]}})).toBe(
+      0
+    );
+
+    // Resending mutations 4-10 as a new batch: #4 (the boundary mutation) reads
+    // back its recorded conflict from the ledger idempotently; 5-10 apply.
+    const resend = mutations.slice(3);
+    const resendResponse = await applySyncMutationBatch({mutations: resend, user: owner});
+    expect(resendResponse.results).toHaveLength(1);
+    const [resentFourth] = resendResponse.results;
+    expect(resentFourth.type).toBe("nack");
+    if (resentFourth.type !== "nack") {
+      throw new Error("expected nack");
+    }
+    expect(resentFourth.nack.code).toBe("conflict");
+
+    // The client, having recorded #4 as conflicted, resends only 5-10 next.
+    const tail = mutations.slice(4);
+    const tailResponse = await applySyncMutationBatch({mutations: tail, user: owner});
+    expect(tailResponse.results).toHaveLength(6);
+    expect(tailResponse.results.every((r) => r.type === "ack")).toBe(true);
+    for (const name of ["item 5", "item 6", "item 7", "item 8", "item 9", "item 10"]) {
+      expect(await MutStuffModel.countDocuments({name})).toBe(1);
+    }
+  });
+
+  it("a whole-batch duplicate resend is idempotent: all results served from the ledger, docs written once", async () => {
+    const mutations = Array.from({length: 5}, (_v, i) => create(`batch-dup-${i}`, `dup ${i}`));
+    const first = await applySyncMutationBatch({mutations, user: owner});
+    expect(first.results.every((r) => r.type === "ack")).toBe(true);
+
+    const second: SyncMutateBatchResponse = await applySyncMutationBatch({mutations, user: owner});
+    expect(second.results).toHaveLength(5);
+    expect(second).toEqual(first);
+
+    for (let i = 0; i < 5; i++) {
+      expect(await MutStuffModel.countDocuments({name: `dup ${i}`})).toBe(1);
+    }
+  });
+
+  it("order proof: create, update, delete for one entity in one batch works", async () => {
+    const entityId = new mongoose.Types.ObjectId().toString();
+    const mutations: SyncMutateRequest[] = [
+      {
+        collection: "mutStuff",
+        data: {name: "v1", ownerId: owner.id},
+        id: entityId,
+        mutationId: "order-create",
+        operation: "create",
+      },
+      {
+        baseVersion: 1,
+        collection: "mutStuff",
+        data: {name: "v2"},
+        id: entityId,
+        mutationId: "order-update",
+        operation: "update",
+      },
+      {
+        baseVersion: 2,
+        collection: "mutStuff",
+        id: entityId,
+        mutationId: "order-delete",
+        operation: "delete",
+      },
+    ];
+    const response = await applySyncMutationBatch({mutations, user: owner});
+    expect(response.results).toHaveLength(3);
+    expect(response.results.every((r) => r.type === "ack")).toBe(true);
+    const seqs = response.results.map((r) => (r.type === "ack" ? r.ack.seq : -1));
+    expect(seqs).toEqual([1, 2, 3]);
+    const tombstones = await MutStuffModel.find({_id: entityId, deleted: true});
+    expect(tombstones).toHaveLength(1);
+  });
+
+  it("order proof reversed: a failing first mutation halts before the second/third are touched", async () => {
+    const entityId = new mongoose.Types.ObjectId().toString();
+    const mutations: SyncMutateRequest[] = [
+      // Update against a non-existent document fails first.
+      {
+        baseVersion: 0,
+        collection: "mutStuff",
+        data: {name: "nope"},
+        id: entityId,
+        mutationId: "reversed-update",
+        operation: "update",
+      },
+      {
+        collection: "mutStuff",
+        data: {name: "v1", ownerId: owner.id},
+        id: entityId,
+        mutationId: "reversed-create",
+        operation: "create",
+      },
+      {
+        collection: "mutStuff",
+        id: entityId,
+        mutationId: "reversed-delete",
+        operation: "delete",
+      },
+    ];
+    const response = await applySyncMutationBatch({mutations, user: owner});
+    expect(response.results).toHaveLength(1);
+    expect(response.results[0].type).toBe("nack");
+    expect(await SyncMutation.findOne({mutationId: "reversed-create"})).toBeNull();
+    expect(await SyncMutation.findOne({mutationId: "reversed-delete"})).toBeNull();
+    expect(await MutStuffModel.findById(entityId)).toBeNull();
   });
 });

--- a/api/src/sync/mutationHandler.ts
+++ b/api/src/sync/mutationHandler.ts
@@ -3,7 +3,7 @@ import type express from "express";
 import {DateTime} from "luxon";
 import mongoose from "mongoose";
 import type {User} from "../auth";
-import {isAPIError} from "../errors";
+import {APIError, isAPIError} from "../errors";
 import {logger} from "../logger";
 import {findOneOrNoneFor} from "../plugins";
 import {
@@ -18,6 +18,7 @@ import {
 import {SYNC_MUTATION_LEASE_MS, SyncMutation, type SyncMutationDocument} from "./models";
 import {findSyncEntryByCollectionTag, type SyncRegistryEntry} from "./registry";
 import {serializeSyncDoc} from "./routes";
+import {getScopeField} from "./streams";
 import type {
   SyncAck,
   SyncMutateBatchResponse,
@@ -25,6 +26,82 @@ import type {
   SyncNack,
   SyncNackCode,
 } from "./types";
+
+/**
+ * C6 (M6): the sync-boundary write-scope backstop. Resolve `getUserScopes` lazily from
+ * the active SyncApp options (registered once, regardless of plugin order) so the check
+ * runs against the same membership resolver the snapshot/subscribe paths use.
+ */
+let scopeResolver:
+  | ((user: User, entry: SyncRegistryEntry) => Promise<string[]> | string[])
+  | undefined;
+
+/** Called by SyncApp.register so the mutation-scope check can resolve tenant memberships. */
+export const setSyncMutationScopeResolver = (
+  resolver: ((user: User, entry: SyncRegistryEntry) => Promise<string[]> | string[]) | undefined
+): void => {
+  scopeResolver = resolver;
+};
+
+/**
+ * C6 (M6): enforce write scope at the sync boundary regardless of consumer `preCreate`
+ * quality. For `owner` strategy, force/verify the owner field equals the authenticated
+ * user id; for `tenant` strategy, verify the incoming tenant value is in the user's
+ * memberships. Throws a 403 APIError (mapped to `unauthorized`) otherwise. A no-op for
+ * broadcast/custom scopes and for update data that does not touch the scope field.
+ */
+const enforceWriteScope = async ({
+  entry,
+  user,
+  operation,
+  data,
+}: {
+  entry: SyncRegistryEntry;
+  user: User;
+  operation: "create" | "update" | "delete";
+  data: Record<string, unknown> | undefined;
+}): Promise<void> => {
+  if (operation === "delete") {
+    return;
+  }
+  const {scope} = entry.config;
+  if (typeof scope === "function" || scope.type === "broadcast") {
+    return;
+  }
+  const field = getScopeField(scope) as string;
+  const incoming = data?.[field];
+  if (scope.type === "owner") {
+    // Create must belong to the caller; an update may not move ownership to someone else.
+    if (operation === "create" && (incoming === undefined || incoming === null)) {
+      // preCreate typically injects ownerId; nothing to verify if absent here.
+      return;
+    }
+    if (incoming !== undefined && incoming !== null && String(incoming) !== String(user.id)) {
+      throw new APIError({
+        status: 403,
+        title: `Write scope violation on ${entry.collectionTag}: ${field} must be the caller`,
+      });
+    }
+    return;
+  }
+  // Tenant: the incoming value (create) or the changed value (update) must be a membership.
+  if (incoming === undefined || incoming === null) {
+    return;
+  }
+  if (!scopeResolver) {
+    throw new APIError({
+      status: 500,
+      title: `Sync collection ${entry.collectionTag} is tenant-scoped but SyncApp has no getUserScopes resolver`,
+    });
+  }
+  const memberships = await scopeResolver(user, entry);
+  if (!memberships.map(String).includes(String(incoming))) {
+    throw new APIError({
+      status: 403,
+      title: `Write scope violation on ${entry.collectionTag}: ${field} ${String(incoming)} is not a membership`,
+    });
+  }
+};
 
 /**
  * Shared mutation handler for the sync channel: `POST /sync/mutate` (HTTP fallback)
@@ -374,6 +451,14 @@ const applyClaimedMutation = async ({
   const model = mongoose.model(entry.modelName);
 
   try {
+    // C6 (M6): sync-boundary write-scope backstop before any write pipeline runs.
+    await enforceWriteScope({
+      data: mutation.data,
+      entry,
+      operation: mutation.operation,
+      user,
+    });
+
     let doc: mongoose.Document;
     let postHook: (() => Promise<void>) | undefined;
     if (mutation.operation === "create") {
@@ -543,6 +628,12 @@ export const applySyncMutation = async ({
   }
   if ((mutation.operation === "update" || mutation.operation === "delete") && !mutation.id) {
     return validationNack(`id is required for ${mutation.operation} mutations`);
+  }
+  // C8: an update MUST carry an explicit baseVersion — omitting it would silently become
+  // a `baseSeq: 0` check (an accidental conflict against every non-fresh doc, or an
+  // accidental success against a seq-0 doc). Reject it as a client bug up front.
+  if (mutation.operation === "update" && typeof mutation.baseVersion !== "number") {
+    return validationNack("baseVersion is required for update mutations");
   }
 
   const entry = findSyncEntryByCollectionTag(mutation.collection);

--- a/api/src/sync/mutationHandler.ts
+++ b/api/src/sync/mutationHandler.ts
@@ -1,12 +1,21 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: the mutation handler operates generically across registered models
 import type express from "express";
+import {DateTime} from "luxon";
 import mongoose from "mongoose";
 import type {User} from "../auth";
 import {isAPIError} from "../errors";
 import {logger} from "../logger";
 import {findOneOrNoneFor} from "../plugins";
-import {executeCreate, executeDelete, executeUpdate, isExecutorConflictError} from "./executors";
-import {SyncMutation, type SyncMutationDocument} from "./models";
+import {
+  executeCreate,
+  executeDelete,
+  executeUpdate,
+  isExecutorConflictError,
+  runPostCreate,
+  runPostDelete,
+  runPostUpdate,
+} from "./executors";
+import {SYNC_MUTATION_LEASE_MS, SyncMutation, type SyncMutationDocument} from "./models";
 import {findSyncEntryByCollectionTag, type SyncRegistryEntry} from "./registry";
 import {serializeSyncDoc} from "./routes";
 import type {
@@ -30,6 +39,28 @@ import type {
  * Conflict rule: the client's `baseVersion` (the `_syncSeq` it last saw) is passed to
  * executeUpdate as a seq concurrency check; a mismatch yields a `conflict` nack carrying
  * the canonical serialized server document and its current seq.
+ *
+ * C5 crash resilience (FIX 6):
+ * - **Lease/takeover (M4).** A `pending` row carries `claimedAt`. If a server crashes
+ *   between claiming the row and finalizing it, the mutationId would otherwise be wedged
+ *   for the full 30-day TTL. A duplicate-claim attempt older than
+ *   {@link SYNC_MUTATION_LEASE_MS} may take over via an atomic
+ *   `findOneAndUpdate({_id, status: "pending", claimedAt: {$lt: cutoff}}, {$set: {claimedAt: now}})`
+ *   and re-run the mutation as the new claimant. Because the original attempt may have
+ *   already landed the write before crashing, the executor path tolerates that: a create
+ *   that hits E11000 on the SAME `_id` reads the doc back and reports it as the ack instead
+ *   of nacking; an update/delete whose current server seq already reflects this mutation's
+ *   expected post-write seq (`baseVersion + 1`) is treated as already-applied and reported
+ *   from the current doc rather than re-executed (which would otherwise spuriously conflict
+ *   against the write it is itself retrying).
+ * - **Finalize-before-post-hooks (M5).** The pipeline is: document write → finalize the
+ *   ledger `applied` (with the ack payload) → THEN run the model's post-hook
+ *   (`postCreate`/`postUpdate`/`postDelete`). A post-hook throw is `logger.error`'d and
+ *   reported back as an ack with a `warning` field — never converted into a nack, since the
+ *   write (and its delta) already committed and rolling the client back would be a lie. If
+ *   the `applied` finalize itself throws, the request is allowed to fail loudly (500); the
+ *   client's transport retry lands on the lease-takeover path above, which resolves it from
+ *   the ledger/doc state rather than double-applying.
  */
 
 /** Outcome of applying a sync mutation: an ack for the client, or a typed nack. */
@@ -77,16 +108,43 @@ const outcomeFromLedgerRow = (row: SyncMutationDocument): SyncMutationOutcome | 
 };
 
 /**
+ * C5 (FIX 6) lease takeover: a `pending` row older than {@link SYNC_MUTATION_LEASE_MS}
+ * is assumed abandoned (the original claimant crashed between claiming the row and
+ * finalizing it) — atomically re-claim it via `findOneAndUpdate` so exactly one
+ * concurrent delivery wins the takeover. Returns the re-claimed row (with a bumped
+ * `claimedAt`) on success, or `undefined` if the row is not stale/pending (someone else
+ * is actively working it, or it already finalized).
+ */
+const takeoverStaleLease = async (
+  mutationId: string
+): Promise<SyncMutationDocument | undefined> => {
+  const cutoff = DateTime.now().minus({milliseconds: SYNC_MUTATION_LEASE_MS}).toJSDate();
+  const claimed = await SyncMutation.findOneAndUpdate(
+    {claimedAt: {$lt: cutoff}, mutationId, status: "pending"},
+    {$set: {claimedAt: new Date()}},
+    {new: true}
+  );
+  return claimed ?? undefined;
+};
+
+/**
  * Another delivery claimed this mutationId: poll the ledger row until its status leaves
- * `pending` and return the recorded outcome. If it stays pending past the timeout, nack
- * `error` without modifying the row — the owning delivery will still finalize it.
+ * `pending` and return the recorded outcome. Before each poll, attempt a lease takeover
+ * (C5/FIX 6) — a `pending` row older than {@link SYNC_MUTATION_LEASE_MS} is assumed
+ * abandoned by a crashed claimant, so this delivery re-claims and re-applies it instead
+ * of waiting out the full poll budget (or worse, the 30-day TTL). If the row stays
+ * pending and un-stale past the timeout, nack `error` without modifying the row — the
+ * owning delivery will still finalize it.
  */
 const waitForRecordedOutcome = async ({
   mutationId,
   user,
+  onTakeover,
 }: {
   mutationId: string;
   user: User;
+  /** Invoked with the re-claimed row when a stale lease is taken over. */
+  onTakeover: (row: SyncMutationDocument) => Promise<SyncMutationOutcome>;
 }): Promise<SyncMutationOutcome> => {
   for (let attempt = 0; attempt < PENDING_POLL_ATTEMPTS; attempt++) {
     const row = await findOneOrNoneFor(SyncMutation, {mutationId});
@@ -102,6 +160,16 @@ const waitForRecordedOutcome = async ({
       if (outcome) {
         return outcome;
       }
+      if (row.status === "pending") {
+        const takenOver = await takeoverStaleLease(mutationId);
+        if (takenOver) {
+          logger.warn("[sync] Took over a stale mutation lease", {
+            mutationId,
+            staleForMs: Date.now() - new Date(row.claimedAt).getTime(),
+          });
+          return onTakeover(takenOver);
+        }
+      }
     }
     await sleep(PENDING_POLL_INTERVAL_MS);
   }
@@ -109,6 +177,50 @@ const waitForRecordedOutcome = async ({
     code: "error",
     message: `Mutation ${mutationId} is still in flight`,
     mutationId,
+  });
+};
+
+/**
+ * C5 (FIX 6): true when `error` is (or wraps, via `APIError.error` — see
+ * `executeCreate`'s `model.create()` catch, which wraps the raw Mongo driver
+ * error in an APIError before it ever reaches the caller) a MongoDB E11000
+ * duplicate-key error.
+ */
+const isE11000Error = (error: unknown): boolean => {
+  const candidate = error as {code?: number; error?: unknown};
+  if (candidate?.code === 11000) {
+    return true;
+  }
+  const wrapped = candidate?.error as {code?: number} | undefined;
+  return wrapped?.code === 11000;
+};
+
+/**
+ * C5 (FIX 6): true when every key/value in `data` (the mutation's own
+ * intended write) is already present on `doc` — used alongside the
+ * expected-post-write-seq check to distinguish "this mutation's own write
+ * already landed" (safe to report as already-applied) from "a genuinely
+ * different write landed and happens to have advanced the seq by exactly
+ * one" (a real conflict; a seq match alone cannot tell these apart).
+ */
+const docMatchesMutationData = (
+  doc: unknown,
+  data: Record<string, unknown> | undefined
+): boolean => {
+  if (!data) {
+    return true;
+  }
+  const asDocument = doc as {toObject?: () => Record<string, unknown>} | undefined;
+  const plain =
+    typeof asDocument?.toObject === "function"
+      ? asDocument.toObject()
+      : (doc as Record<string, unknown>);
+  return Object.entries(data).every(([key, value]) => {
+    const current = plain?.[key];
+    if (current instanceof Date && typeof value === "string") {
+      return current.toISOString() === new Date(value).toISOString();
+    }
+    return JSON.stringify(current) === JSON.stringify(value);
   });
 };
 
@@ -192,6 +304,216 @@ const finalizeNack = async ({
 };
 
 /**
+ * C5 (FIX 6): read the doc back and report it as the ack for an ALREADY-APPLIED write —
+ * used both by the create-E11000 tolerance and the update/delete already-applied check.
+ * Finalizes the ledger `applied` from the doc's actual state (not assumed) before
+ * returning, exactly like the normal apply path, so a subsequent duplicate delivery
+ * reads back the same outcome.
+ */
+const finalizeAlreadyApplied = async ({
+  claimedId,
+  doc,
+  mutation,
+}: {
+  claimedId: mongoose.Types.ObjectId;
+  doc: mongoose.Document;
+  mutation: SyncMutateRequest;
+}): Promise<{resultId: string; resultSeq: number}> => {
+  const resultId = String(doc._id);
+  const resultSeq = (doc as unknown as {_syncSeq?: number})._syncSeq ?? 0;
+  await SyncMutation.updateOne({_id: claimedId}, {$set: {resultId, resultSeq, status: "applied"}});
+  logger.info("[sync] Mutation already applied (lease-takeover tolerance)", {
+    collection: mutation.collection,
+    mutationId: mutation.mutationId,
+    seq: resultSeq,
+  });
+  return {resultId, resultSeq};
+};
+
+/**
+ * Apply a client mutation through the transport-agnostic executors (permissions,
+ * pre/post hooks, validation) against an ALREADY-CLAIMED ledger row (either a fresh claim
+ * or a lease takeover of an abandoned one — C5/FIX 6). Always finalizes the claimed row
+ * before returning so duplicate deliveries can read the outcome back.
+ *
+ * Reorder (M5): the document write finalizes the ledger `applied` BEFORE the model's
+ * post-hook runs. A post-hook throw is logged and reported as a `warning` on the ack —
+ * never converted into a nack, since the write already committed.
+ *
+ * Already-applied tolerance (M4, `isLeaseTakeover` only — a normal first attempt reports
+ * genuine conflicts/errors as usual): a lease takeover re-runs a mutation whose FIRST
+ * attempt may have already landed the write before crashing.
+ * - create: an E11000 on the same target `_id` is treated as success — the doc is read
+ *   back and reported as the ack (a genuine `_id` collision from a DIFFERENT mutation is
+ *   not expected for client-minted ids and is out of scope here).
+ * - update: re-checked reactively — if the executor's seq concurrency check throws a
+ *   conflict whose `serverSeq` is EXACTLY `baseVersion + 1` (what this mutation's own
+ *   write would have produced) while retrying via a lease takeover, that is treated as
+ *   "this exact write already landed" rather than a genuine external conflict, and the
+ *   current doc is reported as the ack instead of nacking.
+ * - delete: idempotent already (executeDelete on an already-deleted tombstone is a no-op
+ *   success in this codebase's soft-delete model), so no special tolerance is needed.
+ */
+const applyClaimedMutation = async ({
+  claimed,
+  entry,
+  mutation,
+  request,
+  user,
+  isLeaseTakeover = false,
+}: {
+  claimed: SyncMutationDocument;
+  entry: SyncRegistryEntry;
+  mutation: SyncMutateRequest;
+  request: express.Request;
+  user: User;
+  /** True when `claimed` was re-claimed from a stale lease rather than freshly inserted. */
+  isLeaseTakeover?: boolean;
+}): Promise<SyncMutationOutcome> => {
+  const mutationId = mutation.mutationId;
+  const model = mongoose.model(entry.modelName);
+
+  try {
+    let doc: mongoose.Document;
+    let postHook: (() => Promise<void>) | undefined;
+    if (mutation.operation === "create") {
+      const body: Record<string, unknown> = {...(mutation.data ?? {})};
+      if (mutation.id) {
+        body._id = mutation.id;
+      }
+      try {
+        const result = await executeCreate({
+          body,
+          model,
+          options: entry.options,
+          req: request,
+          skipPostHooks: true,
+          user,
+        });
+        doc = result.doc;
+        postHook = (): Promise<void> =>
+          runPostCreate({doc: result.doc, options: entry.options, request});
+      } catch (createError: unknown) {
+        // M4 (lease takeover only): an E11000 on the exact target _id is
+        // tolerated as "already applied" — a prior (crashed) attempt at
+        // THIS mutation landed the write before finalizing the ledger. A
+        // normal (non-takeover) first attempt reports the error as usual —
+        // client-minted UUIDs make a genuine unrelated _id collision
+        // vanishingly unlikely, so gating this on isLeaseTakeover keeps the
+        // tolerance scoped to its actual crash-recovery purpose.
+        if (isLeaseTakeover && isE11000Error(createError) && typeof mutation.id === "string") {
+          const existing = await findOneOrNoneFor(model, {_id: mutation.id});
+          if (existing) {
+            const {resultId, resultSeq} = await finalizeAlreadyApplied({
+              claimedId: claimed._id,
+              doc: existing as unknown as mongoose.Document,
+              mutation,
+            });
+            return {ack: {id: resultId, mutationId, seq: resultSeq}, type: "ack"};
+          }
+        }
+        throw createError;
+      }
+    } else if (mutation.operation === "update") {
+      try {
+        const result = await executeUpdate({
+          body: mutation.data ?? {},
+          concurrencyCheck: {baseSeq: mutation.baseVersion ?? 0, type: "seq"},
+          id: mutation.id as string,
+          model,
+          options: entry.options,
+          req: request,
+          skipPostHooks: true,
+          user,
+        });
+        doc = result.doc;
+        // biome-ignore lint/style/noNonNullAssertion: executeUpdate with skipPostHooks always returns cleanedBody/prevDoc.
+        const cleanedBody = result.cleanedBody!;
+        // biome-ignore lint/style/noNonNullAssertion: executeUpdate with skipPostHooks always returns cleanedBody/prevDoc.
+        const prevDoc = result.prevDoc!;
+        postHook = (): Promise<void> =>
+          runPostUpdate({cleanedBody, doc: result.doc, options: entry.options, prevDoc, request});
+      } catch (updateError: unknown) {
+        // M4 (lease takeover only): a conflict whose serverSeq is EXACTLY
+        // this mutation's own expected post-write seq COULD mean the write
+        // this very mutation intended already landed on a prior (crashed)
+        // attempt — but a seq match alone is ambiguous (any other write
+        // landing between the claim and the retry would also bump the seq
+        // by exactly one). Additionally require the current doc's fields to
+        // already contain every value this mutation's own `data` would have
+        // written — only THEN is it safe to treat as already-applied and
+        // report success; otherwise it is a genuine external conflict and
+        // must nack as usual, exactly like a normal (non-takeover) apply.
+        if (
+          isLeaseTakeover &&
+          isExecutorConflictError(updateError) &&
+          updateError.conflictType === "seq" &&
+          updateError.serverSeq === (mutation.baseVersion ?? 0) + 1 &&
+          docMatchesMutationData(updateError.doc, mutation.data)
+        ) {
+          const {resultId, resultSeq} = await finalizeAlreadyApplied({
+            claimedId: claimed._id,
+            doc: updateError.doc as mongoose.Document,
+            mutation,
+          });
+          return {ack: {id: resultId, mutationId, seq: resultSeq}, type: "ack"};
+        }
+        throw updateError;
+      }
+    } else {
+      const result = await executeDelete({
+        id: mutation.id as string,
+        model,
+        options: entry.options,
+        req: request,
+        skipPostHooks: true,
+        user,
+      });
+      doc = result.doc;
+      postHook = (): Promise<void> =>
+        runPostDelete({doc: result.doc, options: entry.options, request});
+    }
+
+    const resultId = String(doc._id);
+    const resultSeq = (doc as unknown as {_syncSeq?: number})._syncSeq ?? 0;
+    // M5: finalize the ledger BEFORE the post-hook runs — a post-hook throw
+    // must never make a committed write look like a failure.
+    await SyncMutation.updateOne(
+      {_id: claimed._id},
+      {$set: {resultId, resultSeq, status: "applied"}}
+    );
+    logger.info("[sync] Mutation applied", {
+      collection: mutation.collection,
+      mutationId,
+      seq: resultSeq,
+    });
+
+    let warning: string | undefined;
+    if (postHook) {
+      try {
+        await postHook();
+      } catch (postHookError: unknown) {
+        warning = errorMessageOf(postHookError);
+        logger.error("[sync] Post-hook failed after a committed mutation", {
+          collection: mutation.collection,
+          error: warning,
+          mutationId,
+        });
+      }
+    }
+    return {
+      ack: {id: resultId, mutationId, seq: resultSeq, ...(warning ? {warning} : {})},
+      type: "ack",
+    };
+  } catch (error: unknown) {
+    return finalizeNack({claimedId: claimed._id, entry, error, mutation, request});
+  }
+};
+
+const errorMessageOf = (error: unknown): string =>
+  isAPIError(error) ? error.title : error instanceof Error ? error.message : String(error);
+
+/**
  * Apply a client mutation through the transport-agnostic executors (permissions,
  * pre/post hooks, validation) with an atomic idempotency claim. Always finalizes the
  * claimed ledger row before returning so duplicate deliveries can read the outcome back.
@@ -228,10 +550,13 @@ export const applySyncMutation = async ({
     return validationNack(`Unknown sync collection: ${mutation.collection}`);
   }
 
+  const request = req ?? ({user} as unknown as express.Request);
+
   // Atomic claim: inserting the pending row first means exactly one delivery applies.
   let claimed: SyncMutationDocument;
   try {
     claimed = await SyncMutation.create({
+      claimedAt: new Date(),
       mutationId,
       status: "pending",
       userId: String(user.id),
@@ -240,54 +565,22 @@ export const applySyncMutation = async ({
     if ((error as {code?: number}).code !== 11000) {
       throw error;
     }
-    return waitForRecordedOutcome({mutationId, user});
-  }
-
-  const request = req ?? ({user} as unknown as express.Request);
-  const model = mongoose.model(entry.modelName);
-  try {
-    let doc: mongoose.Document;
-    if (mutation.operation === "create") {
-      const body: Record<string, unknown> = {...(mutation.data ?? {})};
-      if (mutation.id) {
-        body._id = mutation.id;
-      }
-      ({doc} = await executeCreate({body, model, options: entry.options, req, user}));
-    } else if (mutation.operation === "update") {
-      ({doc} = await executeUpdate({
-        body: mutation.data ?? {},
-        concurrencyCheck: {baseSeq: mutation.baseVersion ?? 0, type: "seq"},
-        id: mutation.id as string,
-        model,
-        options: entry.options,
-        req,
-        user,
-      }));
-    } else {
-      ({doc} = await executeDelete({
-        id: mutation.id as string,
-        model,
-        options: entry.options,
-        req,
-        user,
-      }));
-    }
-
-    const resultId = String(doc._id);
-    const resultSeq = (doc as unknown as {_syncSeq?: number})._syncSeq ?? 0;
-    await SyncMutation.updateOne(
-      {_id: claimed._id},
-      {$set: {resultId, resultSeq, status: "applied"}}
-    );
-    logger.info("[sync] Mutation applied", {
-      collection: mutation.collection,
+    return waitForRecordedOutcome({
       mutationId,
-      seq: resultSeq,
+      onTakeover: (takenOver) =>
+        applyClaimedMutation({
+          claimed: takenOver,
+          entry,
+          isLeaseTakeover: true,
+          mutation,
+          request,
+          user,
+        }),
+      user,
     });
-    return {ack: {id: resultId, mutationId, seq: resultSeq}, type: "ack"};
-  } catch (error: unknown) {
-    return finalizeNack({claimedId: claimed._id, entry, error, mutation, request});
   }
+
+  return applyClaimedMutation({claimed, entry, mutation, request, user});
 };
 
 /** Outcome of a batch validation pre-check (before any mutation is attempted). */

--- a/api/src/sync/mutationHandler.ts
+++ b/api/src/sync/mutationHandler.ts
@@ -9,7 +9,13 @@ import {executeCreate, executeDelete, executeUpdate, isExecutorConflictError} fr
 import {SyncMutation, type SyncMutationDocument} from "./models";
 import {findSyncEntryByCollectionTag, type SyncRegistryEntry} from "./registry";
 import {serializeSyncDoc} from "./routes";
-import type {SyncAck, SyncMutateRequest, SyncNack, SyncNackCode} from "./types";
+import type {
+  SyncAck,
+  SyncMutateBatchResponse,
+  SyncMutateRequest,
+  SyncNack,
+  SyncNackCode,
+} from "./types";
 
 /**
  * Shared mutation handler for the sync channel: `POST /sync/mutate` (HTTP fallback)
@@ -32,6 +38,9 @@ export type SyncMutationOutcome = {type: "ack"; ack: SyncAck} | {type: "nack"; n
 const PENDING_POLL_ATTEMPTS = 10;
 const PENDING_POLL_INTERVAL_MS = 100;
 const VALID_OPERATIONS = new Set(["create", "update", "delete"]);
+
+/** Maximum mutations accepted in a single `sync:mutateBatch` / `POST /sync/mutate/batch` request. */
+export const MAX_SYNC_MUTATIONS_PER_BATCH = 100;
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -279,4 +288,90 @@ export const applySyncMutation = async ({
   } catch (error: unknown) {
     return finalizeNack({claimedId: claimed._id, entry, error, mutation, request});
   }
+};
+
+/** Outcome of a batch validation pre-check (before any mutation is attempted). */
+export type SyncBatchValidationOutcome =
+  | {ok: true}
+  | {ok: false; response: SyncMutateBatchResponse};
+
+/**
+ * Up-front validation shared by both batch transports (HTTP and socket): reject an
+ * oversized batch or one with intra-batch duplicate mutationIds before anything is
+ * applied. On failure, returns a single-element `results` array carrying a
+ * `validation` nack for the offending mutation (or an empty-batch guard) — mirroring
+ * the shape callers expect from `applySyncMutationBatch`, but produced without
+ * touching the idempotency ledger since nothing was attempted.
+ */
+export const validateSyncMutationBatch = (
+  mutations: SyncMutateRequest[]
+): SyncBatchValidationOutcome => {
+  if (mutations.length > MAX_SYNC_MUTATIONS_PER_BATCH) {
+    return {
+      ok: false,
+      response: {
+        results: [
+          makeNack({
+            code: "validation",
+            message: `Batch of ${mutations.length} exceeds the maximum of ${MAX_SYNC_MUTATIONS_PER_BATCH} mutations`,
+            mutationId: "",
+          }) as {type: "nack"; nack: SyncNack},
+        ],
+      },
+    };
+  }
+  const seen = new Set<string>();
+  for (const mutation of mutations) {
+    const mutationId = typeof mutation?.mutationId === "string" ? mutation.mutationId : "";
+    if (mutationId && seen.has(mutationId)) {
+      return {
+        ok: false,
+        response: {
+          results: [
+            makeNack({
+              code: "validation",
+              message: `Duplicate mutationId within batch: ${mutationId}`,
+              mutationId,
+            }) as {type: "nack"; nack: SyncNack},
+          ],
+        },
+      };
+    }
+    seen.add(mutationId);
+  }
+  return {ok: true};
+};
+
+/**
+ * Apply a batch of mutations strictly serially, in array order, reusing
+ * `applySyncMutation` per item — full reuse of the idempotency ledger, executors,
+ * permissions, and delta emission. Stops immediately at the first non-ack outcome
+ * (the user's hard requirement, INV-1): mutations after it are neither attempted nor
+ * ledgered, and are safe for the client to resend later (INV-3).
+ *
+ * Callers MUST run {@link validateSyncMutationBatch} first (oversized/duplicate
+ * rejection happens before any mutation is attempted); this function assumes the
+ * batch already passed that check.
+ */
+export const applySyncMutationBatch = async ({
+  user,
+  mutations,
+  req,
+}: {
+  user: User;
+  mutations: SyncMutateRequest[];
+  /** The real Express request when called over HTTP; hooks receive a `{user}` stub otherwise. */
+  req?: express.Request;
+}): Promise<SyncMutateBatchResponse> => {
+  const results: SyncMutateBatchResponse["results"] = [];
+  for (const mutation of mutations) {
+    const outcome = await applySyncMutation({mutation, req, user});
+    results.push(outcome);
+    if (outcome.type === "nack") {
+      // Stop-on-error: the client re-sends everything after this point, and
+      // INV-3's idempotency ledger makes that overlap safe.
+      break;
+    }
+  }
+  return {results};
 };

--- a/api/src/sync/registry.ts
+++ b/api/src/sync/registry.ts
@@ -26,6 +26,16 @@ export interface SyncRegistryEntry {
 const syncRegistry: SyncRegistryEntry[] = [];
 
 /**
+ * C8: snapshot-index creation is kicked off (fire-and-forget) at registration, but its
+ * failure must be a STARTUP error, not a swallowed warning (a missing index table-scans
+ * the snapshot query under load). Each registration records its index promise here;
+ * `ensureSyncIndexes()` awaits them and throws on any failure so server startup can fail
+ * loudly. A detached failure is also logged so it is never silent even if startup never
+ * calls `ensureSyncIndexes`.
+ */
+const indexCreationPromises: Promise<void>[] = [];
+
+/**
  * Register a model for local-first sync. Called automatically by modelRouter when the
  * `sync` option is provided. Validates the schema contract at startup and throws with
  * an actionable message when it is not met:
@@ -73,10 +83,19 @@ export const registerSync = ({
   if (syncRegistry.some((entry) => entry.modelName === name)) {
     throw new Error(`Model ${name} is already registered for sync.`);
   }
+  // C8: a duplicate collectionTag would make two models share sync streams and route
+  // snapshots/deltas ambiguously — reject it loudly at registration.
+  const collectionTag = routePath.replace(/^\//, "");
+  if (syncRegistry.some((entry) => entry.collectionTag === collectionTag)) {
+    throw new Error(
+      `Sync collection tag "${collectionTag}" is already registered (routePath ${routePath}). ` +
+        "Each synced model must have a unique route path."
+    );
+  }
 
   syncRegistry.push({
     collectionName: model.collection.collectionName,
-    collectionTag: routePath.replace(/^\//, ""),
+    collectionTag,
     config,
     modelName: name,
     options,
@@ -85,10 +104,33 @@ export const registerSync = ({
 
   // Compound index for snapshot/catch-up queries: {scopeField, _syncSeq}. Created
   // directly on the collection because the model is already compiled at registration.
+  // C8: track the promise so `ensureSyncIndexes()` (server startup) can fail loudly on a
+  // createIndex error — a missing index table-scans the snapshot query under load. The
+  // detached path only logs (never throws into an orphaned promise).
   const indexSpec: Record<string, 1> = scopeField ? {[scopeField]: 1, _syncSeq: 1} : {_syncSeq: 1};
-  void model.collection.createIndex(indexSpec).catch((error: unknown) => {
-    logger.warn(`[sync] Failed to create sync index for ${name}`, {error: String(error)});
-  });
+  const indexPromise = model.collection
+    .createIndex(indexSpec)
+    .then(() => {})
+    .catch((error: unknown) => {
+      logger.error(`[sync] Failed to create sync index for ${name}`, {error: String(error)});
+      throw new Error(
+        `Failed to create sync snapshot index for ${name}: ${String(error)}. ` +
+          "The snapshot/catch-up query requires this index; fix the schema/DB and restart."
+      );
+    });
+  indexCreationPromises.push(indexPromise);
+  // Swallow the detached rejection (already logged) so it is not an unhandled rejection;
+  // `ensureSyncIndexes()` still observes it via the retained promise above.
+  indexPromise.catch(() => {});
+};
+
+/**
+ * C8: await every registered snapshot-index creation, throwing on the first failure.
+ * Call at server startup (after all models register) so a missing index fails the boot
+ * loudly rather than silently degrading the snapshot query to a table scan.
+ */
+export const ensureSyncIndexes = async (): Promise<void> => {
+  await Promise.all(indexCreationPromises);
 };
 
 /** Get all registered sync models. */
@@ -113,4 +155,5 @@ export const findSyncEntryByCollectionName = (
 /** Clear the registry (for testing). */
 export const clearSyncRegistry = (): void => {
   syncRegistry.length = 0;
+  indexCreationPromises.length = 0;
 };

--- a/api/src/sync/routes.ts
+++ b/api/src/sync/routes.ts
@@ -6,16 +6,57 @@ import {authenticateMiddleware, type User} from "../auth";
 import {APIError, apiErrorMiddleware} from "../errors";
 import {checkPermissions} from "../permissions";
 import {getOrCreateSyncKeyMaterial} from "./models";
-import {applySyncMutation} from "./mutationHandler";
+import {
+  applySyncMutation,
+  applySyncMutationBatch,
+  MAX_SYNC_MUTATIONS_PER_BATCH,
+  validateSyncMutationBatch,
+} from "./mutationHandler";
 import {findSyncEntryByCollectionTag, type SyncRegistryEntry} from "./registry";
 import {serializeSyncPayload} from "./serialize";
 import {getScopeField} from "./streams";
 import type {
   SyncEntityPayload,
+  SyncMutateBatchRequest,
   SyncMutateRequest,
   SyncNackCode,
   SyncSnapshotResponse,
 } from "./types";
+
+/** Maximum `POST /sync/mutate` and `/sync/mutate/batch` requests per user per second (HTTP). */
+export const MAX_SYNC_HTTP_MUTATIONS_PER_SECOND = 100;
+
+/**
+ * Rolling one-second per-user mutation counter for the HTTP mutate routes, mirroring
+ * the socket path's rate limit (which counts each mutation in a batch, not each
+ * request/batch itself). Module-level so it survives across requests on the same
+ * process; per-userId windows keep one heavy user from limiting another.
+ */
+const httpMutationWindows = new Map<string, {windowStart: number; count: number}>();
+
+/**
+ * Returns true when `weight` more mutations would exceed the per-second budget for
+ * `userId`, WITHOUT consuming budget (callers decide whether to still count it).
+ */
+const wouldExceedHttpMutationRateLimit = (userId: string, weight: number): boolean => {
+  const now = Date.now();
+  const entry = httpMutationWindows.get(userId);
+  if (!entry || now - entry.windowStart >= 1000) {
+    return weight > MAX_SYNC_HTTP_MUTATIONS_PER_SECOND;
+  }
+  return entry.count + weight > MAX_SYNC_HTTP_MUTATIONS_PER_SECOND;
+};
+
+/** Consume `weight` mutations from the user's rolling one-second HTTP window. */
+const consumeHttpMutationRateLimit = (userId: string, weight: number): void => {
+  const now = Date.now();
+  const entry = httpMutationWindows.get(userId);
+  if (!entry || now - entry.windowStart >= 1000) {
+    httpMutationWindows.set(userId, {count: weight, windowStart: now});
+    return;
+  }
+  entry.count += weight;
+};
 
 /** Options for the SyncApp plugin's HTTP routes. */
 export interface SyncAppOptions {
@@ -190,6 +231,17 @@ export const addSyncRoutes = (app: express.Application, options: SyncAppOptions 
       if (!user) {
         throw new APIError({status: 401, title: "Authentication required"});
       }
+      const userId = String(user.id);
+      if (wouldExceedHttpMutationRateLimit(userId, 1)) {
+        return res.status(NACK_HTTP_STATUS.error).json({
+          nack: {
+            code: "error",
+            message: `Rate limit of ${MAX_SYNC_HTTP_MUTATIONS_PER_SECOND} mutations per second exceeded`,
+            mutationId: String((req.body as SyncMutateRequest | undefined)?.mutationId ?? ""),
+          },
+        });
+      }
+      consumeHttpMutationRateLimit(userId, 1);
       const outcome = await applySyncMutation({
         mutation: req.body as SyncMutateRequest,
         req,
@@ -200,6 +252,55 @@ export const addSyncRoutes = (app: express.Application, options: SyncAppOptions 
       }
       // Duplicate deliveries reading a recorded outcome map to the same statuses.
       return res.status(NACK_HTTP_STATUS[outcome.nack.code]).json({nack: outcome.nack});
+    })
+  );
+
+  router.post(
+    "/sync/mutate/batch",
+    authenticateMiddleware(),
+    asyncHandler(async (req, res) => {
+      const user = req.user as User | undefined;
+      if (!user) {
+        throw new APIError({status: 401, title: "Authentication required"});
+      }
+      const body = req.body as SyncMutateBatchRequest | undefined;
+      const mutations = Array.isArray(body?.mutations) ? body.mutations : [];
+
+      // Batch size cap enforced BEFORE anything else (including rate limiting) —
+      // an oversized batch is a client bug, rejected loudly with no side effects.
+      if (mutations.length > MAX_SYNC_MUTATIONS_PER_BATCH) {
+        const validation = validateSyncMutationBatch(mutations);
+        if (!validation.ok) {
+          return res.status(422).json(validation.response);
+        }
+      }
+
+      const userId = String(user.id);
+      // The socket path's rate limiter counts each mutation in the batch (not
+      // each batch) against the window; mirror that here.
+      if (wouldExceedHttpMutationRateLimit(userId, mutations.length)) {
+        return res.status(NACK_HTTP_STATUS.error).json({
+          results: [
+            {
+              nack: {
+                code: "error",
+                message: `Rate limit of ${MAX_SYNC_HTTP_MUTATIONS_PER_SECOND} mutations per second exceeded`,
+                mutationId: "",
+              },
+              type: "nack",
+            },
+          ],
+        });
+      }
+      consumeHttpMutationRateLimit(userId, mutations.length);
+
+      const validation = validateSyncMutationBatch(mutations);
+      if (!validation.ok) {
+        return res.status(422).json(validation.response);
+      }
+
+      const response = await applySyncMutationBatch({mutations, req, user});
+      return res.json(response);
     })
   );
 

--- a/api/src/sync/routes.ts
+++ b/api/src/sync/routes.ts
@@ -5,22 +5,30 @@ import {asyncHandler} from "../api";
 import {authenticateMiddleware, type User} from "../auth";
 import {APIError, apiErrorMiddleware} from "../errors";
 import {checkPermissions} from "../permissions";
-import {getOrCreateSyncKeyMaterial} from "./models";
+import {
+  computeStableFrontier,
+  getOrCreateSyncKeyMaterial,
+  SyncCounter,
+  SyncScopeMove,
+  type SyncScopeMoveDocument,
+} from "./models";
 import {
   applySyncMutation,
   applySyncMutationBatch,
   MAX_SYNC_MUTATIONS_PER_BATCH,
   validateSyncMutationBatch,
 } from "./mutationHandler";
-import {findSyncEntryByCollectionTag, type SyncRegistryEntry} from "./registry";
+import {findSyncEntryByCollectionTag, getSyncRegistry, type SyncRegistryEntry} from "./registry";
 import {serializeSyncPayload} from "./serialize";
-import {getScopeField} from "./streams";
+import {getScopeField, parseStreamKey, resolveUserStreamsForEntry} from "./streams";
 import type {
   SyncEntityPayload,
   SyncMutateBatchRequest,
   SyncMutateRequest,
   SyncNackCode,
   SyncSnapshotResponse,
+  SyncStreamInfo,
+  SyncStreamsResponse,
 } from "./types";
 
 /** Maximum `POST /sync/mutate` and `/sync/mutate/batch` requests per user per second (HTTP). */
@@ -107,45 +115,39 @@ export const serializeSyncDoc = async ({
 }): Promise<unknown> =>
   serializeSyncPayload({doc: doc as unknown as Record<string, unknown>, entry, req});
 
-/** Build the server-enforced scope filter for a snapshot request. */
-export const buildSnapshotScopeFilter = async ({
+/**
+ * C2: build the server-enforced scope filter for a SINGLE stream. The stream's scope
+ * value has already been verified against the user's membership set by the caller, so
+ * this filters to exactly that one value (`{field: value}`), never an `$in`.
+ *
+ * Custom-resolver scopes cannot be inverted into a query field, so they still route
+ * through the required `snapshotFilter` (parameterized by the user, as before).
+ */
+export const buildSnapshotScopeFilter = ({
   entry,
-  user,
-  options,
+  scopeValue,
+  snapshotFilterResult,
 }: {
   entry: SyncRegistryEntry;
-  user: User;
-  options: SyncAppOptions;
-}): Promise<Record<string, unknown>> => {
-  const {scope, snapshotFilter} = entry.config;
-  if (snapshotFilter) {
-    return snapshotFilter({id: String(user.id)});
-  }
+  scopeValue: string | null;
+  snapshotFilterResult?: Record<string, unknown>;
+}): Record<string, unknown> => {
+  const {scope} = entry.config;
   if (typeof scope === "function") {
-    // Unreachable for registered models (validated at registration), kept as a guard.
-    throw new APIError({
-      status: 500,
-      title: `Sync collection ${entry.collectionTag} has a custom scope without a snapshotFilter`,
-    });
+    // Custom scope: snapshotFilter is required at registration.
+    if (!snapshotFilterResult) {
+      throw new APIError({
+        status: 500,
+        title: `Sync collection ${entry.collectionTag} has a custom scope without a snapshotFilter`,
+      });
+    }
+    return snapshotFilterResult;
   }
   if (scope.type === "broadcast") {
     return {};
   }
   const field = getScopeField(scope) as string;
-  if (scope.type === "owner") {
-    return {[field]: user.id};
-  }
-  // Tenant scope: restrict to the user's tenant memberships.
-  if (!options.getUserScopes) {
-    throw new APIError({
-      status: 500,
-      title:
-        `Sync collection ${entry.collectionTag} is tenant-scoped but SyncApp has no ` +
-        "getUserScopes resolver",
-    });
-  }
-  const scopes = await options.getUserScopes(user, entry);
-  return {[field]: {$in: scopes}};
+  return {[field]: scopeValue};
 };
 
 const parseNonNegativeInt = (raw: unknown, name: string, fallback: number): number => {
@@ -160,13 +162,160 @@ const parseNonNegativeInt = (raw: unknown, name: string, fallback: number): numb
 };
 
 /**
+ * C3: page the legacy (seq-0) stratum by `_id`. Legacy documents predate `syncPlugin`
+ * and carry no `_syncSeq` (or a literal 0). Returns a page + a forward `legacyCursor`
+ * while the stratum has more; returns `undefined` once the stratum is exhausted, at
+ * which point the caller switches to normal seq paging. Runs the same per-doc read
+ * check as the seq page (C6/M2).
+ */
+const pageLegacyStratum = async ({
+  model,
+  scopeFilter,
+  legacyCursorIn,
+  limit,
+  entry,
+  req,
+}: {
+  model: any;
+  scopeFilter: Record<string, unknown>;
+  legacyCursorIn?: string;
+  limit: number;
+  entry: SyncRegistryEntry;
+  req: express.Request;
+}): Promise<{entities: SyncEntityPayload[]; legacyCursor: string} | undefined> => {
+  const user = req.user as User | undefined;
+  // `deleted` MUST stay a TOP-LEVEL key so isDeletedPlugin does not re-inject its
+  // {deleted: {$ne: true}} exclusion (which only fires when the top-level filter has no
+  // `deleted` key) and hide legacy tombstones. See the seq-page query for the full note.
+  const legacyFilter: Record<string, unknown> = {
+    $and: [
+      scopeFilter,
+      {_syncSeq: {$in: [null, 0]}},
+      ...(legacyCursorIn ? [{_id: {$gt: new mongoose.Types.ObjectId(legacyCursorIn)}}] : []),
+    ],
+    deleted: {$in: [true, false]},
+  };
+  const docs = await model
+    .find(legacyFilter)
+    .sort({_id: 1})
+    .limit(limit + 1);
+  if (docs.length === 0) {
+    // Stratum exhausted (or never had legacy docs) — caller proceeds by seq.
+    return undefined;
+  }
+  const page = docs.slice(0, limit);
+  const entities: SyncEntityPayload[] = [];
+  for (const doc of page) {
+    if (!(await checkPermissions("read", entry.options.permissions.read, user, doc))) {
+      continue;
+    }
+    entities.push({
+      data: await serializeSyncDoc({doc, entry, req}),
+      deleted: Boolean(doc.deleted),
+      id: String(doc._id),
+      seq: 0,
+    });
+  }
+  const lastId = String(page[page.length - 1]._id);
+  return {entities, legacyCursor: lastId};
+};
+
+/**
+ * C7: the lowest `_syncSeq` still retained for this stream (the retention floor). A
+ * client whose stored cursor is below this may have missed compacted tombstones and must
+ * re-bootstrap. Computed as the minimum seq present among the stream's non-legacy docs
+ * and its scope-move markers; 0 when nothing has been compacted (no retention gap).
+ */
+const computeOldestRetainedSeq = async ({
+  model,
+  scopeFilter,
+  streamKey,
+}: {
+  model: any;
+  scopeFilter: Record<string, unknown>;
+  streamKey: string;
+}): Promise<number> => {
+  // `deleted` stays top-level so tombstones (retained rows too) are counted in the floor
+  // rather than hidden by isDeletedPlugin's injected exclusion.
+  const lowestDoc = await model
+    .findOne({$and: [scopeFilter, {_syncSeq: {$gt: 0}}], deleted: {$in: [true, false]}})
+    .sort({_syncSeq: 1})
+    .select({_syncSeq: 1})
+    .lean();
+  const lowestMarker = await SyncScopeMove.findOne({fromStream: streamKey})
+    .sort({seq: 1})
+    .select({seq: 1})
+    .lean();
+  const candidates: number[] = [];
+  if (lowestDoc && typeof (lowestDoc as {_syncSeq?: number})._syncSeq === "number") {
+    candidates.push((lowestDoc as {_syncSeq: number})._syncSeq);
+  }
+  if (lowestMarker && typeof (lowestMarker as {seq?: number}).seq === "number") {
+    candidates.push((lowestMarker as {seq: number}).seq);
+  }
+  // No retained rows → no retention floor to enforce.
+  return candidates.length > 0 ? Math.min(...candidates) : 0;
+};
+
+/**
+ * C1: true when the stream's head (highest claimed seq) exceeds the stable frontier —
+ * i.e. committed seqs are still coming once the in-flight writes below the frontier land.
+ */
+const frontierBelowStreamHead = async (
+  streamKey: string,
+  frontierSeq: number
+): Promise<boolean> => {
+  const counter = await SyncCounter.findOne({stream: streamKey}).select({seq: 1}).lean();
+  const head = counter ? ((counter as {seq?: number}).seq ?? 0) : 0;
+  return head > frontierSeq;
+};
+
+/**
  * Mount the SyncDB HTTP routes:
- * - GET /sync/snapshot — bootstrap/catch-up per collection with server-enforced scoping
+ * - GET /sync/streams — the authoritative set of streams the caller belongs to (C2)
+ * - GET /sync/snapshot — per-stream bootstrap/catch-up with server-enforced scoping
  * - POST /sync/mutate — HTTP fallback mutation channel over applySyncMutation
  * - GET /sync/key — per-user key material for the default encryption KeyProvider
  */
 export const addSyncRoutes = (app: express.Application, options: SyncAppOptions = {}): void => {
   const router = express.Router();
+
+  // C2: authoritative membership discovery. Runs against the full req.user (D2) so
+  // tenant memberships resolve from current organizationIds.
+  router.get(
+    "/sync/streams",
+    authenticateMiddleware(),
+    asyncHandler(async (req, res) => {
+      const user = req.user as User | undefined;
+      if (!user) {
+        throw new APIError({status: 401, title: "Authentication required"});
+      }
+      const streams: SyncStreamInfo[] = [];
+      for (const entry of getSyncRegistry()) {
+        if (!(await checkPermissions("list", entry.options.permissions.list, user))) {
+          continue;
+        }
+        try {
+          const entryStreams = await resolveUserStreamsForEntry({
+            entry,
+            getUserScopes: options.getUserScopes,
+            user,
+          });
+          for (const stream of entryStreams) {
+            streams.push({collection: entry.collectionTag, stream});
+          }
+        } catch (error: unknown) {
+          throw new APIError({
+            status: 500,
+            title: `Failed to resolve streams for ${entry.collectionTag}: ${String(error)}`,
+          });
+        }
+      }
+      const response: SyncStreamsResponse = {streams};
+      return res.json(response);
+    })
+  );
+
   router.get(
     "/sync/snapshot",
     authenticateMiddleware(),
@@ -175,18 +324,37 @@ export const addSyncRoutes = (app: express.Application, options: SyncAppOptions 
       if (!user) {
         throw new APIError({status: 401, title: "Authentication required"});
       }
-      const collection = String(req.query.collection ?? "");
-      if (!collection) {
-        throw new APIError({status: 400, title: "collection query parameter is required"});
+      const streamKey = String(req.query.stream ?? "");
+      if (!streamKey) {
+        throw new APIError({status: 400, title: "stream query parameter is required"});
       }
-      const entry = findSyncEntryByCollectionTag(collection);
+      const parsed = parseStreamKey(streamKey);
+      if (!parsed) {
+        throw new APIError({status: 400, title: `Invalid stream key: ${streamKey}`});
+      }
+      const entry = findSyncEntryByCollectionTag(parsed.collectionTag);
       if (!entry) {
-        throw new APIError({status: 404, title: `Unknown sync collection: ${collection}`});
+        throw new APIError({
+          status: 404,
+          title: `Unknown sync collection: ${parsed.collectionTag}`,
+        });
       }
       if (!(await checkPermissions("list", entry.options.permissions.list, user))) {
         throw new APIError({
           status: 403,
-          title: `Access to sync snapshot for ${collection} denied for ${user.id}`,
+          title: `Access to sync snapshot for ${parsed.collectionTag} denied for ${user.id}`,
+        });
+      }
+      // C2: a client must not snapshot a stream it does not belong to.
+      const memberStreams = await resolveUserStreamsForEntry({
+        entry,
+        getUserScopes: options.getUserScopes,
+        user,
+      });
+      if (!memberStreams.includes(streamKey)) {
+        throw new APIError({
+          status: 403,
+          title: `User ${user.id} does not belong to stream ${streamKey}`,
         });
       }
 
@@ -197,37 +365,118 @@ export const addSyncRoutes = (app: express.Application, options: SyncAppOptions 
         options.defaultSnapshotLimit ?? DEFAULT_SNAPSHOT_LIMIT
       );
       const limit = Math.min(Math.max(requestedLimit, 1), MAX_SNAPSHOT_LIMIT);
+      const legacyCursorIn =
+        typeof req.query.legacyCursor === "string" && req.query.legacyCursor.length > 0
+          ? req.query.legacyCursor
+          : undefined;
 
-      const scopeFilter = await buildSnapshotScopeFilter({entry, options, user});
+      const snapshotFilterResult = entry.config.snapshotFilter
+        ? await entry.config.snapshotFilter({id: String(user.id)})
+        : undefined;
+      const scopeFilter = buildSnapshotScopeFilter({
+        entry,
+        scopeValue: parsed.scopeValue,
+        snapshotFilterResult,
+      });
       const model = mongoose.model(entry.modelName);
-      // deleted must be explicitly matched: isDeletedPlugin auto-injects
-      // {deleted: {$ne: true}} into find() and would silently hide the tombstones
-      // that catch-up depends on. Legacy docs without a _syncSeq are included in the
-      // first page (cursor=0) and report seq 0.
-      const seqFilter =
-        cursor === 0
-          ? {$or: [{_syncSeq: {$gt: 0}}, {_syncSeq: {$exists: false}}]}
-          : {_syncSeq: {$gt: cursor}};
+      const frontierSeq = await computeStableFrontier({stream: streamKey});
+      const oldestRetainedSeq = await computeOldestRetainedSeq({model, scopeFilter, streamKey});
+
+      // C3: legacy (seq-0) stratum, paged by _id. Drained fully before seq paging begins.
+      if (cursor === 0) {
+        const legacyResult = await pageLegacyStratum({
+          entry,
+          legacyCursorIn,
+          limit,
+          model,
+          req,
+          scopeFilter,
+        });
+        if (legacyResult) {
+          const response: SyncSnapshotResponse = {
+            cursor: 0,
+            entities: legacyResult.entities,
+            frontierSeq,
+            hasMore: true,
+            legacyCursor: legacyResult.legacyCursor,
+            oldestRetainedSeq,
+            stream: streamKey,
+          };
+          return res.json(response);
+        }
+      }
+
+      // C1: never page past the stable frontier — a cursor must not cross an uncommitted hole.
+      const seqFilter = {_syncSeq: {$gt: cursor, $lte: frontierSeq}};
+      // M1: compose the scope + seq clauses with $and (never spread-merge, which lets a
+      // scopeFilter $or clobber the seq clause). `deleted` MUST stay a TOP-LEVEL key:
+      // isDeletedPlugin injects {deleted: {$ne: true}} only when the top-level filter has
+      // no `deleted` key — burying it inside $and would let the plugin re-inject its
+      // exclusion and hide the tombstones catch-up depends on.
+      const query = {$and: [scopeFilter, seqFilter], deleted: {$in: [true, false]}};
       const docs = await model
-        .find({...scopeFilter, deleted: {$in: [true, false]}, ...seqFilter})
+        .find(query)
         .sort({_syncSeq: 1})
         .limit(limit + 1);
 
+      // C4: merge SyncScopeMove markers for THIS (old) stream into the page as tombstones,
+      // so an offline old-stream client learns the doc left its stream.
+      const markers = await SyncScopeMove.find({
+        fromStream: streamKey,
+        seq: {$gt: cursor, $lte: frontierSeq},
+      })
+        .sort({seq: 1})
+        .limit(limit + 1)
+        .lean();
+
       const page = docs.slice(0, limit);
-      const entities: SyncEntityPayload[] = await Promise.all(
-        page.map(
-          async (doc: any): Promise<SyncEntityPayload> => ({
-            data: await serializeSyncDoc({doc, entry, req}),
-            deleted: Boolean(doc.deleted),
-            id: String(doc._id),
-            seq: doc._syncSeq ?? 0,
-          })
-        )
+      // C6 (M2): run the same per-doc read permission the delta path uses; drop denied
+      // docs but still advance the cursor past them (parity with delta behavior).
+      const docEntities: SyncEntityPayload[] = [];
+      for (const doc of page as any[]) {
+        const allowed = await checkPermissions("read", entry.options.permissions.read, user, doc);
+        if (!allowed) {
+          continue;
+        }
+        const isTombstone = Boolean(doc.deleted);
+        docEntities.push({
+          // C7: tombstones carry no data (privacy + payload growth) — only id/seq/deleted.
+          data: isTombstone ? null : await serializeSyncDoc({doc, entry, req}),
+          deleted: isTombstone,
+          id: String(doc._id),
+          seq: doc._syncSeq ?? 0,
+        });
+      }
+      const markerEntities: SyncEntityPayload[] = markers.map(
+        (m: SyncScopeMoveDocument): SyncEntityPayload => ({
+          data: null,
+          deleted: true,
+          id: m.entityId,
+          seq: m.seq,
+        })
       );
+      // Union doc page + marker tombstones, sort by seq, page by frontier/limit.
+      const merged = [...docEntities, ...markerEntities].sort((a, b) => a.seq - b.seq);
+      const entities = merged.slice(0, limit);
+
+      // hasMore when: a full doc page was returned, extra markers remain, or the frontier
+      // sits below the head (more committed seqs are coming once in-flight writes land).
+      const docsHaveMore = docs.length > limit;
+      const markersHaveMore = markers.length > limit || merged.length > entities.length;
+      const frontierBelowHead = await frontierBelowStreamHead(streamKey, frontierSeq);
+      const hasMore = docsHaveMore || markersHaveMore || frontierBelowHead;
+
+      // C1: never advance the client past an uncommitted hole — clamp the returned cursor
+      // to the frontier (and to the highest entity seq actually included).
+      const lastEntitySeq = entities.length > 0 ? entities[entities.length - 1].seq : cursor;
+      const nextCursor = Math.min(Math.max(lastEntitySeq, cursor), frontierSeq);
       const response: SyncSnapshotResponse = {
-        cursor: entities.length > 0 ? entities[entities.length - 1].seq : cursor,
+        cursor: nextCursor,
         entities,
-        hasMore: docs.length > limit,
+        frontierSeq,
+        hasMore,
+        oldestRetainedSeq,
+        stream: streamKey,
       };
       return res.json(response);
     })

--- a/api/src/sync/routes.ts
+++ b/api/src/sync/routes.ts
@@ -58,6 +58,15 @@ const consumeHttpMutationRateLimit = (userId: string, weight: number): void => {
   entry.count += weight;
 };
 
+/** Milliseconds remaining in `userId`'s current rate-limit window, for `retryAfterMs`. */
+const httpMutationRateLimitRetryAfterMs = (userId: string): number => {
+  const entry = httpMutationWindows.get(userId);
+  if (!entry) {
+    return 1000;
+  }
+  return Math.max(0, 1000 - (Date.now() - entry.windowStart));
+};
+
 /** Options for the SyncApp plugin's HTTP routes. */
 export interface SyncAppOptions {
   /**
@@ -77,6 +86,7 @@ const DEFAULT_SNAPSHOT_LIMIT = 500;
 const NACK_HTTP_STATUS: Record<SyncNackCode, number> = {
   conflict: 409,
   error: 500,
+  rate_limited: 429,
   unauthorized: 403,
   validation: 422,
 };
@@ -233,11 +243,12 @@ export const addSyncRoutes = (app: express.Application, options: SyncAppOptions 
       }
       const userId = String(user.id);
       if (wouldExceedHttpMutationRateLimit(userId, 1)) {
-        return res.status(NACK_HTTP_STATUS.error).json({
+        return res.status(NACK_HTTP_STATUS.rate_limited).json({
           nack: {
-            code: "error",
+            code: "rate_limited",
             message: `Rate limit of ${MAX_SYNC_HTTP_MUTATIONS_PER_SECOND} mutations per second exceeded`,
             mutationId: String((req.body as SyncMutateRequest | undefined)?.mutationId ?? ""),
+            retryAfterMs: httpMutationRateLimitRetryAfterMs(userId),
           },
         });
       }
@@ -279,13 +290,14 @@ export const addSyncRoutes = (app: express.Application, options: SyncAppOptions 
       // The socket path's rate limiter counts each mutation in the batch (not
       // each batch) against the window; mirror that here.
       if (wouldExceedHttpMutationRateLimit(userId, mutations.length)) {
-        return res.status(NACK_HTTP_STATUS.error).json({
+        return res.status(NACK_HTTP_STATUS.rate_limited).json({
           results: [
             {
               nack: {
-                code: "error",
+                code: "rate_limited",
                 message: `Rate limit of ${MAX_SYNC_HTTP_MUTATIONS_PER_SECOND} mutations per second exceeded`,
                 mutationId: "",
+                retryAfterMs: httpMutationRateLimitRetryAfterMs(userId),
               },
               type: "nack",
             },

--- a/api/src/sync/scripts/compactTombstones.test.ts
+++ b/api/src/sync/scripts/compactTombstones.test.ts
@@ -1,0 +1,175 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: test model typing
+import {beforeAll, beforeEach, describe, expect, it} from "bun:test";
+import {DateTime} from "luxon";
+import {model, Schema} from "mongoose";
+import type {ModelRouterOptions} from "../../api";
+import {Permissions} from "../../permissions";
+import {createdUpdatedPlugin, type IsDeleted, isDeletedPlugin} from "../../plugins";
+import {setupDb} from "../../tests";
+import {SyncCounter, SyncScopeMove} from "../models";
+import {clearSyncRegistry, registerSync} from "../registry";
+import {syncPlugin} from "../syncSeqPlugin";
+import {
+  compactEntryTombstones,
+  compactTombstones,
+  DEFAULT_TOMBSTONE_RETENTION_DAYS,
+} from "./compactTombstones";
+
+interface CompactStuff extends IsDeleted {
+  _id: string;
+  name: string;
+  ownerId: string;
+  created: Date;
+  updated?: Date;
+  _syncSeq?: number;
+}
+
+const compactStuffSchema = new Schema<CompactStuff>({
+  name: {description: "The name of the item", required: true, type: String},
+  ownerId: {description: "The owner", type: String},
+});
+compactStuffSchema.plugin(isDeletedPlugin);
+compactStuffSchema.plugin(createdUpdatedPlugin);
+compactStuffSchema.plugin(syncPlugin);
+const CompactStuffModel = model<CompactStuff>("SyncCompactStuff", compactStuffSchema);
+
+const options = {
+  permissions: {
+    create: [Permissions.IsAuthenticated],
+    delete: [Permissions.IsAuthenticated],
+    list: [Permissions.IsAuthenticated],
+    read: [Permissions.IsAuthenticated],
+    update: [Permissions.IsAuthenticated],
+  },
+} as unknown as ModelRouterOptions<any>;
+
+beforeAll(async () => {
+  await setupDb();
+});
+
+describe("compactTombstones (C7 retention)", () => {
+  beforeEach(async () => {
+    clearSyncRegistry();
+    await Promise.all([
+      CompactStuffModel.collection.deleteMany({}),
+      SyncCounter.deleteMany({}),
+      SyncScopeMove.deleteMany({}),
+    ]);
+  });
+
+  const registerWithRetention = (retentionDays?: number): void => {
+    registerSync({
+      config: {scope: {type: "owner"}, ...(retentionDays !== undefined ? {retentionDays} : {})},
+      model: CompactStuffModel as any,
+      options,
+      routePath: "/compactStuff",
+    });
+  };
+
+  it("hard-deletes tombstones older than the retention window and keeps recent ones", async () => {
+    registerWithRetention();
+    const oldCutoff = DateTime.now()
+      .minus({days: DEFAULT_TOMBSTONE_RETENTION_DAYS + 5})
+      .toJSDate();
+
+    // Old tombstone (should be compacted): bypass mongoose so we can backdate `updated`.
+    await CompactStuffModel.collection.insertMany([
+      {created: oldCutoff, deleted: true, name: "old tombstone", ownerId: "u1", updated: oldCutoff},
+      {
+        created: new Date(),
+        deleted: true,
+        name: "recent tombstone",
+        ownerId: "u1",
+        updated: new Date(),
+      },
+      {created: new Date(), deleted: false, name: "live", ownerId: "u1", updated: new Date()},
+    ]);
+
+    const result = await compactTombstones();
+    expect(result.totalTombstones).toBe(1);
+    expect(result.byCollection.compactStuff.tombstones).toBe(1);
+
+    const remaining = await CompactStuffModel.collection.find({}).toArray();
+    const names = remaining.map((d: any) => d.name).sort();
+    // The old tombstone is gone; the recent tombstone and the live doc remain.
+    expect(names).toEqual(["live", "recent tombstone"]);
+  });
+
+  it("hard-deletes scope-move markers older than the retention window", async () => {
+    registerWithRetention();
+    const old = DateTime.now()
+      .minus({days: DEFAULT_TOMBSTONE_RETENTION_DAYS + 1})
+      .toJSDate();
+    await SyncScopeMove.collection.insertMany([
+      {
+        collectionTag: "compactStuff",
+        created: old,
+        entityId: "e-old",
+        fromStream: "compactStuff|owner:u1",
+        seq: 5,
+        toStream: "compactStuff|owner:u2",
+      },
+      {
+        collectionTag: "compactStuff",
+        created: new Date(),
+        entityId: "e-new",
+        fromStream: "compactStuff|owner:u1",
+        seq: 6,
+        toStream: "compactStuff|owner:u2",
+      },
+    ]);
+
+    const result = await compactTombstones();
+    expect(result.totalMarkers).toBe(1);
+    const remaining = await SyncScopeMove.find({});
+    expect(remaining.map((m) => m.entityId)).toEqual(["e-new"]);
+  });
+
+  it("honors a per-model retentionDays override", async () => {
+    // 1-day retention: a 2-day-old tombstone is compacted even though the default (90) would keep it.
+    registerWithRetention(1);
+    const twoDaysAgo = DateTime.now().minus({days: 2}).toJSDate();
+    await CompactStuffModel.collection.insertMany([
+      {
+        created: twoDaysAgo,
+        deleted: true,
+        name: "two days old",
+        ownerId: "u1",
+        updated: twoDaysAgo,
+      },
+    ]);
+    const entry = clearSyncRegistryAndReRegister(1);
+    const counts = await compactEntryTombstones(entry);
+    expect(counts.tombstones).toBe(1);
+    expect(await CompactStuffModel.collection.countDocuments({})).toBe(0);
+  });
+
+  it("leaves everything intact when nothing is past retention", async () => {
+    registerWithRetention();
+    await CompactStuffModel.collection.insertMany([
+      {created: new Date(), deleted: true, name: "recent", ownerId: "u1", updated: new Date()},
+    ]);
+    const result = await compactTombstones();
+    expect(result.totalTombstones).toBe(0);
+    expect(await CompactStuffModel.collection.countDocuments({})).toBe(1);
+  });
+});
+
+// Helper: re-register and return the entry (retentionDays override) for compactEntryTombstones.
+const clearSyncRegistryAndReRegister = (retentionDays: number) => {
+  clearSyncRegistry();
+  registerSync({
+    config: {retentionDays, scope: {type: "owner"}},
+    model: CompactStuffModel as any,
+    options,
+    routePath: "/compactStuff",
+  });
+  return {
+    collectionName: CompactStuffModel.collection.collectionName,
+    collectionTag: "compactStuff",
+    config: {retentionDays, scope: {type: "owner"} as const},
+    modelName: CompactStuffModel.modelName,
+    options,
+    routePath: "/compactStuff",
+  };
+};

--- a/api/src/sync/scripts/compactTombstones.ts
+++ b/api/src/sync/scripts/compactTombstones.ts
@@ -1,0 +1,84 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: operates generically across registered sync models
+import {DateTime} from "luxon";
+import mongoose from "mongoose";
+import {logger} from "../../logger";
+import {SyncScopeMove} from "../models";
+import {getSyncRegistry, type SyncRegistryEntry} from "../registry";
+
+/**
+ * C7 tombstone retention maintenance.
+ *
+ * Tombstones (soft-deleted documents kept so offline clients learn of deletions) and
+ * `SyncScopeMove` markers accumulate forever otherwise. This script hard-deletes both
+ * once they are older than the model's `retentionDays` (default 90). It is paired with
+ * the client-side rule that a cursor older than the snapshot response's
+ * `oldestRetainedSeq` triggers a full re-bootstrap of that stream — so compacting
+ * tombstones a client has already seen is safe, and a client that missed them recovers
+ * by re-bootstrapping rather than silently keeping stale data.
+ *
+ * Run as a periodic maintenance job (cron), NOT on the request path. Requires an active
+ * Mongoose connection.
+ */
+
+/** Default retention window when a model does not override `sync.retentionDays`. */
+export const DEFAULT_TOMBSTONE_RETENTION_DAYS = 90;
+
+export interface CompactTombstonesResult {
+  /** Per-collection counts of hard-deleted tombstones and scope-move markers. */
+  byCollection: Record<string, {tombstones: number; markers: number}>;
+  /** Total tombstones hard-deleted. */
+  totalTombstones: number;
+  /** Total scope-move markers hard-deleted. */
+  totalMarkers: number;
+}
+
+const retentionCutoff = (entry: SyncRegistryEntry): Date => {
+  const days = entry.config.retentionDays ?? DEFAULT_TOMBSTONE_RETENTION_DAYS;
+  return DateTime.now().minus({days}).toJSDate();
+};
+
+/**
+ * Compact tombstones and scope-move markers for one registry entry: hard-delete
+ * soft-deleted documents whose `updated` (falling back to `created`) predates the
+ * retention window, plus scope-move markers older than the window.
+ */
+export const compactEntryTombstones = async (
+  entry: SyncRegistryEntry
+): Promise<{tombstones: number; markers: number}> => {
+  const cutoff = retentionCutoff(entry);
+  const model = mongoose.model(entry.modelName);
+  // Hard delete soft-deleted docs older than the cutoff. deleteMany on the raw collection
+  // bypasses the syncPlugin guard (which blocks deleteMany on the model) — this is a
+  // deliberate maintenance-only escape hatch.
+  const tombstoneResult = await model.collection.deleteMany({
+    $or: [{updated: {$lt: cutoff}}, {created: {$lt: cutoff}, updated: {$exists: false}}],
+    deleted: true,
+  });
+  const markerResult = await SyncScopeMove.collection.deleteMany({
+    collectionTag: entry.collectionTag,
+    created: {$lt: cutoff},
+  });
+  return {
+    markers: markerResult.deletedCount ?? 0,
+    tombstones: tombstoneResult.deletedCount ?? 0,
+  };
+};
+
+/** Compact tombstones across every registered sync model. */
+export const compactTombstones = async (): Promise<CompactTombstonesResult> => {
+  const byCollection: CompactTombstonesResult["byCollection"] = {};
+  let totalTombstones = 0;
+  let totalMarkers = 0;
+  for (const entry of getSyncRegistry()) {
+    const counts = await compactEntryTombstones(entry);
+    byCollection[entry.collectionTag] = counts;
+    totalTombstones += counts.tombstones;
+    totalMarkers += counts.markers;
+    logger.info("[sync] Compacted tombstones", {
+      collection: entry.collectionTag,
+      markers: counts.markers,
+      tombstones: counts.tombstones,
+    });
+  }
+  return {byCollection, totalMarkers, totalTombstones};
+};

--- a/api/src/sync/serialize.ts
+++ b/api/src/sync/serialize.ts
@@ -34,7 +34,11 @@ export const serializeSyncPayload = async ({
     return entry.config.responseHandler(plain, method);
   }
   if (entry.options.responseHandler) {
-    return entry.options.responseHandler(doc as any, "list", req, entry.options);
+    // C8: sync serializes a SINGLE entity (snapshot row, conflict doc, or delta), so the
+    // modelRouter responseHandler must run with single-entity `"read"` semantics — not
+    // the hardcoded `"list"`, which can trigger list-only shaping (field trimming, array
+    // wrapping) that corrupts a single-doc payload.
+    return entry.options.responseHandler(doc as any, "read", req, entry.options);
   }
   if (typeof (doc as any).toJSON === "function") {
     return (doc as any).toJSON();

--- a/api/src/sync/sessionRevalidationIntegration.test.ts
+++ b/api/src/sync/sessionRevalidationIntegration.test.ts
@@ -1,0 +1,282 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: the rig bridges generic model/router/test types
+/**
+ * Integration coverage for D1 (socket session re-validation sweep) and D4
+ * (membership revocation vs socket rooms), using a REAL @terreno/syncdb client
+ * against a REAL @terreno/api backend — the same rig shape as integration.test.ts,
+ * but a dedicated file/registry/server so a short `sessionRevalidationIntervalMs`
+ * and a tenant-scoped model don't interact with that file's sequential scenarios.
+ *
+ * Scenarios:
+ * - D1: a disabled user's socket is disconnected by the sweep within one interval,
+ *   emitting sync:auth-expired first; the client lands in auth-pause with the
+ *   outbox intact (INV-2).
+ * - D4: revoking a user's only organization membership mid-session causes the
+ *   sweep to leave the tenant's sync room — no further deltas for that org reach
+ *   the live socket, even though the connection itself stays up (still a valid,
+ *   non-disabled user).
+ */
+
+import {afterAll, beforeAll, describe, expect, it} from "bun:test";
+import {createServer, type Server as HttpServer} from "node:http";
+import type {AddressInfo} from "node:net";
+import {
+  type AuthProvider,
+  clearMemoryPersisterData,
+  createHttpChannel,
+  createSocketTransport,
+  createSyncDb,
+  memoryPersisterFactory,
+  type SyncDb,
+} from "@terreno/syncdb";
+import mongoose, {model, Schema} from "mongoose";
+
+import {modelRouter} from "../api";
+import {addAuthRoutes, generateTokens, setupAuth} from "../auth";
+import {createdUpdatedPlugin, findOneOrNoneFor, type IsDeleted, isDeletedPlugin} from "../plugins";
+import {RealtimeApp} from "../realtime/realtimeApp";
+import {getBaseServer, setupDb, UserModel} from "../tests";
+import {SyncCounter, SyncMutation} from "./models";
+import {clearSyncRegistry} from "./registry";
+import {clearActiveSyncAppOptions} from "./socketHandlers";
+import {SyncApp} from "./syncApp";
+import {syncPlugin} from "./syncSeqPlugin";
+
+interface RevalProject extends IsDeleted {
+  _id: string;
+  title: string;
+  organizationId: string;
+  created: Date;
+  _syncSeq?: number;
+}
+
+const revalProjectSchema = new Schema<RevalProject>({
+  _id: {
+    default: (): string => new mongoose.Types.ObjectId().toHexString(),
+    description: "The document id (string so offline clients can mint ids)",
+    type: String,
+  },
+  organizationId: {description: "Tenant organization id", type: String},
+  title: {description: "Project title", required: true, type: String},
+});
+revalProjectSchema.plugin(isDeletedPlugin);
+revalProjectSchema.plugin(createdUpdatedPlugin);
+revalProjectSchema.plugin(syncPlugin);
+const RevalProjectModel = model<RevalProject>("RevalIntegrationProject", revalProjectSchema);
+
+const COLLECTION = "revalProjects";
+const SESSION_REVALIDATION_INTERVAL_MS = 200;
+
+/** Poll until the predicate holds; throws on timeout so failures name the wait. */
+const waitFor = async (
+  predicate: () => boolean | Promise<boolean>,
+  {label = "condition", timeoutMs = 8_000}: {label?: string; timeoutMs?: number} = {}
+): Promise<void> => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for ${label}`);
+};
+
+/** Waits at least `ms`, useful for asserting something did NOT happen by a deadline. */
+const settleFor = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Change streams (D4's delta fan-out) require a replica set — mirrors integration.test.ts. */
+const hasReplicaSet = async (): Promise<boolean> => {
+  try {
+    const admin = mongoose.connection.db?.admin();
+    const status = await admin?.command({replSetGetStatus: 1});
+    return Boolean(status?.ok);
+  } catch {
+    return false;
+  }
+};
+
+describe("session re-validation sweep integration (D1/D4)", () => {
+  let httpServer: HttpServer;
+  let realtimeApp: RealtimeApp;
+  let baseUrl = "";
+  let userDoc: {_id: unknown};
+  let replicaSetAvailable = false;
+  const memberships = new Map<string, string[]>();
+  const clients: SyncDb[] = [];
+
+  const makeAuthProvider = (user: {_id: unknown}): AuthProvider => ({
+    getToken: async () => (await generateTokens(user)).token ?? null,
+    getUserId: async () => String(user._id),
+    onAuthChange: () => () => {},
+  });
+
+  const makeClient = (name: string, user: {_id: unknown}): SyncDb => {
+    const authProvider = makeAuthProvider(user);
+    const httpChannel = createHttpChannel({authProvider, baseUrl});
+    const transport = createSocketTransport({authProvider, baseUrl, timeoutMs: 4_000});
+    clearMemoryPersisterData({databaseName: name});
+    const client = createSyncDb({
+      authProvider,
+      collections: [COLLECTION],
+      httpChannel,
+      name,
+      persisterFactory: memoryPersisterFactory,
+      reconcileIntervalMs: 0,
+      transport,
+    });
+    clients.push(client);
+    return client;
+  };
+
+  beforeAll(async () => {
+    const [, notAdmin] = await setupDb();
+    userDoc = notAdmin as unknown as {_id: unknown};
+    memberships.set(String(userDoc._id), ["org-a"]);
+    replicaSetAvailable = await hasReplicaSet();
+
+    await Promise.all([SyncCounter.ensureIndexes(), SyncMutation.ensureIndexes()]);
+    await Promise.all([
+      RevalProjectModel.collection.deleteMany({}),
+      SyncCounter.deleteMany({}),
+      SyncMutation.deleteMany({}),
+    ]);
+
+    clearSyncRegistry();
+    const registration = modelRouter<RevalProject>("/revalProjects", RevalProjectModel, {
+      permissions: {
+        create: [() => true],
+        delete: [() => true],
+        list: [() => true],
+        read: [() => true],
+        update: [() => true],
+      },
+      preCreate: (body) => body as RevalProject,
+      sync: {scope: {field: "organizationId", type: "tenant"}},
+    });
+
+    const app = getBaseServer();
+    setupAuth(app as any, UserModel as any);
+    addAuthRoutes(app as any, UserModel as any);
+    new SyncApp({
+      getUserScopes: (user) => memberships.get(String(user.id)) ?? [],
+    }).register(app);
+    app.use(registration.path, registration.router);
+
+    realtimeApp = new RealtimeApp({
+      // D1: a short sweep interval so the tests don't wait a full 60s default.
+      sessionRevalidationIntervalMs: SESSION_REVALIDATION_INTERVAL_MS,
+      userModel: UserModel as any,
+    });
+    realtimeApp.register(app);
+
+    httpServer = createServer(app);
+    await new Promise<void>((resolve) => {
+      httpServer.listen(0, () => resolve());
+    });
+    const {port} = httpServer.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+
+    realtimeApp.onServerCreated(httpServer);
+    // Give the change-stream cursor a moment to open (only delivers post-open
+    // events) — same settle the sibling integration/change-stream tests use.
+    if (replicaSetAvailable) {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    }
+  });
+
+  afterAll(async () => {
+    for (const client of clients) {
+      await client.stop().catch(() => {});
+    }
+    realtimeApp?.getIo()?.disconnectSockets(true);
+    httpServer?.closeAllConnections?.();
+    await realtimeApp?.close();
+    await new Promise<void>((resolve) => {
+      httpServer.close(() => resolve());
+    });
+    clearSyncRegistry();
+    clearActiveSyncAppOptions();
+  });
+
+  it("D1: the sweep disconnects a disabled user's socket, and the client lands in auth-pause with the outbox intact", async () => {
+    const client = makeClient("d1-disabled-user", userDoc);
+    await client.start();
+    await waitFor(() => client.getSyncStatus().isOnline, {label: "initial connect"});
+
+    // Disable the user mid-session — the sweep should notice within one interval
+    // and disconnect the socket (sync:auth-expired). Note: the HTTP channel would
+    // ALSO independently 401 on the disabled user (the existing A4 path), so wait
+    // for the socket-specific signal (isOnline flipping false) first — the only
+    // thing that can disconnect this socket mid-test is the sweep, since nothing
+    // else in this scenario touches the transport.
+    const fullUser = await findOneOrNoneFor(UserModel as any, {_id: userDoc._id});
+    (fullUser as any).disabled = true;
+    await (fullUser as any).save();
+
+    await waitFor(() => !client.getSyncStatus().isOnline, {
+      label: "socket disconnected by the sweep after being disabled",
+      timeoutMs: 5_000,
+    });
+    await waitFor(() => client.getSyncStatus().paused === "auth", {
+      label: "client paused for auth after being disabled",
+      timeoutMs: 5_000,
+    });
+    expect(client.getSyncStatus().isOnline).toBe(false);
+
+    // A mutation made while paused stays queued — nothing is lost, no budget burned.
+    const {mutationId} = client.mutate({
+      collection: COLLECTION,
+      data: {organizationId: "org-a", title: "queued while disabled"},
+      operation: "create",
+    });
+    const mutation = client.outbox.getMutation({mutationId});
+    expect(mutation?.status).toBe("queued");
+    expect(mutation?.errorNackCount).toBe(0);
+
+    // Re-enable so afterAll's client.stop() and any later scenario aren't left
+    // fighting a disabled user; also proves recovery is possible.
+    (fullUser as any).disabled = false;
+    await (fullUser as any).save();
+  }, 15_000);
+
+  it("D4: revoking the user's only organization membership stops further deltas for that tenant on the live socket", async () => {
+    if (!replicaSetAvailable) {
+      // Deltas are change-stream-driven; without a replica set there is nothing
+      // to observe. Same gating convention as api/src/sync/integration.test.ts.
+      return;
+    }
+    const client = makeClient("d4-membership-revoked", userDoc);
+    await client.start();
+    await waitFor(() => client.getSyncStatus().isOnline, {label: "initial connect"});
+
+    // Confirm the tenant stream is live: a doc created for org-a arrives as a delta.
+    const before = await RevalProjectModel.create({
+      organizationId: "org-a",
+      title: "before revoke",
+    });
+    await waitFor(
+      () => client.store.getEntity({collection: COLLECTION, id: String(before._id)}) !== undefined,
+      {label: "delta before revocation", timeoutMs: 5_000}
+    );
+
+    // Revoke membership — the sweep should leave the sync:revalProjects|tenant:org-a
+    // room within one interval.
+    memberships.set(String(userDoc._id), []);
+    await settleFor(SESSION_REVALIDATION_INTERVAL_MS * 3);
+
+    // The connection itself stays up (this user is not disabled) — only the
+    // stream membership changed.
+    expect(client.getSyncStatus().isOnline).toBe(true);
+    expect(client.getSyncStatus().paused).toBeUndefined();
+
+    const after = await RevalProjectModel.create({organizationId: "org-a", title: "after revoke"});
+    // Give a fair chance for a (wrongly) delivered delta to arrive, then assert it
+    // did not.
+    await settleFor(1_000);
+    expect(client.store.getEntity({collection: COLLECTION, id: String(after._id)})).toBeUndefined();
+
+    // Restore membership for hygiene (afterAll doesn't depend on it, but keeps the
+    // shared UserModel doc's expectations obvious to a future reader).
+    memberships.set(String(userDoc._id), ["org-a"]);
+  }, 20_000);
+});

--- a/api/src/sync/socketHandlers.ts
+++ b/api/src/sync/socketHandlers.ts
@@ -161,15 +161,24 @@ export const installSyncSocketHandlers = (
   let mutationWindowStart = 0;
   let mutationCount = 0;
 
-  /** Returns true when `weight` more mutations would exceed the per-second budget. */
-  const consumeMutationRateLimit = (weight: number): boolean => {
+  /**
+   * Consumes `weight` mutations from the rolling one-second budget. Returns
+   * `undefined` when within budget, or the remaining window (ms) to wait
+   * before retrying when the budget would be exceeded — the caller nacks
+   * `rate_limited` with that as `retryAfterMs` rather than burning any
+   * retry budget (rate limiting must never look like a durable-data error).
+   */
+  const consumeMutationRateLimit = (weight: number): number | undefined => {
     const now = Date.now();
     if (now - mutationWindowStart >= 1000) {
       mutationWindowStart = now;
       mutationCount = 0;
     }
     mutationCount += weight;
-    return mutationCount > MAX_SYNC_MUTATIONS_PER_SECOND;
+    if (mutationCount <= MAX_SYNC_MUTATIONS_PER_SECOND) {
+      return undefined;
+    }
+    return Math.max(0, 1000 - (now - mutationWindowStart));
   };
 
   socket.on("sync:subscribe", async (payload: {collections?: unknown}): Promise<void> => {
@@ -268,11 +277,13 @@ export const installSyncSocketHandlers = (
         });
       };
 
-      if (consumeMutationRateLimit(1)) {
+      const retryAfterMs = consumeMutationRateLimit(1);
+      if (retryAfterMs !== undefined) {
         logInfo(`[sync] User ${userId} hit the sync:mutate rate limit`);
         nack({
-          code: "error",
+          code: "rate_limited",
           message: `Rate limit of ${MAX_SYNC_MUTATIONS_PER_SECOND} mutations per second exceeded`,
+          retryAfterMs,
         });
         return;
       }
@@ -294,6 +305,16 @@ export const installSyncSocketHandlers = (
   socket.on(
     "sync:mutateBatch",
     async (payload: SyncMutateBatchRequest, ack?: (response: unknown) => void): Promise<void> => {
+      // FIX 5: emit the receipt IMMEDIATELY, before any processing (including
+      // rate-limit/auth checks) — this is what lets the client distinguish
+      // "no sync:mutateBatch handler at all" (silence past the grace period)
+      // from "the server is just slow finishing this batch" (a receipt
+      // arrived; the client then waits the full batch timeout instead of
+      // falling back to single sends and possibly double-processing).
+      if (typeof payload?.batchId === "string" && payload.batchId.length > 0) {
+        socket.emit("sync:batchReceived", {batchId: payload.batchId});
+      }
+
       const respondBatch = (response: SyncMutateBatchResponse): void => {
         if (typeof ack === "function") {
           ack(response);
@@ -317,11 +338,13 @@ export const installSyncSocketHandlers = (
 
       // The rate limiter counts each mutation in the batch (not the batch itself)
       // against the same window sync:mutate uses.
-      if (consumeMutationRateLimit(mutations.length)) {
+      const retryAfterMs = consumeMutationRateLimit(mutations.length);
+      if (retryAfterMs !== undefined) {
         logInfo(`[sync] User ${userId} hit the sync:mutateBatch rate limit`);
         singleNackBatch({
-          code: "error",
+          code: "rate_limited",
           message: `Rate limit of ${MAX_SYNC_MUTATIONS_PER_SECOND} mutations per second exceeded`,
+          retryAfterMs,
         });
         return;
       }

--- a/api/src/sync/socketHandlers.ts
+++ b/api/src/sync/socketHandlers.ts
@@ -5,11 +5,22 @@ import type {User} from "../auth";
 import {logger} from "../logger";
 import {checkPermissions} from "../permissions";
 import {getSocketUser, type SocketWithDecodedToken} from "../realtime/socketUser";
-import {applySyncMutation, type SyncMutationOutcome} from "./mutationHandler";
+import {
+  applySyncMutation,
+  applySyncMutationBatch,
+  MAX_SYNC_MUTATIONS_PER_BATCH,
+  type SyncMutationOutcome,
+  validateSyncMutationBatch,
+} from "./mutationHandler";
 import {findSyncEntryByCollectionTag, type SyncRegistryEntry} from "./registry";
 import type {SyncAppOptions} from "./routes";
 import {streamForScopeValue} from "./streams";
-import type {SyncMutateRequest, SyncNack} from "./types";
+import type {
+  SyncMutateBatchRequest,
+  SyncMutateBatchResponse,
+  SyncMutateRequest,
+  SyncNack,
+} from "./types";
 
 /**
  * Socket handlers for the SyncDB local-first protocol:
@@ -144,9 +155,22 @@ export const installSyncSocketHandlers = (
   // collection tag -> joined sync rooms, for unsubscribe/disconnect cleanup.
   const subscriptions = new Map<string, Set<string>>();
 
-  // Rolling one-second window for the sync:mutate rate limit.
+  // Rolling one-second window for the sync:mutate / sync:mutateBatch rate limit —
+  // shared between both events so a batch counts each of its mutations against the
+  // same budget as individual sync:mutate calls (not once per batch).
   let mutationWindowStart = 0;
   let mutationCount = 0;
+
+  /** Returns true when `weight` more mutations would exceed the per-second budget. */
+  const consumeMutationRateLimit = (weight: number): boolean => {
+    const now = Date.now();
+    if (now - mutationWindowStart >= 1000) {
+      mutationWindowStart = now;
+      mutationCount = 0;
+    }
+    mutationCount += weight;
+    return mutationCount > MAX_SYNC_MUTATIONS_PER_SECOND;
+  };
 
   socket.on("sync:subscribe", async (payload: {collections?: unknown}): Promise<void> => {
     const collections = Array.isArray(payload?.collections) ? payload.collections : null;
@@ -244,13 +268,7 @@ export const installSyncSocketHandlers = (
         });
       };
 
-      const now = Date.now();
-      if (now - mutationWindowStart >= 1000) {
-        mutationWindowStart = now;
-        mutationCount = 0;
-      }
-      mutationCount += 1;
-      if (mutationCount > MAX_SYNC_MUTATIONS_PER_SECOND) {
+      if (consumeMutationRateLimit(1)) {
         logInfo(`[sync] User ${userId} hit the sync:mutate rate limit`);
         nack({
           code: "error",
@@ -269,6 +287,61 @@ export const installSyncSocketHandlers = (
       } catch (error: unknown) {
         logger.error(`[sync] sync:mutate failed for socket ${socket.id}: ${error}`);
         nack({code: "error", message: "Internal error applying mutation"});
+      }
+    }
+  );
+
+  socket.on(
+    "sync:mutateBatch",
+    async (payload: SyncMutateBatchRequest, ack?: (response: unknown) => void): Promise<void> => {
+      const respondBatch = (response: SyncMutateBatchResponse): void => {
+        if (typeof ack === "function") {
+          ack(response);
+        }
+      };
+      const singleNackBatch = (partial: Omit<SyncNack, "mutationId">, mutationId = ""): void => {
+        respondBatch({results: [{nack: {mutationId, ...partial}, type: "nack"}]});
+      };
+
+      const mutations = Array.isArray(payload?.mutations) ? payload.mutations : [];
+
+      // Batch size cap enforced before rate limiting or auth checks — an oversized
+      // batch is a client bug, rejected loudly with no side effects.
+      if (mutations.length > MAX_SYNC_MUTATIONS_PER_BATCH) {
+        const validation = validateSyncMutationBatch(mutations);
+        if (!validation.ok) {
+          respondBatch(validation.response);
+          return;
+        }
+      }
+
+      // The rate limiter counts each mutation in the batch (not the batch itself)
+      // against the same window sync:mutate uses.
+      if (consumeMutationRateLimit(mutations.length)) {
+        logInfo(`[sync] User ${userId} hit the sync:mutateBatch rate limit`);
+        singleNackBatch({
+          code: "error",
+          message: `Rate limit of ${MAX_SYNC_MUTATIONS_PER_SECOND} mutations per second exceeded`,
+        });
+        return;
+      }
+
+      if (!user) {
+        singleNackBatch({code: "unauthorized", message: "Authentication required"});
+        return;
+      }
+
+      const validation = validateSyncMutationBatch(mutations);
+      if (!validation.ok) {
+        respondBatch(validation.response);
+        return;
+      }
+
+      try {
+        respondBatch(await applySyncMutationBatch({mutations, user}));
+      } catch (error: unknown) {
+        logger.error(`[sync] sync:mutateBatch failed for socket ${socket.id}: ${error}`);
+        singleNackBatch({code: "error", message: "Internal error applying batch"});
       }
     }
   );

--- a/api/src/sync/socketHandlers.ts
+++ b/api/src/sync/socketHandlers.ts
@@ -172,15 +172,24 @@ export const installSyncSocketHandlers = (
   let mutationWindowStart = 0;
   let mutationCount = 0;
 
-  /** Returns true when `weight` more mutations would exceed the per-second budget. */
-  const consumeMutationRateLimit = (weight: number): boolean => {
+  /**
+   * Consumes `weight` mutations from the rolling one-second budget. Returns
+   * `undefined` when within budget, or the remaining window (ms) to wait
+   * before retrying when the budget would be exceeded — the caller nacks
+   * `rate_limited` with that as `retryAfterMs` rather than burning any
+   * retry budget (rate limiting must never look like a durable-data error).
+   */
+  const consumeMutationRateLimit = (weight: number): number | undefined => {
     const now = Date.now();
     if (now - mutationWindowStart >= 1000) {
       mutationWindowStart = now;
       mutationCount = 0;
     }
     mutationCount += weight;
-    return mutationCount > MAX_SYNC_MUTATIONS_PER_SECOND;
+    if (mutationCount <= MAX_SYNC_MUTATIONS_PER_SECOND) {
+      return undefined;
+    }
+    return Math.max(0, 1000 - (now - mutationWindowStart));
   };
 
   socket.on("sync:subscribe", async (payload: {collections?: unknown}): Promise<void> => {
@@ -280,11 +289,13 @@ export const installSyncSocketHandlers = (
         });
       };
 
-      if (consumeMutationRateLimit(1)) {
+      const retryAfterMs = consumeMutationRateLimit(1);
+      if (retryAfterMs !== undefined) {
         logInfo(`[sync] User ${userId} hit the sync:mutate rate limit`);
         nack({
-          code: "error",
+          code: "rate_limited",
           message: `Rate limit of ${MAX_SYNC_MUTATIONS_PER_SECOND} mutations per second exceeded`,
+          retryAfterMs,
         });
         return;
       }
@@ -307,6 +318,16 @@ export const installSyncSocketHandlers = (
   socket.on(
     "sync:mutateBatch",
     async (payload: SyncMutateBatchRequest, ack?: (response: unknown) => void): Promise<void> => {
+      // FIX 5: emit the receipt IMMEDIATELY, before any processing (including
+      // rate-limit/auth checks) — this is what lets the client distinguish
+      // "no sync:mutateBatch handler at all" (silence past the grace period)
+      // from "the server is just slow finishing this batch" (a receipt
+      // arrived; the client then waits the full batch timeout instead of
+      // falling back to single sends and possibly double-processing).
+      if (typeof payload?.batchId === "string" && payload.batchId.length > 0) {
+        socket.emit("sync:batchReceived", {batchId: payload.batchId});
+      }
+
       const respondBatch = (response: SyncMutateBatchResponse): void => {
         if (typeof ack === "function") {
           ack(response);
@@ -330,11 +351,13 @@ export const installSyncSocketHandlers = (
 
       // The rate limiter counts each mutation in the batch (not the batch itself)
       // against the same window sync:mutate uses.
-      if (consumeMutationRateLimit(mutations.length)) {
+      const retryAfterMs = consumeMutationRateLimit(mutations.length);
+      if (retryAfterMs !== undefined) {
         logInfo(`[sync] User ${userId} hit the sync:mutateBatch rate limit`);
         singleNackBatch({
-          code: "error",
+          code: "rate_limited",
           message: `Rate limit of ${MAX_SYNC_MUTATIONS_PER_SECOND} mutations per second exceeded`,
+          retryAfterMs,
         });
         return;
       }

--- a/api/src/sync/socketHandlers.ts
+++ b/api/src/sync/socketHandlers.ts
@@ -149,11 +149,22 @@ export const installSyncSocketHandlers = (
   handlerOptions: {logInfo?: (msg: string) => void} = {}
 ): void => {
   const logInfo = handlerOptions.logInfo ?? ((): void => {});
-  const user = getSocketUser(socket);
   const userId = socket.decodedToken?.id;
 
-  // collection tag -> joined sync rooms, for unsubscribe/disconnect cleanup.
-  const subscriptions = new Map<string, Set<string>>();
+  // D2: re-derive the authorizing user on every event rather than capturing it once
+  // at install time — `socket.data.fullUser` is loaded at handshake and refreshed by
+  // D1's sweep, so a mutation sent after a refresh (e.g. after `organizationIds`
+  // changed) sees the current full user, not a handshake-time snapshot.
+  const currentUser = (): User | undefined => getSocketUser(socket);
+
+  // collection tag -> joined sync rooms, for unsubscribe/disconnect cleanup and D4's
+  // sweep-time re-resolution. Exposed on socket.data (when present — real sockets
+  // always have it; minimal test doubles may not) so the sweep, which runs outside
+  // this closure, can read and mutate it directly.
+  const subscriptions: Map<string, Set<string>> = socket.data?.syncSubscriptions ?? new Map();
+  if (socket.data) {
+    socket.data.syncSubscriptions = subscriptions;
+  }
 
   // Rolling one-second window for the sync:mutate / sync:mutateBatch rate limit —
   // shared between both events so a batch counts each of its mutations against the
@@ -198,6 +209,7 @@ export const installSyncSocketHandlers = (
         socket.emit("sync:error", {collection, message: `Unknown sync collection: ${collection}`});
         continue;
       }
+      const user = currentUser();
       if (!user) {
         socket.emit("sync:error", {collection, message: "Authentication required"});
         continue;
@@ -277,6 +289,7 @@ export const installSyncSocketHandlers = (
         return;
       }
 
+      const user = currentUser();
       if (!user) {
         nack({code: "unauthorized", message: "Authentication required"});
         return;
@@ -326,6 +339,7 @@ export const installSyncSocketHandlers = (
         return;
       }
 
+      const user = currentUser();
       if (!user) {
         singleNackBatch({code: "unauthorized", message: "Authentication required"});
         return;

--- a/api/src/sync/socketHandlers.ts
+++ b/api/src/sync/socketHandlers.ts
@@ -14,7 +14,7 @@ import {
 } from "./mutationHandler";
 import {findSyncEntryByCollectionTag, type SyncRegistryEntry} from "./registry";
 import type {SyncAppOptions} from "./routes";
-import {streamForScopeValue} from "./streams";
+import {MissingScopeResolverError, resolveUserStreamsForEntry} from "./streams";
 import type {
   SyncMutateBatchRequest,
   SyncMutateBatchResponse,
@@ -47,6 +47,13 @@ import type {
 
 /** Maximum distinct collection subscriptions per socket (DoS protection). */
 export const MAX_SYNC_COLLECTION_SUBSCRIPTIONS = 50;
+
+/**
+ * C8: maximum entries accepted in a single `sync:subscribe`/`sync:unsubscribe`
+ * `collections` array — checked BEFORE iterating so an oversized array is rejected
+ * with no per-entry work.
+ */
+export const MAX_SYNC_SUBSCRIBE_ARRAY_LENGTH = 100;
 
 /** Maximum `sync:mutate` requests accepted per socket per second. */
 export const MAX_SYNC_MUTATIONS_PER_SECOND = 100;
@@ -102,37 +109,25 @@ const resolveUserStreams = async ({
   options: SyncAppOptions;
   socket: SyncSocketLike;
 }): Promise<string[] | null> => {
-  const {scope} = entry.config;
   const collection = entry.collectionTag;
   const emitError = (message: string): void => {
     socket.emit("sync:error", {collection, message});
   };
-
-  if (typeof scope !== "function" && scope.type === "broadcast") {
-    return [streamForScopeValue({collectionTag: collection, scope, scopeValue: null})];
-  }
-  if (typeof scope !== "function" && scope.type === "owner") {
-    // Owner streams are always keyed by the authenticated socket's own userId — a
-    // client-supplied id must never select the stream.
-    return [streamForScopeValue({collectionTag: collection, scope, scopeValue: user.id})];
-  }
-
-  // Tenant and custom scopes need the server-configured membership resolver.
-  if (!options.getUserScopes) {
-    emitError(`Sync collection ${collection} requires a getUserScopes resolver on SyncApp`);
-    return null;
-  }
-  let scopeValues: string[];
   try {
-    scopeValues = await options.getUserScopes(user, entry);
+    return await resolveUserStreamsForEntry({
+      entry,
+      getUserScopes: options.getUserScopes,
+      user,
+    });
   } catch (error: unknown) {
+    if (error instanceof MissingScopeResolverError) {
+      emitError(error.message);
+      return null;
+    }
     logger.error(`[sync] getUserScopes threw for ${collection}: ${error}`);
     emitError(`Failed to resolve scopes for ${collection}`);
     return null;
   }
-  return scopeValues.map((scopeValue) =>
-    streamForScopeValue({collectionTag: collection, scope, scopeValue})
-  );
 };
 
 /**
@@ -195,6 +190,15 @@ export const installSyncSocketHandlers = (
   socket.on("sync:subscribe", async (payload: {collections?: unknown}): Promise<void> => {
     const collections = Array.isArray(payload?.collections) ? payload.collections : null;
     if (!collections) {
+      return;
+    }
+    // C8: reject an oversized array up front (length check before iterating).
+    if (collections.length > MAX_SYNC_SUBSCRIBE_ARRAY_LENGTH) {
+      logInfo(`[sync] User ${userId} sent an oversized sync:subscribe array`);
+      socket.emit("sync:error", {
+        collection: "",
+        message: `sync:subscribe accepts at most ${MAX_SYNC_SUBSCRIBE_ARRAY_LENGTH} collections`,
+      });
       return;
     }
     for (const collection of collections) {

--- a/api/src/sync/streams.ts
+++ b/api/src/sync/streams.ts
@@ -1,3 +1,5 @@
+import type {User} from "../auth";
+import type {SyncRegistryEntry} from "./registry";
 import type {SyncScope} from "./types";
 
 /**
@@ -44,6 +46,35 @@ export const streamForScopeValue = ({
   return `${collectionTag}|all`;
 };
 
+/**
+ * Parse a stream key into its collection tag and scope value. The value is everything
+ * after the first `:` following the `|`-delimited collection tag, so custom values
+ * containing `:` survive intact. Broadcast streams (`{tag}|all`) yield `scopeValue: null`.
+ * Returns null when the key is not a valid stream key.
+ */
+export const parseStreamKey = (
+  stream: string
+): {collectionTag: string; scopeKind: string; scopeValue: string | null} | null => {
+  const pipe = stream.indexOf("|");
+  if (pipe <= 0) {
+    return null;
+  }
+  const collectionTag = stream.slice(0, pipe);
+  const rest = stream.slice(pipe + 1);
+  if (rest === "all") {
+    return {collectionTag, scopeKind: "all", scopeValue: null};
+  }
+  const colon = rest.indexOf(":");
+  if (colon < 0) {
+    return null;
+  }
+  return {
+    collectionTag,
+    scopeKind: rest.slice(0, colon),
+    scopeValue: rest.slice(colon + 1),
+  };
+};
+
 /** Resolve the stream a document belongs to under the given scope. */
 export const resolveStreamForDoc = ({
   collectionTag,
@@ -62,4 +93,51 @@ export const resolveStreamForDoc = ({
   }
   const field = getScopeField(scope) as string;
   return streamForScopeValue({collectionTag, scope, scopeValue: doc[field]});
+};
+
+/**
+ * Resolve the streams a user currently belongs to for one registered entry — the
+ * authoritative membership set, shared by the socket `sync:subscribe` handler,
+ * `GET /sync/streams`, and the snapshot stream-membership check.
+ *
+ * - broadcast → the single `{collection}|all` stream.
+ * - owner → the single stream keyed by the authenticated user's own id (a client-supplied
+ *   id must never select the stream).
+ * - tenant / custom → one stream per value from `getUserScopes`. Requires the resolver;
+ *   throws {@link MissingScopeResolverError} when it is absent.
+ *
+ * Runs against the FULL user (D2) so tenant memberships resolve from current
+ * `organizationIds`.
+ */
+export class MissingScopeResolverError extends Error {
+  constructor(public collection: string) {
+    super(`Sync collection ${collection} requires a getUserScopes resolver on SyncApp`);
+    this.name = "MissingScopeResolverError";
+  }
+}
+
+export const resolveUserStreamsForEntry = async ({
+  entry,
+  user,
+  getUserScopes,
+}: {
+  entry: SyncRegistryEntry;
+  user: User;
+  getUserScopes?: (user: User, entry: SyncRegistryEntry) => Promise<string[]> | string[];
+}): Promise<string[]> => {
+  const {scope} = entry.config;
+  const collection = entry.collectionTag;
+  if (typeof scope !== "function" && scope.type === "broadcast") {
+    return [streamForScopeValue({collectionTag: collection, scope, scopeValue: null})];
+  }
+  if (typeof scope !== "function" && scope.type === "owner") {
+    return [streamForScopeValue({collectionTag: collection, scope, scopeValue: user.id})];
+  }
+  if (!getUserScopes) {
+    throw new MissingScopeResolverError(collection);
+  }
+  const scopeValues = await getUserScopes(user, entry);
+  return scopeValues.map((scopeValue) =>
+    streamForScopeValue({collectionTag: collection, scope, scopeValue})
+  );
 };

--- a/api/src/sync/sync.test.ts
+++ b/api/src/sync/sync.test.ts
@@ -457,17 +457,19 @@ describe("claimSyncSeqs", () => {
   });
 
   it("claims monotonic seqs and batch ranges", async () => {
-    expect(await claimSyncSeqs({stream: "s|a"})).toBe(1);
-    expect(await claimSyncSeqs({count: 5, stream: "s|a"})).toBe(6);
-    expect(await claimSyncSeqs({stream: "s|a"})).toBe(7);
-    expect(await claimSyncSeqs({stream: "s|b"})).toBe(1);
+    expect((await claimSyncSeqs({stream: "s|a"})).lastSeq).toBe(1);
+    const batch = await claimSyncSeqs({count: 5, stream: "s|a"});
+    expect(batch.lastSeq).toBe(6);
+    expect(batch.seqs).toEqual([2, 3, 4, 5, 6]);
+    expect((await claimSyncSeqs({stream: "s|a"})).lastSeq).toBe(7);
+    expect((await claimSyncSeqs({stream: "s|b"})).lastSeq).toBe(1);
   });
 
   it("survives concurrent first claims for a new stream", async () => {
     const results = await Promise.all(
       Array.from({length: 5}, () => claimSyncSeqs({stream: "s|fresh"}))
     );
-    expect(results.sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
+    expect(results.map((r) => r.lastSeq).sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
   });
 });
 

--- a/api/src/sync/syncApp.ts
+++ b/api/src/sync/syncApp.ts
@@ -1,5 +1,6 @@
 import type express from "express";
 import type {TerrenoPlugin} from "../terrenoPlugin";
+import {setSyncMutationScopeResolver} from "./mutationHandler";
 import {addSyncRoutes, type SyncAppOptions} from "./routes";
 import {setActiveSyncAppOptions} from "./socketHandlers";
 
@@ -23,6 +24,8 @@ export class SyncApp implements TerrenoPlugin {
 
   register(app: express.Application): void {
     setActiveSyncAppOptions(this.options);
+    // C6: the mutation-scope backstop resolves tenant memberships via the same resolver.
+    setSyncMutationScopeResolver(this.options.getUserScopes);
     addSyncRoutes(app, this.options);
   }
 }

--- a/api/src/sync/syncFrontier.test.ts
+++ b/api/src/sync/syncFrontier.test.ts
@@ -1,0 +1,274 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: test model typing
+import {beforeAll, beforeEach, describe, expect, it} from "bun:test";
+import {model, Schema} from "mongoose";
+import type {ModelRouterOptions} from "../api";
+import {createdUpdatedPlugin, type IsDeleted, isDeletedPlugin} from "../plugins";
+import {setupDb} from "../tests";
+import {
+  claimSyncSeqs,
+  computeStableFrontier,
+  confirmSyncSeqs,
+  PENDING_CLAIM_LEASE_MS,
+  SyncCounter,
+  SyncScopeMove,
+} from "./models";
+import {clearSyncRegistry, registerSync} from "./registry";
+import {syncPlugin} from "./syncSeqPlugin";
+import type {SyncConfig} from "./types";
+
+/**
+ * C1 stable-frontier + C4 scope-move-marker tests.
+ *
+ * The stable frontier is what guarantees no committed document is ever permanently
+ * skipped by cursor catch-up: a cursor may advance to seq N only when every seq <= N in
+ * the stream is committed (its claim confirmed) or reclaimed (stale lease). These tests
+ * exercise the claim/confirm/frontier math directly (forced commit inversion, random
+ * interleavings with crashes) and the write-path guards (m9/m10) + scope-move markers.
+ */
+
+interface FrontierStuff extends IsDeleted {
+  _id: string;
+  name: string;
+  ownerId: string;
+  orgId?: string;
+  created: Date;
+  updated?: Date;
+  _syncSeq?: number;
+  _syncPrevStream?: string | null;
+}
+
+const frontierSchema = new Schema<FrontierStuff>({
+  name: {description: "The name of the item", required: true, type: String},
+  orgId: {description: "The organization this item belongs to", type: String},
+  ownerId: {description: "The user who owns this item", type: String},
+});
+frontierSchema.plugin(isDeletedPlugin);
+frontierSchema.plugin(createdUpdatedPlugin);
+frontierSchema.plugin(syncPlugin);
+const FrontierModel = model<FrontierStuff>("FrontierStuff", frontierSchema);
+
+const stubOptions = {
+  permissions: {create: [], delete: [], list: [], read: [], update: []},
+} as unknown as ModelRouterOptions<any>;
+
+describe("C1 claimSyncSeqs / confirmSyncSeqs / computeStableFrontier", () => {
+  beforeAll(async () => {
+    await setupDb();
+    await SyncCounter.ensureIndexes();
+  });
+
+  beforeEach(async () => {
+    await SyncCounter.deleteMany({});
+    await SyncScopeMove.deleteMany({});
+  });
+
+  it("empty stream frontier is 0; fresh stamped stream frontier is the head once confirmed", async () => {
+    expect(await computeStableFrontier({stream: "f|empty"})).toBe(0);
+    const claim = await claimSyncSeqs({stream: "f|a"});
+    expect(claim.lastSeq).toBe(1);
+    expect(claim.registered).toBe(true);
+    // Before confirm, seq 1 is pending → frontier holds below it.
+    expect(await computeStableFrontier({stream: "f|a"})).toBe(0);
+    await confirmSyncSeqs({seqs: claim.seqs, stream: "f|a"});
+    expect(await computeStableFrontier({stream: "f|a"})).toBe(1);
+  });
+
+  it("session-backed claim registers nothing (frontier is the head immediately)", async () => {
+    // A session-backed claim commits atomically with its write — no pending window.
+    // We simulate by manually seeding the counter head without pending entries.
+    await SyncCounter.create({pending: [], seq: 5, stream: "f|session"});
+    expect(await computeStableFrontier({stream: "f|session"})).toBe(5);
+  });
+
+  it("forced commit inversion: frontier holds at 4 while seq 5 is pending, jumps to 6 after 5 confirms", async () => {
+    const stream = "f|inv";
+    // Seed a committed history up to seq 4 (no pending).
+    await SyncCounter.create({pending: [], seq: 4, stream});
+    // Writer A claims 5, writer B claims 6; B commits (confirms) FIRST (inversion).
+    const claimA = await claimSyncSeqs({stream}); // 5
+    const claimB = await claimSyncSeqs({stream}); // 6
+    expect(claimA.lastSeq).toBe(5);
+    expect(claimB.lastSeq).toBe(6);
+    await confirmSyncSeqs({seqs: claimB.seqs, stream}); // 6 committed, 5 still pending
+    // Frontier must stay at 4 — advancing to 6 would permanently skip A's seq 5.
+    expect(await computeStableFrontier({stream})).toBe(4);
+    // A commits.
+    await confirmSyncSeqs({seqs: claimA.seqs, stream});
+    // Now everything <= 6 is committed → frontier jumps to the head.
+    expect(await computeStableFrontier({stream})).toBe(6);
+  });
+
+  it("stale pending claim (crashed writer) is reclaimed at read time so the frontier is not frozen", async () => {
+    const stream = "f|stale";
+    await SyncCounter.create({pending: [], seq: 3, stream});
+    // Claim 4 and 5; 4 will be "stale" (crashed writer never confirmed).
+    const claim4 = await claimSyncSeqs({stream}); // 4
+    const claim5 = await claimSyncSeqs({stream}); // 5
+    await confirmSyncSeqs({seqs: claim5.seqs, stream}); // 5 committed, 4 pending
+    // Age out claim 4's pending entry beyond the lease.
+    const stale = new Date(Date.now() - PENDING_CLAIM_LEASE_MS - 1000);
+    await SyncCounter.updateOne(
+      {stream},
+      {$set: {"pending.$[e].claimedAt": stale}},
+      {arrayFilters: [{"e.seq": claim4.lastSeq}]}
+    );
+    // Frontier excludes the stale claim → advances to the head.
+    expect(await computeStableFrontier({stream})).toBe(5);
+    // The stale entry was opportunistically pulled.
+    const counter = await SyncCounter.findOne({stream});
+    expect((counter?.pending ?? []).some((p) => p.seq === 4)).toBe(false);
+  });
+
+  it("batch claim materializes the full range and confirms all at once", async () => {
+    const stream = "f|batch";
+    const claim = await claimSyncSeqs({count: 3, stream});
+    expect(claim.seqs).toEqual([1, 2, 3]);
+    expect(await computeStableFrontier({stream})).toBe(0);
+    await confirmSyncSeqs({seqs: claim.seqs, stream});
+    expect(await computeStableFrontier({stream})).toBe(3);
+  });
+
+  it("property-style: N writers, random commit interleavings + random crashes, no committed seq skipped", async () => {
+    // 100 seeds: each seed claims N seqs, confirms a random subset in random order,
+    // "crashes" the rest (never confirmed). After forcing every unconfirmed claim stale,
+    // the frontier must equal the head IFF every claim was confirmed-or-stale (which it
+    // is, since we force staleness) — and critically, the frontier must never sit ABOVE
+    // a seq whose claim is still live-pending.
+    for (let seed = 0; seed < 100; seed++) {
+      const stream = `f|prop-${seed}`;
+      await SyncCounter.deleteMany({stream});
+      const n = 2 + (seed % 6); // 2..7 writers
+      const claims: Awaited<ReturnType<typeof claimSyncSeqs>>[] = [];
+      for (let i = 0; i < n; i++) {
+        claims.push(await claimSyncSeqs({stream}));
+      }
+      // Randomly pick a subset to confirm, in shuffled order.
+      const order = claims
+        .map((_, i) => i)
+        .sort(() => (seed % 2 === 0 ? 1 : -1) * (Math.random() - 0.5));
+      const confirmed = new Set<number>();
+      for (const idx of order) {
+        if (Math.random() < 0.6) {
+          await confirmSyncSeqs({seqs: claims[idx].seqs, stream});
+          confirmed.add(claims[idx].lastSeq);
+        }
+      }
+      // Invariant check BEFORE aging: frontier must be < the lowest UNconfirmed seq,
+      // i.e. it never sits at or above a live-pending claim.
+      const frontier = await computeStableFrontier({stream});
+      const unconfirmed = claims.map((c) => c.lastSeq).filter((s) => !confirmed.has(s));
+      if (unconfirmed.length > 0) {
+        const minUnconfirmed = Math.min(...unconfirmed);
+        expect(frontier).toBeLessThan(minUnconfirmed);
+      }
+      // Now force every remaining pending entry stale (simulate crashed writers) and
+      // re-read: a full catch-up at the resulting frontier must include every CONFIRMED
+      // seq (none permanently skipped).
+      const stale = new Date(Date.now() - PENDING_CLAIM_LEASE_MS - 5000);
+      await SyncCounter.updateOne({stream}, {$set: {"pending.$[].claimedAt": stale}});
+      const finalFrontier = await computeStableFrontier({stream});
+      for (const seq of confirmed) {
+        expect(seq).toBeLessThanOrEqual(finalFrontier);
+      }
+    }
+  });
+});
+
+describe("C1 write-path guards (m9 / m10) + C4 scope-move markers", () => {
+  beforeAll(async () => {
+    await setupDb();
+    await SyncCounter.ensureIndexes();
+    clearSyncRegistry();
+    registerSync({
+      config: {scope: {field: "orgId", type: "tenant"}} as SyncConfig,
+      model: FrontierModel as any,
+      options: stubOptions,
+      routePath: "/frontierStuff",
+    });
+  });
+
+  beforeEach(async () => {
+    // deleteMany is blocked on the synced model; clear via the native collection.
+    await FrontierModel.collection.deleteMany({});
+    await SyncCounter.deleteMany({});
+    await SyncScopeMove.deleteMany({});
+  });
+
+  it("m10: a save with no meaningful modified paths claims no new seq", async () => {
+    const doc = await FrontierModel.create({name: "n", orgId: "org1", ownerId: "u1"});
+    const firstSeq = doc._syncSeq;
+    // Re-save without changing anything.
+    await doc.save();
+    expect(doc._syncSeq).toBe(firstSeq as number);
+    // The stream's head did not advance beyond the create.
+    const counter = await SyncCounter.findOne({stream: "frontierStuff|tenant:org1"});
+    expect(counter?.seq).toBe(firstSeq as number);
+  });
+
+  it("m10: a meaningful save DOES claim a new seq", async () => {
+    const doc = await FrontierModel.create({name: "n", orgId: "org1", ownerId: "u1"});
+    const firstSeq = doc._syncSeq as number;
+    doc.name = "renamed";
+    await doc.save();
+    expect(doc._syncSeq).toBeGreaterThan(firstSeq);
+  });
+
+  it("m9: a query-write with a non-_id filter throws the loud error", async () => {
+    await FrontierModel.create({name: "n", orgId: "org1", ownerId: "u1"});
+    await expect(FrontierModel.updateOne({name: "n"}, {$set: {name: "x"}}).exec()).rejects.toThrow(
+      /must target a single document by _id/
+    );
+  });
+
+  it("m9: an _id-targeted query-write is allowed", async () => {
+    const doc = await FrontierModel.create({name: "n", orgId: "org1", ownerId: "u1"});
+    await FrontierModel.updateOne({_id: doc._id}, {$set: {name: "renamed"}});
+    const reloaded = await FrontierModel.findById(doc._id);
+    expect(reloaded?.name).toBe("renamed");
+  });
+
+  it("m8/C6: upsert:true on a query-write throws", async () => {
+    await expect(
+      FrontierModel.updateOne(
+        {_id: "000000000000000000000001"},
+        {$set: {name: "x", orgId: "org1", ownerId: "u1"}},
+        {upsert: true}
+      ).exec()
+    ).rejects.toThrow(/upsert:true is not supported/);
+  });
+
+  it("C4: a scope move writes a durable SyncScopeMove marker on the OLD stream", async () => {
+    const doc = await FrontierModel.create({name: "n", orgId: "org1", ownerId: "u1"});
+    doc.orgId = "org2";
+    await doc.save();
+    const markers = await SyncScopeMove.find({entityId: String(doc._id)});
+    expect(markers).toHaveLength(1);
+    expect(markers[0].fromStream).toBe("frontierStuff|tenant:org1");
+    expect(markers[0].toStream).toBe("frontierStuff|tenant:org2");
+    expect(markers[0].collectionTag).toBe("frontierStuff");
+    expect(markers[0].seq).toBeGreaterThan(0);
+    // The marker's seq came from the OLD stream's counter.
+    const oldCounter = await SyncCounter.findOne({stream: "frontierStuff|tenant:org1"});
+    expect(oldCounter?.seq).toBeGreaterThanOrEqual(markers[0].seq);
+  });
+
+  it("C4: a racing second write cannot erase the marker (durable, not _syncPrevStream)", async () => {
+    const doc = await FrontierModel.create({name: "n", orgId: "org1", ownerId: "u1"});
+    doc.orgId = "org2";
+    await doc.save();
+    // A second write in the NEW stream resets _syncPrevStream to null...
+    doc.name = "again";
+    await doc.save();
+    const reloaded = await FrontierModel.findById(doc._id);
+    expect(reloaded?._syncPrevStream).toBeNull();
+    // ...but the durable marker for the org1 -> org2 move survives.
+    const markers = await SyncScopeMove.find({entityId: String(doc._id)});
+    expect(markers.some((m) => m.fromStream === "frontierStuff|tenant:org1")).toBe(true);
+  });
+
+  it("C1 migration: pre-existing stamped docs (no pending) report frontier = head immediately", async () => {
+    // Simulate a pre-deploy counter: a head with an empty pending array.
+    await SyncCounter.create({pending: [], seq: 42, stream: "frontierStuff|tenant:legacy"});
+    expect(await computeStableFrontier({stream: "frontierStuff|tenant:legacy"})).toBe(42);
+  });
+});

--- a/api/src/sync/syncPhaseC.test.ts
+++ b/api/src/sync/syncPhaseC.test.ts
@@ -1,0 +1,513 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: test model typing
+import {beforeAll, beforeEach, describe, expect, it} from "bun:test";
+import type express from "express";
+import {model, Schema} from "mongoose";
+import supertest from "supertest";
+import type TestAgent from "supertest/lib/agent";
+import type {ModelRouterOptions} from "../api";
+import {addAuthRoutes, setupAuth, type User} from "../auth";
+import {Permissions} from "../permissions";
+import {createdUpdatedPlugin, type IsDeleted, isDeletedPlugin} from "../plugins";
+import {DEFAULT_IGNORED_COLLECTIONS} from "../realtime/changeStreamWatcher";
+import {authAsUser, getBaseServer, setupDb, UserModel} from "../tests";
+import {SyncCounter, SyncKey, SyncMutation} from "./models";
+import {clearSyncRegistry, registerSync, type SyncRegistryEntry} from "./registry";
+import {SyncApp} from "./syncApp";
+import {syncPlugin} from "./syncSeqPlugin";
+
+/**
+ * Phase C route/scope tests: per-stream snapshot cursors (C2), legacy `_id` pagination
+ * (C3), write-scope enforcement + snapshot read parity (C6), and the C8 minors.
+ * C1 (frontier) and C4 (scope-move markers) have their own dedicated files.
+ */
+
+interface PhaseCTodo extends IsDeleted {
+  _id: string;
+  title: string;
+  ownerId: string;
+  _syncSeq?: number;
+}
+
+const phaseCTodoSchema = new Schema<PhaseCTodo>({
+  ownerId: {description: "The owner", type: String},
+  title: {description: "The title", required: true, type: String},
+});
+phaseCTodoSchema.plugin(isDeletedPlugin);
+phaseCTodoSchema.plugin(createdUpdatedPlugin);
+phaseCTodoSchema.plugin(syncPlugin);
+const PhaseCTodoModel = model<PhaseCTodo>("SyncPhaseCTodo", phaseCTodoSchema);
+
+interface PhaseCProject extends IsDeleted {
+  _id: string;
+  title: string;
+  orgId: string;
+  _syncSeq?: number;
+}
+
+const phaseCProjectSchema = new Schema<PhaseCProject>({
+  orgId: {description: "The organization", type: String},
+  title: {description: "The title", required: true, type: String},
+});
+phaseCProjectSchema.plugin(isDeletedPlugin);
+phaseCProjectSchema.plugin(createdUpdatedPlugin);
+phaseCProjectSchema.plugin(syncPlugin);
+const PhaseCProjectModel = model<PhaseCProject>("SyncPhaseCProject", phaseCProjectSchema);
+
+const authedOptions = {
+  permissions: {
+    create: [Permissions.IsAuthenticated],
+    delete: [Permissions.IsAuthenticated],
+    list: [Permissions.IsAuthenticated],
+    read: [Permissions.IsAuthenticated],
+    update: [Permissions.IsAuthenticated],
+  },
+} as unknown as ModelRouterOptions<any>;
+
+// Per-user tenant membership, mutable so join tests can extend it.
+const userOrgs = new Map<string, string[]>();
+
+beforeAll(async () => {
+  await Promise.all([
+    SyncCounter.ensureIndexes(),
+    SyncKey.ensureIndexes(),
+    SyncMutation.ensureIndexes(),
+  ]);
+});
+
+describe("Phase C sync routes", () => {
+  let app: express.Application;
+  let server: TestAgent;
+  let agent: TestAgent;
+  let notAdminId: string;
+
+  const ownerStream = (): string => `phaseCTodos|owner:${notAdminId}`;
+  const enc = encodeURIComponent;
+
+  beforeEach(async () => {
+    const [, notAdmin] = await setupDb();
+    notAdminId = String(notAdmin._id);
+    userOrgs.clear();
+    userOrgs.set(notAdminId, ["org1", "org2"]);
+
+    clearSyncRegistry();
+    registerSync({
+      config: {scope: {type: "owner"}},
+      model: PhaseCTodoModel as any,
+      options: authedOptions,
+      routePath: "/phaseCTodos",
+    });
+    registerSync({
+      config: {scope: {field: "orgId", type: "tenant"}},
+      model: PhaseCProjectModel as any,
+      options: authedOptions,
+      routePath: "/phaseCProjects",
+    });
+
+    await Promise.all([
+      PhaseCTodoModel.collection.deleteMany({}),
+      PhaseCProjectModel.collection.deleteMany({}),
+      SyncCounter.deleteMany({}),
+      SyncKey.deleteMany({}),
+      SyncMutation.deleteMany({}),
+    ]);
+
+    app = getBaseServer();
+    setupAuth(app as any, UserModel as any);
+    addAuthRoutes(app as any, UserModel as any);
+    new SyncApp({
+      getUserScopes: (user: User, entry: SyncRegistryEntry) => {
+        // Custom-scoped entries (used by the $or snapshotFilter test) resolve their
+        // membership to the caller's own id (the custom scope value = ownerId).
+        if (typeof entry.config.scope === "function") {
+          return [String(user.id)];
+        }
+        return userOrgs.get(String(user.id)) ?? [];
+      },
+    }).register(app);
+
+    server = supertest(app);
+    agent = await authAsUser(app, "notAdmin");
+  });
+
+  // ── C2: per-stream cursors + /sync/streams ────────────────────────────────
+  describe("C2 — per-stream cursors and /sync/streams", () => {
+    it("GET /sync/streams returns owner + tenant streams reflecting memberships", async () => {
+      const res = await agent.get("/sync/streams").expect(200);
+      const streams: string[] = res.body.streams.map((s: any) => s.stream);
+      expect(streams).toContain(ownerStream());
+      expect(streams).toContain("phaseCProjects|tenant:org1");
+      expect(streams).toContain("phaseCProjects|tenant:org2");
+      // Every entry carries its collection tag.
+      for (const s of res.body.streams) {
+        expect(typeof s.collection).toBe("string");
+      }
+    });
+
+    it("requires authentication for /sync/streams", async () => {
+      await server.get("/sync/streams").expect(401);
+    });
+
+    it("catches two tenant streams to independent cursors (the flattened-cursor bug does NOT reproduce)", async () => {
+      // org1 has a high seq (many writes), org2 a low seq. Under the OLD flattened cursor,
+      // catching org1 to its head would strand org2 behind org1's cursor. Per-stream, each
+      // catches independently.
+      for (let i = 1; i <= 6; i++) {
+        await PhaseCProjectModel.create({orgId: "org1", title: `org1-${i}`});
+      }
+      await PhaseCProjectModel.create({orgId: "org2", title: "org2-only"});
+
+      const org1 = await agent
+        .get(`/sync/snapshot?stream=${enc("phaseCProjects|tenant:org1")}`)
+        .expect(200);
+      expect(org1.body.entities).toHaveLength(6);
+      expect(org1.body.cursor).toBe(6);
+
+      // org2's stream has its OWN counter — its single doc is seq 1, fully caught up
+      // regardless of org1's cursor being at 6.
+      const org2 = await agent
+        .get(`/sync/snapshot?stream=${enc("phaseCProjects|tenant:org2")}`)
+        .expect(200);
+      expect(org2.body.entities).toHaveLength(1);
+      expect(org2.body.entities[0].data.title).toBe("org2-only");
+      expect(org2.body.entities[0].seq).toBe(1);
+      expect(org2.body.cursor).toBe(1);
+      expect(org2.body.hasMore).toBe(false);
+    });
+
+    it("reflects a tenant join in /sync/streams (new stream becomes available)", async () => {
+      let res = await agent.get("/sync/streams").expect(200);
+      expect(res.body.streams.map((s: any) => s.stream)).not.toContain(
+        "phaseCProjects|tenant:org3"
+      );
+      // Join org3.
+      userOrgs.set(notAdminId, ["org1", "org2", "org3"]);
+      res = await agent.get("/sync/streams").expect(200);
+      expect(res.body.streams.map((s: any) => s.stream)).toContain("phaseCProjects|tenant:org3");
+      // And the newly-joined stream is now snapshottable.
+      await PhaseCProjectModel.create({orgId: "org3", title: "joined"});
+      const snap = await agent
+        .get(`/sync/snapshot?stream=${enc("phaseCProjects|tenant:org3")}`)
+        .expect(200);
+      expect(snap.body.entities[0].data.title).toBe("joined");
+    });
+
+    it("403s snapshotting a tenant stream the user does not belong to", async () => {
+      await agent.get(`/sync/snapshot?stream=${enc("phaseCProjects|tenant:orgOther")}`).expect(403);
+    });
+  });
+
+  // ── C3: legacy _id pagination ──────────────────────────────────────────────
+  describe("C3 — legacy _id-paged stratum", () => {
+    it("drains a large legacy stratum via legacyCursor then continues by seq (no infinite loop)", async () => {
+      // 1201 legacy docs (no _syncSeq) via raw insert; limit 500. The old first-page-only
+      // logic looped forever; the _id stratum drains deterministically.
+      const legacy = Array.from({length: 1201}, (_v, i) => ({
+        deleted: false,
+        name: undefined,
+        ownerId: notAdminId,
+        title: `legacy-${String(i).padStart(4, "0")}`,
+      }));
+      await PhaseCTodoModel.collection.insertMany(legacy as any);
+      // A couple of modern (stamped) docs after the legacy stratum.
+      await PhaseCTodoModel.create({ownerId: notAdminId, title: "modern-1"});
+      await PhaseCTodoModel.create({ownerId: notAdminId, title: "modern-2"});
+
+      const seen = new Set<string>();
+      let cursor = 0;
+      let legacyCursor: string | undefined;
+      let pages = 0;
+      const limit = 500;
+      // Simulate the client loop: echo legacyCursor until absent, then page by seq.
+      for (;;) {
+        pages += 1;
+        expect(pages).toBeLessThan(20); // termination guard
+        const qs = new URLSearchParams({limit: String(limit), stream: ownerStream()});
+        if (cursor > 0) {
+          qs.set("cursor", String(cursor));
+        }
+        if (legacyCursor !== undefined) {
+          qs.set("legacyCursor", legacyCursor);
+        }
+        const res = await agent.get(`/sync/snapshot?${qs.toString()}`).expect(200);
+        for (const e of res.body.entities) {
+          seen.add(e.id);
+        }
+        if (res.body.legacyCursor !== undefined) {
+          legacyCursor = res.body.legacyCursor;
+          continue;
+        }
+        // Legacy stratum drained; now paging by seq.
+        legacyCursor = undefined;
+        if (!res.body.hasMore) {
+          break;
+        }
+        cursor = res.body.cursor;
+      }
+      // All 1201 legacy + 2 modern docs delivered, none missed.
+      expect(seen.size).toBe(1203);
+    }, 30_000);
+
+    it("delivers a small legacy stratum then the seq stratum in order", async () => {
+      await PhaseCTodoModel.collection.insertMany([
+        {deleted: false, ownerId: notAdminId, title: "legacy-a"},
+        {deleted: false, ownerId: notAdminId, title: "legacy-b"},
+      ] as any);
+      await PhaseCTodoModel.create({ownerId: notAdminId, title: "stamped"});
+
+      const page1 = await agent
+        .get(`/sync/snapshot?stream=${enc(ownerStream())}&limit=10`)
+        .expect(200);
+      // First page is the legacy stratum (seq 0), with a legacyCursor.
+      expect(page1.body.entities.every((e: any) => e.seq === 0)).toBe(true);
+      expect(page1.body.legacyCursor).toBeDefined();
+      expect(page1.body.hasMore).toBe(true);
+
+      const page2 = await agent
+        .get(
+          `/sync/snapshot?stream=${enc(ownerStream())}&limit=10&legacyCursor=${enc(
+            page1.body.legacyCursor
+          )}`
+        )
+        .expect(200);
+      // Legacy stratum exhausted; falls through to seq paging (no legacyCursor).
+      expect(page2.body.legacyCursor).toBeUndefined();
+      const stamped = page2.body.entities.find((e: any) => e.data?.title === "stamped");
+      expect(stamped?.seq).toBe(1);
+    });
+  });
+
+  // ── C6: write-scope enforcement + snapshot read parity ─────────────────────
+  describe("C6 — write-scope enforcement + read parity", () => {
+    const create = (mutationId: string, data: Record<string, unknown>) => ({
+      collection: "phaseCTodos",
+      data,
+      mutationId,
+      operation: "create",
+    });
+
+    it("nacks unauthorized a create with a foreign ownerId (owner scope)", async () => {
+      const res = await agent
+        .post("/sync/mutate")
+        .send(create("c6-owner-foreign", {ownerId: "someoneElse", title: "x"}))
+        .expect(403);
+      expect(res.body.nack.code).toBe("unauthorized");
+      expect(await PhaseCTodoModel.countDocuments({title: "x"})).toBe(0);
+    });
+
+    it("allows a create with the caller's own ownerId", async () => {
+      const res = await agent
+        .post("/sync/mutate")
+        .send(create("c6-owner-self", {ownerId: notAdminId, title: "mine"}))
+        .expect(200);
+      expect(res.body.ack.mutationId).toBe("c6-owner-self");
+    });
+
+    it("nacks unauthorized a tenant create for a non-member org", async () => {
+      const res = await agent
+        .post("/sync/mutate")
+        .send({
+          collection: "phaseCProjects",
+          data: {orgId: "orgNotMine", title: "sneaky"},
+          mutationId: "c6-tenant-foreign",
+          operation: "create",
+        })
+        .expect(403);
+      expect(res.body.nack.code).toBe("unauthorized");
+    });
+
+    it("allows a tenant create for a member org", async () => {
+      await agent
+        .post("/sync/mutate")
+        .send({
+          collection: "phaseCProjects",
+          data: {orgId: "org1", title: "ours"},
+          mutationId: "c6-tenant-member",
+          operation: "create",
+        })
+        .expect(200);
+    });
+
+    it("snapshot omits per-doc read-denied docs but still advances the cursor past them", async () => {
+      // A read permission that denies odd-titled docs.
+      clearSyncRegistry();
+      registerSync({
+        config: {scope: {type: "owner"}},
+        model: PhaseCTodoModel as any,
+        options: {
+          ...authedOptions,
+          permissions: {
+            ...(authedOptions as any).permissions,
+            read: [
+              (_method: any, _user: any, doc?: any) => {
+                if (!doc) {
+                  return true;
+                }
+                return !String(doc.title).endsWith("-secret");
+              },
+            ],
+          },
+        } as unknown as ModelRouterOptions<any>,
+        routePath: "/phaseCTodos",
+      });
+
+      await PhaseCTodoModel.create({ownerId: notAdminId, title: "visible-1"});
+      await PhaseCTodoModel.create({ownerId: notAdminId, title: "hidden-secret"});
+      await PhaseCTodoModel.create({ownerId: notAdminId, title: "visible-2"});
+
+      const res = await agent.get(`/sync/snapshot?stream=${enc(ownerStream())}`).expect(200);
+      const titles = res.body.entities.map((e: any) => e.data.title);
+      expect(titles).toEqual(["visible-1", "visible-2"]);
+      // The cursor advanced past the denied doc (seq 3), so it is never re-fetched.
+      expect(res.body.cursor).toBe(3);
+    });
+
+    it("composes a custom-scope $or snapshotFilter with $and (does not clobber deleted/seq)", async () => {
+      // A custom scope whose snapshotFilter is an $or; the route must $and it with the
+      // deleted/seq clauses so tombstones and seq bounds still apply.
+      clearSyncRegistry();
+      registerSync({
+        config: {
+          scope: (doc: Record<string, unknown>) => String(doc.ownerId),
+          snapshotFilter: () => ({$or: [{ownerId: notAdminId}, {ownerId: "shared"}]}),
+        },
+        model: PhaseCTodoModel as any,
+        options: authedOptions,
+        routePath: "/phaseCTodos",
+      });
+      const mine = await PhaseCTodoModel.create({ownerId: notAdminId, title: "mine"});
+      await PhaseCTodoModel.create({ownerId: "shared", title: "shared"});
+      await PhaseCTodoModel.create({ownerId: "other", title: "other"});
+      // Soft-delete one so the tombstone path is exercised under the $or filter.
+      mine.deleted = true;
+      await mine.save();
+
+      const customStream = `phaseCTodos|custom:${notAdminId}`;
+      const res = await agent.get(`/sync/snapshot?stream=${enc(customStream)}`).expect(200);
+      const byTitle = new Map(res.body.entities.map((e: any) => [e.id, e]));
+      // "other" is excluded by the $or filter; "mine" appears as a tombstone (data null).
+      const titles = res.body.entities
+        .filter((e: any) => !e.deleted)
+        .map((e: any) => e.data.title)
+        .sort();
+      expect(titles).toEqual(["shared"]);
+      const tombstone = byTitle.get(String(mine._id)) as any;
+      expect(tombstone?.deleted).toBe(true);
+      expect(tombstone?.data).toBeNull();
+    });
+
+    it("throws on a query updateOne with upsert:true (m8)", async () => {
+      const doc = await PhaseCTodoModel.create({ownerId: notAdminId, title: "u"});
+      // upsert:true on a synced model must throw at the plugin layer.
+      let threw = false;
+      try {
+        await PhaseCTodoModel.updateOne({_id: doc._id}, {$set: {title: "u2"}}, {upsert: true});
+      } catch (error) {
+        threw = true;
+        expect(String(error)).toMatch(/upsert/i);
+      }
+      expect(threw).toBe(true);
+    });
+
+    it("nacks validation an update with baseVersion omitted (C8)", async () => {
+      const doc = await PhaseCTodoModel.create({ownerId: notAdminId, title: "needs base"});
+      const res = await agent
+        .post("/sync/mutate")
+        .send({
+          collection: "phaseCTodos",
+          data: {title: "changed"},
+          id: String(doc._id),
+          mutationId: "c8-no-base",
+          operation: "update",
+          // baseVersion intentionally omitted
+        })
+        .expect(422);
+      expect(res.body.nack.code).toBe("validation");
+      expect(res.body.nack.message).toMatch(/baseVersion/i);
+    });
+  });
+
+  // ── C8: minors ─────────────────────────────────────────────────────────────
+  describe("C8 — minors", () => {
+    it("returns an idempotent ack when deleting an already-deleted doc (not 404/validation)", async () => {
+      const doc = await PhaseCTodoModel.create({ownerId: notAdminId, title: "to delete"});
+      const first = await agent
+        .post("/sync/mutate")
+        .send({
+          collection: "phaseCTodos",
+          id: String(doc._id),
+          mutationId: "c8-del-1",
+          operation: "delete",
+        })
+        .expect(200);
+      expect(first.body.ack).toBeDefined();
+
+      // Second delete of the (now soft-deleted) doc, distinct mutationId: idempotent ack.
+      const second = await agent
+        .post("/sync/mutate")
+        .send({
+          collection: "phaseCTodos",
+          id: String(doc._id),
+          mutationId: "c8-del-2",
+          operation: "delete",
+        })
+        .expect(200);
+      expect(second.body.ack).toBeDefined();
+      expect(second.body.ack.id).toBe(String(doc._id));
+    });
+
+    it("passes 'read' (not 'list') to the modelRouter responseHandler for single-entity sync serialization", async () => {
+      const seenMethods: string[] = [];
+      clearSyncRegistry();
+      registerSync({
+        config: {scope: {type: "owner"}},
+        model: PhaseCTodoModel as any,
+        options: {
+          ...authedOptions,
+          responseHandler: (value: any, method: string) => {
+            seenMethods.push(method);
+            return method === "read" ? {shape: "read", title: value.title} : value;
+          },
+        } as unknown as ModelRouterOptions<any>,
+        routePath: "/phaseCTodos",
+      });
+      await PhaseCTodoModel.create({ownerId: notAdminId, title: "rh"});
+      const res = await agent.get(`/sync/snapshot?stream=${enc(ownerStream())}`).expect(200);
+      expect(seenMethods).toContain("read");
+      expect(seenMethods).not.toContain("list");
+      expect(res.body.entities[0].data).toEqual({shape: "read", title: "rh"});
+    });
+
+    it("rejects a duplicate collectionTag at registration", () => {
+      clearSyncRegistry();
+      registerSync({
+        config: {scope: {type: "owner"}},
+        model: PhaseCTodoModel as any,
+        options: authedOptions,
+        routePath: "/dupTag",
+      });
+      // A different model under the SAME tag must be rejected (the tag, not the model,
+      // is the duplicate). PhaseCProjectModel's valid tenant scope passes the field check
+      // so registration reaches the duplicate-tag guard.
+      expect(() =>
+        registerSync({
+          config: {scope: {field: "orgId", type: "tenant"}},
+          model: PhaseCProjectModel as any,
+          options: authedOptions,
+          routePath: "/dupTag",
+        })
+      ).toThrow(/already registered/i);
+    });
+  });
+
+  // ── C7: change-stream watcher ignores sync bookkeeping collections ──────────
+  describe("C7 — watcher ignores sync bookkeeping collections", () => {
+    it("adds the sync bookkeeping collections to the watcher's default ignore list", () => {
+      // The watcher's change-stream pipeline excludes these collections, so their own
+      // internal writes (counter $inc, ledger rows, scope-move markers, key material)
+      // never drive fan-out or get reprocessed as deltas.
+      for (const coll of ["synccounters", "syncmutations", "syncscopemoves", "synckeys"]) {
+        expect(DEFAULT_IGNORED_COLLECTIONS).toContain(coll);
+      }
+    });
+  });
+});

--- a/api/src/sync/syncRoutes.test.ts
+++ b/api/src/sync/syncRoutes.test.ts
@@ -11,6 +11,7 @@ import {Permissions} from "../permissions";
 import {createdUpdatedPlugin, type IsDeleted, isDeletedPlugin} from "../plugins";
 import {authAsUser, getBaseServer, setupDb, UserModel} from "../tests";
 import {SyncCounter, SyncKey, SyncMutation} from "./models";
+import {MAX_SYNC_MUTATIONS_PER_BATCH} from "./mutationHandler";
 import {clearSyncRegistry, registerSync} from "./registry";
 import {SyncApp} from "./syncApp";
 import {syncPlugin} from "./syncSeqPlugin";
@@ -437,6 +438,76 @@ describe("sync routes", () => {
         })
         .expect(500);
       expect(res.body.nack.code).toBe("error");
+    });
+  });
+
+  describe("POST /sync/mutate/batch", () => {
+    const create = (mutationId: string, name: string) => ({
+      collection: "routeStuff",
+      data: {name, ownerId: notAdminId},
+      mutationId,
+      operation: "create",
+    });
+
+    it("requires authentication", async () => {
+      await server
+        .post("/sync/mutate/batch")
+        .send({mutations: [create("batch-http-noauth", "x")]})
+        .expect(401);
+    });
+
+    it("applies mutations strictly in order and returns one ack per mutation", async () => {
+      const mutations = Array.from({length: 5}, (_v, i) => create(`batch-http-${i}`, `item ${i}`));
+      const res = await agent.post("/sync/mutate/batch").send({mutations}).expect(200);
+      expect(res.body.results).toHaveLength(5);
+      expect(res.body.results.every((r: any) => r.type === "ack")).toBe(true);
+      const seqs = res.body.results.map((r: any) => r.ack.seq);
+      expect(seqs).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it("stops at the first nack: results shorter than the request", async () => {
+      const mutations = [
+        create("batch-http-halt-1", "ok 1"),
+        {
+          collection: "routeStuff",
+          data: {name: "bad"},
+          mutationId: "batch-http-halt-2",
+          operation: "update", // no id supplied -> validation nack
+        },
+        create("batch-http-halt-3", "never applied"),
+      ];
+      const res = await agent.post("/sync/mutate/batch").send({mutations}).expect(200);
+      expect(res.body.results).toHaveLength(2);
+      expect(res.body.results[0].type).toBe("ack");
+      expect(res.body.results[1].type).toBe("nack");
+      expect(res.body.results[1].nack.code).toBe("validation");
+      expect(await RouteStuffModel.countDocuments({name: "never applied"})).toBe(0);
+    });
+
+    it("rejects an oversized batch with a 422 before processing anything", async () => {
+      const mutations = Array.from({length: MAX_SYNC_MUTATIONS_PER_BATCH + 1}, (_v, i) =>
+        create(`batch-http-oversized-${i}`, `item ${i}`)
+      );
+      const res = await agent.post("/sync/mutate/batch").send({mutations}).expect(422);
+      expect(res.body.results).toHaveLength(1);
+      expect(res.body.results[0].nack.code).toBe("validation");
+      expect(await RouteStuffModel.countDocuments({})).toBe(0);
+    });
+
+    it("rejects intra-batch duplicate mutationIds with a 422", async () => {
+      const mutations = [create("batch-http-dup", "a"), create("batch-http-dup", "b")];
+      const res = await agent.post("/sync/mutate/batch").send({mutations}).expect(422);
+      expect(res.body.results[0].nack.code).toBe("validation");
+      expect(await RouteStuffModel.countDocuments({})).toBe(0);
+    });
+
+    it("a whole-batch duplicate resend is idempotent", async () => {
+      const mutations = [create("batch-http-idem-1", "once"), create("batch-http-idem-2", "twice")];
+      const first = await agent.post("/sync/mutate/batch").send({mutations}).expect(200);
+      const second = await agent.post("/sync/mutate/batch").send({mutations}).expect(200);
+      expect(second.body).toEqual(first.body);
+      expect(await RouteStuffModel.countDocuments({name: "once"})).toBe(1);
+      expect(await RouteStuffModel.countDocuments({name: "twice"})).toBe(1);
     });
   });
 

--- a/api/src/sync/syncRoutes.test.ts
+++ b/api/src/sync/syncRoutes.test.ts
@@ -13,6 +13,7 @@ import {authAsUser, getBaseServer, setupDb, UserModel} from "../tests";
 import {SyncCounter, SyncKey, SyncMutation} from "./models";
 import {MAX_SYNC_MUTATIONS_PER_BATCH} from "./mutationHandler";
 import {clearSyncRegistry, registerSync} from "./registry";
+import {MAX_SYNC_HTTP_MUTATIONS_PER_SECOND} from "./routes";
 import {SyncApp} from "./syncApp";
 import {syncPlugin} from "./syncSeqPlugin";
 
@@ -439,6 +440,33 @@ describe("sync routes", () => {
         .expect(500);
       expect(res.body.nack.code).toBe("error");
     });
+
+    it("returns 429 with a rate_limited nack carrying retryAfterMs once the per-second budget is exceeded (FIX 1)", async () => {
+      // notAdminId is fresh per test (setupDb() runs in beforeEach), so this
+      // user's rolling window starts empty here. Fire the budget-filling
+      // requests CONCURRENTLY (not sequentially awaited) so 100 requests
+      // cannot spread across the 1-second rolling window under machine load
+      // (a sequential loop's wall-clock time is unbounded and would let the
+      // window reset mid-flood, making the final request wrongly succeed).
+      const body = (mutationId: string) => ({
+        collection: "routeStuff",
+        data: {name: "flood", ownerId: notAdminId},
+        mutationId,
+        operation: "create",
+      });
+      await Promise.all(
+        Array.from({length: MAX_SYNC_HTTP_MUTATIONS_PER_SECOND}, (_v, i) =>
+          agent
+            .post("/sync/mutate")
+            .send(body(`hm-flood-${i}`))
+            .expect(200)
+        )
+      );
+      const res = await agent.post("/sync/mutate").send(body("hm-flood-over")).expect(429);
+      expect(res.body.nack.code).toBe("rate_limited");
+      expect(typeof res.body.nack.retryAfterMs).toBe("number");
+      expect(res.body.nack.retryAfterMs).toBeGreaterThan(0);
+    });
   });
 
   describe("POST /sync/mutate/batch", () => {
@@ -508,6 +536,42 @@ describe("sync routes", () => {
       expect(second.body).toEqual(first.body);
       expect(await RouteStuffModel.countDocuments({name: "once"})).toBe(1);
       expect(await RouteStuffModel.countDocuments({name: "twice"})).toBe(1);
+    });
+
+    it("returns 429 with a rate_limited nack carrying retryAfterMs once the shared per-second budget is exceeded (FIX 1)", async () => {
+      // The batch route counts each mutation in the batch (not the batch
+      // itself) against the same per-user window as POST /sync/mutate. Two
+      // batches: the first (at the batch-size cap) nearly exhausts the
+      // per-second budget, the second (small) tips it over — a single batch
+      // over MAX_SYNC_HTTP_MUTATIONS_PER_SECOND would also exceed
+      // MAX_SYNC_MUTATIONS_PER_BATCH and get rejected as oversized first.
+      // A cheap validation nack (unknown collection, mirroring the sibling
+      // sync:mutateBatch rate-limit test) — no DB writes — keeps the first
+      // batch's wall-clock time well under the 1-second window even on a
+      // loaded machine, so it can't spuriously reset before the second
+      // request lands (100 real document creates would risk exactly that).
+      // The batch route always returns 200 with a `results` array (the
+      // client inspects each entry's type) — stop-on-first-nack means only
+      // the first mutation's validation nack comes back, but the FULL
+      // batch length (100) still counts against the rate-limit window
+      // (consumed before any mutation is applied).
+      const firstBatch = Array.from({length: MAX_SYNC_MUTATIONS_PER_BATCH}, (_v, i) => ({
+        collection: "nope",
+        mutationId: `batch-http-flood-a-${i}`,
+        operation: "create",
+      }));
+      const firstRes = await agent
+        .post("/sync/mutate/batch")
+        .send({mutations: firstBatch})
+        .expect(200);
+      expect(firstRes.body.results[0].nack.code).toBe("validation");
+      const secondBatch = [create("batch-http-flood-b-0", "over budget")];
+      const res = await agent.post("/sync/mutate/batch").send({mutations: secondBatch}).expect(429);
+      expect(res.body.results).toHaveLength(1);
+      expect(res.body.results[0].nack.code).toBe("rate_limited");
+      expect(typeof res.body.results[0].nack.retryAfterMs).toBe("number");
+      expect(res.body.results[0].nack.retryAfterMs).toBeGreaterThan(0);
+      expect(await RouteStuffModel.countDocuments({name: "over budget"})).toBe(0);
     });
   });
 

--- a/api/src/sync/syncRoutes.test.ts
+++ b/api/src/sync/syncRoutes.test.ts
@@ -87,11 +87,12 @@ describe("sync routes", () => {
   let agent: TestAgent;
   let adminAgent: TestAgent;
   let notAdminId: string;
+  let adminId: string;
 
   beforeEach(async () => {
     const [admin, notAdmin] = await setupDb();
     notAdminId = String(notAdmin._id);
-    void admin;
+    adminId = String(admin._id);
 
     clearSyncRegistry();
     registerSync({
@@ -127,23 +128,42 @@ describe("sync routes", () => {
     adminAgent = await authAsUser(app, "admin");
   });
 
+  // C2: the snapshot endpoint is now per-STREAM. The owner stream for notAdmin is
+  // `routeStuff|owner:{notAdminId}`; the tenant stream (getUserScopes -> ["org1"]) is
+  // `routeProjects|tenant:org1`.
   describe("GET /sync/snapshot", () => {
+    const ownerStream = (): string => `routeStuff|owner:${notAdminId}`;
+
     it("requires authentication", async () => {
-      await server.get("/sync/snapshot?collection=routeStuff").expect(401);
+      await server
+        .get(`/sync/snapshot?stream=${encodeURIComponent("routeStuff|owner:x")}`)
+        .expect(401);
     });
 
-    it("requires a collection parameter", async () => {
+    it("requires a stream parameter", async () => {
       const res = await agent.get("/sync/snapshot").expect(400);
-      expect(res.body.title).toMatch(/collection/);
+      expect(res.body.title).toMatch(/stream/);
+    });
+
+    it("400s for an unparseable stream key", async () => {
+      await agent.get("/sync/snapshot?stream=notAStreamKey").expect(400);
     });
 
     it("404s for unknown collections", async () => {
-      await agent.get("/sync/snapshot?collection=nope").expect(404);
+      await agent.get(`/sync/snapshot?stream=${encodeURIComponent("nope|owner:x")}`).expect(404);
+    });
+
+    it("403s when the caller does not belong to the requested stream", async () => {
+      // notAdmin's own owner stream is keyed by their id; someoneElse's is not theirs.
+      await agent
+        .get(`/sync/snapshot?stream=${encodeURIComponent("routeStuff|owner:someoneElse")}`)
+        .expect(403);
     });
 
     it("400s for invalid cursor and limit", async () => {
-      await agent.get("/sync/snapshot?collection=routeStuff&cursor=abc").expect(400);
-      await agent.get("/sync/snapshot?collection=routeStuff&limit=-2").expect(400);
+      const s = encodeURIComponent(ownerStream());
+      await agent.get(`/sync/snapshot?stream=${s}&cursor=abc`).expect(400);
+      await agent.get(`/sync/snapshot?stream=${s}&limit=-2`).expect(400);
     });
 
     it("enforces the model's list permissions", async () => {
@@ -154,8 +174,14 @@ describe("sync routes", () => {
         options: adminOnlyOptions,
         routePath: "/routeStuff",
       });
-      await agent.get("/sync/snapshot?collection=routeStuff").expect(403);
-      await adminAgent.get("/sync/snapshot?collection=routeStuff").expect(200);
+      // notAdmin is denied at the list-permission gate; admin's own owner stream is allowed.
+      await agent.get(`/sync/snapshot?stream=${encodeURIComponent(ownerStream())}`).expect(403);
+      const admin = await UserModel.findOne({email: "admin@example.com"});
+      await adminAgent
+        .get(
+          `/sync/snapshot?stream=${encodeURIComponent(`routeStuff|owner:${String(admin?._id)}`)}`
+        )
+        .expect(200);
     });
 
     it("returns a full owner-scoped snapshot at cursor 0", async () => {
@@ -163,19 +189,27 @@ describe("sync routes", () => {
       await RouteStuffModel.create({name: "mine 2", ownerId: notAdminId});
       await RouteStuffModel.create({name: "theirs", ownerId: "someoneElse"});
 
-      const res = await agent.get("/sync/snapshot?collection=routeStuff").expect(200);
+      const res = await agent
+        .get(`/sync/snapshot?stream=${encodeURIComponent(ownerStream())}`)
+        .expect(200);
+      expect(res.body.stream).toBe(ownerStream());
       expect(res.body.entities).toHaveLength(2);
       expect(res.body.entities.map((e: any) => e.data.name)).toEqual(["mine 1", "mine 2"]);
       expect(res.body.entities.map((e: any) => e.seq)).toEqual([1, 2]);
       expect(res.body.cursor).toBe(2);
       expect(res.body.hasMore).toBe(false);
+      // C1/C7 response fields present.
+      expect(res.body.frontierSeq).toBe(2);
+      expect(typeof res.body.oldestRetainedSeq).toBe("number");
     });
 
     it("returns incremental changes and tombstones past a cursor", async () => {
       const doc1 = await RouteStuffModel.create({name: "first", ownerId: notAdminId});
       const doc2 = await RouteStuffModel.create({name: "second", ownerId: notAdminId});
 
-      const initial = await agent.get("/sync/snapshot?collection=routeStuff").expect(200);
+      const initial = await agent
+        .get(`/sync/snapshot?stream=${encodeURIComponent(ownerStream())}`)
+        .expect(200);
       const cursor = initial.body.cursor;
 
       doc1.name = "first updated";
@@ -184,7 +218,7 @@ describe("sync routes", () => {
       await doc2.save();
 
       const res = await agent
-        .get(`/sync/snapshot?collection=routeStuff&cursor=${cursor}`)
+        .get(`/sync/snapshot?stream=${encodeURIComponent(ownerStream())}&cursor=${cursor}`)
         .expect(200);
       expect(res.body.entities).toHaveLength(2);
       const updated = res.body.entities.find((e: any) => e.id === String(doc1._id));
@@ -192,6 +226,8 @@ describe("sync routes", () => {
       expect(updated.data.name).toBe("first updated");
       expect(updated.deleted).toBe(false);
       expect(tombstone.deleted).toBe(true);
+      // C7: tombstones carry no data.
+      expect(tombstone.data).toBeNull();
       expect(tombstone.seq).toBeGreaterThan(cursor);
     });
 
@@ -199,18 +235,19 @@ describe("sync routes", () => {
       for (let i = 1; i <= 5; i++) {
         await RouteStuffModel.create({name: `item ${i}`, ownerId: notAdminId});
       }
-      const page1 = await agent.get("/sync/snapshot?collection=routeStuff&limit=2").expect(200);
+      const s = encodeURIComponent(ownerStream());
+      const page1 = await agent.get(`/sync/snapshot?stream=${s}&limit=2`).expect(200);
       expect(page1.body.entities).toHaveLength(2);
       expect(page1.body.hasMore).toBe(true);
 
       const page2 = await agent
-        .get(`/sync/snapshot?collection=routeStuff&limit=2&cursor=${page1.body.cursor}`)
+        .get(`/sync/snapshot?stream=${s}&limit=2&cursor=${page1.body.cursor}`)
         .expect(200);
       expect(page2.body.entities).toHaveLength(2);
       expect(page2.body.hasMore).toBe(true);
 
       const page3 = await agent
-        .get(`/sync/snapshot?collection=routeStuff&limit=2&cursor=${page2.body.cursor}`)
+        .get(`/sync/snapshot?stream=${s}&limit=2&cursor=${page2.body.cursor}`)
         .expect(200);
       expect(page3.body.entities).toHaveLength(1);
       expect(page3.body.hasMore).toBe(false);
@@ -221,28 +258,23 @@ describe("sync routes", () => {
       expect(names).toEqual(["item 1", "item 2", "item 3", "item 4", "item 5"]);
     });
 
-    it("delivers legacy docs without _syncSeq in the first page only", async () => {
-      // Bypass mongoose entirely to simulate documents created before sync was enabled.
-      await RouteStuffModel.collection.insertMany([
-        {deleted: false, name: "legacy", ownerId: notAdminId},
-      ]);
-      await RouteStuffModel.create({name: "modern", ownerId: notAdminId});
-
-      const first = await agent.get("/sync/snapshot?collection=routeStuff").expect(200);
-      expect(first.body.entities.map((e: any) => e.data.name)).toEqual(["legacy", "modern"]);
-      expect(first.body.entities[0].seq).toBe(0);
-
-      const incremental = await agent
-        .get(`/sync/snapshot?collection=routeStuff&cursor=${first.body.cursor}`)
+    it("never advances the returned cursor beyond the stable frontier (C1)", async () => {
+      await RouteStuffModel.create({name: "committed 1", ownerId: notAdminId});
+      await RouteStuffModel.create({name: "committed 2", ownerId: notAdminId});
+      const res = await agent
+        .get(`/sync/snapshot?stream=${encodeURIComponent(ownerStream())}`)
         .expect(200);
-      expect(incremental.body.entities).toHaveLength(0);
+      // With no in-flight writes, frontier == head and the cursor equals the frontier.
+      expect(res.body.cursor).toBeLessThanOrEqual(res.body.frontierSeq);
     });
 
-    it("scopes tenant collections to the user's tenants", async () => {
+    it("scopes tenant collections to the requested tenant stream only", async () => {
       await RouteProjectModel.create({orgId: "org1", title: "visible"});
       await RouteProjectModel.create({orgId: "org2", title: "hidden"});
 
-      const res = await agent.get("/sync/snapshot?collection=routeProjects").expect(200);
+      const res = await agent
+        .get("/sync/snapshot?stream=routeProjects%7Ctenant%3Aorg1")
+        .expect(200);
       expect(res.body.entities).toHaveLength(1);
       expect(res.body.entities[0].data.title).toBe("visible");
     });
@@ -253,7 +285,7 @@ describe("sync routes", () => {
       addAuthRoutes(bareApp as any, UserModel as any);
       new SyncApp().register(bareApp);
       const bareAgent = await authAsUser(bareApp, "notAdmin");
-      await bareAgent.get("/sync/snapshot?collection=routeProjects").expect(500);
+      await bareAgent.get("/sync/snapshot?stream=routeProjects%7Ctenant%3Aorg1").expect(500);
     });
 
     it("uses the sync responseHandler to serialize entities", async () => {
@@ -268,7 +300,9 @@ describe("sync routes", () => {
         routePath: "/routeStuff",
       });
       await RouteStuffModel.create({name: "secret", ownerId: notAdminId});
-      const res = await agent.get("/sync/snapshot?collection=routeStuff").expect(200);
+      const res = await agent
+        .get(`/sync/snapshot?stream=${encodeURIComponent(ownerStream())}`)
+        .expect(200);
       expect(res.body.entities[0].data).toEqual({redactedName: "x-secret"});
     });
   });
@@ -370,15 +404,17 @@ describe("sync routes", () => {
         options: adminOnlyOptions,
         routePath: "/routeStuff",
       });
-      const body = (mutationId: string) => ({
+      // Each caller writes to their OWN owner scope (C6 rejects a foreign ownerId with a
+      // separate scope-violation nack — exercised in the C6 tests, not here).
+      const body = (mutationId: string, ownerId: string) => ({
         collection: "routeStuff",
-        data: {name: "admin only", ownerId: notAdminId},
+        data: {name: "admin only", ownerId},
         mutationId,
         operation: "create",
       });
-      const res = await agent.post("/sync/mutate").send(body("hm-perm-1")).expect(403);
+      const res = await agent.post("/sync/mutate").send(body("hm-perm-1", notAdminId)).expect(403);
       expect(res.body.nack.code).toBe("unauthorized");
-      await adminAgent.post("/sync/mutate").send(body("hm-perm-2")).expect(200);
+      await adminAgent.post("/sync/mutate").send(body("hm-perm-2", adminId)).expect(200);
     });
 
     it("returns 422 with a validation nack for invalid mutations", async () => {

--- a/api/src/sync/syncSeqPlugin.ts
+++ b/api/src/sync/syncSeqPlugin.ts
@@ -1,29 +1,49 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: Schema/Query generics must be loose to accept arbitrary consumer schemas
-import type {CallbackWithoutResultAndOptionalError, Model, Query, Schema} from "mongoose";
-import {claimSyncSeqs} from "./models";
+import type {
+  CallbackWithoutResultAndOptionalError,
+  ClientSession,
+  Model,
+  Query,
+  Schema,
+} from "mongoose";
+import {logger} from "../logger";
+import {claimSyncSeqs, confirmSyncSeqs, SyncScopeMove} from "./models";
 import {findSyncEntryByModelName, type SyncRegistryEntry} from "./registry";
 import {getScopeField, resolveStreamForDoc, streamForScopeValue} from "./streams";
 
 /**
  * Schema plugin for sync-enabled models. Stamps a monotonic per-stream `_syncSeq` on
  * every single-document write and records `_syncPrevStream` when a write moves the
- * document between scopes (owner/tenant change), so the change-stream watcher can
- * tombstone the old stream without MongoDB pre-images.
+ * document between scopes (owner/tenant change).
  *
  * Apply to the schema alongside `isDeletedPlugin`; activation is keyed off the sync
  * registry, so models that are not registered via modelRouter's `sync` option no-op.
  *
- * Sequencing guarantees:
+ * Sequencing guarantees (C1 — stable frontier):
  * - Validation failures never consume a seq: Mongoose runs validation before user
  *   pre('save') hooks, so the claim happens post-validation.
- * - The claim joins the caller's session when one is present, so caller-managed
- *   transactions get counter+write atomicity for free. Without a caller session the
- *   claim is a plain atomic `$inc`; a rare write failure after a claim burns a seq,
- *   which the client treats as a benign gap (rate-limited reconcile).
- * - `updateMany`, `deleteMany`, hard deletes, and `bulkWrite` are unsupported on
- *   synced models: multi-document writes cannot stamp per-document seqs, and hard
- *   deletes would be invisible to tombstone catch-up. All but `bulkWrite` throw
- *   (Model.bulkWrite bypasses middleware entirely — documented restriction).
+ * - Each claim registers the claimed seq on the counter's in-flight `pending` registry;
+ *   the matching post-write hook (`confirmSyncSeqs`) clears it. Until confirmed, the
+ *   stream's stable frontier holds below the claimed seq, so a snapshot/delta cursor
+ *   never advances past a seq whose owning write has not yet committed. A crash between
+ *   claim and confirm leaves a stale pending entry that ages out via the lease.
+ * - The claim joins the caller's session when one is present; that path gets true
+ *   counter+write atomicity and skips the pending registry entirely (no confirm due).
+ *
+ * Scope moves (C4): when a write moves the document between streams, a durable
+ * `SyncScopeMove` marker is written in the same op-scope, carrying a seq claimed from
+ * the OLD stream's counter. The change-stream watcher and old-stream snapshot catch-up
+ * tombstone the document from the marker (not the racy `_syncPrevStream` post-image),
+ * so a racing second write can no longer erase the tombstone. `_syncPrevStream` is still
+ * stamped (harmless), but the marker is the source of truth.
+ *
+ * Write restrictions:
+ * - `updateMany`, `deleteMany`, hard deletes, and `bulkWrite` are unsupported on synced
+ *   models (all but `bulkWrite` throw; `Model.bulkWrite` bypasses middleware).
+ * - Query-writes MUST target a single document by `_id` (m9): a non-`_id` filter could
+ *   match a different document than intended and stamp the wrong stream's seq.
+ * - `upsert: true` is rejected on query-writes (m8/C6): an upsert can create a document
+ *   the pre-write lookup never saw, escaping seq stamping.
  */
 
 const INITIAL_STREAM_KEY = "_syncInitialStream";
@@ -38,6 +58,82 @@ const unsupportedWrite = (modelName: string, operation: string): Error =>
       "stamping requires single-document writes (and deletes must be soft). " +
       "Loop per document instead."
   );
+
+/**
+ * m9: a query-write on a synced model must target exactly one document by `_id`, so the
+ * pre-write lookup resolves the stream of the SAME document the update mutates. A non-`_id`
+ * filter can match a different document and stamp the wrong stream's seq (duplicate seqs
+ * within a stream). Accept `{_id: value}` and `{_id: {$eq: value}}`.
+ */
+const filterTargetsSingleId = (filter: Record<string, unknown>): boolean => {
+  const idClause = filter._id;
+  if (idClause === undefined || idClause === null) {
+    return false;
+  }
+  // A plain string/number id, or an ObjectId (or any BSON value — has a `_bsontype`),
+  // is a direct single-document match.
+  if (typeof idClause !== "object" || (idClause as {_bsontype?: unknown})._bsontype) {
+    return true;
+  }
+  // A query-operator object is only single-document when it is exactly `{$eq: value}`.
+  const keys = Object.keys(idClause as Record<string, unknown>);
+  return keys.length === 1 && keys[0] === "$eq";
+};
+
+const nonIdFilterError = (modelName: string, operation: string): Error =>
+  new Error(
+    `${operation} on sync-enabled model ${modelName} must target a single document by _id ` +
+      "(use findByIdAndUpdate or loop per document): a non-_id filter can stamp the wrong " +
+      "stream's seq."
+  );
+
+const upsertError = (modelName: string, operation: string): Error =>
+  new Error(
+    `${operation} with upsert:true is not supported on sync-enabled model ${modelName}: an ` +
+      "upsert can create a document the pre-write lookup never saw, escaping seq stamping."
+  );
+
+/**
+ * C4: write the scope-move marker (claim a seq from the OLD stream so it orders in that
+ * stream's frontier). Joins the caller session so the marker commits with the move.
+ */
+const writeScopeMoveMarker = async ({
+  entry,
+  entityId,
+  fromStream,
+  toStream,
+  session,
+}: {
+  entry: SyncRegistryEntry;
+  entityId: string;
+  fromStream: string;
+  toStream: string;
+  session: ClientSession | null;
+}): Promise<void> => {
+  const claim = await claimSyncSeqs({session, stream: fromStream});
+  await SyncScopeMove.create(
+    [
+      {
+        collectionTag: entry.collectionTag,
+        entityId,
+        fromStream,
+        seq: claim.lastSeq,
+        toStream,
+      },
+    ],
+    session ? {session} : {}
+  );
+  // The marker's own seq on the old stream is confirmed immediately: the marker insert
+  // above is the committing write for that claim.
+  if (claim.registered) {
+    await confirmSyncSeqs({seqs: claim.seqs, stream: fromStream}).catch((error: unknown) => {
+      logger.error("[sync] Failed to confirm scope-move marker seq", {
+        error: String(error),
+        stream: fromStream,
+      });
+    });
+  }
+};
 
 export const syncPlugin = (schema: Schema<any, any, any, any>): void => {
   schema.add({
@@ -65,11 +161,26 @@ export const syncPlugin = (schema: Schema<any, any, any, any>): void => {
     this.$locals[INITIAL_STREAM_KEY] = streamForObject(entry, this.toObject());
   });
 
+  const PENDING_CONFIRM_KEY = "_syncPendingConfirm";
+
   schema.pre("save", async function () {
     const entry = findSyncEntryByModelName((this.constructor as Model<any>).modelName);
     if (!entry) {
       return;
     }
+    // m10: a save that changes nothing meaningful must not burn a seq or emit a delta.
+    // Excluded from the "meaningful" set: the sync stamps this hook writes (`_syncSeq`,
+    // `_syncPrevStream`) and auto-managed timestamp metadata (`updated`, which
+    // createdUpdatedPlugin bumps on EVERY save — otherwise no save would ever be a
+    // no-op). A save whose only modified paths are these is a no-op: skip the claim.
+    if (!this.isNew) {
+      const ignored = new Set(["_syncSeq", "_syncPrevStream", "updated"]);
+      const meaningful = this.modifiedPaths().filter((p) => !ignored.has(p));
+      if (meaningful.length === 0) {
+        return;
+      }
+    }
+    const session = this.$session() ?? null;
     const currentStream = streamForObject(entry, this.toObject());
     let prevStream: string | null = null;
     if (!this.isNew) {
@@ -78,10 +189,43 @@ export const syncPlugin = (schema: Schema<any, any, any, any>): void => {
         prevStream = initialStream;
       }
     }
-    const seq = await claimSyncSeqs({session: this.$session() ?? null, stream: currentStream});
-    this.set({_syncPrevStream: prevStream, _syncSeq: seq});
+    const claim = await claimSyncSeqs({session, stream: currentStream});
+    this.set({_syncPrevStream: prevStream, _syncSeq: claim.lastSeq});
+    // Stash the claim so post('save') can confirm it once the write commits.
+    this.$locals[PENDING_CONFIRM_KEY] = claim.registered
+      ? {seqs: claim.seqs, stream: currentStream}
+      : undefined;
+    // C4: durable scope-move marker (claims + confirms its own seq on the OLD stream).
+    if (prevStream) {
+      await writeScopeMoveMarker({
+        entityId: String(this._id),
+        entry,
+        fromStream: prevStream,
+        session,
+        toStream: currentStream,
+      });
+    }
     // The just-saved stream becomes the baseline for the next save on this instance.
     this.$locals[INITIAL_STREAM_KEY] = currentStream;
+  });
+
+  // C1: confirm the claimed seq once the document write commits, so the stable frontier
+  // can advance past it. Document post('save') `this` is the saved document.
+  schema.post("save", async function () {
+    const confirm = this.$locals[PENDING_CONFIRM_KEY] as
+      | {stream: string; seqs: number[]}
+      | undefined;
+    if (!confirm) {
+      return;
+    }
+    this.$locals[PENDING_CONFIRM_KEY] = undefined;
+    await confirmSyncSeqs({seqs: confirm.seqs, stream: confirm.stream}).catch((error: unknown) => {
+      // Never fail the user write for a confirm error: the entry ages out via the lease.
+      logger.error("[sync] Failed to confirm seq after save", {
+        error: String(error),
+        stream: confirm.stream,
+      });
+    });
   });
 
   schema.pre(
@@ -101,11 +245,21 @@ export const syncPlugin = (schema: Schema<any, any, any, any>): void => {
           byStream.set(stream, group);
         }
         for (const [stream, group] of byStream) {
-          const lastSeq = await claimSyncSeqs({count: group.length, stream});
+          const claim = await claimSyncSeqs({count: group.length, stream});
           group.forEach((doc, index) => {
             doc._syncPrevStream = null;
-            doc._syncSeq = lastSeq - group.length + 1 + index;
+            doc._syncSeq = claim.seqs[index];
           });
+          // insertMany commits the docs after this hook returns; confirm the claim so the
+          // frontier advances. A crash between here and commit ages out via the lease.
+          if (claim.registered) {
+            await confirmSyncSeqs({seqs: claim.seqs, stream}).catch((error: unknown) => {
+              logger.error("[sync] Failed to confirm insertMany seqs", {
+                error: String(error),
+                stream,
+              });
+            });
+          }
         }
         return next();
       } catch (error: unknown) {
@@ -122,10 +276,20 @@ export const syncPlugin = (schema: Schema<any, any, any, any>): void => {
     if (!entry) {
       return;
     }
+    const operation = (this as unknown as {op?: string}).op ?? "query-write";
+    // m8/C6: reject upserts — an upsert can create a doc the lookup never saw.
+    if (this.getOptions().upsert) {
+      throw upsertError(model.modelName, operation);
+    }
+    const rawFilter = this.getFilter();
+    // m9: refuse a non-single-_id filter — it could match a different doc than intended.
+    if (!filterTargetsSingleId(rawFilter as Record<string, unknown>)) {
+      throw nonIdFilterError(model.modelName, operation);
+    }
     const session = this.getOptions().session ?? null;
     // Mirror update semantics: query updates are NOT auto-filtered by isDeletedPlugin
     // (it only hooks find/findOne), so the lookup must see tombstones too.
-    const filter: Record<string, unknown> = {...this.getFilter()};
+    const filter: Record<string, unknown> = {...rawFilter};
     if (filter.deleted === undefined) {
       filter.deleted = {$in: [true, false]};
     }
@@ -174,22 +338,79 @@ export const syncPlugin = (schema: Schema<any, any, any, any>): void => {
     }
 
     const prevStream = previousStream !== currentStream ? previousStream : null;
-    const seq = await claimSyncSeqs({session, stream: currentStream});
+    const claim = await claimSyncSeqs({session, stream: currentStream});
 
     if (isTrueReplacement || !hasOperators) {
       // True replacements and implicit-$set plain objects both take plain keys.
       rawUpdate._syncPrevStream = prevStream;
-      rawUpdate._syncSeq = seq;
+      rawUpdate._syncSeq = claim.lastSeq;
     } else {
-      rawUpdate.$set = {...(rawUpdate.$set ?? {}), _syncPrevStream: prevStream, _syncSeq: seq};
+      rawUpdate.$set = {
+        ...(rawUpdate.$set ?? {}),
+        _syncPrevStream: prevStream,
+        _syncSeq: claim.lastSeq,
+      };
     }
     this.setUpdate(rawUpdate);
+    // Stash the claim + move info so the query post hook confirms/records after commit.
+    (this as unknown as {_syncPendingConfirm?: unknown})._syncPendingConfirm = {
+      claim,
+      currentStream,
+      entityId: String(target._id),
+      entry,
+      prevStream,
+      session,
+    };
+  };
+
+  // C1/C4: after the query write commits, confirm the claimed seq and record the
+  // scope-move marker. Query post middleware `this` is the Query (not a document).
+  const postQueryWrite = async function (this: Query<any, any>): Promise<void> {
+    const pending = (this as unknown as {_syncPendingConfirm?: any})._syncPendingConfirm;
+    if (!pending) {
+      return;
+    }
+    (this as unknown as {_syncPendingConfirm?: unknown})._syncPendingConfirm = undefined;
+    const {claim, currentStream, entityId, entry, prevStream, session} = pending as {
+      claim: {registered: boolean; seqs: number[]};
+      currentStream: string;
+      entityId: string;
+      entry: SyncRegistryEntry;
+      prevStream: string | null;
+      session: ClientSession | null;
+    };
+    if (claim.registered) {
+      await confirmSyncSeqs({seqs: claim.seqs, stream: currentStream}).catch((error: unknown) => {
+        logger.error("[sync] Failed to confirm seq after query write", {
+          error: String(error),
+          stream: currentStream,
+        });
+      });
+    }
+    if (prevStream) {
+      await writeScopeMoveMarker({
+        entityId,
+        entry,
+        fromStream: prevStream,
+        session,
+        toStream: currentStream,
+      }).catch((error: unknown) => {
+        logger.error("[sync] Failed to write scope-move marker after query write", {
+          error: String(error),
+          fromStream: prevStream,
+        });
+      });
+    }
   };
 
   schema.pre("updateOne", {document: false, query: true}, preQueryWrite);
   schema.pre("findOneAndUpdate", preQueryWrite);
   schema.pre("replaceOne", preQueryWrite);
   schema.pre("findOneAndReplace", preQueryWrite);
+  schema.post("updateOne", {document: false, query: true}, postQueryWrite);
+  schema.post("findOneAndUpdate", postQueryWrite);
+  schema.post("replaceOne", postQueryWrite);
+  schema.post("findOneAndReplace", postQueryWrite);
 
   // Unsupported multi-document / hard-delete paths throw for registered models.
   const guardQuery = (operation: string) =>

--- a/api/src/sync/syncSocket.test.ts
+++ b/api/src/sync/syncSocket.test.ts
@@ -587,7 +587,7 @@ describe("installSyncSocketHandlers — sync:mutate", () => {
     expect(lastNack(socket)?.code).toBe("unauthorized");
   });
 
-  it("rate-limits mutations beyond the per-second cap with an error nack", async () => {
+  it("rate-limits mutations beyond the per-second cap with a rate_limited nack carrying retryAfterMs (FIX 1)", async () => {
     const socket = createMockSocket({id: "user1"});
     install(socket);
     // Exceed the window with cheap validation nacks (unknown collection) — the rate limit
@@ -605,6 +605,14 @@ describe("installSyncSocketHandlers — sync:mutate", () => {
       (e.payload as SyncNack).message?.includes("Rate limit")
     );
     expect(rateLimited).toHaveLength(5);
+    // FIX 1: the nack code is "rate_limited" (never "error") so the client
+    // never treats it as a durable-data failure, and it carries a
+    // retryAfterMs hint for the client's backoff floor.
+    for (const nack of rateLimited) {
+      const payload = nack.payload as SyncNack;
+      expect(payload.code).toBe("rate_limited");
+      expect(typeof (payload as {retryAfterMs?: number}).retryAfterMs).toBe("number");
+    }
   });
 });
 
@@ -705,7 +713,7 @@ describe("installSyncSocketHandlers — sync:mutateBatch", () => {
     expect(response.results[0].nack?.code).toBe("unauthorized");
   });
 
-  it("rate-limits batch mutations against the same window as sync:mutate", async () => {
+  it("rate-limits batch mutations against the same window as sync:mutate with a rate_limited nack carrying retryAfterMs (FIX 1)", async () => {
     const socket = createMockSocket({id: "user1"});
     install(socket);
     // Two batches within the per-batch size cap, but together exceeding the
@@ -725,6 +733,29 @@ describe("installSyncSocketHandlers — sync:mutateBatch", () => {
     const response = await triggerBatch(socket, secondBatch);
     expect(response.results).toHaveLength(1);
     expect(response.results[0].nack?.message).toContain("Rate limit");
+    // FIX 1: rate limiting must never look like a durable-data error — the
+    // client treats "rate_limited" like a transport failure (never terminal).
+    expect(response.results[0].nack?.code).toBe("rate_limited");
+    expect(typeof (response.results[0].nack as {retryAfterMs?: number})?.retryAfterMs).toBe(
+      "number"
+    );
+  });
+
+  it("emits sync:batchReceived immediately, before any mutation is applied (FIX 5)", async () => {
+    const socket = createMockSocket({id: "user1"});
+    install(socket);
+    const mutations = [create("sock-batch-receipt-1", "a")];
+    await socket.trigger("sync:mutateBatch", {batchId: "b-123", mutations}, () => {});
+    const receipts = socket.emitted.filter((e) => e.event === "sync:batchReceived");
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0].payload).toEqual({batchId: "b-123"});
+  });
+
+  it("does not emit sync:batchReceived when the request has no batchId (HTTP-shaped payload)", async () => {
+    const socket = createMockSocket({id: "user1"});
+    install(socket);
+    await triggerBatch(socket, [create("sock-batch-no-id", "a")]);
+    expect(socket.emitted.filter((e) => e.event === "sync:batchReceived")).toHaveLength(0);
   });
 });
 

--- a/api/src/sync/syncSocket.test.ts
+++ b/api/src/sync/syncSocket.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../realtime/socketAuth";
 import {setupDb} from "../tests";
 import {SyncCounter, SyncMutation} from "./models";
+import {MAX_SYNC_MUTATIONS_PER_BATCH} from "./mutationHandler";
 import {
   clearSyncRegistry,
   findSyncEntryByCollectionTag,
@@ -604,6 +605,126 @@ describe("installSyncSocketHandlers — sync:mutate", () => {
       (e.payload as SyncNack).message?.includes("Rate limit")
     );
     expect(rateLimited).toHaveLength(5);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// sync:mutateBatch
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("installSyncSocketHandlers — sync:mutateBatch", () => {
+  beforeAll(async () => {
+    await setupDb();
+  });
+
+  beforeEach(async () => {
+    registerAll();
+    await Promise.all([
+      SockStuffModel.collection.deleteMany({}),
+      SyncCounter.deleteMany({}),
+      SyncMutation.deleteMany({}),
+    ]);
+  });
+
+  afterEach(() => {
+    clearSyncRegistry();
+  });
+
+  const create = (mutationId: string, name: string) => ({
+    collection: "sockStuff",
+    data: {name, ownerId: "user1"},
+    mutationId,
+    operation: "create",
+  });
+
+  const triggerBatch = async (
+    socket: MockSocket,
+    mutations: unknown[]
+  ): Promise<{results: Array<{type: string; ack?: SyncAck; nack?: SyncNack}>}> => {
+    let response: any;
+    await socket.trigger("sync:mutateBatch", {mutations}, (res: unknown) => {
+      response = res;
+    });
+    return response;
+  };
+
+  it("applies a batch strictly in order via the ack callback", async () => {
+    const socket = createMockSocket({id: "user1"});
+    install(socket);
+    const mutations = Array.from({length: 5}, (_v, i) => create(`sock-batch-${i}`, `item ${i}`));
+    const response = await triggerBatch(socket, mutations);
+    expect(response.results).toHaveLength(5);
+    expect(response.results.every((r) => r.type === "ack")).toBe(true);
+    const seqs = response.results.map((r) => r.ack?.seq);
+    expect(seqs).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("stops at the first nack, leaving later mutations unattempted", async () => {
+    const socket = createMockSocket({id: "user1"});
+    install(socket);
+    const mutations = [
+      create("sock-batch-halt-1", "ok"),
+      {collection: "nope", mutationId: "sock-batch-halt-2", operation: "create"},
+      create("sock-batch-halt-3", "never"),
+    ];
+    const response = await triggerBatch(socket, mutations);
+    expect(response.results).toHaveLength(2);
+    expect(response.results[0].type).toBe("ack");
+    expect(response.results[1].type).toBe("nack");
+    expect(response.results[1].nack?.code).toBe("validation");
+    expect(await SockStuffModel.countDocuments({name: "never"})).toBe(0);
+  });
+
+  it("rejects an oversized batch before processing", async () => {
+    const socket = createMockSocket({id: "user1"});
+    install(socket);
+    const mutations = Array.from({length: MAX_SYNC_MUTATIONS_PER_BATCH + 1}, (_v, i) =>
+      create(`sock-batch-oversized-${i}`, `item ${i}`)
+    );
+    const response = await triggerBatch(socket, mutations);
+    expect(response.results).toHaveLength(1);
+    expect(response.results[0].nack?.code).toBe("validation");
+    expect(await SockStuffModel.countDocuments({})).toBe(0);
+  });
+
+  it("rejects intra-batch duplicate mutationIds before processing", async () => {
+    const socket = createMockSocket({id: "user1"});
+    install(socket);
+    const mutations = [create("sock-batch-dup", "a"), create("sock-batch-dup", "b")];
+    const response = await triggerBatch(socket, mutations);
+    expect(response.results).toHaveLength(1);
+    expect(response.results[0].nack?.code).toBe("validation");
+    expect(await SockStuffModel.countDocuments({})).toBe(0);
+  });
+
+  it("nacks unauthorized for unauthenticated sockets", async () => {
+    const socket = createMockSocket(undefined);
+    install(socket);
+    const response = await triggerBatch(socket, [create("sock-batch-anon", "x")]);
+    expect(response.results).toHaveLength(1);
+    expect(response.results[0].nack?.code).toBe("unauthorized");
+  });
+
+  it("rate-limits batch mutations against the same window as sync:mutate", async () => {
+    const socket = createMockSocket({id: "user1"});
+    install(socket);
+    // Two batches within the per-batch size cap, but together exceeding the
+    // per-second mutation budget — the shared window rejects the second batch
+    // before any of its mutations are attempted.
+    const firstBatch = Array.from({length: MAX_SYNC_MUTATIONS_PER_BATCH}, (_v, i) => ({
+      collection: "nope",
+      mutationId: `flood-batch-a-${i}`,
+      operation: "create",
+    }));
+    const secondBatch = Array.from({length: 10}, (_v, i) => ({
+      collection: "nope",
+      mutationId: `flood-batch-b-${i}`,
+      operation: "create",
+    }));
+    await triggerBatch(socket, firstBatch);
+    const response = await triggerBatch(socket, secondBatch);
+    expect(response.results).toHaveLength(1);
+    expect(response.results[0].nack?.message).toContain("Rate limit");
   });
 });
 

--- a/api/src/sync/syncSocket.test.ts
+++ b/api/src/sync/syncSocket.test.ts
@@ -4,11 +4,12 @@
  *   - socketHandlers.ts (sync:subscribe / sync:unsubscribe / sync:mutate, caps, rate limit)
  *   - changeStreamWatcher.ts sync:delta emission (mock change streams + real change
  *     streams gated on replica-set availability, following realtime.test.ts conventions)
- *   - socketAuth.ts (legacy JWT validator chain + Better Auth session validator)
+ *
+ * socketAuth.ts (legacy JWT validator chain + Better Auth session validator) has its own
+ * dedicated test file: realtime/socketAuth.test.ts.
  */
 
 import {afterEach, beforeAll, beforeEach, describe, expect, it} from "bun:test";
-import jwt from "jsonwebtoken";
 import mongoose, {model, Schema} from "mongoose";
 
 import type {ModelRouterOptions} from "../api";
@@ -19,12 +20,6 @@ import {
   stopChangeStreamWatcher,
 } from "../realtime/changeStreamWatcher";
 import {clearRealtimeRegistry, registerRealtime} from "../realtime/registry";
-import {
-  type AuthenticatableSocket,
-  createBetterAuthValidator,
-  createLegacyJwtValidator,
-  createSocketAuthMiddleware,
-} from "../realtime/socketAuth";
 import {setupDb} from "../tests";
 import {SyncCounter, SyncMutation} from "./models";
 import {MAX_SYNC_MUTATIONS_PER_BATCH} from "./mutationHandler";
@@ -1243,215 +1238,5 @@ describe("sync:delta — change stream integration", () => {
     const deltas = io.emissions.filter((e: any) => e.event === "sync:delta");
     expect(deltas).toHaveLength(1);
     expect(io.emissions.filter((e: any) => e.event === "sync")).toHaveLength(0);
-  });
-});
-
-// ─────────────────────────────────────────────────────────────────────────────
-// socketAuth — legacy JWT chain + Better Auth validator
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe("socketAuth", () => {
-  const tokenSecret = "socket-auth-test-secret";
-
-  const makeAuthSocket = (token?: string): AuthenticatableSocket & {decodedToken?: any} => ({
-    handshake: {auth: token === undefined ? {} : {token}},
-  });
-
-  const runMiddleware = (
-    middleware: (socket: any, next: (error?: Error) => void) => void,
-    socket: AuthenticatableSocket
-  ): Promise<Error | undefined> =>
-    new Promise((resolve) => {
-      middleware(socket, (error?: Error) => resolve(error));
-    });
-
-  describe("createLegacyJwtValidator", () => {
-    it("accepts a valid Bearer JWT and populates decodedToken", async () => {
-      const validator = createLegacyJwtValidator(tokenSecret);
-      const token = jwt.sign({admin: true, id: "jwt-user"}, tokenSecret);
-      const socket = makeAuthSocket(`Bearer ${token}`);
-      await validator(socket);
-      expect(socket.decodedToken?.id).toBe("jwt-user");
-      expect(socket.decodedToken?.admin).toBe(true);
-    });
-
-    it("rejects a token signed with the wrong secret", async () => {
-      const validator = createLegacyJwtValidator(tokenSecret);
-      const token = jwt.sign({id: "jwt-user"}, "wrong-secret");
-      await expect(validator(makeAuthSocket(`Bearer ${token}`))).rejects.toThrow(
-        "Token is missing or invalid Bearer"
-      );
-    });
-
-    it("rejects a token without the Bearer prefix", async () => {
-      const validator = createLegacyJwtValidator(tokenSecret);
-      const token = jwt.sign({id: "jwt-user"}, tokenSecret);
-      await expect(validator(makeAuthSocket(token))).rejects.toThrow(
-        "Format is Authorization: Bearer [token]"
-      );
-    });
-
-    it("rejects when no token is provided", async () => {
-      const validator = createLegacyJwtValidator(tokenSecret);
-      await expect(validator(makeAuthSocket(undefined))).rejects.toThrow("no token provided");
-    });
-  });
-
-  describe("createBetterAuthValidator", () => {
-    const stubAuth = (session: unknown, capture?: {headers?: unknown}): any => ({
-      api: {
-        getSession: async ({headers}: {headers: unknown}) => {
-          if (capture) {
-            capture.headers = headers;
-          }
-          return session;
-        },
-      },
-    });
-
-    it("populates decodedToken from a valid Better Auth session", async () => {
-      const validator = createBetterAuthValidator({
-        auth: stubAuth({session: {id: "sess-1"}, user: {id: "ba-user-1"}}),
-      });
-      const socket = makeAuthSocket("session-token-abc");
-      await validator(socket);
-      expect(socket.decodedToken).toEqual({admin: false, id: "ba-user-1", isAnonymous: false});
-    });
-
-    it("passes the token as a bearer authorization header only", async () => {
-      const capture: {headers?: any} = {};
-      const validator = createBetterAuthValidator({
-        auth: stubAuth({session: {id: "s"}, user: {id: "u"}}, capture),
-      });
-      await validator(makeAuthSocket("Bearer session-token-xyz"));
-      expect(capture.headers.authorization).toBe("Bearer session-token-xyz");
-      // A raw (unsigned) token cookie fails signature verification and can shadow the
-      // bearer path, so the validator must not send one.
-      expect(capture.headers.cookie).toBeUndefined();
-    });
-
-    it("rejects when the session lookup returns null", async () => {
-      const validator = createBetterAuthValidator({auth: stubAuth(null)});
-      await expect(validator(makeAuthSocket("bad-session"))).rejects.toThrow(
-        "Better Auth session is missing or invalid"
-      );
-    });
-
-    it("rejects when no token is provided", async () => {
-      const validator = createBetterAuthValidator({auth: stubAuth(null)});
-      await expect(validator(makeAuthSocket(undefined))).rejects.toThrow("no token provided");
-    });
-
-    it("resolves the app user for id and admin when a userModel is provided", async () => {
-      const userModel = {
-        find: () => {
-          throw new Error("unused");
-        },
-      };
-      const appUser = {_id: "app-user-1", admin: true};
-      const findOneOrNone = async (query: Record<string, unknown>) =>
-        query.betterAuthId === "ba-user-1" ? appUser : null;
-      const validator = createBetterAuthValidator({
-        auth: stubAuth({session: {id: "s"}, user: {id: "ba-user-1"}}),
-        userModel: {...userModel, findOneOrNone} as any,
-      });
-      const socket = makeAuthSocket("session-token");
-      await validator(socket);
-      expect(socket.decodedToken).toEqual({admin: true, id: "app-user-1", isAnonymous: false});
-    });
-
-    it("rejects when the Better Auth user has no application user", async () => {
-      const validator = createBetterAuthValidator({
-        auth: stubAuth({session: {id: "s"}, user: {id: "ba-orphan"}}),
-        userModel: {findOneOrNone: async () => null} as any,
-      });
-      await expect(validator(makeAuthSocket("session-token"))).rejects.toThrow(
-        "no application user"
-      );
-    });
-  });
-
-  describe("createSocketAuthMiddleware — validator chain", () => {
-    it("accepts a legacy JWT with the default chain", async () => {
-      const middleware = createSocketAuthMiddleware({tokenSecret});
-      const token = jwt.sign({admin: false, id: "chain-user"}, tokenSecret);
-      const socket = makeAuthSocket(`Bearer ${token}`);
-      const error = await runMiddleware(middleware, socket);
-      expect(error).toBeUndefined();
-      expect(socket.decodedToken?.id).toBe("chain-user");
-    });
-
-    it("rejects an invalid token with the default chain", async () => {
-      const middleware = createSocketAuthMiddleware({tokenSecret});
-      const socket = makeAuthSocket("Bearer not-a-jwt");
-      const error = await runMiddleware(middleware, socket);
-      expect(error).toBeDefined();
-      expect(error?.message).toContain("invalid");
-      expect(socket.decodedToken).toBeUndefined();
-    });
-
-    it("falls through to the Better Auth validator when the JWT validator fails", async () => {
-      const middleware = createSocketAuthMiddleware({
-        betterAuth: {
-          auth: {
-            api: {getSession: async () => ({session: {id: "s"}, user: {id: "ba-user-2"}})},
-          } as any,
-        },
-        tokenSecret,
-      });
-      const socket = makeAuthSocket("better-auth-session-token");
-      const error = await runMiddleware(middleware, socket);
-      expect(error).toBeUndefined();
-      expect(socket.decodedToken).toEqual({admin: false, id: "ba-user-2", isAnonymous: false});
-    });
-
-    it("prefers the legacy JWT validator when both would work", async () => {
-      const middleware = createSocketAuthMiddleware({
-        betterAuth: {
-          auth: {
-            api: {
-              getSession: async () => {
-                throw new Error("should not be called for a valid JWT");
-              },
-            },
-          } as any,
-        },
-        tokenSecret,
-      });
-      const token = jwt.sign({admin: true, id: "jwt-first"}, tokenSecret);
-      const socket = makeAuthSocket(`Bearer ${token}`);
-      const error = await runMiddleware(middleware, socket);
-      expect(error).toBeUndefined();
-      expect(socket.decodedToken?.id).toBe("jwt-first");
-      expect(socket.decodedToken?.admin).toBe(true);
-    });
-
-    it("rejects with the last validator's error when every validator fails", async () => {
-      const middleware = createSocketAuthMiddleware({
-        betterAuth: {auth: {api: {getSession: async () => null}} as any},
-        tokenSecret,
-      });
-      const socket = makeAuthSocket("neither-jwt-nor-session");
-      const error = await runMiddleware(middleware, socket);
-      expect(error?.message).toContain("Better Auth session is missing or invalid");
-    });
-
-    it("supports extra validators appended to the chain", async () => {
-      const middleware = createSocketAuthMiddleware({
-        extraValidators: [
-          async (socket) => {
-            if (socket.handshake.auth.token !== "magic") {
-              throw new Error("not magic");
-            }
-            socket.decodedToken = {admin: false, id: "magic-user", isAnonymous: false};
-          },
-        ],
-        tokenSecret,
-      });
-      const socket = makeAuthSocket("magic");
-      const error = await runMiddleware(middleware, socket);
-      expect(error).toBeUndefined();
-      expect(socket.decodedToken?.id).toBe("magic-user");
-    });
   });
 });

--- a/api/src/sync/syncSocket.test.ts
+++ b/api/src/sync/syncSocket.test.ts
@@ -21,7 +21,7 @@ import {
 } from "../realtime/changeStreamWatcher";
 import {clearRealtimeRegistry, registerRealtime} from "../realtime/registry";
 import {setupDb} from "../tests";
-import {SyncCounter, SyncMutation} from "./models";
+import {SyncCounter, SyncMutation, SyncScopeMove} from "./models";
 import {MAX_SYNC_MUTATIONS_PER_BATCH} from "./mutationHandler";
 import {
   clearSyncRegistry,
@@ -36,6 +36,7 @@ import {
   installSyncSocketHandlers,
   MAX_SYNC_COLLECTION_SUBSCRIPTIONS,
   MAX_SYNC_MUTATIONS_PER_SECOND,
+  MAX_SYNC_SUBSCRIBE_ARRAY_LENGTH,
   type SyncSocketLike,
   setActiveSyncAppOptions,
   syncRoomForStream,
@@ -411,6 +412,22 @@ describe("installSyncSocketHandlers — subscribe/unsubscribe", () => {
     const syncRooms = Array.from(socket.rooms).filter((r) => r.startsWith("sync:"));
     expect(syncRooms).toHaveLength(MAX_SYNC_COLLECTION_SUBSCRIPTIONS);
     expect(syncErrors(socket)).toHaveLength(3);
+  });
+
+  it("C8: rejects an oversized sync:subscribe array before iterating (length check first)", async () => {
+    const socket = createMockSocket({id: "user1"});
+    install(socket);
+    // An array over the cap must be rejected wholesale with a single sync:error and NO
+    // room joins — the length guard runs before any per-collection work.
+    const collections = Array.from(
+      {length: MAX_SYNC_SUBSCRIBE_ARRAY_LENGTH + 1},
+      (_v, i) => `sockStuff${i}`
+    );
+    await socket.trigger("sync:subscribe", {collections});
+    expect(Array.from(socket.rooms).filter((r) => r.startsWith("sync:"))).toHaveLength(0);
+    const errors = syncErrors(socket);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toMatch(/at most/i);
   });
 
   it("sync:unsubscribe leaves the rooms and frees the cap slot", async () => {
@@ -907,7 +924,7 @@ describe("emitSyncDeltaForChange", () => {
     expect(receiver.decodedToken.id).toBe("user1");
   });
 
-  it("soft delete emits a delete delta with deleted true and tombstone data", async () => {
+  it("C7: soft delete emits a delete delta with deleted true and NO data (tombstone stripped)", async () => {
     const entry = ownerEntry();
     const io = makeTrackedIo();
     io.addSocketToRoom(syncRoomForStream("sockStuff|owner:user1"), {admin: false, id: "user1"});
@@ -930,11 +947,21 @@ describe("emitSyncDeltaForChange", () => {
     expect(delta.method).toBe("delete");
     expect(delta.deleted).toBe(true);
     expect(delta.seq).toBe(3);
-    expect((delta.data as any).name).toBe("gone");
+    // C7: a tombstone delta carries no data (privacy + payload growth).
+    expect(delta.data).toBeUndefined();
   });
 
-  it("scope move emits a data-less tombstone to the previous stream and a create to the new stream", async () => {
+  it("C4: scope move emits a data-less tombstone (from the durable marker) to the previous stream and a create to the new stream", async () => {
     const entry = ownerEntry();
+    await SyncScopeMove.deleteMany({});
+    // C4: the tombstone is driven by a durable SyncScopeMove marker, not _syncPrevStream.
+    await SyncScopeMove.create({
+      collectionTag: "sockStuff",
+      entityId: "doc-1",
+      fromStream: "sockStuff|owner:user1",
+      seq: 9,
+      toStream: "sockStuff|owner:user2",
+    });
     const io = makeTrackedIo();
     const oldRoom = syncRoomForStream("sockStuff|owner:user1");
     const newRoom = syncRoomForStream("sockStuff|owner:user2");
@@ -945,7 +972,6 @@ describe("emitSyncDeltaForChange", () => {
       change: makeChange({
         fullDocument: {
           _id: "doc-1",
-          _syncPrevStream: "sockStuff|owner:user1",
           _syncSeq: 9,
           name: "moved",
           ownerId: "user2",
@@ -973,10 +999,58 @@ describe("emitSyncDeltaForChange", () => {
     expect(create.method).toBe("create");
     expect(create.stream).toBe("sockStuff|owner:user2");
     expect((create.data as any).name).toBe("moved");
+    await SyncScopeMove.deleteMany({});
   });
 
-  it("ignores a stale _syncPrevStream equal to the current stream", async () => {
+  it("C4: a racing second write cannot suppress the tombstone (the marker is durable, not the post-image)", async () => {
+    // Simulates the race the design fixes: a second write reset _syncPrevStream to null
+    // before this change event was processed. With the OLD implementation the old stream
+    // would never get a tombstone; with the marker it still does.
     const entry = ownerEntry();
+    await SyncScopeMove.deleteMany({});
+    await SyncScopeMove.create({
+      collectionTag: "sockStuff",
+      entityId: "doc-1",
+      fromStream: "sockStuff|owner:user1",
+      seq: 11,
+      toStream: "sockStuff|owner:user2",
+    });
+    const io = makeTrackedIo();
+    const oldRoom = syncRoomForStream("sockStuff|owner:user1");
+    io.addSocketToRoom(oldRoom, {admin: true, id: "admin"});
+    io.addSocketToRoom(syncRoomForStream("sockStuff|owner:user2"), {admin: true, id: "admin"});
+
+    await emitSyncDeltaForChange({
+      change: makeChange({
+        fullDocument: {
+          _id: "doc-1",
+          // _syncPrevStream is null (overwritten by the racing second write) — irrelevant now.
+          _syncPrevStream: null,
+          _syncSeq: 12,
+          name: "moved then edited",
+          ownerId: "user2",
+        },
+        operationType: "update",
+        updateDescription: {updatedFields: {name: "moved then edited"}},
+      }),
+      docId: "doc-1",
+      entry,
+      io,
+      logDebug: () => {},
+    });
+
+    const deltas = io.emissions.filter((e: any) => e.event === "sync:delta");
+    const tombstone = deltas.find((e: any) => e.room === oldRoom)?.payload as SyncDelta;
+    expect(tombstone).toBeDefined();
+    expect(tombstone.method).toBe("delete");
+    expect(tombstone.stream).toBe("sockStuff|owner:user1");
+    expect(tombstone.seq).toBe(11);
+    await SyncScopeMove.deleteMany({});
+  });
+
+  it("C4: no marker for the current stream means a plain update (no spurious tombstone)", async () => {
+    const entry = ownerEntry();
+    await SyncScopeMove.deleteMany({});
     const io = makeTrackedIo();
     io.addSocketToRoom(syncRoomForStream("sockStuff|owner:user1"), {admin: false, id: "user1"});
 
@@ -984,7 +1058,6 @@ describe("emitSyncDeltaForChange", () => {
       change: makeChange({
         fullDocument: {
           _id: "doc-1",
-          _syncPrevStream: "sockStuff|owner:user1",
           _syncSeq: 4,
           name: "same stream",
           ownerId: "user1",

--- a/api/src/sync/syncSocket.test.ts
+++ b/api/src/sync/syncSocket.test.ts
@@ -582,7 +582,7 @@ describe("installSyncSocketHandlers — sync:mutate", () => {
     expect(lastNack(socket)?.code).toBe("unauthorized");
   });
 
-  it("rate-limits mutations beyond the per-second cap with an error nack", async () => {
+  it("rate-limits mutations beyond the per-second cap with a rate_limited nack carrying retryAfterMs (FIX 1)", async () => {
     const socket = createMockSocket({id: "user1"});
     install(socket);
     // Exceed the window with cheap validation nacks (unknown collection) — the rate limit
@@ -600,6 +600,14 @@ describe("installSyncSocketHandlers — sync:mutate", () => {
       (e.payload as SyncNack).message?.includes("Rate limit")
     );
     expect(rateLimited).toHaveLength(5);
+    // FIX 1: the nack code is "rate_limited" (never "error") so the client
+    // never treats it as a durable-data failure, and it carries a
+    // retryAfterMs hint for the client's backoff floor.
+    for (const nack of rateLimited) {
+      const payload = nack.payload as SyncNack;
+      expect(payload.code).toBe("rate_limited");
+      expect(typeof (payload as {retryAfterMs?: number}).retryAfterMs).toBe("number");
+    }
   });
 });
 
@@ -700,7 +708,7 @@ describe("installSyncSocketHandlers — sync:mutateBatch", () => {
     expect(response.results[0].nack?.code).toBe("unauthorized");
   });
 
-  it("rate-limits batch mutations against the same window as sync:mutate", async () => {
+  it("rate-limits batch mutations against the same window as sync:mutate with a rate_limited nack carrying retryAfterMs (FIX 1)", async () => {
     const socket = createMockSocket({id: "user1"});
     install(socket);
     // Two batches within the per-batch size cap, but together exceeding the
@@ -720,6 +728,29 @@ describe("installSyncSocketHandlers — sync:mutateBatch", () => {
     const response = await triggerBatch(socket, secondBatch);
     expect(response.results).toHaveLength(1);
     expect(response.results[0].nack?.message).toContain("Rate limit");
+    // FIX 1: rate limiting must never look like a durable-data error — the
+    // client treats "rate_limited" like a transport failure (never terminal).
+    expect(response.results[0].nack?.code).toBe("rate_limited");
+    expect(typeof (response.results[0].nack as {retryAfterMs?: number})?.retryAfterMs).toBe(
+      "number"
+    );
+  });
+
+  it("emits sync:batchReceived immediately, before any mutation is applied (FIX 5)", async () => {
+    const socket = createMockSocket({id: "user1"});
+    install(socket);
+    const mutations = [create("sock-batch-receipt-1", "a")];
+    await socket.trigger("sync:mutateBatch", {batchId: "b-123", mutations}, () => {});
+    const receipts = socket.emitted.filter((e) => e.event === "sync:batchReceived");
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0].payload).toEqual({batchId: "b-123"});
+  });
+
+  it("does not emit sync:batchReceived when the request has no batchId (HTTP-shaped payload)", async () => {
+    const socket = createMockSocket({id: "user1"});
+    install(socket);
+    await triggerBatch(socket, [create("sock-batch-no-id", "a")]);
+    expect(socket.emitted.filter((e) => e.event === "sync:batchReceived")).toHaveLength(0);
   });
 });
 

--- a/api/src/sync/types.ts
+++ b/api/src/sync/types.ts
@@ -102,9 +102,16 @@ export interface SyncAck {
   id: string;
   /** The document's new `_syncSeq`. */
   seq: number;
+  /**
+   * C5 (FIX 6): set when the document write succeeded and the ledger
+   * finalized `applied`, but the model's post-hook (`postCreate`/
+   * `postUpdate`/`postDelete`) threw. The mutation is still a full success —
+   * this is informational only, never a reason to retry or roll back.
+   */
+  warning?: string;
 }
 
-export type SyncNackCode = "conflict" | "unauthorized" | "validation" | "error";
+export type SyncNackCode = "conflict" | "unauthorized" | "validation" | "error" | "rate_limited";
 
 /** Rejected mutation. Conflict nacks carry the canonical server document. */
 export interface SyncNack {
@@ -115,6 +122,11 @@ export interface SyncNack {
   /** The server document's current `_syncSeq` (conflict nacks). */
   serverSeq?: number;
   message?: string;
+  /**
+   * Minimum time (ms) the client should wait before retrying, filled by the
+   * server with the remaining rate-limit window (`rate_limited` nacks only).
+   */
+  retryAfterMs?: number;
 }
 
 /**
@@ -125,6 +137,15 @@ export interface SyncNack {
 export interface SyncMutateBatchRequest {
   /** Ordered mutations; each still carries its own mutationId. */
   mutations: SyncMutateRequest[];
+  /**
+   * Client-generated correlation id, socket transport only (ignored over
+   * HTTP). Echoed back immediately via `sync:batchReceived {batchId}` before
+   * processing begins, so the client can distinguish "the server has no
+   * sync:mutateBatch handler" (silence past the grace period, batching
+   * unsupported) from "the server is just slow to finish this batch" (a
+   * receipt arrived; keep waiting up to the full batch timeout).
+   */
+  batchId?: string;
 }
 
 /** One result per PROCESSED mutation in a batch, in request order. */

--- a/api/src/sync/types.ts
+++ b/api/src/sync/types.ts
@@ -117,6 +117,31 @@ export interface SyncNack {
   message?: string;
 }
 
+/**
+ * A batch of client mutations delivered via `sync:mutateBatch` or
+ * `POST /sync/mutate/batch`. The server MUST apply strictly in array order and
+ * stop at the first non-ack outcome (see `applySyncMutationBatch`).
+ */
+export interface SyncMutateBatchRequest {
+  /** Ordered mutations; each still carries its own mutationId. */
+  mutations: SyncMutateRequest[];
+}
+
+/** One result per PROCESSED mutation in a batch, in request order. */
+export type SyncMutateBatchResult = {type: "ack"; ack: SyncAck} | {type: "nack"; nack: SyncNack};
+
+/**
+ * Response to a batch mutation request.
+ *
+ * `results.length < request.mutations.length` means the server halted at the
+ * first non-ack: `results[results.length - 1]` is that failing outcome, and
+ * every mutation after it was NOT attempted (not ledgered, not applied) —
+ * still safe to resend in a later batch (INV-3).
+ */
+export interface SyncMutateBatchResponse {
+  results: SyncMutateBatchResult[];
+}
+
 /** A change event delivered to subscribed clients via `sync:delta`. */
 export interface SyncDelta {
   /** Collection tag (e.g. "todos"). */

--- a/api/src/sync/types.ts
+++ b/api/src/sync/types.ts
@@ -55,6 +55,12 @@ export interface SyncConfig {
   snapshotFilter?: (user: {
     id: string;
   }) => Record<string, unknown> | Promise<Record<string, unknown>>;
+  /**
+   * C7: tombstone retention window in days (default 90). Tombstones older than this may
+   * be hard-deleted by the `compactTombstones` maintenance script; a client whose cursor
+   * predates the retained floor re-bootstraps (see `oldestRetainedSeq`).
+   */
+  retentionDays?: number;
 }
 
 export type SyncMutationOperation = "create" | "update" | "delete";
@@ -71,13 +77,47 @@ export interface SyncEntityPayload {
   deleted: boolean;
 }
 
-/** Response shape for `GET /sync/snapshot`. */
+/**
+ * Response shape for `GET /sync/snapshot` (C2: one stream per request).
+ */
 export interface SyncSnapshotResponse {
+  /** The stream this page belongs to (echoed from the request). */
+  stream: string;
   entities: SyncEntityPayload[];
-  /** Highest seq included in this page; pass back as `cursor` to continue. */
+  /**
+   * Highest seq included in this page (C1: never above `frontierSeq`); pass back as
+   * `cursor` to continue.
+   */
   cursor: number;
-  /** True when more pages remain past `cursor`. */
+  /** True when more pages remain past `cursor` (more committed OR uncommitted seqs). */
   hasMore: boolean;
+  /** C1: the stream's stable frontier — the client must not advance its cursor beyond this. */
+  frontierSeq: number;
+  /**
+   * C7: the lowest seq still retained for this stream after tombstone compaction. A
+   * client whose stored cursor is below this may have missed compacted tombstones and
+   * must re-bootstrap the stream from 0 (sanctioned wipe: retention gap, not auth).
+   */
+  oldestRetainedSeq: number;
+  /**
+   * C3: opaque forward token for paging the legacy (seq-0) stratum by `_id`. Present
+   * while unstamped legacy documents remain; absent once the stratum is exhausted and
+   * paging proceeds by seq. The client echoes it back verbatim.
+   */
+  legacyCursor?: string;
+}
+
+/** One stream a user currently belongs to, from `GET /sync/streams`. */
+export interface SyncStreamInfo {
+  /** The stream key (e.g. "todos|owner:123"). */
+  stream: string;
+  /** The collection tag the stream belongs to. */
+  collection: string;
+}
+
+/** Response shape for `GET /sync/streams`. */
+export interface SyncStreamsResponse {
+  streams: SyncStreamInfo[];
 }
 
 /** A client mutation delivered via `sync:mutate` or `POST /sync/mutate`. */
@@ -163,7 +203,20 @@ export interface SyncMutateBatchResponse {
   results: SyncMutateBatchResult[];
 }
 
-/** A change event delivered to subscribed clients via `sync:delta`. */
+/**
+ * A change event delivered to subscribed clients via `sync:delta`.
+ *
+ * ## Per-entity ordering & the LWW-by-seq contract (C8)
+ *
+ * The server serializes delta dispatch PER entity (`{collection}:{id}`): two deltas for
+ * the same document are always emitted in change-stream (commit) order, so their `seq`
+ * values arrive monotonically for that entity. Deltas for DIFFERENT entities may arrive
+ * in any order (they dispatch concurrently). Clients therefore apply last-writer-wins
+ * BY SEQ within an entity: a delta whose `seq` is at or below the entity's applied seq is
+ * an idempotent no-op; only a strictly higher `seq` mutates local state. Combined with
+ * the C1 frontier (`frontierSeq`), a cursor never advances past an uncommitted seq, so no
+ * committed delta is ever permanently skipped.
+ */
 export interface SyncDelta {
   /** Collection tag (e.g. "todos"). */
   collection: string;
@@ -176,6 +229,12 @@ export interface SyncDelta {
   seq: number;
   /** Stream key this delta belongs to (e.g. "todos|owner:123"). */
   stream: string;
+  /**
+   * C1: the stream's stable frontier at emit time. The client advances its cursor to
+   * `min(seq, frontierSeq)` so a delta observed out of commit order never advances a
+   * cursor past an uncommitted hole.
+   */
+  frontierSeq?: number;
   /** True when the entity is soft-deleted. */
   deleted?: boolean;
 }

--- a/api/src/terrenoApp.ts
+++ b/api/src/terrenoApp.ts
@@ -24,6 +24,7 @@ import {
   requestContextMiddleware,
   updateRequestContextFromRequest,
 } from "./requestContext";
+import {ensureSyncIndexes} from "./sync/registry";
 import type {TerrenoPlugin} from "./terrenoPlugin";
 import openapi from "./vendor/wesleytodd-openapi/index";
 
@@ -426,24 +427,31 @@ export class TerrenoApp {
 
     if (!this.options.skipListen) {
       const port = process.env.PORT || "9000";
-      try {
-        const server = createServer(app);
+      // Await sync snapshot-index creation before listening so a failed createIndex
+      // (which would degrade the snapshot/catch-up query to a table scan) is a loud
+      // startup error rather than a silent perf cliff. No-op when no sync models are
+      // registered. Detached because start() returns the app synchronously.
+      void (async (): Promise<void> => {
+        try {
+          await ensureSyncIndexes();
+          const server = createServer(app);
 
-        // Notify plugins that need access to the HTTP server (e.g. WebSocket plugins)
-        for (const reg of this.registrations) {
-          if (!this.isModelRouterRegistration(reg) && typeof reg.onServerCreated === "function") {
-            reg.onServerCreated(server);
+          // Notify plugins that need access to the HTTP server (e.g. WebSocket plugins)
+          for (const reg of this.registrations) {
+            if (!this.isModelRouterRegistration(reg) && typeof reg.onServerCreated === "function") {
+              reg.onServerCreated(server);
+            }
           }
-        }
 
-        server.listen(port, () => {
-          logger.info(`Listening on port ${port}`);
-        });
-      } catch (error) {
-        const stack = error instanceof Error ? error.stack : String(error);
-        logger.error(`Error trying to start HTTP server: ${error}\n${stack}`);
-        process.exit(1);
-      }
+          server.listen(port, () => {
+            logger.info(`Listening on port ${port}`);
+          });
+        } catch (error) {
+          const stack = error instanceof Error ? error.stack : String(error);
+          logger.error(`Error trying to start HTTP server: ${error}\n${stack}`);
+          process.exit(1);
+        }
+      })();
     }
 
     return app;

--- a/docs/implementationPlans/syncdb-local-first.md
+++ b/docs/implementationPlans/syncdb-local-first.md
@@ -549,3 +549,91 @@ None user-facing. Server-side `logger` instrumentation: applied mutations at `in
 *Structured task breakdown for automated implementation. The canonical copy lives at `docs/tasks/syncdb-local-first.md`; keep the two in sync.*
 
 See `docs/tasks/syncdb-local-first.md` for the full 26-task breakdown across the 7 phases above (including Task 2.0, the modelRouter executor extraction).
+
+---
+
+## Phase C — Sync protocol correctness (updated contract)
+
+Phase C hardened the wire protocol. The rules below OVERRIDE the earlier descriptions of
+the snapshot endpoint, cursor advancement, and scope-move handling.
+
+### C1 — Stable frontier (seq commit fence)
+
+A client cursor for a stream may advance to seq N **only when the server reports N ≤ that
+stream's *stable frontier***: every seq ≤ N in the stream is committed (its owning write
+durably landed, or its claim was reclaimed after the crash lease expired).
+
+- The `SyncCounter` carries an in-flight `pending: [{seq, claimedAt}]` registry. A claim
+  registers its seq(s); the post-write hook (`confirmSyncSeqs`) clears them. The frontier
+  is `min(live pending.seq) − 1`, or the head `seq` when no live pending entries remain.
+  A pending entry older than `PENDING_CLAIM_LEASE_MS` (60s) is treated as abandoned
+  (crashed writer) and excluded — a crash can never freeze the frontier forever.
+- A **session-backed** claim commits atomically with its write, so it skips the pending
+  registry entirely (nothing to confirm; frontier = head).
+- **Snapshots** never return a `cursor` above `frontierSeq`. `hasMore` is true when a full
+  page returned, extra scope-move markers remain, OR the frontier sits below the stream
+  head (more committed seqs are coming). A client at the frontier with `hasMore: true`
+  and no new entities polls/reconciles (rate-limited) until the frontier moves.
+- **Deltas** carry `frontierSeq`; the client advances its cursor to
+  `min(delta.seq, delta.frontierSeq)`, closing the delta-side commit-order inversion with
+  no server round-trip.
+- **Consequence:** no committed document is ever permanently skipped by cursor catch-up.
+
+Write-path guards landed with C1: a query-write on a synced model MUST target a single
+document by `_id` (m9 — a non-`_id` filter could stamp the wrong stream's seq); a save
+whose only modified paths are auto-managed metadata (`_syncSeq`, `_syncPrevStream`,
+`updated`) claims no seq (m10 — no-op saves do not burn seqs).
+
+### C2 — Per-stream snapshots + stream discovery
+
+- `GET /sync/streams` → `{streams: [{stream, collection}]}` — the authoritative set of
+  streams the caller currently belongs to (resolved against the full user so tenant
+  memberships reflect current `organizationIds`).
+- `GET /sync/snapshot?stream={streamKey}&cursor={n}&limit={n}&legacyCursor={opaque}` →
+  `{stream, entities, cursor, hasMore, frontierSeq, oldestRetainedSeq, legacyCursor?}`.
+  One stream per request. The old `?collection=` param and the single flattened cursor are
+  **removed**. The server verifies the caller belongs to the requested stream (403
+  otherwise) and filters to the single scope value (`{field: value}`, never `$in`).
+- The client keeps `_cursors` rows keyed by the **real stream key** (the same key deltas
+  use). It persists a `_knownStreams` set and, on `start()`/`reconcile()`, diffs
+  `GET /sync/streams` against it:
+  - **New stream** → bootstrap from cursor 0 (tenant-join backfill).
+  - **Removed stream** → purge that stream's local entities + cursor + known-stream entry —
+    **only when `GET /sync/streams` returned HTTP 200** (INV-2). A 401 (AuthRequiredError)
+    enters auth-pause and leaves everything intact; a transport error rethrows without
+    purging. A 401/403/transport error is NEVER a membership change.
+- Each local entity row records the `stream` it was written under, so leave-purge is
+  O(stream).
+- **Migration:** a client holding legacy `snapshot:{collection}` cursors deletes them and
+  clears `_knownStreams` on start, then re-bootstraps every stream from 0 (idempotent
+  upserts + seq guards make this cheap and non-destructive; local entities are not wiped).
+
+### C3 — Legacy-doc pagination
+
+Documents predating the seq plugin (no `_syncSeq`, or a literal 0) are paged as a separate
+stratum by `_id`. While the stratum has more, the snapshot returns `cursor: 0` plus an
+opaque `legacyCursor` (the last `_id` seen); the client echoes it back verbatim. When the
+stratum is exhausted the server omits `legacyCursor` and paging proceeds by seq. This
+terminates deterministically — no infinite loop when `> limit` unstamped docs exist.
+
+### C4 — Scope-move markers (durable, not `_syncPrevStream`)
+
+A scope move (owner/tenant change) writes a durable `SyncScopeMove` marker
+`{collectionTag, entityId, fromStream, toStream, seq, created}` in the same op-scope as the
+move, with the `seq` claimed from the OLD stream's counter. The change-stream watcher and
+old-stream snapshot catch-up emit the old-stream tombstone **from the marker**, not from
+the racy `_syncPrevStream` post-image — so a racing second write that resets
+`_syncPrevStream` can no longer erase the tombstone. Markers share the tombstone retention
+window (TTL). An offline old-stream client learns of the move because the marker is merged
+into its snapshot page as a `{deleted: true, data: null}` entity.
+
+### C7 — Retention + re-bootstrap
+
+Tombstone deltas and snapshot tombstones carry **no data** (only id/seq/deleted). The sync
+bookkeeping collections (`synccounters`, `syncmutations`, `syncscopemoves`, `synckeys`) are
+in `DEFAULT_IGNORED_COLLECTIONS` so their own change events drive no fan-out. Tombstones and
+markers older than the model's `retentionDays` (default 90) may be hard-deleted by the
+`compactTombstones` maintenance script. The snapshot response reports `oldestRetainedSeq`;
+a client whose stored cursor for a stream is **below** it may have missed compacted
+tombstones → it purges that stream and re-bootstraps from 0 (a sanctioned retention-gap
+wipe, distinct from an auth wipe — INV-2).

--- a/docs/implementationPlans/syncdb-phase-c-design.md
+++ b/docs/implementationPlans/syncdb-phase-c-design.md
@@ -1,0 +1,425 @@
+# SyncDB Phase C Design (syncdb-2)
+
+Design authority doc for Phase C (server protocol correctness). Hand this verbatim to a
+Sonnet implementer. Read alongside `terreno-syncdb-2.md` (INV-1..4, C1-C8). C5 (mutation
+ledger lease) is owned/implemented elsewhere — this doc designs *around* it and never
+edits `mutationHandler.ts` beyond what C6/C8 already touch.
+
+Global invariants restated in Phase-C terms: INV-1 ordering is per-stream monotonic;
+INV-2 never purge/wipe on 401 — only on confirmed membership change or explicit wipe;
+INV-3 idempotency ledger owns exactly-once; INV-4 repo conventions.
+
+Line refs are anchors, not truth — locate by described code.
+
+---
+
+## 1. C1 — Seq commit fence
+
+### Decision: **Option 2 (stable frontier) with a hardened optimistic claim.** Reject Option 1 and 3.
+
+**Why not Option 1 (transactional counter+write).** Every synced write currently flows
+through Mongoose `save()` (executors AND arbitrary consumer `.save()` in pre/post hooks
+and app code) or the query-write hooks. A transaction requires a `ClientSession` plumbed
+through *every* one of those call sites. `syncSeqPlugin.claimSyncSeqs` already joins
+`this.$session()` when present, but the executors do NOT open a session, and we cannot
+force a session onto consumer code that calls `doc.save()` directly (the plugin's own
+doc comment admits "without a caller session the claim is a plain atomic `$inc`"). A
+transaction that only wraps the executor path leaves every direct-`.save()` write
+un-fenced — a partial fix that hides the bug. Honest assessment: full transactional
+coverage is **not achievable** without a breaking API change forcing sessions on all
+consumers. Rejected.
+
+**Why not Option 3 (post-commit sequencing singleton).** Adds an ordering singleton
+(SPOF + horizontal-scale hazard) and a second write per mutation; makes the ack path
+async w.r.t. seq assignment, breaking the current synchronous `ack.seq` contract that
+the client's `baseVersion` chaining (A2) depends on. Rejected.
+
+**Chosen: stable frontier.** Keep the cheap optimistic `$inc` claim (no transaction, no
+per-write session plumbing — zero new cost on the hot path). Add a *frontier* that
+consumers (snapshot + delta cursor advancement) never cross until the claim is known
+committed. A client cursor may advance to seq N **only when every seq ≤ N in that stream
+is committed** (its owning write durably landed or its claim was reclaimed).
+
+#### Write-path algorithm (`syncSeqPlugin.ts` + `models.ts`)
+
+Extend `SyncCounter` with an in-flight registry so the frontier is computable:
+
+```
+SyncCounterDocument {
+  stream: string;                // unchanged
+  seq: number;                   // last claimed (unchanged)
+  pending: Array<{seq: number; claimedAt: Date}>;  // NEW — uncommitted claims
+}
+```
+
+`claimSyncSeqs({stream, count, session})` becomes two atomic phases:
+
+1. **Claim + register (pre-write).** One `findOneAndUpdate`:
+   `{$inc: {seq: count}, $push: {pending: {$each: [{seq, claimedAt: now}, ...]}}}`
+   returning `new: true`. The claimed range is `[seq-count+1, seq]`. Stamp `_syncSeq`
+   as today. (Still joins `this.$session()` when a caller opened one — that path gets
+   true atomicity for free and skips the pending registry via a fast path below.)
+2. **Confirm (post-write).** After the document write commits, remove the claim:
+   `{$pull: {pending: {seq: {$in: claimedRange}}}}`. This runs in `schema.post("save")`
+   and in a `post` hook on the query-writes. A crash between phases leaves a stale
+   `pending` entry — handled by the reclaim lease below.
+
+Fast path: when a caller session is present, the write and `$inc` are already atomic;
+skip the pending registry entirely (register nothing, confirm nothing). Frontier logic
+treats a stream with no `pending` entries as fully committed up to `seq`.
+
+**Frontier computation** (`models.ts`, `computeStableFrontier({stream})`):
+`frontier = (min pending.seq) - 1`, or `seq` (the head) when `pending` is empty. A stale
+pending entry (claimedAt older than `PENDING_CLAIM_LEASE_MS`, default 60s) is treated as
+abandoned: it is `$pull`ed opportunistically at read time and excluded from the min, so a
+crashed writer cannot freeze the frontier forever. (Liveness cost of the frontier: a live
+write in flight briefly holds the frontier at its seq-1; snapshots see the gap fill within
+one write latency, or one lease on crash.)
+
+#### Where the frontier gates cursor advancement
+
+- **Snapshot (`routes.ts`):** the page's `seqFilter` upper-bounds at the frontier:
+  `{_syncSeq: {$gt: cursor, $lte: frontier}}`. `hasMore` is true when either the frontier
+  is below `seq` (more coming, not yet committed) OR a full page was returned. The response
+  `cursor` is `min(lastEntitySeq, frontier)` — never advance a client past an uncommitted
+  hole. A client at the frontier with `hasMore:true` and zero new entities polls/reconciles
+  (rate-limited) until the frontier moves.
+- **Delta (`changeStreamWatcher.ts`):** deltas are only observed via the change stream
+  *after* commit, so a delta's seq is always ≤ committed. BUT a delta can arrive for seq N
+  while N-1's claim is still pending (out-of-commit-order). The watcher already emits deltas
+  as they arrive and the client's `applyDelta` advances the per-stream cursor to `delta.seq`
+  unconditionally. **Fix:** the watcher stamps each delta with the *stream frontier at emit
+  time* (`frontierSeq` field on `SyncDelta`); the client advances its cursor to
+  `min(delta.seq, delta.frontierSeq)` (see §5). This closes the delta-side inversion with
+  no server round-trip.
+
+#### Multi-doc lookup mis-stamp (m9)
+
+`preQueryWrite` does `model.find(filter).limit(1)` — a non-`_id` filter can match a
+different doc than the one the update targets, stamping the wrong stream's seq. **Fix:**
+refuse to sequence a query-write whose filter is not a single-document identity filter.
+Require the filter to contain `_id` (or `{_id: {$eq}}`); if absent, throw the same loud
+`unsupportedWrite`-style error ("query-write on a synced model must target a single
+document by _id; use findByIdAndUpdate or loop"). This is the same contract stance the
+plugin already takes for `updateMany`/`upsert`. Consumer code that did ad-hoc
+`updateOne({field: x})` on a synced model must migrate to `_id`-targeted writes — a loud,
+one-time break beats silent duplicate seqs.
+
+#### No-op save seq burn (m10)
+
+`schema.pre("save")` claims a seq even when nothing changed. **Fix:** in `pre("save")`,
+if `!this.isNew && this.modifiedPaths().filter(p => p !== "_syncSeq" && p !== "_syncPrevStream").length === 0`,
+skip the claim and leave `_syncSeq` untouched (no delta emitted because the doc write is a
+no-op Mongoose skips anyway). For query-writes, if the effective `$set`/replacement is
+empty, skip.
+
+#### Failure / retry semantics
+
+- Claim registered but write throws → the confirm never runs; the pending entry ages out
+  in one lease and is reclaimed. The burned seq is a benign gap (client rate-limited
+  reconcile, as today). No transaction to roll back.
+- Confirm `$pull` throws after a successful write → log `logger.error`; the entry ages out
+  via lease. Never fail the user write for a confirm error.
+- `TransientTransactionError` — N/A (no transactions).
+
+#### Client-visible contract (write into `syncdb-local-first.md`)
+
+> A client cursor for a stream may advance to seq N only when the server reports N ≤ that
+> stream's *stable frontier*: every seq ≤ N in the stream is committed. Snapshots never
+> return a cursor above the frontier; deltas carry the frontier so the client clamps.
+> Consequence: no committed document is ever permanently skipped by cursor catch-up.
+
+#### Performance
+
+Hot path adds one array `$push` on claim and one `$pull` on confirm per write (both on the
+already-fetched counter doc, indexed by `stream`). `pending` stays tiny (bounded by
+concurrent in-flight writes per stream, seconds-scale). Session-backed writes pay nothing.
+
+#### Migration of existing stamped data
+
+None required for stamped docs — they are already committed (no pending entries exist
+pre-deploy; `pending` defaults to `[]`, frontier = head). The counter's new `pending`
+field is additive and `strict:"throw"`-safe (defined in schema).
+
+---
+
+## 2. C2 — Per-stream snapshot cursors
+
+### Decision: **one stream per request**, with a discovery endpoint.
+
+Simpler than `cursors: Record<stream,number>` (no partial-progress bookkeeping in one
+response; each request is independently retryable and rate-limited; maps 1:1 onto the
+existing `_cursors` rows). The collection-flattened cursor is removed.
+
+#### Stream discovery — `GET /sync/streams`
+
+```
+GET /sync/streams  ->  { streams: Array<{stream: string; collection: string}> }
+```
+
+Implementation reuses `resolveUserStreams` (already in `socketHandlers.ts`, extract to
+`streams.ts` as `resolveUserStreamsForEntry`): for each registered entry the user can
+`list`, resolve owner/tenant/broadcast/custom stream keys. This is the authoritative set
+of streams the user currently belongs to. Runs against the **full user** (D2) so tenant
+memberships resolve.
+
+#### Snapshot request/response
+
+```
+GET /sync/snapshot?stream={streamKey}&cursor={n}&limit={n}
+  ->  SyncStreamSnapshotResponse {
+        stream: string;
+        entities: SyncEntityPayload[];       // unchanged shape
+        cursor: number;                       // clamped to frontier (§1)
+        hasMore: boolean;
+        frontierSeq: number;                  // stream stable frontier (§1)
+        oldestRetainedSeq: number;            // C7 retention floor (§ interactions)
+      }
+```
+
+Server decodes `stream` → `{collectionTag, scopeValue}`, looks up the entry, verifies the
+stream is in the user's `resolveUserStreamsForEntry` set (403 otherwise — a client must
+not snapshot a stream it does not belong to), builds the scope filter as
+`{[scopeField]: scopeValue}` (single value, not `$in`), and pages with the frontier-bounded
+`seqFilter` from §1. Keep the C3 legacy stratum (§3) and C6 per-doc read checks.
+
+The old `?collection=` param is removed. `snapshotFilter` for custom scopes still applies
+but is now parameterized by the single stream value.
+
+#### Client stream discovery, join, leave (INV-2)
+
+Client keeps `_cursors` rows keyed by the **real stream key** (delta plumbing already does
+this). The `snapshot:{collection}` pseudo-cursors are deleted.
+
+- On `start()` and each `reconcile()`: call `GET /sync/streams`. Diff against the streams
+  present in `_cursors` and a persisted `_knownStreams` set:
+  - **New stream** (in server set, not in `_knownStreams`) → cursor 0, bootstrap it
+    incrementally (cheap: idempotent upserts). Add to `_knownStreams`. This is the
+    tenant-join backfill.
+  - **Removed stream** (in `_knownStreams`, absent from server set) → **only when the
+    `GET /sync/streams` call succeeded (HTTP 200)** purge that stream's local entities and
+    its cursor + `_knownStreams` entry. A 401/403/transport error is NOT a membership
+    change (INV-2): leave everything intact, enter/keep auth-pause if 401. Purge = delete
+    all entities whose stream resolves to the removed key (client stores `collection`; it
+    must be able to map entity→stream — see §5 client work item).
+- Bootstrap iterates `GET /sync/streams` result, not `config.collections`. `config.collections`
+  becomes the *subscribe* list only.
+
+#### Migration for deployed clients holding legacy `snapshot:{collection}` cursors
+
+On `start()`, if any `_cursors` row key matches `/^snapshot:/`, delete all of them and
+clear `_knownStreams`, then let the normal discovery path bootstrap every stream from
+cursor 0. Idempotent upserts + seq guards make re-bootstrap cheap and non-destructive
+(existing entities keep their data; only stale/lower seqs are re-fetched). Gate this behind
+the E2 schema-version bump so it runs exactly once. Legacy entities already local are NOT
+wiped — this is a cursor migration, not a data wipe.
+
+---
+
+## 3. C3 — Legacy-doc pagination
+
+### Decision: **`_id`-paged legacy stratum with an opaque `legacyCursor`.** Reject the migration-script-only option.
+
+A back-stamp migration must run per stream across all deployments and races live writes;
+the `_id` stratum is self-contained in the route and needs no ops coordination. (A
+back-stamp maintenance script MAY still be offered later as an optimization, but the route
+must be correct without it.)
+
+#### Wire change
+
+Snapshot request gains optional `legacyCursor` (opaque string = last `_id` seen in the
+seq-0 stratum). Response gains optional `legacyCursor` (echo-forward token; absent when the
+legacy stratum is exhausted).
+
+Algorithm in `routes.ts`:
+
+- When `cursor === 0` AND no `legacyCursor` yet, OR `legacyCursor` present: page the
+  **seq-0 stratum** with `{_syncSeq: {$exists: false}}` (or `{$in: [null, 0]}` for legacy
+  zeros), sorted `{_id: 1}`, filter `_id > legacyCursor`, `limit+1`. Return
+  `cursor: 0`, `legacyCursor: <last _id>`, `hasMore: true` while the stratum has more.
+- When the seq-0 stratum is exhausted, return `legacyCursor: undefined` and switch to
+  normal seq paging (`{_syncSeq: {$gt: 0, $lte: frontier}}`) starting at `cursor: 0`.
+- Client (`bootstrap.ts`) echoes `legacyCursor` back until absent, then proceeds by seq.
+
+Loud failure: none needed — the stratum terminates deterministically by `_id`. Keep the
+existing client loop-guard (`hasMore && page.cursor > cursor`) but extend it to also treat
+`legacyCursor` advancement as progress (so a page of seq-0 docs with an advancing
+`legacyCursor` does not trip the guard).
+
+---
+
+## 4. C4 — Scope-move tombstones from the write path
+
+### Decision: explicit `SyncScopeMove` marker doc written in the same op as the move.
+
+The current post-image read of `_syncPrevStream` (`changeStreamWatcher.ts` ~576) is racy:
+a second write resets the field before the first change event is processed. Move the signal
+to the write.
+
+#### Schema (`models.ts`, new `SyncScopeMove`)
+
+```
+SyncScopeMoveDocument {
+  _id;
+  collection: string;      // collectionTag
+  entityId: string;        // moved doc _id
+  fromStream: string;      // old stream (the one to tombstone)
+  toStream: string;        // new stream
+  seq: number;             // claimed from the OLD stream's counter
+  created: Date;           // TTL-indexed, same retention as tombstones (C7)
+}
+```
+
+Index `{fromStream: 1, seq: 1}` for old-stream snapshot catch-up. TTL index on `created`
+with the model's tombstone retention (default 90d, C7).
+
+#### When written
+
+In `syncSeqPlugin` (both `pre("save")` and `preQueryWrite`) when a scope move is detected
+(`prevStream !== null`): claim a seq from the **old** stream's counter and insert a
+`SyncScopeMove` marker, joining the caller session when present so it commits with the
+move. Still stamp `_syncPrevStream` on the doc (harmless; the marker is now the source of
+truth). The marker's seq participates in the old stream's frontier (§1) exactly like a
+tombstone.
+
+#### Watcher emission
+
+Add `synccounters`, `syncmutations`, `syncscopemoves`, `synckeys` to
+`DEFAULT_IGNORED_COLLECTIONS` (C7) so the marker's own change event does NOT drive fan-out.
+Instead, when the watcher processes the *moved document's* change event (or a dedicated
+watch on `SyncScopeMove` inserts — pick the document-event path to reuse existing plumbing),
+it emits the old-stream tombstone from the marker's `fromStream` + `seq` rather than from
+the racy `_syncPrevStream` post-image. Concretely: change `emitSyncDelta` to, on any synced
+doc change, look up any `SyncScopeMove` markers for `{collection, entityId}` with
+`seq > lastEmittedForOldStream` and emit a `{deleted:true}` tombstone to each `fromStream`
+room, then emit the create/normal delta to the new stream. Because the marker is durable,
+a racing second write cannot erase it.
+
+#### Snapshot catch-up on the old stream
+
+`GET /sync/snapshot?stream={oldStream}` must merge `SyncScopeMove` markers into its page:
+markers with `fromStream === stream` and `seq in (cursor, frontier]` become tombstone
+entities (`{id: entityId, deleted: true, seq, data: null}`). Union with the normal entity
+page, sort by seq, page by frontier. This is how a client that was offline during the move
+learns the doc left its stream.
+
+#### TTL / retention
+
+Same window as tombstones (C7 `retentionDays`, default 90). A cursor older than
+`oldestRetainedSeq` triggers full re-bootstrap (§ interactions), which re-derives current
+membership and drops the moved-away doc naturally.
+
+---
+
+## 5. Interactions & client work items
+
+**C1 fence ↔ C2 cursor.** C2's per-stream `cursor` is upper-bounded by C1's `frontierSeq`.
+The snapshot response carries `frontierSeq`; the client stores it but advances its
+`_cursors` seq only to the returned `cursor` (already clamped). Deltas carry `frontierSeq`;
+`applyDelta` advances the cursor to `min(delta.seq, delta.frontierSeq)`.
+
+**C7 retention ↔ C2 response.** `oldestRetainedSeq` (the lowest seq still retained for the
+stream after tombstone compaction) is added to the snapshot response. On reconcile, if the
+client's stored cursor for a stream `< oldestRetainedSeq`, it may have missed compacted
+tombstones → drop that stream's local entities + cursor and re-bootstrap from 0 (sanctioned
+wipe: retention gap, not auth).
+
+### Exact syncdb client work items
+
+1. `types.ts` — add `frontierSeq` and (optional) `legacyCursor` to `SyncSnapshotResponse`;
+   add `SyncStreamInfo`/`GET /sync/streams` response type; add `frontierSeq` to `SyncDelta`.
+2. `httpChannel.ts` — `fetchSnapshotPage` sends `stream` (not `collection`) + optional
+   `legacyCursor`, returns the new fields; add `fetchStreams(): Promise<SyncStreamInfo[]>`.
+3. `cursor.ts` — unchanged API; document that keys are now real stream keys only.
+4. `bootstrap.ts` — rewrite to page **per stream** (loop streams from `fetchStreams`),
+   echo `legacyCursor`, clamp cursor to `frontierSeq`, honor `oldestRetainedSeq`
+   re-bootstrap. Remove `snapshotCursorStream`/`snapshot:` pseudo-cursors.
+5. `deltaApplier.ts` — advance cursor to `min(delta.seq, delta.frontierSeq)`.
+6. `client.ts` — `start()`/`reconcile()` call `fetchStreams`, run join-backfill /
+   leave-purge diff against persisted `_knownStreams` (new store table), gated by HTTP-200
+   success (INV-2); legacy `snapshot:` cursor migration on start (behind E2 version bump);
+   entity→stream mapping helper for purge (store `stream` on each entity row OR recompute
+   from `collection`+scope — prefer storing `stream` at apply time).
+7. Store schema — add `_knownStreams` table and (recommended) a `stream` column on entity
+   rows to make leave-purge O(stream). Bump `SYNC_SCHEMA_VERSION` (triggers E2 wipe path
+   for old stores — acceptable, re-bootstrap is cheap).
+
+---
+
+## 6. Test matrix
+
+**C1 (concurrency, `api/src/sync/sync.test.ts` + new `syncFrontier.test.ts`):**
+- Forced commit inversion: two writers claim seq 5 and 6 on one stream; a `pre("save")`
+  test hook delays writer-5's commit. Assert `computeStableFrontier` returns 4 while 5 is
+  pending; snapshot at cursor 4 returns nothing (hasMore true); after 5 commits, frontier
+  jumps to 6 and snapshot returns both docs. A client looping catch-up at every intermediate
+  cursor eventually sees BOTH.
+- Property-style: N writers, random commit interleavings + random crashes (skip confirm);
+  after lease expiry, every committed doc appears in a full catch-up; no committed doc
+  skipped. Loop 100 seeds.
+- m9: `updateOne({nonIdField: x})` on a synced model throws the loud error.
+- m10: `doc.save()` with no modified paths claims no new seq (counter unchanged, no delta).
+- Migration: pre-existing stamped docs (empty `pending`) → frontier = head immediately.
+
+**C2 (`syncRoutes.test.ts` + integration):**
+- Two-tenant skew: user in org1 (seq 1000) + org2 (seq 5). Per-stream snapshot catches org2
+  to 5 and org1 to 1000 independently; the old flattened cursor bug (org2 stuck at 1000)
+  does NOT reproduce.
+- `GET /sync/streams` returns owner + both tenant streams; reflects `organizationIds`.
+- Join: add org3 membership → `fetchStreams` includes it → client bootstraps org3 from 0.
+- Leave: remove org2 → `fetchStreams` omits it (200) → client purges org2 entities.
+- Leave under 401: `fetchStreams` 401 → NO purge, auth-pause, data intact (INV-2 regression).
+- Legacy migration: store seeded with `snapshot:todos` cursor → start() deletes it,
+  re-bootstraps per stream, entities converge, no data loss.
+
+**C3 (`syncRoutes.test.ts` + `bootstrap.test.ts`):**
+- 1,201 legacy docs (no `_syncSeq`), limit 500 → bootstrap terminates with all 1,201 via
+  `legacyCursor` paging, then continues into seq stratum. Loop-guard not tripped.
+- Mixed legacy + stamped: legacy stratum fully drained before seq paging begins; no doc
+  fetched twice, none missed.
+
+**C4 (`changeStreamWatcher.test.ts` / integration):**
+- Move + immediate second write with artificially delayed change-event processing → old
+  stream still receives the tombstone (from the marker, not the overwritten
+  `_syncPrevStream`). Assert tombstone delivered to `fromStream` room.
+- Offline old-stream client: snapshot from a pre-move cursor returns the move as a tombstone
+  entity (marker merged into the page).
+- Marker TTL/retention: marker older than `retentionDays` is absent; cursor older than
+  `oldestRetainedSeq` triggers re-bootstrap.
+
+---
+
+## 7. Implementation task list (ordered, Sonnet-executable)
+
+1. **`models.ts`** — add `pending` to `SyncCounter`; rewrite `claimSyncSeqs` (claim+register
+   / session fast path); add `confirmSyncSeqs({stream, seqs, session})` (`$pull`) and
+   `computeStableFrontier({stream})` (min-pending-1, opportunistic stale `$pull`,
+   `PENDING_CLAIM_LEASE_MS`). Add `SyncScopeMove` model + indexes. **[Opus-care: the
+   frontier + lease math and the session fast path — get the pending-registry invariants
+   reviewed.]**
+2. **`syncSeqPlugin.ts`** — no-op skip (m10); `_id`-only guard for query-writes (m9);
+   call `confirmSyncSeqs` in `post("save")` + query-write post hooks; write `SyncScopeMove`
+   marker on detected scope move (claim from old stream). **[Opus-care: post-hook wiring —
+   the `this` context differs between save and query middleware.]**
+3. **`streams.ts`** — extract `resolveUserStreamsForEntry` from `socketHandlers.ts` (shared
+   by socket subscribe + `GET /sync/streams` + snapshot stream-membership check).
+4. **`routes.ts`** — `GET /sync/streams`; rewrite `GET /sync/snapshot` to per-stream
+   (membership check, single-value scope filter, frontier-bounded seqFilter, `legacyCursor`
+   stratum (C3), `frontierSeq` + `oldestRetainedSeq` in response, `SyncScopeMove` merge for
+   old-stream catch-up). Remove `?collection=` path.
+5. **`changeStreamWatcher.ts`** — add sync bookkeeping collections to
+   `DEFAULT_IGNORED_COLLECTIONS`; emit old-stream tombstones from `SyncScopeMove` markers
+   instead of `_syncPrevStream`; stamp `frontierSeq` on emitted deltas. **[Opus-care:
+   change-stream/marker interleaving.]**
+6. **`types.ts` (api + syncdb)** — add `frontierSeq`, `legacyCursor`, `oldestRetainedSeq`,
+   `SyncScopeMove`/streams types, per-stream snapshot response.
+7. **syncdb client** — items 1-7 of §5 (httpChannel, bootstrap, deltaApplier, client,
+   store schema + version bump, `_knownStreams`, entity `stream` column). **[Opus-care:
+   the join/leave diff under INV-2 — the 200-gate is the whole ballgame.]**
+8. **Tests** — the full §6 matrix, one focused test per fix.
+9. **Docs** — `syncdb-local-first.md`: the C1 cursor contract, per-stream snapshot protocol,
+   `GET /sync/streams`, `SyncScopeMove`, retention/`oldestRetainedSeq` re-bootstrap rule.
+
+Sequencing: 1→2 (write path) can land before 3→6 (read path); 7 (client) depends on 6; C3
+(within 4) and C4 (2/4/5) are independent slices. C1 fence must land before C2 client rollout
+so cursors never advance past uncommitted seqs.

--- a/docs/implementationPlans/terreno-syncdb-2.md
+++ b/docs/implementationPlans/terreno-syncdb-2.md
@@ -1,0 +1,800 @@
+# SyncDB Hardening Plan (terreno-syncdb-2)
+
+Implementation plan for hardening PR #869 (`@terreno/syncdb` local-first data layer,
+branch `worktree-ip-syncdb`). This plan is self-contained: it restates each defect,
+the exact fix, the files involved, and the tests that prove it. Work happens on a
+branch cut from `worktree-ip-syncdb` (or on that branch directly).
+
+Every file path below is relative to the repo root. Line numbers reference the PR
+head commit `c854c146` and may drift slightly — always locate by the described code,
+not the line number alone.
+
+---
+
+## Global invariants — apply to EVERY task in this plan
+
+These override anything else in this document if there is a conflict.
+
+**INV-1: Ordering is sacred.**
+Mutation order matters. Within an entity, order is absolute. Across entities and
+collections, assume order matters too (creates can be referenced by later mutations
+in other collections). The replay pipeline must preserve **global FIFO order by
+`enqueueOrder`** unless a task explicitly says otherwise. When any mutation fails
+with a retryable outcome, **stop the line** — do not skip ahead and apply later
+mutations while an earlier one is unresolved. The only sanctioned exception is
+per-entity conflict skipping (Task B4), which is explicitly specified there.
+
+**INV-2: A 401 / auth failure NEVER destroys local data.**
+Unauthorized outcomes (HTTP 401, `AuthRequiredError`, `unauthorized` nack, socket
+auth rejection) must: (a) leave every outbox row, entity, cursor, and conflict
+exactly as it was; (b) not increment retry budgets; (c) transition the client into
+a visible `paused: "auth"` state; (d) resume automatically and completely when the
+SAME user re-authenticates. Local data is wiped only when a DIFFERENT userId
+authenticates (existing `runUserCheck` behavior) or when the host app explicitly
+calls the wipe API. Token expiry, session revocation, and transient 401s are
+recoverable states, not logout.
+
+**INV-3: Idempotency is the retry safety net — never weaken it.**
+Every mutation keeps its client-minted `mutationId`, and the server ledger
+(`api/src/sync/mutationHandler.ts`) keeps exactly-once semantics per id. Any retry
+mechanism (batch or single) must be safe to replay wholesale because of this.
+Changes that could double-apply a mutation are wrong by definition.
+
+**INV-4: Repo conventions.**
+bun test + expect; Luxon (never `Date` in app logic); RORO; const arrow functions;
+interfaces over types; early returns; `logger.*` on backend, `console.info/debug/
+warn/error` on frontend. E2E: testIDs only, no `waitForTimeout`.
+
+---
+
+## Model flags summary
+
+Most tasks are **Sonnet-implementable** because this plan does the design work.
+Flags where that is not enough:
+
+| Task | Flag | Why |
+|---|---|---|
+| C1 (seq commit fence) | **OPUS — design + implementation** | Distributed-ordering correctness under concurrent writers; requires reasoning about Mongo transaction/commit semantics that a spec can't fully pin down. |
+| C2 (per-stream cursors) | **OPUS — design; Sonnet can execute after** | Client-visible protocol change with migration for already-deployed cursors; get the contract reviewed before code. |
+| C4 (scope-move tombstones on write path) | **OPUS recommended** | Change-stream/write-path interleaving is subtle; wrong fix silently loses tombstones. |
+| B1–B5 (batch protocol) | Sonnet implement, **OPUS review the final semantics** before merge | Spec below is complete, but ordering edge cases deserve a second set of eyes. |
+| Everything else (A, D, E, F) | **Sonnet** | Mechanical once specified. |
+
+Suggested execution order: Phase A → B → D → E → C → F. A/B/D/E are independent
+enough to parallelize; C changes the wire contract and should land before any real
+external consumer adopts the protocol; F (tests/infra) accompanies each phase and
+finishes last.
+
+---
+
+# Phase A — Client replay correctness & scheduling (Sonnet)
+
+The replay scheduler is trigger-driven with no self-wake-up, no crash recovery, and
+a baseVersion scheme that self-conflicts. These five tasks kill the observed
+"queues everything up and gets stuck" symptoms.
+
+## A1. Startup recovery for stranded outbox rows
+
+**Problem.** Nothing recovers durable `inFlight` rows after a crash/reload.
+`outbox.listQueued` only returns `status === "queued"`
+(`syncdb/src/mutations/outbox.ts` ~line 163), and `client.start()`
+(`syncdb/src/client.ts` ~382-404) has no recovery pass. A row stranded `inFlight`
+never replays, and its entity's `pendingMutationId` blocks every future delta
+(`syncdb/src/sync/deltaApplier.ts` ~47-50) and snapshot page
+(`syncdb/src/sync/bootstrap.ts` ~56-59) forever. Sibling crash windows:
+between `markAcked` and `releaseEntity`, and between `markConflicted` and
+`writeConflict` (`syncdb/src/sync/replayCoordinator.ts`).
+
+**Fix.**
+1. Add `outbox.recoverStartupState({userId})`:
+   - Every `inFlight` row → transition back to `queued`. Do NOT increment
+     `attemptCount` (recovery is not an attempt).
+   - Every `acked` row whose entity still has `pendingMutationId === mutationId`
+     → clear the entity's `pendingMutationId` (replays the missing
+     `releaseEntity`).
+   - Every `conflicted` row with no matching `_conflicts` row → write the conflict
+     row now (localData from the entity, serverData `null`, `serverSeq 0`), so the
+     UI can surface it. Alternatively re-queue it; pick writing the conflict row —
+     it is the state the machine had committed to.
+2. Call it from `client.start()` immediately after the persister finishes
+   `startAutoLoad()` and `runUserCheck` resolves the userId, before the first
+   `replayOutbox()`.
+
+**Tests** (`syncdb/src/mutations/outbox.test.ts`, `syncdb/src/client.test.ts`):
+- Store persisted with an `inFlight` row → after `start()`, row is `queued` and
+  replays; entity receives deltas again after resolution.
+- `acked` row + entity still pending → pendingMutationId cleared on start.
+- `conflicted` row without conflict row → conflict row exists after start.
+
+## A2. Send-time baseVersion refresh
+
+**Problem.** `mutate()` captures `baseVersion: existing?.seq` at enqueue time
+(`syncdb/src/client.ts` ~470, ~497). Optimistic writes never advance `seq`, so two
+queued edits to the same entity carry the same base; after the first acks at seq
+N+1, the second (base N) is a guaranteed `conflict` nack against the server's
+strict equality check (`api/src/sync/executors.ts` ~400). Every offline session
+with >1 edit per doc manufactures conflicts.
+
+**Fix.** In the replay coordinator, when building the request
+(`replayCoordinator.ts` `buildRequest`), for `update`/`delete` operations read the
+entity's CURRENT `seq` from the store and use it as `baseVersion` when it is newer
+than the stored one (the stored one remains the floor; never send a lower value
+than stored). The prior mutation's ack has already stamped the entity's seq via
+`releaseEntity(mutation, ack.seq)`, so this chains bases correctly through a queue
+of edits. Keep the enqueue-time capture as the initial value.
+
+Do NOT coalesce mutations in this task. (Optional coalescing is a follow-up,
+gated behind a config flag, and is intentionally out of scope: server-side hooks
+observe each write, and collapsing intermediate states changes semantics.)
+
+**Tests** (`syncdb/src/sync/replayCoordinator.test.ts`, plus one integration test
+in `api/src/sync/integration.test.ts`):
+- Enqueue create + update to same entity offline → replay online → both ack, no
+  conflict.
+- Enqueue update + update → both ack; second request carried the first's acked seq.
+- Regression: a genuinely stale base (server changed underneath) still conflicts.
+
+## A3. Real scheduler: drain-until-empty + timed wake-ups + jittered backoff
+
+**Problem.** Four park-without-wakeup paths (`replayCoordinator.ts`):
+transport failure returns with no reschedule; error-nack backoff sets `retryAt`
+but no timer fires when it elapses; a mutation enqueued during a running replay
+coalesces into a stale snapshot and is never sent; and the only safety net is the
+5-minute periodic timer (`client.ts` `DEFAULT_RECONCILE_INTERVAL_MS`). Plus:
+transport failures burn the error-nack `attemptCount` budget (outbox
+`markInFlight` increments every attempt; the terminality check reads the same
+counter), so an offline stretch can push the first real server error straight to
+terminal `failed`.
+
+**Fix.** Rework `createReplayCoordinator`:
+1. **Drain until empty.** After a drain pass completes, re-run `listQueued`; if
+   new queued mutations exist (and nothing parked the queue), immediately run
+   another pass. `replay()` resolves only when the queue is empty or parked.
+2. **Timed wake-ups.** Whenever a drain parks (transport failure or error-nack
+   backoff), arm a single `setTimeout` for the earliest `retryAt` (transport
+   failures get their own backoff schedule, below) that calls the internal drain
+   again. Store the timer handle; clear it on `stop()` (coordinator needs a
+   `dispose()` called from `client.stop()`), on wipe, and when an external
+   trigger runs a drain first. Never hold more than one armed timer per user.
+3. **Two separate retry budgets:**
+   - *Server error-nacks* keep the existing budget: `MAX_ERROR_NACK_ATTEMPTS`
+     (5), exponential backoff — but add full jitter:
+     `delay = random(0, base * 2^(attempt-1))`, capped at 30s.
+   - *Transport failures* (thrown sends, timeouts) get UNLIMITED retries with
+     the same capped jittered backoff and must NOT count toward the error-nack
+     budget. Implement by tracking a separate in-memory
+     `transportFailures: Map<mutationId, count>` for backoff computation, and by
+     changing terminality to use a dedicated `errorNackCount` cell on the outbox
+     row (new column, incremented only on error-nacks) instead of `attemptCount`.
+     `attemptCount` stays as a diagnostic total.
+4. **Global FIFO drain (INV-1).** Replace the per-collection parallel drain
+   (`Promise.all` over collections) with ONE serial drain over the global
+   `enqueueOrder`-sorted queue. This removes cross-collection reordering. (The
+   batch task B3 builds directly on this.)
+5. `client.replayOutbox()` must skip the extra full `listQueued` scan when debug
+   logging is disabled (currently unconditional, `client.ts` ~250).
+
+**Tests** (`replayCoordinator.test.ts` with injected `now` + fake timers):
+- Enqueue during an active drain → sent by the same `replay()` call, no external
+  trigger.
+- Error-nack → backoff elapses → retry fires from the armed timer alone.
+- Transport failure ×10 → still queued (not terminal); a subsequent error-nack
+  starts its budget at 1.
+- Jitter: two backoffs for the same attempt differ (seeded random injectable).
+- Global order: mutations across two collections replay strictly in enqueue
+  order.
+- `dispose()` clears armed timers (no post-stop sends).
+
+## A4. Auth-pause pipeline (the 401 contract) — INV-2 made concrete
+
+**Problem.** Today: `unauthorized` socket nacks pause correctly, but
+`AuthRequiredError` thrown by the HTTP channel (`syncdb/src/sync/httpChannel.ts`
+~15-20, 77-79) is swallowed by the coordinator's bare `catch` as a generic
+transport failure — retried forever with the dead token, burning budget. There is
+no user-visible paused state, no re-auth hook, and nothing resumes replay
+specifically on re-authentication of the same user.
+
+**Fix.**
+1. In `drainCollection`'s catch, detect `AuthRequiredError` (instanceof, exported
+   from httpChannel) and treat it exactly like an `unauthorized` nack: requeue
+   (no budget consumption), set `authPaused`, stop the drain, return
+   `{paused: "auth"}`.
+2. Add to client state and `SyncStatus` (`client.ts` `getSyncStatus`, and
+   `syncdb/src/react/hooks.ts` `useSyncStatus`): `paused?: "auth"`, plus
+   `queuedCount` already present and new `failedCount`. Set `paused: "auth"`
+   whenever a replay returns it OR the socket transport reports an auth-rejected
+   (re)connect; clear it when replay subsequently succeeds.
+3. Add `onAuthRequired?: () => void` to `SyncDbConfig`, fired (debounced — at most
+   once per pause episode) when entering the paused state, so the host app can
+   show a re-login prompt.
+4. On `authProvider` change events (`handleAuthChange`): if the resolved userId
+   equals `currentUserId`, clear the pause and immediately replay — with the
+   outbox fully intact. (Different userId keeps existing wipe behavior.) When
+   `getUserId()` returns null/undefined (logged out), DO NOT wipe: keep data and
+   remain paused. Wipe on logout only if the host app opts in via a new
+   `wipeOnSignOut?: boolean` config consumed by an explicit `client.signOut()`
+   method (which the app calls deliberately) — never inferred from a 401.
+5. Before surfacing the pause, give the auth adapter one chance to refresh:
+   `betterAuthAdapter` (`syncdb/src/auth/betterAuthAdapter.ts`) should expose an
+   optional `refresh(): Promise<boolean>`; the client calls it once per pause
+   episode and retries replay if it returns true.
+6. While paused for auth, the reconcile/bootstrap loops must also stand down
+   (they hit the same 401s) — gate `reconcile()` on the pause flag, and make
+   `handleStatusChange`/timer triggers no-op replay+reconcile while paused
+   (auth-change is the only unpause path).
+
+**Tests** (`client.test.ts`, `replayCoordinator.test.ts`,
+`api/src/sync/integration.test.ts`):
+- HTTP channel throws `AuthRequiredError` → status shows `paused: "auth"`,
+  outbox untouched, zero budget consumed, `onAuthRequired` fired once.
+- Same-user re-auth → pause clears, queue drains fully, entities converge.
+- Logout (userId → undefined) → data retained; later same-user login → queue
+  drains (integration: offline edits survive a token expiry + re-login round
+  trip).
+- Different-user login → wipe still happens (regression).
+- No reconcile/snapshot requests are issued while paused.
+
+## A5. Outbox hygiene: pruning, O(1) ordering, durable sort key
+
+**Problem.** Acked/failed rows are never deleted; `nextEnqueueOrder` scans the
+whole table per enqueue; `listQueued` scans per replay/mutate/status; FIFO sorts
+primarily on locale-offset ISO `createdAt` via `localeCompare` (DST/timezone
+travel can reorder an update before its create).
+
+**Fix** (all in `syncdb/src/mutations/outbox.ts`):
+1. Sort `listQueued` by `enqueueOrder` primary, `createdAt` tiebreak (invert
+   today's order).
+2. Keep a `_meta` value cell (`store.raw.setValue`) holding the max
+   `enqueueOrder`; `nextEnqueueOrder` reads/increments it (rebuild from a table
+   scan once at startup if absent).
+3. Add `outbox.prune({userId, keepFailed?: number})`: delete `acked` rows
+   immediately upon a successful drain pass (they carry no future value — the
+   server ledger owns idempotency), keep the most recent N `failed` rows
+   (default 50) for debugging/UI, delete older ones. Call from the coordinator
+   after each drain pass. `conflicted` rows are never pruned automatically.
+
+**Tests:** pruning after drain; enqueueOrder survives restart; ordering stable
+across a simulated timezone offset change in `createdAt`.
+
+---
+
+# Phase B — Ordered batch protocol (Sonnet implement; OPUS review semantics)
+
+Goal: N queued mutations should cost ~N/50 round-trips instead of N, without ever
+reordering or continuing past a failure.
+
+## B1. Wire contract
+
+New request/response types in `api/src/sync/types.ts` and `syncdb/src/types.ts`:
+
+```ts
+interface SyncMutateBatchRequest {
+  /** Ordered. The server MUST apply strictly in array order. */
+  mutations: SyncMutateRequest[];   // each still carries its own mutationId
+}
+
+interface SyncMutateBatchResponse {
+  /**
+   * One result per PROCESSED mutation, in the same order as the request.
+   * Length < request length means the server halted at the first non-ack:
+   * results[last] is that failing outcome, and every mutation after it was
+   * NOT attempted (still safe to resend).
+   */
+  results: ({type: "ack"; ack: SyncAck} | {type: "nack"; nack: SyncNack})[];
+}
+```
+
+Transports: `POST /sync/mutate/batch` (`api/src/sync/routes.ts`) and socket event
+`sync:mutateBatch` (`api/src/sync/socketHandlers.ts`). Batch size limit: server
+rejects > 100 mutations per batch with a `validation` nack-shaped 422; enforce
+before any processing.
+
+## B2. Server: strict-order, stop-on-first-non-ack
+
+In `api/src/sync/mutationHandler.ts` add `applySyncMutationBatch`:
+1. Iterate the array **strictly serially** (`for … await`), calling the existing
+   `applySyncMutation` per item — full reuse of the idempotency ledger,
+   executors, permissions, and delta emission. No parallelism, ever.
+2. **Stop-on-error (the user's hard requirement):** on the first result whose
+   type is `nack`, append that nack to `results` and RETURN immediately.
+   Mutations after it are not attempted, not ledgered, not acked — the client
+   re-sends them later and INV-3 makes the overlap safe.
+3. Rate limiting: the socket path's existing mutation limiter counts each
+   mutation in the batch (not each batch) against the window; add the same
+   counting to the HTTP route (which currently has no limiter — add one).
+4. Duplicate `mutationId`s *within* one batch: reject the whole batch up front
+   with a `validation` outcome (client bug; fail loudly).
+
+**Tests** (`api/src/sync/mutationHandler.test.ts`, `syncRoutes.test.ts`,
+`syncSocket.test.ts`):
+- 10 mutations, #4 conflicts → results length 4, mutations 5–10 unledgered;
+  resending 4–10 as a new batch: #4 returns its recorded conflict from the
+  ledger (idempotent), 5–10 apply.
+- Whole-batch duplicate resend → all results served from ledger, docs written
+  once.
+- Order proof: create → update → delete for one entity in one batch works;
+  reversed order fails at #1 without touching #2/#3.
+- Oversized batch and intra-batch duplicate ids rejected before processing.
+
+## B3. Client: batched drain on top of A3's global FIFO
+
+In `replayCoordinator.ts`:
+1. Build each send as the next contiguous chunk (≤ 50, configurable
+   `batchSize`) of the global queue — preserving `enqueueOrder`, possibly mixing
+   collections (the request items each carry their collection).
+2. `baseVersion` refresh (A2) applies per item at chunk-build time. Within one
+   chunk, if it contains multiple mutations for the same entity, compute later
+   items' `baseVersion` optimistically as "previous item's expected post-ack
+   seq" is NOT possible (seqs are server-assigned) — so instead: **a chunk may
+   contain at most one mutation per entity**; the chunk builder cuts the chunk
+   short when it would include a second mutation for an entity already in it.
+   The next chunk (after acks land and A2 refreshes bases) carries the rest.
+   This keeps per-entity chaining correct without guessing seqs.
+3. Response handling walks `results` in order, applying the existing
+   single-mutation handlers (`handleAck`, `handleConflict`,
+   `handleTerminalFailure`, unauthorized-pause, error-backoff). Every request
+   mutation with no result (server halted) → back to `queued`, untouched
+   budgets. Then apply the stop-the-line rules of B4.
+4. Transport fallback & capability detection: on HTTP 404 / socket
+   `sync:error {code: "unknown-event"}` for the batch call, set a per-connection
+   `batchUnsupported` flag and fall back to the existing single-mutation sends
+   (still in global FIFO order). Re-probe after reconnect.
+5. Send path: batches prefer the socket when connected, HTTP channel otherwise
+   (mirror the existing single-send selection in `client.ts`).
+
+## B4. Stop-the-line rules (client-side outcome policy)
+
+After processing a batch response, decide whether the drain continues:
+
+| First non-ack outcome | Policy |
+|---|---|
+| `error` (transient) | **Halt the whole drain.** Jittered backoff (A3), timed wake-up retries from that mutation onward. Nothing after it is sent this pass. |
+| transport failure / timeout | **Halt the whole drain.** Unlimited-budget backoff (A3). The whole batch is safe to resend (INV-3). |
+| `unauthorized` | **Halt everything**, enter auth pause (A4). No data touched. |
+| `conflict` | Mark conflicted + write conflict row (existing). The ENTITY is now blocked: subsequent drains **skip every queued mutation for an entity that has an unresolved conflict or a queued predecessor that was skipped** (they stay `queued`, budgets untouched). Other entities continue — with one escape hatch: config `haltQueueOnConflict?: boolean` (default `false`) halts the entire drain instead, for apps with cross-entity ordering dependencies. Document both modes in `syncdb/README.md`. |
+| `validation` | Terminal for that mutation (existing `markFailed` + release). Then apply the same per-entity skip rule to its queued successors — a successor building on a rejected write is very likely also invalid; skip-and-surface beats blind apply. Successors become eligible again only via explicit `client.retryFailed({entityId})` (new API) or when the user resolves/dismisses. Continue the drain for other entities. |
+
+Rationale for the per-entity (not global) default on conflict/validation: a global
+halt on a *user-resolvable* outcome can freeze all sync for days behind one
+conflict sheet. Transient/auth outcomes halt globally because retrying will fix
+them without user action. **OPUS should review this table before merge.**
+
+**Tests** (`replayCoordinator.test.ts` + `integration.test.ts`):
+- 120 queued across 2 collections → exactly 3 batch round-trips (lock in the
+  contract), global order preserved on the server (assert via seq order).
+- Conflict on entity X mid-batch → X's later mutations stay queued and are
+  absent from subsequent batches; entity Y's mutations proceed; after the user
+  resolves X (keepMine requeue), X's successors drain in original relative
+  order.
+- Same scenario with `haltQueueOnConflict: true` → nothing after the conflict is
+  sent at all.
+- Batch response shorter than request → tail re-queued untouched; next drain
+  resends from the halt point; server ledger dedupes the boundary mutation.
+- Mid-batch socket disconnect → entire batch re-queued, resent on reconnect,
+  applied exactly once (integration).
+- Validation failure → successors for that entity skipped and surfaced via
+  status; `retryFailed` re-enables them.
+
+## B5. SyncStatus + UI surfacing
+
+Extend `SyncStatus` (client + `useSyncStatus` + `ui/src/SyncStatusBanner.tsx`):
+`queuedCount`, `failedCount`, `blockedEntities: number`, `paused?: "auth"`,
+`draining: boolean`, and drain progress (`sentThisDrain/totalThisDrain`).
+Banner states: syncing (with progress when > 20 queued), paused-for-auth (tap →
+`onAuthRequired`), N failed (tap → detail). Keep testIDs
+(`sync-status-*`) per convention; add `sync-paused-auth-indicator`.
+
+---
+
+# Phase C — Server protocol correctness
+
+## C1. Seq commit fence — **OPUS (design + implementation)**
+
+**Problem.** `_syncSeq` is claimed from a separate counter in `pre("save")`
+(`api/src/sync/syncSeqPlugin.ts` ~81) before the document write commits, with no
+transaction and no ordering fence. Writer A claims seq 5, stalls; writer B claims
+6 and commits first; any client whose cursor reaches 6 (via delta or snapshot)
+uses `$gt: 6` forever and permanently misses A's doc (`api/src/sync/routes.ts`
+~159). Also: the pre-query-write lookup can stamp a seq from stream X's counter
+onto a doc in stream Y (non-`_id` filters), producing duplicate seqs in a stream.
+
+**Direction to evaluate (Opus decides):**
+- Option 1 — transactional assignment: counter `$inc` + document write in one
+  Mongo transaction (replica set is already required for change streams). Cost:
+  transactions on every synced write; retry logic for `TransientTransactionError`;
+  Mongoose session plumbed through the executors.
+- Option 2 — stable frontier: keep optimistic claims, but expose per stream a
+  `stableSeq` = highest seq below which no claim is uncommitted (track in-flight
+  claims in the counter doc: claim registers, commit confirms; frontier =
+  min(pending)−1 or head). Snapshot/delta consumers only advance cursors to the
+  frontier. Cost: complexity + a liveness dependency on claim cleanup for
+  crashed writers (needs a lease/TTL).
+- Option 3 — post-commit sequencing: writes commit without a seq; a single
+  ordered assigner (change-stream driven) stamps seqs afterward. Cost: an extra
+  write per mutation and an ordering singleton.
+
+Whatever is chosen must also fix: the multi-doc lookup mis-stamp (m9), no-op
+`save()` burning seqs and emitting deltas (m10), and must define the contract in
+`docs/implementationPlans/syncdb-local-first.md`.
+
+**Tests:** concurrent writers with forced commit inversion (delay the lower seq's
+commit via a `pre("save")` test hook) → a client bootstrapping/catching up at
+every intermediate cursor sees BOTH docs eventually; property-style test looping
+random interleavings.
+
+## C2. Per-stream snapshot cursors — **OPUS design, Sonnet execute**
+
+**Problem.** `GET /sync/snapshot` merges all of a user's streams into one query
+and returns a single max-seq cursor (`routes.ts` ~142-180), but each stream has
+an independent counter. A user in org1 (seq 1000) and org2 (seq 5) can never
+catch up org2 past cursor 1000; joining a tenant post-bootstrap never backfills.
+
+**Fix shape (contract for Opus to ratify):** snapshot request/response become
+per-stream: client sends `cursors: Record<stream, number>` (or requests one
+stream at a time — simpler and preferred); server returns entities + per-stream
+next cursor + `hasMore`. Server must expose "which streams does this user have"
+(`GET /sync/streams` or embedded in the snapshot response) so the client can
+detect NEW streams (tenant joined → cursor 0 backfill) and REMOVED streams
+(tenant left → local purge of that stream's entities — respecting INV-2: purge
+only on confirmed membership change, never on 401). Client keeps
+`_cursors` rows per real stream (the plumbing already exists for deltas;
+`snapshot:{collection}` pseudo-streams get replaced). Migration: on first run
+with the new client, discard legacy snapshot cursors and re-bootstrap
+incrementally (cursor 0 per stream — cheap because pages are idempotent upserts).
+
+**Tests:** two-tenant skew scenario end-to-end; tenant join backfills; tenant
+leave purges locally; legacy-cursor migration path.
+
+## C3. Legacy-doc pagination infinite loop (Sonnet)
+
+**Problem.** With > `limit` docs lacking `_syncSeq`, the first snapshot page is
+all `seq: 0`, cursor never advances, `hasMore` stays true → client loops forever
+(`routes.ts` ~157-179; the client-side guard in `bootstrap.ts` stops the loop but
+bootstrap then never completes).
+
+**Fix.** Page the seq-0 stratum by `_id`: when `cursor === 0`, sort
+`{_syncSeq: 1, _id: 1}` and return an opaque `legacyCursor` (last `_id`) the
+client echoes back until the unsynced stratum is exhausted, then switch to seq
+paging. Alternative (simpler, evaluate): a one-time migration script/plugin
+startup pass that back-stamps `_syncSeq` on legacy docs per stream — if chosen,
+the route should refuse (500 with clear message) when unstamped docs exceed the
+page limit, pointing at the migration. Either way the failure mode must be loud,
+not an infinite loop.
+
+**Tests:** 1,201 legacy docs, limit 500 → bootstrap terminates with all docs;
+mixed legacy+stamped pagination; loop-guard regression.
+
+## C4. Scope-move tombstones from the write path — **OPUS recommended**
+
+**Problem.** The old-stream tombstone is derived from `_syncPrevStream` read via
+change-stream `updateLookup` post-image (`api/src/realtime/changeStreamWatcher.ts`
+~576-608): a second write racing the first event's processing resets the field,
+and the moved-away-from user never gets the tombstone (keeps stale data +
+post-move edits until reconcile).
+
+**Fix direction.** Emit the removal signal at write time, not stream time: when
+`syncSeqPlugin` detects a stream change, write an explicit tombstone marker
+(e.g. a `SyncScopeMove` document: {stream, entityId, seq claimed from the OLD
+stream's counter}) in the same operation scope as the move; the watcher emits
+old-stream tombstones from those markers (and they appear in snapshots for the
+old stream). This makes moves durable and replayable instead of racy. TTL the
+markers with the same retention as tombstones (E7/C7).
+
+**Tests:** move + immediate second write with artificially delayed change-event
+processing → old-scope client still receives the tombstone; snapshot catch-up
+from a pre-move cursor sees it too.
+
+## C5. Mutation-ledger crash resilience (Sonnet)
+
+**Problem A (M4).** A server crash between inserting the `pending` ledger row and
+finalizing it wedges that `mutationId` for the 30-day TTL — every retry polls 1s
+then nacks "still in flight" (`api/src/sync/mutationHandler.ts` ~75-104,
+~223-235).
+**Problem B (M5).** A post-hook throw AFTER the document write finalizes the
+ledger as `failed`/`validation` even though the write (and its delta) happened —
+client rolls back real data, ledger lies forever.
+
+**Fix.**
+- A: add a lease — `pending` rows carry `claimedAt`; the duplicate-claim path may
+  take over rows older than 60s via
+  `findOneAndUpdate({_id, status: "pending", claimedAt: {$lt: cutoff}},
+  {$set: {claimedAt: now}})` and re-run the mutation (idempotent by INV-3 —
+  the executor path must tolerate the write having already landed: treat
+  create-E11000-on-same-id + identical `mutationId` provenance as success by
+  reading the doc back; for update/delete re-check seq before re-applying).
+- B: reorder the pipeline — run the document write, then finalize the ledger
+  `applied` (with the ack payload) BEFORE running post-hooks; post-hook errors
+  are logged (`logger.error`) and reported to the response as ack-with-warning,
+  not converted into a nack. If the `applied` finalize itself fails, crash the
+  request loudly (500 → client transport-retry → duplicate path returns the
+  doc-derived outcome via the lease takeover above).
+
+**Tests:** kill between claim and finalize (simulate by stubbing) → retry after
+lease expiry succeeds; post-hook throw → doc changed AND ack returned AND ledger
+`applied`; replay returns the recorded ack.
+
+## C6. Sync write-scope enforcement + snapshot read parity (Sonnet)
+
+- **Create scope check (M6):** in `applySyncMutation` for `create` (and for
+  `update` when the incoming data changes the scope field), resolve the entry's
+  scope; for `owner` strategy force/verify the owner field equals the
+  authenticated user id; for `tenant` strategy verify the tenant field value is
+  in `getUserScopes(user, entry)` — nack `unauthorized` otherwise. This is the
+  sync boundary backstop regardless of consumer `preCreate` quality.
+- **Snapshot per-doc read checks (M2):** after fetching a page in
+  `GET /sync/snapshot`, run the same per-document `read` permission the delta
+  path uses (`checkPermissions("read", …, doc)`), dropping denied docs but STILL
+  advancing the cursor past them (parity with delta behavior). Also honor
+  `options.queryFilter`.
+- **`$or`/`deleted` clobber (M1):** build the snapshot query as
+  `{$and: [scopeFilter, {deleted: {$in: [true,false]}}, seqFilter]}` — never
+  spread-merge filters.
+- **Upsert bypass (M8):** `syncSeqPlugin` pre-query-write hook must throw on
+  `upsert: true` for synced models (same loud contract as `updateMany`).
+- **Socket user parity (D2 dependency):** these checks must run against the full
+  user (see D2), not the synthetic socket user.
+
+**Tests:** create with foreign ownerId/tenant nacked over both transports;
+snapshot omits per-doc-denied docs that deltas also omit; `$or` snapshotFilter
+composes correctly (page respects both filters); upsert throws.
+
+## C7. Server tombstone/ledger retention (Sonnet)
+
+Tombstones are served forever with full `data` (privacy + payload growth); the
+watcher also processes bookkeeping collections' own change events. Fix: (a) strip
+`data` from tombstones at write time or serialization time — a tombstone needs
+only id/seq/deleted; (b) add `synccounters`, `syncmutations` (and C4's marker
+collection) to `DEFAULT_IGNORED_COLLECTIONS` in
+`api/src/realtime/changeStreamWatcher.ts`; (c) document a retention policy:
+tombstones older than N days (default 90, configurable per model in the sync
+options) may be hard-deleted by a provided maintenance script
+(`api/src/sync/scripts/compactTombstones.ts`), paired with the client-side rule
+that a cursor older than the retention window must trigger full re-bootstrap
+(client compares snapshot response's `oldestRetainedSeq` — add to response — with
+its cursor).
+
+**Tests:** tombstone payloads carry no data; ignored collections generate no
+watcher work (spy); stale-cursor client detects retention gap and re-bootstraps.
+
+## C8. Server minor batch (Sonnet, one PR)
+
+- `baseVersion` omitted on update → `validation` nack (never accidental
+  conflict/accidental success) — `mutationHandler.ts` ~250.
+- Delete of already-deleted doc → idempotent ack (return current seq), not 404
+  `validation` — `executors.ts` ~488-492.
+- Cap `sync:subscribe` array length (e.g. 100) before iterating; length check
+  first — `socketHandlers.ts` ~151.
+- Reject duplicate `collectionTag` at registration; make snapshot-index
+  `createIndex` failure a startup error, not a warn — `registry.ts`.
+- `serialize.ts` responseHandler method fidelity: pass `"read"` for
+  single-entity sync serialization instead of hardcoded `"list"`/`"update"`.
+- Await/serialize change-handler dispatch per document id (keep cross-doc
+  concurrency) so per-entity delta order is guaranteed; document the per-entity
+  LWW-by-seq contract in `api/src/sync/types.ts`.
+
+Each with a focused test.
+
+---
+
+# Phase D — Auth & security (Sonnet)
+
+## D1. Socket session re-validation
+
+**Problem.** Sockets authenticate once at handshake (`api/src/realtime/
+socketAuth.ts` ~141-177); expiry/revocation/disable never disconnects — deltas
+(PHI) keep flowing indefinitely.
+
+**Fix.** Add to the realtime app a periodic re-validation sweep (default every
+60s, configurable): for each connected socket, re-run the cheap parts of its
+validator (JWT: verify expiry locally; Better Auth: batch session lookups) and
+re-load the user's `disabled` flag; on failure emit `sync:auth-expired` then
+`socket.disconnect(true)`. The syncdb client must map `sync:auth-expired` +
+subsequent reconnect auth failure into the A4 auth-pause path (NO wipe — INV-2).
+Also: pass `issuer` to the legacy JWT socket validator for parity with HTTP
+(`socketAuth.ts` vs `api/src/auth.ts` ~359-361), and replace the
+dot-count JWT discrimination in `auth.ts` ~362-370 with header-decode detection.
+
+**Tests:** new `api/src/realtime/socketAuth.test.ts` — validator matrix (valid/
+expired/wrong-secret/wrong-issuer JWT; valid/invalid Better Auth bearer; chain
+fall-through; missing token). Sweep disconnects an expired/disabled session;
+client lands in auth-pause with outbox intact.
+
+## D2. Full user for socket-side authorization
+
+**Problem.** Socket paths authorize with a synthetic `{_id, admin, id}` user
+(`api/src/realtime/socketUser.ts`), so `getUserScopes` sees no
+`organizationIds` — tenant sync over sockets silently returns nothing (fails
+closed here, but consumers can fail open).
+
+**Fix.** Load the full user document once at handshake (by decoded id), cache on
+`socket.data.user`, refresh during D1's sweep; pass THAT to `getUserScopes`,
+`checkPermissions`, and delta filters. Remove the synthetic-shape pathway for
+sync. Add a test where `getUserScopes` actually reads `user.organizationIds`
+(every existing test stubs it — that masked this bug).
+
+## D3. Tenant create-escape + reference hardening
+
+Fix `example-backend/src/api/projects.ts` `preCreate`: spread body FIRST, then
+force/validate `organizationId ∈ user.organizationIds` (throw `APIError` 403
+otherwise). C6 adds the framework backstop; the reference implementation must
+still model the right pattern. Test both transports.
+
+## D4. Membership revocation vs socket rooms
+
+On D1's sweep (or a user-updated hook), re-resolve the user's streams and
+`socket.leave()` rooms for streams no longer held. Test: revoke org membership →
+no further deltas for that org on the live socket.
+
+## D5. Admin/password hygiene
+
+`setPasswordForUser` route (`example-backend/src/api/adminUsers.ts` +
+`api/src/auth.ts` helper): add `logger.info` audit line (admin id, target id,
+timestamp — never the password), an upper length bound (e.g. 256), and a test
+for `requireAdminMiddleware` 403 paths. Small task, do alongside D1.
+
+---
+
+# Phase E — Client storage & React (Sonnet)
+
+## E1. Lifecycle serialization (`start`/`stop`/auth-change mutex)
+
+**Problem.** `stop()` re-reads module-level `persister` after awaiting the
+debounced `save()`; interleaved `start()` for a new user gets its persister
+destroyed → client half-started, every `mutate()` throws (`client.ts` ~406-422 +
+`example-frontend/app/_layout.tsx` ~133-150). `start()` twice also double-
+registers listeners and leaks the reconcile interval.
+
+**Fix.** Introduce a generation counter + a single promise-chain mutex
+(`lifecycle = lifecycle.then(op)`) through which `start`, `stop`,
+`handleAuthChange`, and `runUserCheck` all pass. Capture `persister` into a
+local before any await; after each await, abort if the generation changed.
+`start()` when already started → no-op (or stop-then-start, but pick one and
+test it). `stop()` disposes the A3 coordinator timers.
+
+**Tests:** rapid stop/start user-switch (would have caught the bug — assert new
+user's persistence works and `mutate()` succeeds); double-start listener counts;
+Playwright regression: remove the serial-file workaround comment in
+`example-frontend/playwright.config.ts` (~16-19) once concurrent syncdb clients
+are stable, and let two syncdb specs share a worker.
+
+## E2. Wire schema versioning
+
+`getSchemaVersion()` has zero callers. On `start()` after autoload: if persisted
+`schemaVersion` exists and ≠ `SYNC_SCHEMA_VERSION` → `wipeLocalData` + set
+current version + full re-bootstrap (this wipe is sanctioned: it is a schema
+migration, not an auth event). Always stamp the version on fresh stores.
+Test: persist v1 data, load under v2 → wiped + re-bootstrapped; equal versions
+untouched.
+
+## E3. Persistence failure surfaces
+
+- Move the `idbGet` inside the try in `encryptedIndexedDbPersister.getPersisted`
+  and distinguish "no data" (return undefined → fresh store OK) from "read
+  error" (throw → persister must NOT autosave an empty store over the blob:
+  propagate a load failure state instead) — `syncdb/src/persisters/
+  encryptedIndexedDbPersister.ts` ~79-93.
+- Wire `onDecryptFailure` end-to-end: add to `SyncDbConfig`; default behavior =
+  wipe + re-bootstrap + `console.warn` (documented). This also revives
+  wipe-on-user-change on web.
+- Web factory: check `globalThis.indexedDB`; when absent fall back to the memory
+  persister and emit a one-time `console.warn` + a `persistence: "memory" |
+  "durable" | "error"` field on `SyncStatus`.
+- Track and clear the debounce timer in `destroy()`; wipe `keyCacheDbNames` in
+  `runUserCheck` (`client.ts` ~304) and `SyncDevPanel`.
+
+**Tests:** rejecting `idbGet` at load leaves the stored blob intact; quota-
+exceeded on save surfaces `persistence: "error"`; decrypt failure invokes the
+config hook; destroy-with-pending-save writes nothing after destroy.
+
+## E4. Batched application + render hygiene
+
+- Wrap each snapshot page (`bootstrap.ts` ~92-101) and each socket delta burst
+  (`deltaApplier` callers) in `store.raw.transaction(() => …)` — one listener
+  notification + one autosave per page instead of per row.
+- `useQuery` (`syncdb/src/react/hooks.ts` ~129): skip rows whose `data` is null
+  (corrupt-row guard — currently crashes list consumers).
+- Move `optionsRef.current = options` out of render (layout effect or snapshot
+  path).
+
+**Tests:** listener fire-count == 1 per applied page (would have caught the
+O(N²)); corrupt row present → `useQuery` returns the healthy rows, no throw;
+listener stats return to baseline after unmount (add for all four hooks).
+
+## E5. Client-side compaction
+
+Prune local tombstones after they age past the server retention window (C7):
+on each successful reconcile, delete `deleted: true` rows older than the
+window (age from a `deletedAt` cell to add at tombstone-apply time), and drop
+their MergeableStore metadata where TinyBase allows. Test with fake clock.
+
+## E6. UI minor batch
+
+`ConflictSheet` testIDs suffixed with `mutationId` (duplicate-testID strict-mode
+fix); banner conflict badge gets `accessibilityRole="button"`;
+`debugLog.clear()` resets stats coherently; align its doc comments. One PR.
+
+---
+
+# Phase F — Test & load infrastructure (Sonnet)
+
+Unit/functional tests live inside Phases A–E. This phase is cross-cutting infra.
+
+## F1. Integration additions (`api/src/sync/integration.test.ts`)
+
+- Socket drop after k of n batch-acked → remaining n−k apply exactly once.
+- Token expiry mid-session → auth-pause → re-auth → cursor-correct resume,
+  outbox intact (INV-2 end-to-end).
+- Two real syncdb clients (same user, two "devices") editing one doc —
+  delta-vs-pending interleavings.
+- Ack lost client-side (drop the response, not the request) → resend consumes
+  the recorded ledger ack.
+
+## F2. Server-side load harness (no browser)
+
+New `api/src/sync/loadHarness.ts` (bun script, not in default test run; wire a
+`bun run api:load` script): reuse the integration rig — N socket.io clients on N
+owner streams (start N=50), seed 5k docs via `example-backend/src/api/
+loadtest.ts` generate, then drive batched `POST /sync/mutate/batch` at a target
+rate with mixed ops + deliberate duplicate mutationIds + deliberate mid-batch
+conflicts. Report: mutate p50/p95/p99, change-stream→delta fan-out lag per
+socket, 5k-doc bootstrap wall time, final-state convergence check per client
+(exact set equality vs Mongo). Nightly CI job with generous thresholds
+(p95 mutate < 250ms local-Mongo, delta lag < 2s @ 50 sockets) — fail loudly,
+tune later. Also add plain route tests for `loadtest.ts` (admin guard, clamps).
+
+## F3. Chaos/spotty-connection e2e
+
+Extend `example-frontend/e2e/helpers/syncdbSuite.ts`'s `routeWebSocket` proxy
+into a chaos proxy (do NOT use CDP `emulateNetworkConditions` — it does not
+throttle WebSocket frames):
+- per-frame latency injection: `setTimeout(forward, rand(0, latencyMs))`;
+- `dropSocket()` closing live sockets at random intervals;
+- HTTP jitter via delayed `route.continue()`;
+- a flap loop over existing `goSyncOffline`/`goSyncOnline` with random 1–8s
+  dwells.
+
+New spec `syncdb-chaos.spec.ts` (own CI shard): queue ~30 UI mutations while
+flapping (this covers reconnect-mid-drain), run server-side churn concurrently
+(`loadtest churn`), stop chaos, then assert: queued badge clears, local set ==
+`listTodosAs(user)` via REST, **zero duplicates** (the key assertion — flapping
+mid-ack forges duplicate deliveries), and total mutate-request count ≤
+ceil(mutations/batchSize) + retries budget (locks in batching). All waits by
+testID/`expect.poll`; no `waitForTimeout`.
+
+## F4. Client-side load e2e
+
+`syncdb-loadlab.spec.ts`, `@load` tag, nightly shard (not PR-blocking): admin
+suite user (add one to `fixtures/testUsers.ts` — the loadtest routes are
+admin-guarded), `loadtest generate {count: 2000}`, assert a new `todos-count`
+testID converges (do NOT count DOM rows; virtualize the list first if it isn't),
+then 10 churn rounds with the page open, final convergence + time-to-converge
+recorded via Playwright annotations. This will regress instantly if E4's
+transaction batching breaks.
+
+## F5. Coverage restorations
+
+The PR deletes `offline.spec.ts` (728 lines) covering the legacy RTK offline
+middleware, which non-sync screens still use. Either restore a slim 2–3 test
+version of it or document the deprecation of the RTK offline path explicitly in
+`rtk/README.md`. Decide with the repo owner; default: restore slim version.
+
+---
+
+## Acceptance checklist (definition of done for the whole plan)
+
+- [ ] 500 mutations queued offline drain in ≤ 12 round-trips after reconnect,
+      in exact enqueue order, surviving a mid-drain disconnect with zero
+      duplicates and zero losses (F2/F3 assert this).
+- [ ] Two offline edits to one doc never self-conflict (A2).
+- [ ] App killed mid-send recovers on next start; no permanently frozen
+      entities (A1).
+- [ ] 401 at any point (HTTP, socket, mid-drain, mid-bootstrap) pauses sync
+      visibly, preserves all local data, and fully resumes on same-user re-auth
+      (A4/D1 — INV-2).
+- [ ] A conflict blocks only its entity (or the whole queue when
+      `haltQueueOnConflict`), never silently skipped past (B4 — INV-1).
+- [ ] No client can permanently miss a committed document via cursor catch-up
+      (C1/C2/C3).
+- [ ] Sockets stop delivering data within 60s of revocation/expiry/disable (D1).
+- [ ] `bun run lint`, `bun run api:test`, `bun run ui:test`, syncdb package
+      tests, and all four+2 e2e shards green.

--- a/example-backend/src/api/adminUsers.ts
+++ b/example-backend/src/api/adminUsers.ts
@@ -55,7 +55,8 @@ export const addAdminUserRoutes = (
         throw new APIError({status: 404, title: "User not found"});
       }
 
-      await setPasswordForUser(user, password);
+      const admin = req.user as {_id?: unknown; id?: string} | undefined;
+      await setPasswordForUser(user, password, undefined, {adminId: admin?._id ?? admin?.id});
       await user.save();
 
       return res.json({data: {_id: user._id.toString(), message: "Password updated"}});

--- a/example-backend/src/api/loadtest.test.ts
+++ b/example-backend/src/api/loadtest.test.ts
@@ -1,0 +1,367 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: test server/model bridging mirrors projects.test.ts and server.ts
+import {beforeEach, describe, expect, it} from "bun:test";
+import {
+  generateTokens,
+  type ModelRouterOptions,
+  type ModelRouterRegistration,
+  TerrenoApp,
+} from "@terreno/api";
+import express from "express";
+import supertest from "supertest";
+import {Todo} from "../models";
+import {User as UserModel} from "../models/user";
+import {addLoadTestRoutes} from "./loadtest";
+
+/**
+ * Route tests for the SyncDB "load lab" admin routes (generate/churn/clear). Mirrors the
+ * server-bootstrapping pattern established in `src/api/projects.test.ts`: a standalone
+ * `TerrenoApp` built directly around the route under test (not the full `server.ts`
+ * wiring), real Mongo via the package's bun preload (`src/tests/setup.ts`), real
+ * passport-local-mongoose users, and supertest over HTTP.
+ *
+ * `addLoadTestRoutes` takes a raw `(router, options)` function rather than a
+ * `ModelRouterRegistration`, so it needs the same `createOpenApiAwareRouteRegistration`
+ * adapter `server.ts` uses to mount it on a `TerrenoApp`.
+ */
+type RegisterRoutesWithOptions = (
+  router: express.Router,
+  options?: Partial<ModelRouterOptions<unknown>>
+) => void;
+
+const createOpenApiAwareRouteRegistration = (
+  registerRoutes: RegisterRoutesWithOptions
+): ModelRouterRegistration => {
+  const buildRouter = (openApi?: unknown): express.Router => {
+    const router = express.Router();
+    const routeOptions = openApi ? ({openApi} as Partial<ModelRouterOptions<unknown>>) : undefined;
+    registerRoutes(router, routeOptions);
+    return router;
+  };
+
+  const registration: ModelRouterRegistration = {
+    __type: "modelRouter",
+    _buildWithOpenApi: buildRouter,
+    path: "/",
+    router: express.Router(),
+  };
+  return registration;
+};
+
+describe("loadtest routes", () => {
+  const buildApp = () => {
+    process.env.TOKEN_SECRET = process.env.TOKEN_SECRET || "test-secret";
+    process.env.TOKEN_ISSUER = process.env.TOKEN_ISSUER || "example-backend-test";
+    return new TerrenoApp({
+      authOptions: {
+        generateJWTPayload: (user: unknown) => ({
+          admin: (user as {admin?: boolean}).admin === true,
+        }),
+      },
+      skipListen: true,
+      userModel: UserModel as any,
+    })
+      .register(createOpenApiAwareRouteRegistration(addLoadTestRoutes))
+      .build();
+  };
+
+  const createUser = async (email: string, admin: boolean) => {
+    return UserModel.register(
+      {admin, email, name: email} as any,
+      "password12345"
+    ) as unknown as Promise<{_id: unknown; admin: boolean}>;
+  };
+
+  const tokenFor = async (user: {_id: unknown; admin: boolean}): Promise<string> => {
+    const {token} = await generateTokens(user);
+    if (!token) {
+      throw new Error("Failed to generate a token for test user");
+    }
+    return token;
+  };
+
+  /** Raw collection count, bypassing isDeletedPlugin's default `deleted: {$ne: true}` filter. */
+  const rawTodoCount = async (query: Record<string, unknown>): Promise<number> => {
+    return Todo.collection.countDocuments(query);
+  };
+
+  beforeEach(async () => {
+    // Todo is sync-enabled (syncPlugin forbids multi-document writes, including through
+    // Model.deleteMany) — clear via the raw collection instead, matching the convention
+    // in api/src/sync/integration.test.ts and example-backend/src/api/projects.test.ts.
+    await Todo.collection.deleteMany({});
+    await UserModel.deleteMany({});
+  });
+
+  describe("admin guard", () => {
+    it("rejects an unauthenticated request with 401", async () => {
+      const app = buildApp();
+      const res = await supertest(app).post("/loadtest/todos/generate").send({count: 1});
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects a non-admin authenticated user with 403 on generate", async () => {
+      const app = buildApp();
+      const user = await createUser("nonadmin-generate@example.com", false);
+      const token = await tokenFor(user);
+
+      const res = await supertest(app)
+        .post("/loadtest/todos/generate")
+        .set("Authorization", `Bearer ${token}`)
+        .send({count: 1});
+
+      expect(res.status).toBe(403);
+      expect(await rawTodoCount({})).toBe(0);
+    });
+
+    it("rejects a non-admin authenticated user with 403 on churn", async () => {
+      const app = buildApp();
+      const user = await createUser("nonadmin-churn@example.com", false);
+      const token = await tokenFor(user);
+
+      const res = await supertest(app)
+        .post("/loadtest/todos/churn")
+        .set("Authorization", `Bearer ${token}`)
+        .send({creates: 1});
+
+      expect(res.status).toBe(403);
+    });
+
+    it("rejects a non-admin authenticated user with 403 on clear", async () => {
+      const app = buildApp();
+      const user = await createUser("nonadmin-clear@example.com", false);
+      const token = await tokenFor(user);
+
+      const res = await supertest(app)
+        .post("/loadtest/todos/clear")
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(403);
+    });
+
+    it("allows an admin user through the guard", async () => {
+      const app = buildApp();
+      const admin = await createUser("admin-guard@example.com", true);
+      const token = await tokenFor(admin);
+
+      const res = await supertest(app)
+        .post("/loadtest/todos/generate")
+        .set("Authorization", `Bearer ${token}`)
+        .send({count: 3});
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.created).toBe(3);
+    });
+  });
+
+  describe("count clamps", () => {
+    it("clamps generate's count to MAX_GENERATE (5000) when the request exceeds it", async () => {
+      const app = buildApp();
+      const admin = await createUser("admin-clamp-generate@example.com", true);
+      const token = await tokenFor(admin);
+
+      const res = await supertest(app)
+        .post("/loadtest/todos/generate")
+        .set("Authorization", `Bearer ${token}`)
+        .send({count: 5_001});
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.created).toBe(5_000);
+      expect(await rawTodoCount({ownerId: admin._id})).toBe(5_000);
+    }, 30_000);
+
+    it("defaults generate's count to 1000 when count is omitted", async () => {
+      const app = buildApp();
+      const admin = await createUser("admin-default-generate@example.com", true);
+      const token = await tokenFor(admin);
+
+      const res = await supertest(app)
+        .post("/loadtest/todos/generate")
+        .set("Authorization", `Bearer ${token}`)
+        .send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.created).toBe(1_000);
+    }, 15_000);
+
+    it("clamps churn's creates/updates/deletes each to MAX_CHURN_OPS (500) independently", async () => {
+      const app = buildApp();
+      const admin = await createUser("admin-clamp-churn@example.com", true);
+      const token = await tokenFor(admin);
+
+      // Seed enough existing todos that update/delete sampling isn't starved.
+      await Todo.insertMany(
+        Array.from({length: 1_000}, (_v, i) => ({
+          completed: false,
+          ownerId: admin._id,
+          title: `seed-${i}`,
+        }))
+      );
+
+      const res = await supertest(app)
+        .post("/loadtest/todos/churn")
+        .set("Authorization", `Bearer ${token}`)
+        .send({creates: 501, deletes: 501, updates: 501});
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.created).toBe(500);
+      expect(res.body.data.updated).toBe(500);
+      expect(res.body.data.deleted).toBe(500);
+    }, 30_000);
+
+    it("clampCount behavior via HTTP: zero/negative/non-numeric counts yield zero created", async () => {
+      const app = buildApp();
+      const admin = await createUser("admin-clamp-invalid@example.com", true);
+      const token = await tokenFor(admin);
+
+      for (const invalidCount of [0, -5, "not-a-number"]) {
+        const res = await supertest(app)
+          .post("/loadtest/todos/generate")
+          .set("Authorization", `Bearer ${token}`)
+          .send({count: invalidCount});
+
+        expect(res.status).toBe(200);
+        expect(res.body.data.created).toBe(0);
+      }
+      expect(await rawTodoCount({ownerId: admin._id})).toBe(0);
+    });
+  });
+
+  describe("soft-delete-only invariant", () => {
+    it("clear soft-deletes every todo for the user (raw count unchanged, live query count drops to 0)", async () => {
+      const app = buildApp();
+      const admin = await createUser("admin-clear@example.com", true);
+      const token = await tokenFor(admin);
+
+      await Todo.insertMany(
+        Array.from({length: 10}, (_v, i) => ({
+          completed: false,
+          ownerId: admin._id,
+          title: `clear-me-${i}`,
+        }))
+      );
+
+      const res = await supertest(app)
+        .post("/loadtest/todos/clear")
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.deleted).toBe(10);
+
+      // Raw collection count is unchanged — nothing was hard-deleted.
+      expect(await rawTodoCount({ownerId: admin._id})).toBe(10);
+      // Every raw doc is now a soft-delete tombstone.
+      expect(await rawTodoCount({deleted: true, ownerId: admin._id})).toBe(10);
+      // The normal Mongoose query (isDeletedPlugin's default `deleted: {$ne: true}` filter,
+      // applied via `pre("find")`) now returns none. `countDocuments` bypasses that hook
+      // (isDeletedPlugin only wires `find`/`findOne`), so `find()` is the correct check.
+      expect(await Todo.find({ownerId: admin._id})).toHaveLength(0);
+    });
+
+    it("churn's delete path is soft-delete-only", async () => {
+      const app = buildApp();
+      const admin = await createUser("admin-churn-delete@example.com", true);
+      const token = await tokenFor(admin);
+
+      await Todo.insertMany(
+        Array.from({length: 5}, (_v, i) => ({
+          completed: false,
+          ownerId: admin._id,
+          title: `churn-delete-${i}`,
+        }))
+      );
+
+      const res = await supertest(app)
+        .post("/loadtest/todos/churn")
+        .set("Authorization", `Bearer ${token}`)
+        .send({deletes: 5});
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.deleted).toBe(5);
+
+      // Raw collection count is unchanged — nothing was hard-deleted.
+      expect(await rawTodoCount({ownerId: admin._id})).toBe(5);
+      expect(await rawTodoCount({deleted: true, ownerId: admin._id})).toBe(5);
+      expect(await Todo.find({ownerId: admin._id})).toHaveLength(0);
+    });
+  });
+
+  describe("happy path and ownerId scoping", () => {
+    it("generate creates todos scoped to the caller's own ownerId", async () => {
+      const app = buildApp();
+      const admin = await createUser("admin-happy-generate@example.com", true);
+      const token = await tokenFor(admin);
+
+      const res = await supertest(app)
+        .post("/loadtest/todos/generate")
+        .set("Authorization", `Bearer ${token}`)
+        .send({count: 5});
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual({created: 5});
+
+      const created = await Todo.find({ownerId: admin._id});
+      expect(created).toHaveLength(5);
+      for (const todo of created) {
+        expect(String(todo.ownerId)).toBe(String(admin._id));
+        expect(typeof todo.title).toBe("string");
+        expect(typeof todo.completed).toBe("boolean");
+      }
+    });
+
+    it("churn applies a mixed create/update/delete batch and returns the response shape", async () => {
+      const app = buildApp();
+      const admin = await createUser("admin-happy-churn@example.com", true);
+      const token = await tokenFor(admin);
+
+      await Todo.insertMany(
+        Array.from({length: 6}, (_v, i) => ({
+          completed: false,
+          ownerId: admin._id,
+          title: `churn-seed-${i}`,
+        }))
+      );
+
+      const res = await supertest(app)
+        .post("/loadtest/todos/churn")
+        .set("Authorization", `Bearer ${token}`)
+        .send({creates: 2, deletes: 2, updates: 2});
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual({created: 2, deleted: 2, updated: 2});
+    });
+
+    it("never affects another user's todos via generate/churn/clear (ownerId scoping)", async () => {
+      const app = buildApp();
+      const adminA = await createUser("admin-scope-a@example.com", true);
+      const adminB = await createUser("admin-scope-b@example.com", true);
+      const tokenA = await tokenFor(adminA);
+
+      // B seeds some todos of its own.
+      await Todo.insertMany(
+        Array.from({length: 4}, (_v, i) => ({
+          completed: false,
+          ownerId: adminB._id,
+          title: `b-seed-${i}`,
+        }))
+      );
+
+      // A generates, churns, and clears — none of it should touch B's todos.
+      await supertest(app)
+        .post("/loadtest/todos/generate")
+        .set("Authorization", `Bearer ${tokenA}`)
+        .send({count: 3});
+      await supertest(app)
+        .post("/loadtest/todos/churn")
+        .set("Authorization", `Bearer ${tokenA}`)
+        .send({creates: 1});
+      await supertest(app).post("/loadtest/todos/clear").set("Authorization", `Bearer ${tokenA}`);
+
+      // B's todos are untouched and still live (not soft-deleted).
+      expect(await Todo.find({ownerId: adminB._id})).toHaveLength(4);
+      expect(await rawTodoCount({deleted: true, ownerId: adminB._id})).toBe(0);
+
+      // A's own todos were all soft-deleted by clear.
+      expect(await Todo.find({ownerId: adminA._id})).toHaveLength(0);
+    });
+  });
+});

--- a/example-backend/src/api/projects.test.ts
+++ b/example-backend/src/api/projects.test.ts
@@ -1,0 +1,215 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: test mock/socket shapes are dynamic
+import {beforeEach, describe, expect, it} from "bun:test";
+import {
+  applySyncMutation,
+  generateTokens,
+  installSyncSocketHandlers,
+  type SyncSocketLike,
+  TerrenoApp,
+  type User,
+} from "@terreno/api";
+import supertest from "supertest";
+import {Project} from "../models/project";
+import {User as UserModel} from "../models/user";
+import {projectRouter} from "./projects";
+
+/**
+ * D3 regression: `preCreate` must force/validate `organizationId` against the
+ * caller's own `organizationIds` rather than trusting a client-supplied value that
+ * happens to win because it was spread in after the default. Covers both transports
+ * the sync protocol supports — REST (`POST /projects`) and `sync:mutate` (socket and
+ * the in-process handler `applySyncMutation`, which the HTTP `/sync/mutate` route
+ * also delegates to).
+ */
+describe("projects tenant create-escape (D3)", () => {
+  const orgA = "org-a";
+  const orgB = "org-b";
+
+  const buildApp = () => {
+    process.env.TOKEN_SECRET = "test-secret";
+    process.env.TOKEN_ISSUER = "example-backend-test";
+    return new TerrenoApp({
+      authOptions: {
+        generateJWTPayload: (user: unknown) => ({
+          admin: (user as {admin?: boolean}).admin === true,
+        }),
+      },
+      skipListen: true,
+      userModel: UserModel as any,
+    })
+      .register(projectRouter)
+      .build();
+  };
+
+  const createUser = async (email: string, organizationIds: string[]) => {
+    return UserModel.register(
+      {email, name: email, organizationIds} as any,
+      "password12345"
+    ) as unknown as Promise<{_id: unknown; admin: boolean; organizationIds: string[]}>;
+  };
+
+  beforeEach(async () => {
+    // Project is sync-enabled (syncPlugin forbids multi-document writes like
+    // deleteMany, including through Model.deleteMany) — clear via the raw
+    // collection instead, matching the convention in api/src/sync/integration.test.ts.
+    await Project.collection.deleteMany({});
+    await UserModel.deleteMany({});
+  });
+
+  describe("over REST", () => {
+    it("ignores a caller-supplied organizationId outside the caller's organizations and uses the caller's own org", async () => {
+      const app = buildApp();
+      const user = await createUser("resta@example.com", [orgA]);
+      const {token} = await generateTokens(user);
+
+      const res = await supertest(app)
+        .post("/projects")
+        .set("Authorization", `Bearer ${token}`)
+        .send({organizationId: orgB, title: "escape attempt"});
+
+      // Server ignores/validates the mismatched organizationId — it must not create
+      // a document scoped to an org the caller does not belong to.
+      expect(res.status).toBe(403);
+      expect(await Project.countDocuments({organizationId: orgB})).toBe(0);
+    });
+
+    it("creates the project scoped to the caller's own organization when omitted", async () => {
+      const app = buildApp();
+      const user = await createUser("restb@example.com", [orgA]);
+      const {token} = await generateTokens(user);
+
+      const res = await supertest(app)
+        .post("/projects")
+        .set("Authorization", `Bearer ${token}`)
+        .send({title: "default org"});
+
+      expect(res.status).toBe(201);
+      expect(res.body.data.organizationId).toBe(orgA);
+    });
+
+    it("accepts an explicit organizationId that IS one of the caller's organizations", async () => {
+      const app = buildApp();
+      const user = await createUser("restc@example.com", [orgA, orgB]);
+      const {token} = await generateTokens(user);
+
+      const res = await supertest(app)
+        .post("/projects")
+        .set("Authorization", `Bearer ${token}`)
+        .send({organizationId: orgB, title: "second org"});
+
+      expect(res.status).toBe(201);
+      expect(res.body.data.organizationId).toBe(orgB);
+    });
+
+    it("rejects a caller with no organizations at all", async () => {
+      const app = buildApp();
+      const user = await createUser("restd@example.com", []);
+      const {token} = await generateTokens(user);
+
+      const res = await supertest(app)
+        .post("/projects")
+        .set("Authorization", `Bearer ${token}`)
+        .send({title: "no org"});
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("over sync:mutate (applySyncMutation, shared by HTTP /sync/mutate and the socket handler)", () => {
+    // Mirrors the shape `req.user` has over the real HTTP /sync/mutate route
+    // (authenticateMiddleware populates it with the full Mongoose user document,
+    // organizationIds included) — the preCreate hook under test reads that field.
+    const asFullUser = (user: {_id: unknown; organizationIds: string[]}): User =>
+      ({
+        _id: String(user._id),
+        admin: false,
+        id: String(user._id),
+        organizationIds: user.organizationIds,
+      }) as User;
+
+    it("nacks unauthorized when the mutation's organizationId escapes the caller's tenants", async () => {
+      const user = await createUser("synca@example.com", [orgA]);
+
+      const outcome = await applySyncMutation({
+        mutation: {
+          collection: "projects",
+          data: {organizationId: orgB, title: "sync escape attempt"},
+          mutationId: `d3-sync-${Date.now()}-1`,
+          operation: "create",
+        },
+        user: asFullUser(user),
+      });
+
+      expect(outcome.type).toBe("nack");
+      if (outcome.type === "nack") {
+        expect(outcome.nack.code).toBe("unauthorized");
+      }
+      expect(await Project.countDocuments({organizationId: orgB})).toBe(0);
+    });
+
+    it("acks and scopes to the caller's own organization when organizationId is omitted", async () => {
+      const user = await createUser("syncb@example.com", [orgA]);
+
+      const outcome = await applySyncMutation({
+        mutation: {
+          collection: "projects",
+          data: {title: "sync default org"},
+          mutationId: `d3-sync-${Date.now()}-2`,
+          operation: "create",
+        },
+        user: asFullUser(user),
+      });
+
+      expect(outcome.type).toBe("ack");
+      const doc = await Project.findOne({title: "sync default org"});
+      expect(doc?.organizationId).toBe(orgA);
+    });
+
+    it("denies via the installed socket handler for a subscribed collection", async () => {
+      const user = await createUser("syncc@example.com", [orgA]);
+      const emitted: {event: string; payload: unknown}[] = [];
+      const handlers = new Map<string, (...args: any[]) => any>();
+      const socket: SyncSocketLike = {
+        decodedToken: {admin: false, id: String(user._id), isAnonymous: false},
+        emit: (event, payload) => {
+          emitted.push({event, payload});
+        },
+        id: "socket-1",
+        join: async () => {},
+        leave: async () => {},
+        on: (event, handler) => {
+          handlers.set(event, handler);
+        },
+      };
+
+      installSyncSocketHandlers(null, socket, {
+        getUserScopes: () => [orgA],
+      });
+
+      const mutateHandler = handlers.get("sync:mutate");
+      expect(mutateHandler).toBeDefined();
+
+      // NOTE: the socket path currently authorizes with the synthetic
+      // `{_id, admin, id}` user (see D2), which has no organizationIds — so
+      // preCreate's tenant check denies here regardless of which organizationId
+      // was requested. This still proves the escape attempt is denied (fail
+      // closed); D2 restores full-user authorization so a caller CAN create in
+      // their own org over the socket transport.
+      let ackOrNack: {ack?: unknown; nack?: {code: string}} | undefined;
+      await mutateHandler?.(
+        {
+          collection: "projects",
+          data: {organizationId: orgB, title: "socket escape attempt"},
+          mutationId: `d3-socket-${Date.now()}`,
+          operation: "create",
+        },
+        (response: {ack?: unknown; nack?: {code: string}}) => {
+          ackOrNack = response;
+        }
+      );
+
+      expect(ackOrNack?.nack?.code).toBe("unauthorized");
+      expect(await Project.countDocuments({organizationId: orgB})).toBe(0);
+    });
+  });
+});

--- a/example-backend/src/api/projects.ts
+++ b/example-backend/src/api/projects.ts
@@ -1,4 +1,4 @@
-import {modelRouter, OrganizationQueryFilter, Permissions} from "@terreno/api";
+import {APIError, modelRouter, OrganizationQueryFilter, Permissions} from "@terreno/api";
 import {Project} from "../models";
 import type {ProjectDocument, UserDocument} from "../types";
 
@@ -24,10 +24,21 @@ export const projectRouter = modelRouter("/projects", Project, {
   },
   preCreate: (body, req) => {
     const organizationIds = getUserOrganizationIds(req.user);
+    // D3: spread body FIRST so a caller-supplied organizationId can never win by
+    // ordering, then force/validate it belongs to one of the caller's organizations.
+    // Without this, a client could POST an arbitrary organizationId and create a
+    // document in a tenant it does not belong to (a tenant create-escape).
+    const requested = (body as Partial<ProjectDocument>)?.organizationId;
+    const organizationId = requested ?? organizationIds[0];
+    if (!organizationId || !organizationIds.includes(organizationId)) {
+      throw new APIError({
+        status: 403,
+        title: "organizationId must be one of the caller's organizations",
+      });
+    }
     return {
-      // Default new projects into the user's first organization when unspecified.
-      organizationId: organizationIds[0],
       ...body,
+      organizationId,
     } as ProjectDocument;
   },
   queryFields: ["organizationId", "title"],

--- a/example-frontend/app/_layout.tsx
+++ b/example-frontend/app/_layout.tsx
@@ -16,12 +16,19 @@ import {
   useTerrenoFeatureFlags,
   useUpgradeCheck,
 } from "@terreno/rtk";
-import {Banner, ConsentNavigator, TerrenoProvider, UpgradeRequiredScreen} from "@terreno/ui";
+import {
+  Banner,
+  Box,
+  ConsentNavigator,
+  Spinner,
+  TerrenoProvider,
+  UpgradeRequiredScreen,
+} from "@terreno/ui";
 import {Provider, useSelector} from "react-redux";
 import {PersistGate} from "redux-persist/integration/react";
-import {useReadProfile} from "@/hooks/useReadProfile";
+import type {ProfileData} from "@/hooks/useReadProfile";
 import {getSessionToken} from "@/lib/betterAuth";
-import store, {persistor, syncBetterAuthSession} from "@/store";
+import store, {persistor, syncBetterAuthSession, useGetMeQuery} from "@/store";
 import {terrenoApi} from "@/store/sdk";
 import {setSyncDbReady, syncDb} from "@/store/syncdb";
 
@@ -102,7 +109,10 @@ const RootLayoutNav = (): React.ReactElement => {
   // /(tabs) root once it does, silently discarding the originally requested
   // route.
   const isAuthLoading = useSelector(selectBetterAuthIsLoading);
-  const profile = useReadProfile();
+  const {data: profileData, isLoading: isProfileLoading} = useGetMeQuery(undefined, {
+    skip: !userId,
+  });
+  const profile = profileData as ProfileData | undefined;
   const segments = useSegments();
   const router = useRouter();
   const {
@@ -187,6 +197,20 @@ const RootLayoutNav = (): React.ReactElement => {
       router.replace("/(tabs)");
     }
   }, [userId, segments, router, isAuthLoading]);
+
+  // Hold the navigator until the session (and, for signed-in users, the profile that
+  // decides the ConsentNavigator wrapper below) has settled. The wrapper choice changes
+  // the Stack's position in the React tree, and re-parenting unmounts and remounts the
+  // Stack — a remounted Stack resets to initialRouteName "(tabs)", silently discarding
+  // a deep-linked route like /profile or /admin. Rendering only once the tree shape is
+  // final means the Stack mounts exactly once per auth state and keeps the requested URL.
+  if (isAuthLoading || (Boolean(userId) && isProfileLoading)) {
+    return (
+      <Box alignItems="center" flex="grow" justifyContent="center" testID="app-auth-loading">
+        <Spinner />
+      </Box>
+    );
+  }
 
   if (isRequired) {
     return (

--- a/example-frontend/app/_layout.tsx
+++ b/example-frontend/app/_layout.tsx
@@ -22,7 +22,7 @@ import {useReadProfile} from "@/hooks/useReadProfile";
 import {getSessionToken} from "@/lib/betterAuth";
 import store, {persistor, syncBetterAuthSession} from "@/store";
 import {terrenoApi} from "@/store/sdk";
-import {syncDb} from "@/store/syncdb";
+import {setSyncDbReady, syncDb} from "@/store/syncdb";
 
 const OpenFeatureBridge: FC<{
   children: ReactNode;
@@ -130,19 +130,29 @@ const RootLayoutNav = (): React.ReactElement => {
   }, []);
 
   // Start the local-first syncdb client after login; stop on logout/unmount.
+  // setSyncDbReady only flips true once start() resolves a user, so screens gated on
+  // useSyncDbReady() don't call mutate() during the window where it would throw.
   useEffect(() => {
     if (!userId) {
       return;
     }
     let stopped = false;
-    syncDb.start().catch((error: unknown) => {
-      console.error("[syncdb] Failed to start client", error);
-    });
+    syncDb
+      .start()
+      .then(() => {
+        if (!stopped) {
+          setSyncDbReady(true);
+        }
+      })
+      .catch((error: unknown) => {
+        console.error("[syncdb] Failed to start client", error);
+      });
     return (): void => {
       if (stopped) {
         return;
       }
       stopped = true;
+      setSyncDbReady(false);
       syncDb.stop().catch((error: unknown) => {
         console.warn("[syncdb] Failed to stop client", error);
       });

--- a/example-frontend/app/_layout.tsx
+++ b/example-frontend/app/_layout.tsx
@@ -8,6 +8,7 @@ import "react-native-reanimated";
 import {OpenFeatureProvider} from "@openfeature/react-sdk";
 import {
   baseUrl,
+  selectBetterAuthIsLoading,
   selectBetterAuthUserId,
   setRealtimeSocket,
   useRealtimeDebug,
@@ -92,6 +93,15 @@ const RootLayout = (): React.ReactElement | null => {
 
 const RootLayoutNav = (): React.ReactElement => {
   const userId = useSelector(selectBetterAuthUserId) ?? undefined;
+  // The initial syncBetterAuthSession() call below is async (it awaits
+  // authClient.getSession()), so userId is undefined for one or more render
+  // passes on every fresh page load — including a deep link straight to a
+  // route like /profile or /admin. Without gating on this flag, the auth
+  // redirect effect below sees "no user yet" and replaces the URL with
+  // /login before the session resolves, then bounces to the hardcoded
+  // /(tabs) root once it does, silently discarding the originally requested
+  // route.
+  const isAuthLoading = useSelector(selectBetterAuthIsLoading);
   const profile = useReadProfile();
   const segments = useSegments();
   const router = useRouter();
@@ -160,6 +170,15 @@ const RootLayoutNav = (): React.ReactElement => {
   }, [userId]);
 
   useEffect(() => {
+    // Don't redirect while the initial Better Auth session sync is still in
+    // flight: userId is momentarily undefined on every fresh load (including
+    // deep links to routes like /profile or /admin), and redirecting to
+    // /login now would bounce straight back to the hardcoded /(tabs) root
+    // once the session resolves, losing the originally requested route.
+    if (isAuthLoading) {
+      return;
+    }
+
     const isOnAuthPage = segments[0] === "login" || segments[0] === "signup";
 
     if (!userId && !isOnAuthPage) {
@@ -167,7 +186,7 @@ const RootLayoutNav = (): React.ReactElement => {
     } else if (userId && isOnAuthPage) {
       router.replace("/(tabs)");
     }
-  }, [userId, segments, router]);
+  }, [userId, segments, router, isAuthLoading]);
 
   if (isRequired) {
     return (

--- a/example-frontend/components/SyncDevPanel.tsx
+++ b/example-frontend/components/SyncDevPanel.tsx
@@ -1,4 +1,4 @@
-import {wipeLocalData} from "@terreno/syncdb";
+import {DEFAULT_KEY_CACHE_DB_NAME, wipeLocalData} from "@terreno/syncdb";
 import {useSyncDbClient} from "@terreno/syncdb/react";
 import {Box, Button, Heading, Text} from "@terreno/ui";
 import {useRouter} from "expo-router";
@@ -59,7 +59,14 @@ export const SyncDevPanel: React.FC = () => {
     setIsBusy(true);
     try {
       await client.stop();
-      await wipeLocalData({databaseNames: [SYNC_DB_NAME], store: client.store});
+      // Also drop the cached derived encryption key (web) — a full local
+      // wipe should leave nothing behind, including key material cached in
+      // its own IndexedDB database.
+      await wipeLocalData({
+        databaseNames: [SYNC_DB_NAME],
+        keyCacheDbNames: [DEFAULT_KEY_CACHE_DB_NAME],
+        store: client.store,
+      });
       await client.start();
       setIsOffline(false);
     } catch (error) {

--- a/example-frontend/components/SyncTodosScreen.tsx
+++ b/example-frontend/components/SyncTodosScreen.tsx
@@ -24,6 +24,7 @@ import type React from "react";
 import {useCallback, useState} from "react";
 import {ScrollView} from "react-native";
 import {SyncDevPanel} from "@/components/SyncDevPanel";
+import {useSyncDbReady} from "@/hooks/useSyncDbReady";
 
 /**
  * Shape of a todo in the local syncdb store. Server documents carry the full model
@@ -92,6 +93,7 @@ const SyncTodoItem: React.FC<{
  */
 const SyncTodosScreen: React.FC = () => {
   const client = useSyncDbClient();
+  const isSyncDbReady = useSyncDbReady();
   const [newTodoTitle, setNewTodoTitle] = useState<string>("");
   const [isConflictSheetVisible, setIsConflictSheetVisible] = useState<boolean>(false);
 
@@ -105,7 +107,7 @@ const SyncTodosScreen: React.FC = () => {
 
   const handleCreateTodo = useCallback((): void => {
     const title = newTodoTitle.trim();
-    if (!title) {
+    if (!title || !isSyncDbReady) {
       return;
     }
     // Mint the entity id client-side and embed it in the data so the optimistic local
@@ -118,20 +120,26 @@ const SyncTodosScreen: React.FC = () => {
       operation: "create",
     });
     setNewTodoTitle("");
-  }, [client, newTodoTitle]);
+  }, [client, isSyncDbReady, newTodoTitle]);
 
   const handleToggleTodo = useCallback(
     (todo: SyncTodo): void => {
+      if (!isSyncDbReady) {
+        return;
+      }
       update({data: {completed: !todo.completed}, id: todo._id});
     },
-    [update]
+    [isSyncDbReady, update]
   );
 
   const handleDeleteTodo = useCallback(
     (todo: SyncTodo): void => {
+      if (!isSyncDbReady) {
+        return;
+      }
       remove({id: todo._id});
     },
-    [remove]
+    [isSyncDbReady, remove]
   );
 
   const openConflictSheet = useCallback((): void => {
@@ -184,7 +192,7 @@ const SyncTodosScreen: React.FC = () => {
                 value={newTodoTitle}
               />
               <Button
-                disabled={!newTodoTitle.trim()}
+                disabled={!newTodoTitle.trim() || !isSyncDbReady}
                 fullWidth
                 iconName="plus"
                 onClick={handleCreateTodo}

--- a/example-frontend/components/SyncTodosScreen.tsx
+++ b/example-frontend/components/SyncTodosScreen.tsx
@@ -166,6 +166,9 @@ const SyncTodosScreen: React.FC = () => {
             <Text color="secondaryLight" size="sm">
               Local-first via @terreno/syncdb
             </Text>
+            <Text color="secondaryLight" size="sm" testID="todos-count">
+              {todos.length}
+            </Text>
           </Box>
 
           {/* Add new todo */}

--- a/example-frontend/e2e/admin.spec.ts
+++ b/example-frontend/e2e/admin.spec.ts
@@ -15,7 +15,6 @@ test.describe("Admin Panel", () => {
   test.beforeEach(async ({page}) => {
     await loginAsAdmin(page);
     await page.goto("/admin");
-    await page.waitForLoadState("networkidle");
   });
 
   test("admin panel renders model list", async ({page}) => {
@@ -67,7 +66,6 @@ test.describe("Admin Panel", () => {
     const todoEntry = adminModelEntry(page, "Todo");
     await todoEntry.first().waitFor({state: "visible"});
     await todoEntry.first().click();
-    await page.waitForLoadState("networkidle");
 
     // Verify the todo appears in the admin table. Other screens (e.g. the
     // consumer todos tab) may still be mounted in the background and receive
@@ -88,7 +86,6 @@ test.describe("Admin Access Control", () => {
   test("non-admin user cannot see admin button in profile", async ({page}) => {
     await loginAs(page);
     await page.goto("/profile");
-    await page.waitForLoadState("networkidle");
     await page.getByTestId("profile-name-input").first().waitFor({state: "visible"});
     await expect(page.getByTestId("profile-admin-button")).not.toBeVisible();
   });

--- a/example-frontend/e2e/ai-chat.spec.ts
+++ b/example-frontend/e2e/ai-chat.spec.ts
@@ -6,7 +6,6 @@ test.describe("AI Chat", () => {
   test.beforeEach(async ({page}) => {
     await loginAs(page);
     await page.goto("/ai");
-    await page.waitForLoadState("networkidle");
     await page.getByTestId("gpt-input").waitFor({state: "visible"});
   });
 

--- a/example-frontend/e2e/auth.setup.ts
+++ b/example-frontend/e2e/auth.setup.ts
@@ -1,5 +1,5 @@
 import {type APIRequestContext, test as setup} from "@playwright/test";
-import {ADMIN_USER, ALL_E2E_USERS} from "./fixtures/testUsers";
+import {ADMIN_USER, ALL_E2E_USERS, SYNCDB_LOADLAB_USER} from "./fixtures/testUsers";
 import {setUserAdmin} from "./helpers/adminAuth";
 import {signUpOrSignInBetterAuth} from "./helpers/betterAuthSession";
 
@@ -10,6 +10,9 @@ setup("create test users", async ({request}) => {
     await createUser(request, user);
     if (user.email === ADMIN_USER.email) {
       await setUserAdmin(ADMIN_USER.email);
+    }
+    if (user.email === SYNCDB_LOADLAB_USER.email) {
+      await setUserAdmin(SYNCDB_LOADLAB_USER.email);
     }
     await acceptPendingConsentForms(request, user);
   }

--- a/example-frontend/e2e/consents.spec.ts
+++ b/example-frontend/e2e/consents.spec.ts
@@ -49,7 +49,6 @@ test.describe("Consent Flow", () => {
 
     // Navigate to consents tab
     await page.goto("/consents");
-    await page.waitForLoadState("networkidle");
     await page.getByTestId("consent-history-list").waitFor({state: "visible"});
     await expect(page.getByTestId("consent-history-list")).toBeVisible();
   });

--- a/example-frontend/e2e/fixtures/consoleAllowlist.ts
+++ b/example-frontend/e2e/fixtures/consoleAllowlist.ts
@@ -23,4 +23,14 @@ export const GLOBAL_CONSOLE_ALLOWLIST: ReadonlyArray<string | RegExp> = [
   // exist — expected on signup/login flows (e.g. duplicate-email signup) before a
   // token is available. Broad substring covers the "No token found" message too.
   "terrenoFlagConfiguration rejected query",
+
+  // @terreno/syncdb is started globally by the root layout on every authenticated
+  // login (see app/_layout.tsx), not just in syncdb-focused specs. Its startup
+  // reconcile and the realtime socket's token warmup race the app's own auth-state
+  // propagation immediately after login/signup and can transiently
+  // warn/error before settling — expected noise on any authenticated screen, not
+  // just the syncdb suite (which additionally uses allowSyncDbNoise() for its
+  // offline-simulation-specific messages).
+  /\[syncdb\] (startup|reconnect) reconcile failed/,
+  "[SocketConnection] Attempting to connect socket, but getAuthToken returned no token.",
 ];

--- a/example-frontend/e2e/fixtures/testUsers.ts
+++ b/example-frontend/e2e/fixtures/testUsers.ts
@@ -48,6 +48,13 @@ export const SYNCDB_LOAD_USER = suiteUser("syncdb-load", "E2E SyncDB Load User")
 export const SYNCDB_OFFLINE_USER = suiteUser("syncdb-offline", "E2E SyncDB Offline User");
 export const SYNCDB_CONFLICTS_USER = suiteUser("syncdb-conflicts", "E2E SyncDB Conflicts User");
 export const SYNCDB_STORAGE_USER = suiteUser("syncdb-storage", "E2E SyncDB Storage User");
+export const SYNCDB_CHAOS_USER = suiteUser("syncdb-chaos", "E2E SyncDB Chaos User");
+/**
+ * Admin-capable suite user for the SyncDB Load Lab e2e (Phase F4): the admin-guarded
+ * `/loadtest/todos/*` routes require `user.admin === true`, so this user is promoted
+ * to admin in auth.setup.ts alongside ADMIN_USER.
+ */
+export const SYNCDB_LOADLAB_USER = suiteUser("syncdb-loadlab", "E2E SyncDB LoadLab User");
 
 /** Every user auth.setup.ts must create (ADMIN_USER is additionally promoted). */
 export const ALL_E2E_USERS: E2EUser[] = [
@@ -63,4 +70,6 @@ export const ALL_E2E_USERS: E2EUser[] = [
   SYNCDB_OFFLINE_USER,
   SYNCDB_CONFLICTS_USER,
   SYNCDB_STORAGE_USER,
+  SYNCDB_CHAOS_USER,
+  SYNCDB_LOADLAB_USER,
 ];

--- a/example-frontend/e2e/helpers/betterAuthSession.ts
+++ b/example-frontend/e2e/helpers/betterAuthSession.ts
@@ -45,21 +45,27 @@ export const signUpOrSignInBetterAuth = async (
     data: {email: user.email, name: user.name, password: user.password},
     headers: originHeaders,
   });
+
+  let token: string;
   if (signUpRes.ok()) {
-    return readSessionToken(await signUpRes.json());
+    token = readSessionToken(await signUpRes.json());
+  } else {
+    const signInRes = await request.post(`${API_URL}/api/auth/sign-in/email`, {
+      data: {email: user.email, password: user.password},
+      headers: originHeaders,
+    });
+    if (!signInRes.ok()) {
+      throw new Error(
+        `Better Auth sign-up (${signUpRes.status()}) and sign-in (${signInRes.status()}) failed for ${user.email}`
+      );
+    }
+    token = readSessionToken(await signInRes.json());
   }
 
-  const signInRes = await request.post(`${API_URL}/api/auth/sign-in/email`, {
-    data: {email: user.email, password: user.password},
-    headers: originHeaders,
-  });
-  if (!signInRes.ok()) {
-    throw new Error(
-      `Better Auth sign-up (${signUpRes.status()}) and sign-in (${signInRes.status()}) failed for ${user.email}`
-    );
-  }
-  const token = readSessionToken(await signInRes.json());
-  // Ensure the Mongoose User row exists for owner-scoped routes.
+  // Ensure the Mongoose User row exists for owner-scoped routes. The Better Auth session
+  // middleware only creates it lazily on first authenticated request — without this, a
+  // fresh sign-up returns a valid session token but leaves no User row for callers (e.g.
+  // auth.setup.ts's setUserAdmin) that need to mutate the row immediately afterwards.
   await request.get(`${API_URL}/auth/me`, {
     headers: {authorization: `Bearer ${token}`, ...originHeaders},
   });

--- a/example-frontend/e2e/helpers/betterAuthSession.ts
+++ b/example-frontend/e2e/helpers/betterAuthSession.ts
@@ -1,6 +1,19 @@
 import type {APIRequestContext} from "@playwright/test";
 
 const API_URL = process.env.BACKEND_URL ?? "http://localhost:4000";
+const FRONTEND_ORIGIN = process.env.FRONTEND_URL ?? "http://localhost:8082";
+
+/**
+ * Better Auth's origin-check middleware forces origin validation whenever a request
+ * carries a `Cookie` header (see `validateOrigin` in better-auth's origin-check
+ * middleware). Playwright's `request` fixture is a single shared cookie jar across an
+ * entire test/setup file, so once any Better Auth call sets a session cookie, every
+ * later call in that same context — sign-up or sign-in, for any user — automatically
+ * forwards that cookie and must present a trusted `Origin` header or it 403s with
+ * `MISSING_OR_NULL_ORIGIN`. Sending this on every request keeps auth.setup.ts's
+ * multi-user loop working regardless of cookie state.
+ */
+const originHeaders = {origin: FRONTEND_ORIGIN};
 
 export interface BetterAuthCredentials {
   email: string;
@@ -30,6 +43,7 @@ export const signUpOrSignInBetterAuth = async (
 ): Promise<string> => {
   const signUpRes = await request.post(`${API_URL}/api/auth/sign-up/email`, {
     data: {email: user.email, name: user.name, password: user.password},
+    headers: originHeaders,
   });
   if (signUpRes.ok()) {
     return readSessionToken(await signUpRes.json());
@@ -37,6 +51,7 @@ export const signUpOrSignInBetterAuth = async (
 
   const signInRes = await request.post(`${API_URL}/api/auth/sign-in/email`, {
     data: {email: user.email, password: user.password},
+    headers: originHeaders,
   });
   if (!signInRes.ok()) {
     throw new Error(
@@ -46,7 +61,7 @@ export const signUpOrSignInBetterAuth = async (
   const token = readSessionToken(await signInRes.json());
   // Ensure the Mongoose User row exists for owner-scoped routes.
   await request.get(`${API_URL}/auth/me`, {
-    headers: {authorization: `Bearer ${token}`},
+    headers: {authorization: `Bearer ${token}`, ...originHeaders},
   });
   return token;
 };

--- a/example-frontend/e2e/helpers/login.ts
+++ b/example-frontend/e2e/helpers/login.ts
@@ -8,4 +8,11 @@ export const loginAs = async (page: Page, user = TEST_USER): Promise<void> => {
   await page.getByTestId("login-screen-password-input").fill(user.password);
   await page.getByTestId("login-screen-submit-button").click();
   await page.getByTestId("login-screen").first().waitFor({state: "hidden"});
+  // login.tsx's own router.replace("/(tabs)") is still in flight when the login screen
+  // hides — a caller that immediately does page.goto() to a different route (e.g.
+  // loginAsAdmin() followed by page.goto("/admin")) can race that client-side redirect:
+  // the hard navigation can land before Expo Router's replace resolves, which then
+  // overrides it back to "/(tabs)". Waiting for the tabs root to actually mount closes
+  // that window before control returns to the caller.
+  await page.getByTestId("todos-screen").waitFor({state: "visible"});
 };

--- a/example-frontend/e2e/helpers/syncdbSuite.ts
+++ b/example-frontend/e2e/helpers/syncdbSuite.ts
@@ -34,6 +34,10 @@ export const allowSyncDbNoise = (consoleGuard: ConsoleGuard): void => {
   consoleGuard.allow(/WebSocket/i);
   consoleGuard.allow(/websocket error/i);
   consoleGuard.allow(/socket\.io/i);
+  // The realtime feature-flags/notifications socket (@terreno/rtk's useSocketConnection,
+  // distinct from syncdb's own transport) also can't reach a severed network during
+  // chaos/offline simulation.
+  consoleGuard.allow(/\[SocketConnection\]/);
   consoleGuard.allow("Failed to load resource");
   consoleGuard.allow("Sentry not initialized");
   consoleGuard.allow("[useConsentForms] Failed to fetch pending consent forms");
@@ -41,6 +45,9 @@ export const allowSyncDbNoise = (consoleGuard: ConsoleGuard): void => {
   consoleGuard.allow("rejected mutation: Network unavailable");
   consoleGuard.allow("rejected query");
   consoleGuard.allow("Error fetching OpenAPI spec");
+  // Logging out while offline (see syncdb-storage.spec.ts's user-switch scenario)
+  // legitimately fails Better Auth's sign-out network call.
+  consoleGuard.allow("Better Auth: Error signing out");
 };
 
 export const todoItemByTitle = (page: Page, title: string): Locator =>

--- a/example-frontend/e2e/helpers/syncdbSuite.ts
+++ b/example-frontend/e2e/helpers/syncdbSuite.ts
@@ -113,6 +113,198 @@ export const restoreNetwork = async (page: Page): Promise<void> => {
   await page.unroute(`${API_URL}/**`);
 };
 
+/**
+ * Chaos e2e (Phase F3): helpers that stress the syncdb transport with jitter,
+ * reordering, live-socket drops, and rapid offline/online flapping — distinct from
+ * (and additive to) installOfflineControl above, which stays untouched so the
+ * non-chaos syncdb-*.spec.ts files keep their simpler, deterministic outage model.
+ *
+ * These helpers exist to try to *forge* the failure modes the outbox/idempotency
+ * ledger is supposed to prevent: duplicate deliveries from a reconnect racing an
+ * in-flight ack, or a lost mutation from a frame dropped mid-flight. A chaos test
+ * runs these concurrently with real UI mutations, then stops the chaos and asserts
+ * the client converges to exactly the mutated set with no duplicates.
+ *
+ * Per-repo research already established that Chrome DevTools Protocol's
+ * `Network.emulateNetworkConditions` does NOT throttle WebSocket frames (only HTTP),
+ * so latency/reordering here is injected by hand in the page.routeWebSocket relay
+ * below rather than via CDP.
+ */
+
+/** Uniform random integer/float in [min, max). */
+const rand = (min: number, max: number): number => min + Math.random() * (max - min);
+
+export interface ChaosControl {
+  /** Force-close every currently-live chaos-proxied WebSocket (simulates a dead connection). */
+  dropSocket: () => void;
+  /** Toggle full network outage, reusing the same semantics as goSyncOffline/goSyncOnline. */
+  goOffline: () => Promise<void>;
+  goOnline: () => Promise<void>;
+  /** Stop chaos-proxying: HTTP jitter route is removed and sockets forward immediately. */
+  stop: () => Promise<void>;
+}
+
+export interface ChaosControlOptions {
+  /** Max per-frame WebSocket latency in ms; each frame sleeps rand(0, latencyMs). Default 150. */
+  latencyMs?: number;
+}
+
+/**
+ * Install ONE routeWebSocket handler (Playwright does not expect multiple overlapping
+ * handlers registered for the same URL pattern) that supersets installOfflineControl
+ * with per-frame latency injection and live-socket dropping, plus an HTTP jitter route
+ * for REST calls. Must be called before login/navigation, exactly like
+ * installOfflineControl, so it wraps every socket.io connection the page ever opens.
+ */
+export const installChaosControl = async (
+  page: Page,
+  options?: ChaosControlOptions
+): Promise<ChaosControl> => {
+  const latencyMs = options?.latencyMs ?? 150;
+  let offline = false;
+  let chaosActive = true;
+  const sockets = new Set<WebSocketRoute>();
+
+  // Per-frame latency + jitter in both directions: instead of forwarding immediately,
+  // each message is delayed by an independent random duration so frames can arrive
+  // out of order relative to one another (a truer approximation of a lossy network
+  // than a single fixed delay, and enough to race the outbox drain against acks).
+  const forwardWithJitter = (
+    send: (message: string | Buffer) => void,
+    message: string | Buffer
+  ): void => {
+    if (!chaosActive) {
+      send(message);
+      return;
+    }
+    setTimeout(() => send(message), rand(0, latencyMs));
+  };
+
+  await page.routeWebSocket(/\/socket\.io\//, (ws) => {
+    if (offline) {
+      ws.close();
+      return;
+    }
+    const server = ws.connectToServer();
+    ws.onMessage((message) => forwardWithJitter((m) => server.send(m), message));
+    server.onMessage((message) => forwardWithJitter((m) => ws.send(m), message));
+    sockets.add(ws);
+    ws.onClose(() => sockets.delete(ws));
+  });
+
+  const dropSocket = (): void => {
+    for (const ws of sockets) {
+      ws.close();
+    }
+  };
+
+  const goOffline = async (): Promise<void> => {
+    offline = true;
+    await page.route(`${API_URL}/**`, (route) => route.abort("connectionrefused"));
+    dropSocket();
+    await page.getByTestId("sync-offline-indicator").waitFor({state: "visible", timeout: 15_000});
+  };
+
+  const goOnline = async (): Promise<void> => {
+    offline = false;
+    await page.unroute(`${API_URL}/**`);
+    await page.getByTestId("sync-offline-indicator").waitFor({state: "hidden", timeout: 30_000});
+  };
+
+  const stop = async (): Promise<void> => {
+    chaosActive = false;
+    offline = false;
+    await page.unroute(`${API_URL}/**`);
+  };
+
+  return {dropSocket, goOffline, goOnline, stop};
+};
+
+/**
+ * HTTP-only latency injection (no outage): every REST call to the backend is delayed
+ * by a random duration in [minMs, maxMs) via route.continue(), so requests still
+ * succeed — this simulates a slow/jittery network rather than a severed one, and
+ * composes with installChaosControl's WebSocket jitter for full-stack chaos.
+ */
+export const installHttpJitter = async (
+  page: Page,
+  {minMs, maxMs}: {minMs: number; maxMs: number}
+): Promise<void> => {
+  await page.route(`${API_URL}/**`, async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, rand(minMs, maxMs)));
+    await route.continue();
+  });
+};
+
+export interface SyncFlapLoopController {
+  /**
+   * Signal the loop to stop. Lets any in-flight goOffline/goOnline settle, then
+   * performs one final goOnline so callers can rely on ending online before running
+   * convergence assertions.
+   */
+  stop: () => Promise<void>;
+}
+
+/** Minimal shape a flap loop needs to toggle connectivity — satisfied by ChaosControl. */
+export interface SyncFlapToggle {
+  goOffline: () => Promise<void>;
+  goOnline: () => Promise<void>;
+}
+
+/**
+ * Repeatedly toggle connectivity via the given `toggle` (pass the ChaosControl
+ * returned by installChaosControl — its goOffline/goOnline share the chaos-proxied
+ * WebSocket state, unlike the plain module-level goSyncOffline/goSyncOnline, which
+ * only affect installOfflineControl's separate routing) with a random dwell between
+ * toggles (default 1-8s, per the chaos plan). Runs as a detached background loop the
+ * caller `void`s; call `stop()` to end it deterministically.
+ */
+export const startSyncFlapLoop = (
+  toggle: SyncFlapToggle,
+  options?: {minDwellMs?: number; maxDwellMs?: number}
+): SyncFlapLoopController => {
+  const minDwellMs = options?.minDwellMs ?? 1000;
+  const maxDwellMs = options?.maxDwellMs ?? 8000;
+  let stopped = false;
+  let resolveStopped: (() => void) | undefined;
+  const stoppedPromise = new Promise<void>((resolve) => {
+    resolveStopped = resolve;
+  });
+
+  const dwell = (): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, rand(minDwellMs, maxDwellMs)));
+
+  const loop = async (): Promise<void> => {
+    while (!stopped) {
+      await toggle.goOffline();
+      if (stopped) {
+        break;
+      }
+      await dwell();
+      if (stopped) {
+        break;
+      }
+      await toggle.goOnline();
+      if (stopped) {
+        break;
+      }
+      await dwell();
+    }
+    resolveStopped?.();
+  };
+
+  void loop();
+
+  const stop = async (): Promise<void> => {
+    stopped = true;
+    await stoppedPromise;
+    // Guarantee a known, online end state regardless of which phase the loop was in.
+    await toggle.goOnline();
+  };
+
+  return {stop};
+};
+
 export const createTodoViaUi = async (page: Page, title: string): Promise<void> => {
   await page.getByTestId("todos-title-input").fill(title);
   await page.getByTestId("todos-create-button").click();

--- a/example-frontend/e2e/profile.spec.ts
+++ b/example-frontend/e2e/profile.spec.ts
@@ -6,7 +6,6 @@ test.describe("Profile", () => {
   test.beforeEach(async ({page}) => {
     await loginAs(page);
     await page.goto("/profile");
-    await page.waitForLoadState("networkidle");
     await page.getByTestId("profile-name-input").first().waitFor({state: "visible"});
   });
 

--- a/example-frontend/e2e/signup.spec.ts
+++ b/example-frontend/e2e/signup.spec.ts
@@ -27,13 +27,14 @@ test.describe("Signup", () => {
   });
 
   test("shows error for duplicate email", async ({page, consoleGuard}) => {
-    // The signup fetch is expected to return 500 (duplicate user), which the
+    // Better Auth's sign-up-with-email endpoint returns 422 (duplicate user), which the
     // browser logs and store/errors.ts forwards to Sentry.
     // Unauthenticated signup still mounts feature-flag queries; RTK rejects
     // terrenoFlagConfiguration without a token and errors.ts logs (see offlineHelpers).
     consoleGuard.allow("terrenoFlagConfiguration rejected query: No token found");
     consoleGuard.allow("Sentry not initialized, captured exception Error:");
-    consoleGuard.allow("Failed to load resource: the server responded with a status of 500");
+    consoleGuard.allow("Failed to load resource: the server responded with a status of 422");
+    consoleGuard.allow("USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL");
     consoleGuard.allow("A user with the given username is already registered");
     consoleGuard.allow(/^Object$/);
     // Feature-flags query rejects before auth; Sentry logs in dev without full SDK init.

--- a/example-frontend/e2e/syncdb-chaos.spec.ts
+++ b/example-frontend/e2e/syncdb-chaos.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * SyncDB chaos (Phase F3): flapping connectivity, jittered/reordered WebSocket
+ * frames, and live-socket drops racing a batch of in-flight mutations. Shared suite
+ * notes and helpers live in helpers/syncdbSuite.ts. Uses a dedicated user so it can
+ * run in parallel with the other syncdb-*.spec.ts files.
+ *
+ * The load-bearing assertion is zero duplicates: flapping mid-ack is specifically
+ * designed to try to forge duplicate deliveries (client resends a mutation whose ack
+ * was lost to a socket drop, server change-stream re-delivers a delta across a
+ * reconnect, etc). The idempotency ledger + outbox dedup must prevent that, so this
+ * spec asserts per-title counts rather than just comparing set/array lengths (which
+ * wouldn't catch a duplicate-plus-a-missing-item false negative).
+ */
+
+import {expect, test} from "./fixtures/test";
+import {SYNCDB_CHAOS_USER} from "./fixtures/testUsers";
+import {loginAs} from "./helpers/login";
+import type {ChaosControl} from "./helpers/syncdbSuite";
+import {
+  allowSyncDbNoise,
+  CONVERGE_TIMEOUT,
+  createTodoViaUi,
+  installChaosControl,
+  openSyncTodos,
+  startSyncFlapLoop,
+} from "./helpers/syncdbSuite";
+import {clearTodosAs, listTodosAs} from "./helpers/todosApi";
+
+const USER = SYNCDB_CHAOS_USER;
+const MUTATION_COUNT = 30;
+const CHAOS_LATENCY_MS = 100;
+
+/** Every title created in this test, e.g. ["chaos-todo-0", ..., "chaos-todo-29"]. */
+const chaosTitles = (): string[] =>
+  Array.from({length: MUTATION_COUNT}, (_, i) => `chaos-todo-${i}`);
+
+/** Assert no value in `items` appears more than once — the zero-duplicates check. */
+const assertNoDuplicates = (items: string[], label: string): void => {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    counts.set(item, (counts.get(item) ?? 0) + 1);
+  }
+  const duplicated = [...counts.entries()].filter(([, count]) => count > 1);
+  expect(duplicated, `${label} had duplicate titles: ${JSON.stringify(duplicated)}`).toEqual([]);
+};
+
+test.describe("SyncDB chaos (reconnect-mid-drain)", () => {
+  let chaos: ChaosControl;
+
+  test.beforeEach(async ({page, consoleGuard}) => {
+    allowSyncDbNoise(consoleGuard);
+    await clearTodosAs(USER);
+    // installChaosControl must run before login (and only once per page): it wraps
+    // every socket.io connection the page opens via page.routeWebSocket, and Playwright
+    // does not expect a second overlapping handler registered for the same pattern.
+    // The test body reuses this same `chaos` handle rather than installing again.
+    chaos = await installChaosControl(page, {latencyMs: CHAOS_LATENCY_MS});
+    await loginAs(page, USER);
+    await openSyncTodos(page);
+  });
+
+  test("30 UI mutations survive flapping connectivity with zero duplicates", async ({page}) => {
+    // 30 mutations racing offline/online flaps + jittered frames can take longer than
+    // the default local 60s / CI 30s budget to fully converge.
+    test.setTimeout(120_000);
+
+    const flap = startSyncFlapLoop(chaos, {maxDwellMs: 8000, minDwellMs: 1000});
+
+    const titles = chaosTitles();
+    for (const title of titles) {
+      await createTodoViaUi(page, title);
+    }
+
+    // Stop chaos: flap loop settles into ONLINE, then latency injection is cleared so
+    // the queue can drain at full speed for convergence.
+    await flap.stop();
+    await chaos.stop();
+
+    // The banner shows queued state via ONE of two testIDs depending on volume:
+    // "sync-queued-count" (<=20 queued) or "sync-drain-progress" (>20 queued —
+    // this test's 30 mutations can cross that threshold under chaos). Neither
+    // must be present once the drain is truly finished, or "converged" would
+    // be a false positive the instant the queued count crosses back under the
+    // progress threshold mid-drain.
+    await expect
+      .poll(
+        async () => {
+          const [queuedCount, drainProgress] = await Promise.all([
+            page
+              .getByTestId("sync-queued-count")
+              .textContent()
+              .catch(() => null),
+            page
+              .getByTestId("sync-drain-progress")
+              .textContent()
+              .catch(() => null),
+          ]);
+          return queuedCount === null && drainProgress === null;
+        },
+        {timeout: CONVERGE_TIMEOUT}
+      )
+      .toBe(true);
+
+    const localTitles = await page
+      .locator('[data-testid^="todo-item-"]')
+      .filter({hasText: /^chaos-todo-\d+$/})
+      .allTextContents();
+
+    await expect
+      .poll(async () => (await listTodosAs(USER)).map((todo) => todo.title).sort(), {
+        timeout: CONVERGE_TIMEOUT,
+      })
+      .toEqual([...titles].sort());
+
+    const serverTitles = (await listTodosAs(USER)).map((todo) => todo.title);
+
+    assertNoDuplicates(localTitles, "local DOM-rendered todo list");
+    assertNoDuplicates(serverTitles, "REST-fetched todo list");
+
+    expect(new Set(localTitles)).toEqual(new Set(titles));
+    expect(localTitles.length).toBe(titles.length);
+    expect(serverTitles.length).toBe(titles.length);
+  });
+});

--- a/example-frontend/e2e/syncdb-loadlab.spec.ts
+++ b/example-frontend/e2e/syncdb-loadlab.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * SyncDB Load Lab (Phase F4): client-side load e2e. Drives the admin-guarded
+ * `/loadtest/todos/*` routes (example-backend/src/api/loadtest.ts) directly via REST
+ * — bypassing the SyncLabScreen UI entirely, since these are plain server-side writes
+ * against the owner-scoped todos collection and the generated SDK has no hooks for
+ * them (SyncLabScreen calls them with `fetch` too) — while a real browser session
+ * stays mounted on the synced Todos screen, so the running @terreno/syncdb client
+ * absorbs the resulting `sync:delta` stream exactly as it would for "another client"
+ * mutating shared data.
+ *
+ * Unlike syncdb-load-delta.spec.ts (which seeds a handful of todos via the plain
+ * `/todos` CRUD routes and asserts individual `todo-item-{id}` rows), this spec
+ * generates thousands of documents and therefore asserts ONLY the `todos-count`
+ * testID (SyncTodosScreen.tsx) converging to an exact expected total — asserting on
+ * thousands of unvirtualized DOM rows here would be slow and flaky. See
+ * SyncTodosScreen.tsx: the todo list is intentionally left as a plain `.map()` inside
+ * a ScrollView (not virtualized) since this spec never inspects individual rows.
+ *
+ * Shared suite notes/helpers live in helpers/syncdbSuite.ts. Uses a dedicated
+ * admin-capable user (SYNCDB_LOADLAB_USER) so it can run in parallel with the other
+ * syncdb-*.spec.ts files and so the admin-guarded loadtest routes are callable.
+ */
+import {expect, test} from "./fixtures/test";
+import {SYNCDB_LOADLAB_USER} from "./fixtures/testUsers";
+import {signUpOrSignInBetterAuth} from "./helpers/betterAuthSession";
+import {loginAs} from "./helpers/login";
+import {allowSyncDbNoise, CONVERGE_TIMEOUT, openSyncTodos} from "./helpers/syncdbSuite";
+
+const USER = SYNCDB_LOADLAB_USER;
+const API_URL = process.env.BACKEND_URL ?? "http://localhost:4000";
+
+const GENERATE_COUNT = 2000;
+const CHURN_ROUNDS = 10;
+const CHURN_BODY = {creates: 20, deletes: 10, updates: 20};
+
+// 2000 initial docs + 10 churn rounds is a much heavier convergence scenario than the
+// rest of the syncdb-*.spec.ts suite, so this spec gets a generous multiple of the
+// standard CONVERGE_TIMEOUT rather than sharing the default budget.
+const LOAD_CONVERGE_TIMEOUT = CONVERGE_TIMEOUT * 3;
+
+interface LoadTestResult {
+  created?: number;
+  updated?: number;
+  deleted?: number;
+}
+
+/** Thin REST client for the admin-guarded /loadtest/todos/* routes, bearer-authed as USER. */
+class LoadTestClient {
+  constructor(
+    private readonly request: import("@playwright/test").APIRequestContext,
+    private readonly token: string
+  ) {}
+
+  static async create(
+    request: import("@playwright/test").APIRequestContext
+  ): Promise<LoadTestClient> {
+    const token = await signUpOrSignInBetterAuth(request, USER);
+    return new LoadTestClient(request, token);
+  }
+
+  private async post(path: string, data?: Record<string, unknown>): Promise<LoadTestResult> {
+    const res = await this.request.post(`${API_URL}/loadtest/todos/${path}`, {
+      data: data ?? {},
+      headers: {authorization: `Bearer ${this.token}`},
+    });
+    if (!res.ok()) {
+      throw new Error(`loadtest ${path} failed with status ${res.status()}`);
+    }
+    const json = (await res.json()) as {data?: LoadTestResult};
+    return json.data ?? {};
+  }
+
+  clear(): Promise<LoadTestResult> {
+    return this.post("clear");
+  }
+
+  generate(count: number): Promise<LoadTestResult> {
+    return this.post("generate", {count});
+  }
+
+  churn(body: {creates: number; updates: number; deletes: number}): Promise<LoadTestResult> {
+    return this.post("churn", body);
+  }
+
+  /** Cheap total-count cross-check: modelRouter's list envelope includes `total`. */
+  async totalCount(): Promise<number> {
+    const res = await this.request.get(`${API_URL}/todos?limit=1`, {
+      headers: {authorization: `Bearer ${this.token}`},
+    });
+    if (!res.ok()) {
+      throw new Error(`GET /todos?limit=1 failed with status ${res.status()}`);
+    }
+    const json = (await res.json()) as {total?: number};
+    return json.total ?? -1;
+  }
+}
+
+const pollTodosCount = (page: import("@playwright/test").Page): Promise<number> => {
+  return page
+    .getByTestId("todos-count")
+    .textContent()
+    .then((text) => Number(text));
+};
+
+test.describe("SyncDB Load Lab @load", {tag: "@load"}, () => {
+  // 2000-doc generation + 10 churn rounds well exceeds the default per-test budget
+  // used by the rest of the syncdb-*.spec.ts suite.
+  test.describe.configure({timeout: 180_000});
+
+  test.beforeEach(async ({page, consoleGuard}) => {
+    allowSyncDbNoise(consoleGuard);
+    await loginAs(page, USER);
+    await openSyncTodos(page);
+  });
+
+  test("2000-doc generate + churn rounds converge to an exact count", async ({page, request}) => {
+    const loadTest = await LoadTestClient.create(request);
+
+    // Reset to a known 0 state so the final assertion is an exact count rather than
+    // "at least N" (the suite user's data may carry over between local runs).
+    await loadTest.clear();
+
+    let expectedCount = 0;
+
+    const initialStart = Date.now();
+    const generated = await loadTest.generate(GENERATE_COUNT);
+    expectedCount += generated.created ?? 0;
+
+    await expect
+      .poll(async () => pollTodosCount(page), {timeout: LOAD_CONVERGE_TIMEOUT})
+      .toBe(expectedCount);
+    const initialConvergeMs = Date.now() - initialStart;
+    test.info().annotations.push({
+      description: `initial ${GENERATE_COUNT}-doc convergence: ${initialConvergeMs}ms`,
+      type: "timing",
+    });
+
+    // Several churn rounds with the page open: the live client should keep absorbing
+    // a continuous stream of inbound sync:delta patches while mounted. Rounds are
+    // fired back-to-back without waiting for full convergence between them — only
+    // the final round's convergence is asserted — so this also exercises the client
+    // catching up on a backlog rather than always processing one delta at a time.
+    const churnStart = Date.now();
+    for (let round = 0; round < CHURN_ROUNDS; round++) {
+      const result = await loadTest.churn(CHURN_BODY);
+      expectedCount += (result.created ?? 0) - (result.deleted ?? 0);
+    }
+
+    await expect
+      .poll(async () => pollTodosCount(page), {timeout: LOAD_CONVERGE_TIMEOUT})
+      .toBe(expectedCount);
+    const churnConvergeMs = Date.now() - churnStart;
+    test.info().annotations.push({
+      description: `${CHURN_ROUNDS} churn rounds final convergence: ${churnConvergeMs}ms`,
+      type: "timing",
+    });
+
+    // Cross-check against the server's own total via the cheap `?limit=1` list
+    // envelope (avoids paginating through thousands of rows just to count them).
+    const serverTotal = await loadTest.totalCount();
+    expect(serverTotal).toBe(expectedCount);
+  });
+});

--- a/example-frontend/hooks/index.ts
+++ b/example-frontend/hooks/index.ts
@@ -3,4 +3,5 @@ export {useAppLaunchOrForeground} from "@terreno/ui";
 export * from "./useLogoutUser";
 export * from "./useReadProfile";
 export * from "./useSentryUserSetup";
+export * from "./useSyncDbReady";
 export * from "./useUpdateProfile";

--- a/example-frontend/hooks/useSyncDbReady.ts
+++ b/example-frontend/hooks/useSyncDbReady.ts
@@ -1,0 +1,12 @@
+import {useSyncExternalStore} from "react";
+import {getSyncDbReadySnapshot, subscribeSyncDbReady} from "@/store/syncdb";
+
+/**
+ * True once `syncDb.start()` (fired by the root layout after login) has resolved.
+ * Screens that call `client.mutate()`/`useMutate()` should disable their
+ * mutation-triggering controls while this is false — calling mutate() before start()
+ * resolves throws "requires start() to have resolved an authenticated user".
+ */
+export const useSyncDbReady = (): boolean => {
+  return useSyncExternalStore(subscribeSyncDbReady, getSyncDbReadySnapshot);
+};

--- a/example-frontend/lib/betterAuth.ts
+++ b/example-frontend/lib/betterAuth.ts
@@ -50,12 +50,37 @@ export const getSession = async () => {
   return betterAuthClient.getSession();
 };
 
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Number of `getSession()` attempts `getSessionToken()` makes before giving up.
+ * Callers (e.g. `useSocketConnection`'s `getAuthToken`) only call this once they
+ * believe the user is signed in — right after login/session-sync resolved a userId
+ * into Redux — so an empty session on the first attempt is more likely a transient
+ * race (the freshly-set session cookie not yet consistently queryable) than a real
+ * signed-out state. `useSocketConnection` has no retry of its own for this case (its
+ * token-refresh-driven reconnect only fires for the JWT auth slice, not Better Auth),
+ * so a transient empty result here would otherwise leave the socket connection
+ * permanently unattempted until some unrelated effect re-triggers it.
+ */
+const GET_SESSION_TOKEN_RETRY_ATTEMPTS = 3;
+const GET_SESSION_TOKEN_RETRY_DELAY_MS = 250;
+
 export const getSessionToken = async (): Promise<string | null> => {
-  try {
-    const result = await betterAuthClient.getSession();
-    const envelope = (result as {data?: {session?: {token?: string}}})?.data ?? result;
-    return (envelope as {session?: {token?: string}})?.session?.token ?? null;
-  } catch {
-    return null;
+  for (let attempt = 1; attempt <= GET_SESSION_TOKEN_RETRY_ATTEMPTS; attempt += 1) {
+    try {
+      const result = await betterAuthClient.getSession();
+      const envelope = (result as {data?: {session?: {token?: string}}})?.data ?? result;
+      const token = (envelope as {session?: {token?: string}})?.session?.token ?? null;
+      if (token || attempt === GET_SESSION_TOKEN_RETRY_ATTEMPTS) {
+        return token;
+      }
+    } catch {
+      if (attempt === GET_SESSION_TOKEN_RETRY_ATTEMPTS) {
+        return null;
+      }
+    }
+    await sleep(GET_SESSION_TOKEN_RETRY_DELAY_MS);
   }
+  return null;
 };

--- a/example-frontend/playwright.config.ts
+++ b/example-frontend/playwright.config.ts
@@ -21,7 +21,14 @@ const chromium = {...devices["Desktop Chrome"]};
  * other's todos. To run a single consents/syncdb file without its dependency phases,
  * pass --no-deps (each file's beforeAll ensures the flag state it needs).
  */
-const syncdbFiles = ["syncdb-load-delta", "syncdb-offline", "syncdb-conflicts", "syncdb-storage"];
+const syncdbFiles = [
+  "syncdb-load-delta",
+  "syncdb-offline",
+  "syncdb-conflicts",
+  "syncdb-storage",
+  "syncdb-chaos",
+  "syncdb-loadlab",
+];
 
 const localProjects: Project[] = [
   {name: "setup", testMatch: /auth\.setup\.ts/},

--- a/example-frontend/store/syncdb.ts
+++ b/example-frontend/store/syncdb.ts
@@ -52,5 +52,16 @@ export const syncDb: SyncDb = createSyncDb({
   baseUrl,
   collections: SYNC_COLLECTIONS,
   debug: __DEV__ ? {capacity: 1000} : false,
+  // haltQueueOnConflict: true — the example app is a template other apps grow
+  // from, and it's common to add cross-collection references (e.g. a todo
+  // referencing a project id) as the schema grows. The default per-entity
+  // conflict policy already blocks a queued mutation whose args reference a
+  // currently-blocked entity's id (see the syncdb README "Cross-collection
+  // reference blocking"), but that only covers references present in `args`;
+  // opting into a whole-drain halt here is the stronger, simpler guarantee
+  // for a starter app whose data model isn't fixed yet. Flip to `false` (the
+  // package default) once your entities are truly independent and you want a
+  // conflict on one to never stall unrelated ones.
+  haltQueueOnConflict: true,
   name: SYNC_DB_NAME,
 });

--- a/example-frontend/store/syncdb.ts
+++ b/example-frontend/store/syncdb.ts
@@ -65,3 +65,34 @@ export const syncDb: SyncDb = createSyncDb({
   haltQueueOnConflict: true,
   name: SYNC_DB_NAME,
 });
+
+/**
+ * Tracks whether `syncDb.start()` has resolved for the current login. `start()` is
+ * fired from the root layout as soon as `userId` is set, but it awaits the auth
+ * provider resolving a user id before `mutate()` becomes safe to call — without this
+ * flag, screens can render (and users/tests can click "create") during that window,
+ * and `client.mutate()` throws "requires start() to have resolved an authenticated
+ * user". Module-level (not React state) so both the root layout, which flips it, and
+ * any screen calling `useSyncDbReady()`, which reads it, share one source of truth.
+ */
+let syncDbReady = false;
+const syncDbReadyListeners = new Set<() => void>();
+
+export const setSyncDbReady = (ready: boolean): void => {
+  if (syncDbReady === ready) {
+    return;
+  }
+  syncDbReady = ready;
+  for (const listener of syncDbReadyListeners) {
+    listener();
+  }
+};
+
+export const subscribeSyncDbReady = (listener: () => void): (() => void) => {
+  syncDbReadyListeners.add(listener);
+  return () => {
+    syncDbReadyListeners.delete(listener);
+  };
+};
+
+export const getSyncDbReadySnapshot = (): boolean => syncDbReady;

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "api-health:test": "bun run --filter '@terreno/api-health' test",
     "api:compile": "bun run --filter '@terreno/api' compile",
     "api:lint": "bun run --filter '@terreno/api' lint",
+    "api:load": "bun run --filter '@terreno/api' load",
     "api:test": "bun run --filter '@terreno/api' test",
     "backend:dev": "bun run --filter '@terreno/example-backend' dev",
     "backend:lint": "bun run --filter '@terreno/example-backend' lint",

--- a/syncdb/README.md
+++ b/syncdb/README.md
@@ -137,6 +137,8 @@ const client = createSyncDb({
   transport?, httpChannel?,       // test/DI overrides
   reconcileIntervalMs?,           // periodic reconcile (default 5 min; 0 disables)
   seqJumpReconcileMinIntervalMs?, // seq-jump reconcile rate limit (default 30s)
+  batchSize?,                     // max mutations per batched drain send (default 50; server caps at 100)
+  haltQueueOnConflict?,           // conflict policy — see "Conflict handling modes" below (default false)
 });
 
 client.start() / client.stop();
@@ -144,12 +146,33 @@ client.mutate({collection, operation, id?, data?}); // → {mutationId, id}
 client.reconcile();       // HTTP snapshot catch-up for every collection
 client.replayOutbox();    // drain queued mutations now
 client.resolveConflict({mutationId, strategy: "useServer" | "keepMine"});
-client.getSyncStatus();   // {isOnline, isSyncing, queuedCount, conflictCount, streams}
+client.retryFailed({entityId});  // re-enable an entity's queued successors after a terminal validation failure
+client.getSyncStatus();   // {isOnline, isSyncing, queuedCount, conflictCount, failedCount, blockedEntities,
+                           //  paused?, draining, sentThisDrain, totalThisDrain, streams}
 client.onStatusChange(cb);
 client.store / client.outbox; // low-level access
 ```
 
 React hooks (`@terreno/syncdb/react`): `SyncDbProvider`, `useSyncDbClient`, `useEntity(collection, id)`, `useQuery(collection, {filter?, sort?, includeDeleted?})`, `useMutate(collection)`, `useSyncStatus()`, `useConflicts()`.
+
+## Batched replay & stop-the-line policy
+
+Queued mutations drain in contiguous chunks (≤ `batchSize`, default 50) over `POST /sync/mutate/batch` (or `sync:mutateBatch` when the socket is connected) rather than one request per mutation — an offline session of hundreds of edits costs `~N/batchSize` round-trips instead of `N`. Ordering is never sacrificed for this: a chunk carries at most one mutation per entity (a second mutation for an entity already in the chunk cuts it short — the next chunk picks it up once the first has acked and the send-time `baseVersion` refresh has run), and the server applies a batch strictly in array order, stopping at the first non-ack (results shorter than the request means the client re-sends the untouched tail — safe by idempotency). If the server or transport doesn't support batching (HTTP 404, or a socket that never acknowledges `sync:mutateBatch`), the client falls back to single-mutation sends in the same global order and re-probes batch support on the next reconnect.
+
+Not every failure is handled the same way — the table below is the client's stop-the-line policy:
+
+| Outcome | Policy |
+|---|---|
+| `error` (transient), transport failure/timeout, `unauthorized` | **Halts the whole drain.** Jittered backoff (or auth-pause) applies; nothing after it sends until the retry/re-auth. |
+| `conflict` | **Blocks only that entity** by default: the entity's later queued mutations are skipped (stay `queued`, budgets untouched) until the user resolves the conflict via `resolveConflict`; other entities keep draining. Set `haltQueueOnConflict: true` to escalate a conflict into a whole-drain halt instead (for apps with cross-entity ordering dependencies where an unresolved conflict must not let anything past it). |
+| `validation` | Terminal for that mutation (existing `markFailed` behavior) and its entity's queued successors are skipped-and-surfaced the same way a conflict blocks — a successor built on a rejected write is likely also invalid. Re-enable them with `client.retryFailed({entityId})` once the underlying issue is fixed. |
+
+### Conflict handling modes
+
+- **Default (`haltQueueOnConflict: false`)** — per-entity blocking. A conflict on one entity never stalls unrelated entities; only that entity's own queue is paused pending `resolveConflict`. Best for apps where entities are largely independent (e.g. a todo list).
+- **`haltQueueOnConflict: true`** — whole-drain halt. Any conflict stops the ENTIRE drain until it's resolved, even for unrelated entities. Choose this when later-queued mutations (in any entity/collection) may depend on assumptions invalidated by the conflicting write, and blindly continuing risks compounding the problem.
+
+`client.getSyncStatus().blockedEntities` reports how many distinct entities are currently blocked (conflict or skipped validation failure) so the UI can surface it (see `SyncStatusBanner`'s failed/conflict badges).
 
 ## Stream scoping
 
@@ -201,6 +224,7 @@ Sequencing guarantees: validation failures never consume a seq (the claim happen
 |---|---|---|
 | `GET /sync/snapshot?collection=&cursor=&limit=` | Bootstrap + catch-up. Returns `{entities: [{id, data, seq, deleted}], cursor, hasMore}`. `cursor=0` = full snapshot (legacy docs without `_syncSeq` arrive in the first page with seq 0). Default page 500, max 1000. | Model `list` permissions + server-enforced scope filter |
 | `POST /sync/mutate` | HTTP fallback for outbox replay (same handler as the socket channel). Body: `{mutationId, collection, operation, id?, data?, baseVersion?}`. Returns `{ack}` or `{nack}` with status 409 (conflict), 403 (unauthorized), 422 (validation), 500 (error). | modelRouter create/update/delete write path |
+| `POST /sync/mutate/batch` | HTTP fallback for batched outbox replay. Body: `{mutations: SyncMutateRequest[]}` (max 100; intra-batch duplicate `mutationId`s rejected up front). Returns `{results: ({type:"ack",ack}\|{type:"nack",nack})[]}` — applied strictly in array order, stopping at the first non-ack (a shorter `results` array than the request means everything after it was never attempted). | modelRouter create/update/delete write path, per mutation |
 | `GET /sync/key` | Caller's per-user key material for the server key provider (32 random bytes, base64; created on first call). | Own key only |
 
 ### Socket events (on the `RealtimeApp` Socket.io server)
@@ -214,8 +238,9 @@ Sequencing guarantees: validation failures never consume a seq (the claim happen
 | `sync:mutate` | client → server | `{mutationId, collection, operation, id?, data?, baseVersion?}` (+ optional Socket.io ack callback) |
 | `sync:ack` | server → client | `{mutationId, id, seq}` |
 | `sync:nack` | server → client | `{mutationId, code: "conflict"\|"unauthorized"\|"validation"\|"error", serverDoc?, serverSeq?, message?}` |
+| `sync:mutateBatch` | client → server | `{mutations: SyncMutateRequest[]}` (Socket.io ack callback carries `{results}`, same contract as the HTTP batch route) — a server with no handler for this event never invokes the ack callback, which the client treats as "batching unsupported" after a short grace timeout and falls back to single `sync:mutate` sends. |
 
-Limits: 50 collection subscriptions per socket; 100 `sync:mutate` per second per socket.
+Limits: 50 collection subscriptions per socket; 100 `sync:mutate` per second per socket, shared with `sync:mutateBatch` (each mutation in a batch counts individually against the same window); batches capped at 100 mutations.
 
 ### Conflicts and idempotency
 

--- a/syncdb/README.md
+++ b/syncdb/README.md
@@ -164,15 +164,22 @@ Not every failure is handled the same way — the table below is the client's st
 | Outcome | Policy |
 |---|---|
 | `error` (transient), transport failure/timeout, `unauthorized` | **Halts the whole drain.** Jittered backoff (or auth-pause) applies; nothing after it sends until the retry/re-auth. |
+| `rate_limited` | Treated **exactly like a transport failure**: back to `queued` with the same unlimited jittered backoff (the server's `retryAfterMs`, when present, is a floor on that backoff), never counted against the error-nack budget (`errorNackCount`). A rate limit is the server asking the client to slow down — it must never look like a durable-data error or push the client toward terminal `failed`. Halts the whole drain, same as a transport failure. |
 | `conflict` | **Blocks only that entity** by default: the entity's later queued mutations are skipped (stay `queued`, budgets untouched) until the user resolves the conflict via `resolveConflict`; other entities keep draining. Set `haltQueueOnConflict: true` to escalate a conflict into a whole-drain halt instead (for apps with cross-entity ordering dependencies where an unresolved conflict must not let anything past it). |
-| `validation` | Terminal for that mutation (existing `markFailed` behavior) and its entity's queued successors are skipped-and-surfaced the same way a conflict blocks — a successor built on a rejected write is likely also invalid. Re-enable them with `client.retryFailed({entityId})` once the underlying issue is fixed. |
+| `validation` | Terminal for that mutation (existing `markFailed` behavior) and its entity's queued successors are skipped-and-surfaced the same way a conflict blocks — a successor built on a rejected write is likely also invalid. Re-enable them with `client.retryFailed({entityId})` once the underlying issue is fixed. A block with no queued successor left (e.g. its failed row aged out via `prune()`) is garbage-collected automatically — a brand-new mutation for that entity is never quarantined forever. |
 
 ### Conflict handling modes
 
 - **Default (`haltQueueOnConflict: false`)** — per-entity blocking. A conflict on one entity never stalls unrelated entities; only that entity's own queue is paused pending `resolveConflict`. Best for apps where entities are largely independent (e.g. a todo list).
-- **`haltQueueOnConflict: true`** — whole-drain halt. Any conflict stops the ENTIRE drain until it's resolved, even for unrelated entities. Choose this when later-queued mutations (in any entity/collection) may depend on assumptions invalidated by the conflicting write, and blindly continuing risks compounding the problem.
+- **`haltQueueOnConflict: true`** — whole-drain halt. Any conflict stops the ENTIRE drain until it's resolved, even for unrelated entities. Choose this when later-queued mutations (in any entity/collection, or across collections via foreign-key-style references) may depend on assumptions invalidated by the conflicting write, and blindly continuing risks compounding the problem. This is the stronger guarantee when your data model has cross-collection references (e.g. a todo referencing a project id) and you want ordering correctness to trump availability of unrelated entities during a conflict.
 
 `client.getSyncStatus().blockedEntities` reports how many distinct entities are currently blocked (conflict or skipped validation failure) so the UI can surface it (see `SyncStatusBanner`'s failed/conflict badges).
+
+### Cross-collection reference blocking (per-entity mode)
+
+Under the default per-entity blocking mode, a conflict or validation failure on one entity does not, by itself, stop mutations for *unrelated* entities. But apps commonly have cross-collection references — e.g. creating a project P and then a todo T with `{projectId: P}` — where T is meaningless if P never lands on the server. To keep that case safe without requiring `haltQueueOnConflict: true` for the whole app, the coordinator also blocks a queued mutation whose parsed `args` contain, anywhere (recursively through nested objects/arrays), a string that exactly equals the entity id of a currently-blocked entity belonging to the same user. So if P conflicts, T (referencing P's id) stays `queued` and is never sent until P's conflict is resolved — even though T's own entity has no conflict of its own. This blocking is recomputed fresh on every drain pass from current block state (never a persisted dependency graph), so resolving P via `resolveConflict`/`retryFailed` naturally unblocks T on the next drain. It is intentionally conservative — a false-positive block (a string that happens to match a blocked id but isn't really a reference) is safe; a false negative is not.
+
+If your data model has enough cross-collection references that you want ordering guaranteed for ALL entities (not just ones whose args happen to reference a blocked id), use `haltQueueOnConflict: true` instead — see "Conflict handling modes" above.
 
 ## Stream scoping
 
@@ -223,7 +230,7 @@ Sequencing guarantees: validation failures never consume a seq (the claim happen
 | Endpoint | Purpose | Auth |
 |---|---|---|
 | `GET /sync/snapshot?collection=&cursor=&limit=` | Bootstrap + catch-up. Returns `{entities: [{id, data, seq, deleted}], cursor, hasMore}`. `cursor=0` = full snapshot (legacy docs without `_syncSeq` arrive in the first page with seq 0). Default page 500, max 1000. | Model `list` permissions + server-enforced scope filter |
-| `POST /sync/mutate` | HTTP fallback for outbox replay (same handler as the socket channel). Body: `{mutationId, collection, operation, id?, data?, baseVersion?}`. Returns `{ack}` or `{nack}` with status 409 (conflict), 403 (unauthorized), 422 (validation), 500 (error). | modelRouter create/update/delete write path |
+| `POST /sync/mutate` | HTTP fallback for outbox replay (same handler as the socket channel). Body: `{mutationId, collection, operation, id?, data?, baseVersion?}`. Returns `{ack}` or `{nack}` with status 409 (conflict), 403 (unauthorized), 422 (validation), 429 (rate_limited, carries `retryAfterMs`), 500 (error). | modelRouter create/update/delete write path |
 | `POST /sync/mutate/batch` | HTTP fallback for batched outbox replay. Body: `{mutations: SyncMutateRequest[]}` (max 100; intra-batch duplicate `mutationId`s rejected up front). Returns `{results: ({type:"ack",ack}\|{type:"nack",nack})[]}` — applied strictly in array order, stopping at the first non-ack (a shorter `results` array than the request means everything after it was never attempted). | modelRouter create/update/delete write path, per mutation |
 | `GET /sync/key` | Caller's per-user key material for the server key provider (32 random bytes, base64; created on first call). | Own key only |
 
@@ -237,7 +244,7 @@ Sequencing guarantees: validation failures never consume a seq (the claim happen
 | `sync:delta` | server → client | `{collection, id, method, data?, seq, stream, deleted?}` — emitted by the change-stream watcher |
 | `sync:mutate` | client → server | `{mutationId, collection, operation, id?, data?, baseVersion?}` (+ optional Socket.io ack callback) |
 | `sync:ack` | server → client | `{mutationId, id, seq}` |
-| `sync:nack` | server → client | `{mutationId, code: "conflict"\|"unauthorized"\|"validation"\|"error", serverDoc?, serverSeq?, message?}` |
+| `sync:nack` | server → client | `{mutationId, code: "conflict"\|"unauthorized"\|"validation"\|"error"\|"rate_limited", serverDoc?, serverSeq?, message?, retryAfterMs?}` — `rate_limited` (with `retryAfterMs`, the remaining window in ms) is never terminal: the client requeues and retries with unlimited backoff, exactly like a transport failure. |
 | `sync:mutateBatch` | client → server | `{mutations: SyncMutateRequest[]}` (Socket.io ack callback carries `{results}`, same contract as the HTTP batch route) — a server with no handler for this event never invokes the ack callback, which the client treats as "batching unsupported" after a short grace timeout and falls back to single `sync:mutate` sends. |
 
 Limits: 50 collection subscriptions per socket; 100 `sync:mutate` per second per socket, shared with `sync:mutateBatch` (each mutation in a batch counts individually against the same window); batches capped at 100 mutations.

--- a/syncdb/README.md
+++ b/syncdb/README.md
@@ -139,16 +139,19 @@ const client = createSyncDb({
   seqJumpReconcileMinIntervalMs?, // seq-jump reconcile rate limit (default 30s)
   batchSize?,                     // max mutations per batched drain send (default 50; server caps at 100)
   haltQueueOnConflict?,           // conflict policy — see "Conflict handling modes" below (default false)
+  onDecryptFailure?,              // override the default wipe+re-bootstrap on undecryptable data (web)
+  tombstoneRetentionMs?,          // client-side tombstone compaction window (default 90 days; 0 disables)
 });
 
-client.start() / client.stop();
+client.start() / client.stop();  // start() is idempotent while already started (a second call is a no-op)
 client.mutate({collection, operation, id?, data?}); // → {mutationId, id}
-client.reconcile();       // HTTP snapshot catch-up for every collection
+client.reconcile();       // HTTP snapshot catch-up for every collection; also runs tombstone compaction on success
 client.replayOutbox();    // drain queued mutations now
 client.resolveConflict({mutationId, strategy: "useServer" | "keepMine"});
 client.retryFailed({entityId});  // re-enable an entity's queued successors after a terminal validation failure
 client.getSyncStatus();   // {isOnline, isSyncing, queuedCount, conflictCount, failedCount, blockedEntities,
-                           //  paused?, draining, sentThisDrain, totalThisDrain, streams}
+                           //  paused?, draining, sentThisDrain, totalThisDrain, streams, persistence}
+                           //  persistence: "durable" | "memory" | "error" — see "Encryption at rest" below
 client.onStatusChange(cb);
 client.store / client.outbox; // low-level access
 ```
@@ -259,8 +262,10 @@ Every mutation is idempotent: the handler atomically claims a `SyncMutation` led
 
 Web persistence is **encrypted by default**: the store content is AES-256-GCM encrypted via Web Crypto before it touches IndexedDB. Key management is a pluggable `KeyProvider`:
 
-- `createServerKeyProvider({appName, fetchKeyMaterial})` (**the default**: `createSyncDb` wires it automatically to `GET /sync/key` through its authenticated HTTP channel): fetches per-user key material, derives a non-extractable AES-256-GCM key via HKDF-SHA256 (salt = `{appName}:{userId}`), and caches the derived CryptoKey in IndexedDB so offline cold starts still decrypt. Server rotation of key material makes decryption fail → hook `onDecryptFailure` to wipe and re-bootstrap.
+- `createServerKeyProvider({appName, fetchKeyMaterial})` (**the default**: `createSyncDb` wires it automatically to `GET /sync/key` through its authenticated HTTP channel): fetches per-user key material, derives a non-extractable AES-256-GCM key via HKDF-SHA256 (salt = `{appName}:{userId}`), and caches the derived CryptoKey in IndexedDB so offline cold starts still decrypt. Server rotation of key material makes decryption fail — the client wipes local data, re-stamps the schema version, and runs a full re-bootstrap by default (always preceded by a `console.warn`); pass `onDecryptFailure` in `createSyncDb`'s config to override that default (e.g. prompt the user before wiping) instead.
 - `createLocalKeyProvider()`: a random non-extractable CryptoKey generated on-device and cached in IndexedDB. No server dependency and no server-side copy of the key — strictly stronger for the at-rest case, at the cost of no server-driven rotation/revocation.
+
+A storage **read** error (IndexedDB itself throwing — unavailable, blocked, or corrupted) is a distinct failure mode from "no data yet" or "undecryptable data": the client leaves the persisted blob untouched (no autosave-over) and surfaces `persistence: "error"` on `SyncStatus` instead of wiping. When `globalThis.indexedDB` is unavailable entirely (private-browsing modes that disable it, a locked-down embedded webview), the web persister factory falls back to in-memory persistence for the session (warns once) and reports `persistence: "memory"`.
 
 ```typescript
 import {createLocalKeyProvider} from "@terreno/syncdb";
@@ -284,21 +289,30 @@ Native relies on the OS app sandbox: the expo-sqlite store is plaintext by desig
 
 ## Local store layout
 
-One TinyBase `MergeableStore` per `{app, userId}` (wiped and re-bootstrapped on user change):
+One TinyBase `MergeableStore` per `{app, userId}` (wiped and re-bootstrapped on user change, or on a schema-version mismatch — see below):
 
 ```
 tables:
-  {collection}   → rowId = doc _id; cells: data (JSON string), seq, deleted, pendingMutationId
+  {collection}   → rowId = doc _id; cells: data (JSON string), seq, deleted, deletedAt,
+                   pendingMutationId
   _outbox        → rowId = mutationId; cells: collection, operation, entityId, args (JSON),
                    baseVersion?, status (queued|inFlight|acked|conflicted|failed),
                    attemptCount, userId, createdAt, enqueueOrder
   _cursors       → rowId = stream; cells: seq, updatedAt
   _conflicts     → rowId = mutationId; cells: collection, entityId, localData, serverData,
                    serverSeq, dismissed
-values: schemaVersion, lastUserId
+values: schemaVersion, lastUserId, outboxMaxEnqueueOrder
 ```
 
 The outbox replays FIFO over the socket (HTTP fallback while disconnected), with per-user isolation: queued mutations record `userId` and replay skips on mismatch.
+
+### Schema versioning
+
+`SYNC_SCHEMA_VERSION` (`storage/schema.ts`) is stamped into the store's `schemaVersion` value on every `start()`. If a persisted store's stamped version doesn't match the running client's, the client treats it as a schema migration (not an auth event): wipe all local data, re-stamp the current version, and run a full snapshot re-bootstrap before `start()` resolves. Bump `SYNC_SCHEMA_VERSION` only when a table/cell shape change isn't safely backward-compatible (a new cell with a schema default, for example, does not need a bump).
+
+### Client-side tombstone compaction
+
+Deleted entities are kept locally as tombstones (`deleted: true`) with a `deletedAt` timestamp stamped the moment the tombstone is first applied (via a mutation, a delta, or a snapshot page). After each successful `reconcile()`, tombstones older than `tombstoneRetentionMs` (`createSyncDb` config, default 90 days) are deleted outright. Keep this in sync with the server's own tombstone retention (compaction script in `@terreno/api`) — compacting locally before the server's retention window elapses risks a client permanently missing a delete it hasn't converged on yet. Set `tombstoneRetentionMs: 0` to disable.
 
 ### Why MergeableStore (and the Yjs door)
 

--- a/syncdb/src/auth/betterAuthAdapter.test.ts
+++ b/syncdb/src/auth/betterAuthAdapter.test.ts
@@ -66,6 +66,29 @@ describe("betterAuthAdapter", () => {
     });
   });
 
+  describe("refresh (A4)", () => {
+    it("returns true when a re-fetched session carries a token", async () => {
+      const adapter = betterAuthAdapter(
+        makeClient(async () => ({data: {session: {token: "tok-1"}, user: {id: "u1"}}}))
+      );
+      expect(await adapter.refresh?.()).toBe(true);
+    });
+
+    it("returns false when the re-fetched session has no token (still signed out)", async () => {
+      const adapter = betterAuthAdapter(makeClient(async () => ({data: null})));
+      expect(await adapter.refresh?.()).toBe(false);
+    });
+
+    it("returns false rather than throwing when getSession rejects", async () => {
+      const adapter = betterAuthAdapter(
+        makeClient(async () => {
+          throw new Error("network down");
+        })
+      );
+      await expect(adapter.refresh?.()).resolves.toBe(false);
+    });
+  });
+
   describe("onAuthChange via useSession subscription", () => {
     interface FakeAtom {
       listeners: Set<(value: unknown) => void>;

--- a/syncdb/src/auth/betterAuthAdapter.ts
+++ b/syncdb/src/auth/betterAuthAdapter.ts
@@ -56,6 +56,18 @@ export const betterAuthAdapter = (
     }
   };
 
+  /**
+   * One-shot silent refresh consumed by the client's A4 auth-pause pipeline:
+   * re-fetch the session (Better Auth clients transparently refresh/renew the
+   * underlying token on `getSession()` when the client library supports it)
+   * and report whether a usable token now exists. Never throws — a failed
+   * refresh just means the pause surfaces to the app as usual.
+   */
+  const refresh = async (): Promise<boolean> => {
+    const session = await readSession();
+    return Boolean(session?.session?.token);
+  };
+
   const getToken = async (): Promise<string | null> => {
     const session = await readSession();
     return session?.session?.token ?? null;
@@ -160,5 +172,5 @@ export const betterAuthAdapter = (
     };
   };
 
-  return {getToken, getUserId, onAuthChange};
+  return {getToken, getUserId, onAuthChange, refresh};
 };

--- a/syncdb/src/client.test.ts
+++ b/syncdb/src/client.test.ts
@@ -1,8 +1,13 @@
+import "fake-indexeddb/auto";
+
 import {describe, expect, it} from "bun:test";
 
 import {createSyncDb, type SyncDbConfig} from "./client";
+import {createLocalKeyProvider, DEFAULT_KEY_CACHE_DB_NAME} from "./crypto/keyProviders";
 import {getConflict} from "./mutations/conflicts";
+import {createDefaultPersisterFactory as createWebPersisterFactory} from "./persisters/defaultPersisterFactory.web";
 import {memoryPersisterFactory} from "./persisters/memoryPersister";
+import {idbGet} from "./storage/idb";
 import {createFakeTransport, type FakeTransport} from "./sync/fakeTransport";
 import {AuthRequiredError, type HttpChannel} from "./sync/httpChannel";
 import type {AuthProvider, SyncDelta, SyncSnapshotResponse} from "./types";
@@ -137,6 +142,7 @@ describe("createSyncDb", () => {
       failedCount: 0,
       isOnline: false,
       isSyncing: false,
+      persistence: "durable",
       queuedCount: 0,
       sentThisDrain: 0,
       streams: {},
@@ -603,11 +609,37 @@ describe("createSyncDb", () => {
       const client = createSyncDb(harness.config);
       await client.start();
       harness.transport.setConnected(true);
-
-      client.mutate({collection: "todos", data: {title: "a"}, operation: "create"});
-      client.mutate({collection: "todos", data: {title: "b"}, operation: "create"});
-      client.mutate({collection: "todos", data: {title: "c"}, operation: "create"});
       await flush();
+
+      // Enqueue directly (bypassing mutate()'s own per-call replay trigger,
+      // which would otherwise start draining synchronously — up to its first
+      // real await — before the second/third mutation exist, since each
+      // mutate() call's fire-and-forget replayOutbox() can independently
+      // observe the queue as it existed at that instant instead of all three
+      // landing in the same batch) so a single replayOutbox() call sees all
+      // three together deterministically.
+      client.outbox.enqueue({
+        args: {title: "a"},
+        collection: "todos",
+        entityId: "e1",
+        operation: "create",
+        userId: "u1",
+      });
+      client.outbox.enqueue({
+        args: {title: "b"},
+        collection: "todos",
+        entityId: "e2",
+        operation: "create",
+        userId: "u1",
+      });
+      client.outbox.enqueue({
+        args: {title: "c"},
+        collection: "todos",
+        entityId: "e3",
+        operation: "create",
+        userId: "u1",
+      });
+      await client.replayOutbox();
 
       expect(harness.transport.sentBatches.length).toBeGreaterThanOrEqual(1);
       expect(harness.transport.sentBatches.flat()).toHaveLength(3);
@@ -621,10 +653,23 @@ describe("createSyncDb", () => {
       const client = createSyncDb(harness.config);
       await client.start();
       harness.transport.setConnected(true);
-
-      client.mutate({collection: "todos", data: {title: "a"}, operation: "create"});
-      client.mutate({collection: "todos", data: {title: "b"}, operation: "create"});
       await flush();
+
+      client.outbox.enqueue({
+        args: {title: "a"},
+        collection: "todos",
+        entityId: "e1",
+        operation: "create",
+        userId: "u1",
+      });
+      client.outbox.enqueue({
+        args: {title: "b"},
+        collection: "todos",
+        entityId: "e2",
+        operation: "create",
+        userId: "u1",
+      });
+      await client.replayOutbox();
       expect(client.getSyncStatus().queuedCount).toBe(0);
       expect(harness.transport.sentMutations).toHaveLength(2);
 
@@ -634,9 +679,21 @@ describe("createSyncDb", () => {
       await flush();
       harness.transport.setConnected(true);
       await flush();
-      client.mutate({collection: "todos", data: {title: "c"}, operation: "create"});
-      client.mutate({collection: "todos", data: {title: "d"}, operation: "create"});
-      await flush();
+      client.outbox.enqueue({
+        args: {title: "c"},
+        collection: "todos",
+        entityId: "e3",
+        operation: "create",
+        userId: "u1",
+      });
+      client.outbox.enqueue({
+        args: {title: "d"},
+        collection: "todos",
+        entityId: "e4",
+        operation: "create",
+        userId: "u1",
+      });
+      await client.replayOutbox();
       expect(harness.transport.sentBatches.length).toBeGreaterThanOrEqual(1);
       await client.stop();
     });
@@ -1379,6 +1436,400 @@ describe("createSyncDb", () => {
 
       await client.signOut();
       expect(client.store.listEntities({collection: "todos", includeDeleted: true})).toEqual([]);
+    });
+  });
+
+  describe("lifecycle serialization (E1)", () => {
+    it("a rapid stop()-then-start() for a new user leaves the new user's persistence working", async () => {
+      const name = uniqueName();
+      const harness = makeHarness({name});
+      const client = createSyncDb(harness.config);
+      await client.start();
+      client.mutate({collection: "todos", data: {title: "user one"}, operation: "create"});
+      await flush();
+
+      // Rapid stop() immediately followed by start() for a DIFFERENT user —
+      // this is the exact interleaving the original bug hit: stop() re-reads
+      // the module-level `persister` after awaiting a debounced save(), and
+      // an interleaved start() for the new user had already replaced it,
+      // destroying the NEW user's persister instead of the old one (leaving
+      // mutate() throwing for the new user). Do NOT await stop() before
+      // calling start() — that's the whole point of "rapid".
+      harness.auth.setUserId("u2");
+      const stopPromise = client.stop();
+      const startPromise = client.start();
+      await Promise.all([stopPromise, startPromise]);
+
+      // The new user's session must be fully functional: mutate() succeeds
+      // and the entity persists through its own persister.
+      const {id, mutationId} = client.mutate({
+        collection: "todos",
+        data: {title: "user two"},
+        operation: "create",
+      });
+      expect(client.store.getEntity({collection: "todos", id})?.data).toEqual({title: "user two"});
+      expect(client.outbox.getMutation({mutationId})).toBeDefined();
+      expect(client.store.getLastUserId()).toBe("u2");
+      await client.stop();
+
+      // Re-opening under the same name for u2 must load what was just
+      // written — proving the persister that survived the race was u2's, not
+      // a destroyed/half-wired one.
+      const reopened = createSyncDb({...harness.config, name});
+      harness.auth.setUserId("u2");
+      await reopened.start();
+      expect(reopened.store.listEntities({collection: "todos"}).map((e) => e.data)).toContainEqual({
+        title: "user two",
+      });
+      await reopened.stop();
+    });
+
+    it("double start() is a no-op: listeners are not double-registered", async () => {
+      const harness = makeHarness();
+      let onDeltaCalls = 0;
+      let onStatusChangeCalls = 0;
+      const countingTransport = {
+        ...harness.transport,
+        onDelta: (callback: (delta: SyncDelta) => void): (() => void) => {
+          onDeltaCalls += 1;
+          return harness.transport.onDelta(callback);
+        },
+        onStatusChange: (
+          callback: (status: {connected: boolean; authExpired?: boolean}) => void
+        ): (() => void) => {
+          onStatusChangeCalls += 1;
+          return harness.transport.onStatusChange(callback);
+        },
+      };
+      const client = createSyncDb({...harness.config, transport: countingTransport});
+      await client.start();
+      expect(onDeltaCalls).toBe(1);
+      expect(onStatusChangeCalls).toBe(1);
+
+      // A second start() while already started must be a no-op — no new
+      // listener registration, no thrown error.
+      await client.start();
+      expect(onDeltaCalls).toBe(1);
+      expect(onStatusChangeCalls).toBe(1);
+
+      // The client is still fully functional (the first start() "won").
+      const {mutationId} = client.mutate({
+        collection: "todos",
+        data: {title: "still works"},
+        operation: "create",
+      });
+      expect(client.outbox.getMutation({mutationId})).toBeDefined();
+      await client.stop();
+    });
+
+    it("stop() disposes the coordinator's armed wake-up timer (A3) so no post-stop send fires", async () => {
+      const harness = makeHarness();
+      harness.transport.setDefaultResponder(() => {
+        throw new Error("transient failure");
+      });
+      const client = createSyncDb(harness.config);
+      await client.start();
+      client.mutate({collection: "todos", data: {title: "x"}, operation: "create"});
+      await flush();
+      // The failed send armed a jittered backoff wake-up timer.
+      expect(client.getSyncStatus().queuedCount).toBe(1);
+
+      await client.stop();
+      const sentBeforeWait = harness.transport.sentMutations.length;
+      // Advance well past any plausible backoff window; if the timer were
+      // still armed post-stop it would fire another send here.
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      expect(harness.transport.sentMutations.length).toBe(sentBeforeWait);
+    });
+  });
+
+  describe("schema versioning (E2)", () => {
+    it("wipes and re-bootstraps when the persisted schemaVersion is stale", async () => {
+      const name = uniqueName();
+      const harness = makeHarness({name});
+      const client = createSyncDb(harness.config);
+      await client.start();
+      client.store.upsertEntity({collection: "todos", data: {title: "v1 data"}, id: "t1", seq: 1});
+      // Simulate a persisted store written under an OLDER schema version.
+      client.store.raw.setValue("schemaVersion", 0);
+      await flush();
+      await client.stop();
+
+      // Seed a snapshot page so the re-bootstrap after the wipe has something
+      // to fetch and the test can prove it actually ran.
+      const second = makeHarness({name});
+      second.http.state.pages.todos = {
+        cursor: 5,
+        entities: [{data: {title: "from server"}, deleted: false, id: "server-1", seq: 5}],
+        hasMore: false,
+      };
+      const reopened = createSyncDb(second.config);
+      await reopened.start();
+      await flush();
+
+      // The stale v1 data is gone (wiped, not merged) and the fresh
+      // re-bootstrap populated the store from the server instead.
+      expect(reopened.store.getEntity({collection: "todos", id: "t1"})).toBeUndefined();
+      expect(reopened.store.getEntity({collection: "todos", id: "server-1"})?.data).toEqual({
+        title: "from server",
+      });
+      expect(reopened.store.getSchemaVersion()).toBe(1);
+      await reopened.stop();
+    });
+
+    it("leaves data untouched when the persisted schemaVersion already matches", async () => {
+      const name = uniqueName();
+      const harness = makeHarness({name});
+      const client = createSyncDb(harness.config);
+      await client.start();
+      client.store.upsertEntity({collection: "todos", data: {title: "current"}, id: "t1", seq: 1});
+      await flush();
+      await client.stop();
+
+      const second = makeHarness({name});
+      const reopened = createSyncDb(second.config);
+      await reopened.start();
+      await flush();
+
+      expect(reopened.store.getEntity({collection: "todos", id: "t1"})?.data).toEqual({
+        title: "current",
+      });
+      expect(reopened.store.getSchemaVersion()).toBe(1);
+      await reopened.stop();
+    });
+
+    it("stamps the current schema version on a genuinely fresh store", async () => {
+      const harness = makeHarness();
+      const client = createSyncDb(harness.config);
+      await client.start();
+      expect(client.store.getSchemaVersion()).toBe(1);
+      await client.stop();
+    });
+  });
+
+  describe("persistence failure surfaces (E3)", () => {
+    // These tests exercise the REAL web persister factory (encrypted
+    // IndexedDB) rather than the memoryPersisterFactory default used
+    // elsewhere in this file: under plain bun/Node (no Metro/webpack platform
+    // resolution), importing "./persisters/defaultPersisterFactory" always
+    // resolves to the neutral in-memory fallback, never the `.web.ts`
+    // variant — so `client.ts`'s own E3 hooks (built for that default-factory
+    // branch) are unreachable unless the test supplies the web factory
+    // directly as `persisterFactory`. The client passes its hooks through to
+    // ANY factory via the `hooks` argument (see `PersisterFactory`), so a
+    // directly-supplied web factory still wires up SyncStatus surfacing
+    // exactly as production code would under Metro/webpack.
+    const makeWebPersisterFactory = (
+      overrides: Parameters<typeof createWebPersisterFactory>[0] = {}
+    ): SyncDbConfig["persisterFactory"] =>
+      createWebPersisterFactory({
+        keyProvider: createLocalKeyProvider({cacheDbName: uniqueName()}),
+        saveDebounceMs: 0,
+        ...overrides,
+      });
+
+    it("a quota-exceeded save surfaces persistence: 'error' on SyncStatus", async () => {
+      const harness = makeHarness({
+        persisterFactory: makeWebPersisterFactory({
+          idbSetImpl: async () => {
+            const error = new Error("The quota has been exceeded.");
+            error.name = "QuotaExceededError";
+            throw error;
+          },
+        }),
+      });
+      let statusChanges = 0;
+      const client = createSyncDb(harness.config);
+      const unsubscribe = client.onStatusChange(() => {
+        statusChanges += 1;
+      });
+      // The very first startAutoSave() save already goes through the failing
+      // idbSetImpl, so persistence surfaces "error" immediately on start() —
+      // this is the correct, intentional behavior (a save failure is a save
+      // failure regardless of whether the store was empty or not).
+      await client.start();
+      client.mutate({collection: "todos", data: {title: "x"}, operation: "create"});
+      await flush();
+
+      expect(client.getSyncStatus().persistence).toBe("error");
+      expect(statusChanges).toBeGreaterThan(0);
+      unsubscribe();
+      await client.stop();
+    });
+
+    it("invokes the configured onDecryptFailure hook instead of the default wipe", async () => {
+      const name = uniqueName();
+      const keyProvider = createLocalKeyProvider({cacheDbName: uniqueName()});
+      const harness = makeHarness({
+        name,
+        persisterFactory: createWebPersisterFactory({keyProvider, saveDebounceMs: 0}),
+      });
+      const client = createSyncDb(harness.config);
+      await client.start();
+      client.mutate({collection: "todos", data: {title: "keep"}, operation: "create"});
+      await flush();
+      await client.stop();
+
+      let decryptFailureCalls = 0;
+      const second = makeHarness({
+        name,
+        onDecryptFailure: () => {
+          decryptFailureCalls += 1;
+        },
+        persisterFactory: createWebPersisterFactory({
+          idbGetImpl: async <T>(): Promise<T | undefined> =>
+            new Uint8Array([1, 2, 3, 4, 5]) as unknown as T,
+          keyProvider,
+          saveDebounceMs: 0,
+        }),
+      });
+      const reopened = createSyncDb(second.config);
+      await reopened.start();
+      await flush();
+
+      expect(decryptFailureCalls).toBe(1);
+      await reopened.stop();
+    });
+
+    it("a clean stop() flushes a pending write before destroying the persister", async () => {
+      const name = uniqueName();
+      const keyProvider = createLocalKeyProvider({cacheDbName: uniqueName()});
+      const harness = makeHarness({
+        name,
+        persisterFactory: createWebPersisterFactory({keyProvider, saveDebounceMs: 0}),
+      });
+      const client = createSyncDb(harness.config);
+      await client.start();
+      client.mutate({collection: "todos", data: {title: "before stop"}, operation: "create"});
+      // Let the transaction-triggered autosave settle before stop()'s own
+      // flush — see encryptedIndexedDbPersister.test.ts's
+      // "destroy() flushes a pending debounced save and writes nothing after"
+      // for the narrower, race-free version of this same guarantee at the
+      // persister level.
+      await flush();
+      await client.stop();
+
+      const reopened = createSyncDb({
+        ...harness.config,
+        persisterFactory: createWebPersisterFactory({keyProvider, saveDebounceMs: 0}),
+      });
+      await reopened.start();
+      await flush();
+      expect(
+        reopened.store.listEntities({collection: "todos"}).map((entity) => entity.data)
+      ).toContainEqual({title: "before stop"});
+      await reopened.stop();
+    });
+
+    it("a different-user login clears the cached derived encryption key (E3f)", async () => {
+      // No custom keyProvider/cacheDbName here: `client.ts`'s different-user
+      // wipe path clears `DEFAULT_KEY_CACHE_DB_NAME` specifically (the
+      // default local key provider's cache database), so this test must
+      // exercise that exact default. The test builds the web persister
+      // factory directly (bypassing client.ts's own userId-aware factory
+      // construction — see the describe-level comment on why), so the
+      // cached key's scope key is "local:local" (no userId override) rather
+      // than the "local:{userId}" shape client.ts's own default path uses;
+      // either way it lives in the same DEFAULT_KEY_CACHE_DB_NAME database
+      // client.ts wipes.
+      const harness = makeHarness({
+        persisterFactory: createWebPersisterFactory({saveDebounceMs: 0}),
+      });
+      const client = createSyncDb(harness.config);
+      await client.start();
+      await flush();
+      // The default local key provider derives and caches a key on first use
+      // (during the initial autoload/autosave above).
+      expect(
+        await idbGet<CryptoKey>({databaseName: DEFAULT_KEY_CACHE_DB_NAME, key: "local:local"})
+      ).toBeInstanceOf(CryptoKey);
+
+      harness.auth.setUserId("u2");
+      harness.auth.emitAuthChange();
+      await flush();
+
+      expect(
+        await idbGet<CryptoKey>({databaseName: DEFAULT_KEY_CACHE_DB_NAME, key: "local:local"})
+      ).toBeUndefined();
+      await client.stop();
+    });
+  });
+
+  describe("client-side tombstone compaction (E5)", () => {
+    it("a successful reconcile compacts tombstones older than the retention window", async () => {
+      const harness = makeHarness({tombstoneRetentionMs: 90 * 24 * 60 * 60 * 1_000});
+      const client = createSyncDb(harness.config);
+      await client.start();
+      await flush();
+
+      // A tombstone applied via a delta, stamped at the current (mocked) clock time.
+      harness.transport.deliverDelta({
+        collection: "todos",
+        deleted: true,
+        id: "old-tombstone",
+        method: "delete",
+        seq: 1,
+        stream: "todos|owner:u1",
+      });
+      expect(client.store.getEntity({collection: "todos", id: "old-tombstone"})?.deleted).toBe(
+        true
+      );
+
+      // Advance the clock past the retention window, then trigger a
+      // reconcile (which must succeed for compaction to run at all).
+      harness.clock.value += 91 * 24 * 60 * 60 * 1_000;
+      await client.reconcile();
+
+      expect(client.store.getEntity({collection: "todos", id: "old-tombstone"})).toBeUndefined();
+      await client.stop();
+    });
+
+    it("does not compact tombstones still within the retention window", async () => {
+      const harness = makeHarness({tombstoneRetentionMs: 90 * 24 * 60 * 60 * 1_000});
+      const client = createSyncDb(harness.config);
+      await client.start();
+      await flush();
+
+      harness.transport.deliverDelta({
+        collection: "todos",
+        deleted: true,
+        id: "fresh-tombstone",
+        method: "delete",
+        seq: 1,
+        stream: "todos|owner:u1",
+      });
+
+      harness.clock.value += 5 * 24 * 60 * 60 * 1_000;
+      await client.reconcile();
+
+      expect(client.store.getEntity({collection: "todos", id: "fresh-tombstone"})?.deleted).toBe(
+        true
+      );
+      await client.stop();
+    });
+
+    it("tombstoneRetentionMs: 0 disables compaction entirely", async () => {
+      const harness = makeHarness({tombstoneRetentionMs: 0});
+      const client = createSyncDb(harness.config);
+      await client.start();
+      await flush();
+
+      harness.transport.deliverDelta({
+        collection: "todos",
+        deleted: true,
+        id: "never-compacted",
+        method: "delete",
+        seq: 1,
+        stream: "todos|owner:u1",
+      });
+
+      harness.clock.value += 365 * 24 * 60 * 60 * 1_000;
+      await client.reconcile();
+
+      expect(client.store.getEntity({collection: "todos", id: "never-compacted"})?.deleted).toBe(
+        true
+      );
+      await client.stop();
     });
   });
 });

--- a/syncdb/src/client.test.ts
+++ b/syncdb/src/client.test.ts
@@ -131,12 +131,16 @@ describe("createSyncDb", () => {
       name: uniqueName(),
     });
     expect(client.getSyncStatus()).toEqual({
+      blockedEntities: 0,
       conflictCount: 0,
+      draining: false,
       failedCount: 0,
       isOnline: false,
       isSyncing: false,
       queuedCount: 0,
+      sentThisDrain: 0,
       streams: {},
+      totalThisDrain: 0,
     });
   });
 
@@ -589,6 +593,174 @@ describe("createSyncDb", () => {
       expect(client.store.getEntity({collection: "todos", id: "t1"})?.data).toEqual({
         title: "server wins",
       });
+      await client.stop();
+    });
+  });
+
+  describe("batched drain (B3/B4/B5)", () => {
+    it("sends multiple queued mutations as a single batch via the socket transport", async () => {
+      const harness = makeHarness();
+      const client = createSyncDb(harness.config);
+      await client.start();
+      harness.transport.setConnected(true);
+
+      client.mutate({collection: "todos", data: {title: "a"}, operation: "create"});
+      client.mutate({collection: "todos", data: {title: "b"}, operation: "create"});
+      client.mutate({collection: "todos", data: {title: "c"}, operation: "create"});
+      await flush();
+
+      expect(harness.transport.sentBatches.length).toBeGreaterThanOrEqual(1);
+      expect(harness.transport.sentBatches.flat()).toHaveLength(3);
+      expect(client.getSyncStatus().queuedCount).toBe(0);
+      await client.stop();
+    });
+
+    it("re-probes batch support on reconnect after a batch-unsupported determination", async () => {
+      const harness = makeHarness();
+      harness.transport.setBatchResponder(() => ({type: "unsupported"}));
+      const client = createSyncDb(harness.config);
+      await client.start();
+      harness.transport.setConnected(true);
+
+      client.mutate({collection: "todos", data: {title: "a"}, operation: "create"});
+      client.mutate({collection: "todos", data: {title: "b"}, operation: "create"});
+      await flush();
+      expect(client.getSyncStatus().queuedCount).toBe(0);
+      expect(harness.transport.sentMutations).toHaveLength(2);
+
+      harness.transport.setBatchResponder();
+      // A reconnect re-probes batch support.
+      harness.transport.setConnected(false);
+      await flush();
+      harness.transport.setConnected(true);
+      await flush();
+      client.mutate({collection: "todos", data: {title: "c"}, operation: "create"});
+      client.mutate({collection: "todos", data: {title: "d"}, operation: "create"});
+      await flush();
+      expect(harness.transport.sentBatches.length).toBeGreaterThanOrEqual(1);
+      await client.stop();
+    });
+
+    it("retryFailed re-enables an entity's successors after a validation failure", async () => {
+      const harness = makeHarness();
+      const client = createSyncDb(harness.config);
+      await client.start();
+      harness.transport.setConnected(true);
+
+      harness.transport.respondWithNack({code: "validation", message: "bad data"});
+      const {id} = client.mutate({collection: "todos", data: {title: "bad"}, operation: "create"});
+      await flush();
+      expect(client.getSyncStatus().failedCount).toBe(1);
+
+      client.mutate({collection: "todos", data: {title: "v2"}, id, operation: "update"});
+      await flush();
+      // The successor is blocked and surfaced, not sent.
+      expect(client.getSyncStatus().blockedEntities).toBe(1);
+      expect(client.getSyncStatus().queuedCount).toBe(1);
+
+      client.retryFailed({entityId: id});
+      await flush();
+      expect(client.getSyncStatus().blockedEntities).toBe(0);
+      expect(client.getSyncStatus().queuedCount).toBe(0);
+      await client.stop();
+    });
+
+    it("getSyncStatus reports draining and drain progress while a replay is in flight", async () => {
+      const harness = makeHarness();
+      let release: (() => void) | undefined;
+      harness.transport.respondWith(async (request) => {
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return {ack: {id: request.id ?? "", mutationId: request.mutationId, seq: 1}, type: "ack"};
+      });
+      const client = createSyncDb(harness.config);
+      await client.start();
+      harness.transport.setConnected(true);
+      // Let the startup no-op replay (empty queue) settle before enqueuing,
+      // so the drain this test observes is the one triggered by mutate().
+      await flush();
+
+      client.mutate({collection: "todos", data: {title: "a"}, operation: "create"});
+      await flush();
+      const midDrainStatus = client.getSyncStatus();
+      expect(midDrainStatus.draining).toBe(true);
+      expect(midDrainStatus.totalThisDrain).toBeGreaterThanOrEqual(1);
+
+      release?.();
+      await flush();
+      expect(client.getSyncStatus().draining).toBe(false);
+      await client.stop();
+    });
+
+    it("respects a configured batchSize", async () => {
+      const harness = makeHarness({batchSize: 2});
+      const client = createSyncDb(harness.config);
+      await client.start();
+      harness.transport.setConnected(true);
+      // Let the startup no-op replay (empty queue) settle first.
+      await flush();
+
+      for (let i = 0; i < 5; i++) {
+        client.mutate({collection: "todos", data: {title: `t${i}`}, operation: "create"});
+      }
+      await flush();
+      await flush();
+      // 5 mutations at batchSize 2: two full batches of 2, then a lone
+      // eligible mutation reuses the single-send path (not a batch of one).
+      expect(harness.transport.sentBatches.map((b) => b.length)).toEqual([2, 2]);
+      expect(harness.transport.sentMutations).toHaveLength(1);
+      expect(client.getSyncStatus().queuedCount).toBe(0);
+      await client.stop();
+    });
+
+    it("haltQueueOnConflict config plumbs through to the coordinator: a conflict halts the whole batch", async () => {
+      const harness = makeHarness({haltQueueOnConflict: true});
+      const client = createSyncDb(harness.config);
+      await client.start();
+      harness.transport.setConnected(true);
+      // Let the startup no-op replay (empty queue) settle first.
+      await flush();
+      client.store.upsertEntity({collection: "todos", data: {title: "old"}, id: "t1", seq: 2});
+      client.store.upsertEntity({collection: "todos", data: {title: "other"}, id: "t2"});
+
+      // Enqueue both mutations via the outbox directly (bypassing mutate()'s
+      // own fire-and-forget replay trigger, which would otherwise start
+      // draining synchronously — up to its first real await — before the
+      // second mutation exists, guaranteeing they land in separate chunks)
+      // so a single replayOutbox() call sees both together deterministically.
+      const mutationId = "halt-conflict-t1";
+      client.outbox.enqueue({
+        args: {title: "mine"},
+        baseVersion: 2,
+        collection: "todos",
+        entityId: "t1",
+        mutationId,
+        operation: "update",
+        userId: "u1",
+      });
+      client.outbox.enqueue({
+        args: {title: "other"},
+        collection: "todos",
+        entityId: "t2",
+        mutationId: "halt-conflict-t2",
+        operation: "update",
+        userId: "u1",
+      });
+
+      // Realistic server behavior (B2 stop-on-first-non-ack): t1 is first and
+      // conflicts, so "other" never gets attempted — truncated response.
+      harness.transport.setBatchResponder(() => ({
+        results: [{nack: {code: "conflict", mutationId, serverSeq: 7}, type: "nack"}],
+        type: "results",
+      }));
+      await client.replayOutbox();
+
+      expect(client.getSyncStatus().conflictCount).toBe(1);
+      // The second (distinct-entity) mutation never got a result and never
+      // sent again this pass — haltQueueOnConflict stopped the whole drain.
+      expect(client.getSyncStatus().queuedCount).toBe(1);
+      expect(client.outbox.getMutation({mutationId})?.status).toBe("conflicted");
       await client.stop();
     });
   });

--- a/syncdb/src/client.test.ts
+++ b/syncdb/src/client.test.ts
@@ -3,9 +3,10 @@ import {describe, expect, it} from "bun:test";
 import {createSyncDb, type SyncDbConfig} from "./client";
 import {getConflict} from "./mutations/conflicts";
 import {memoryPersisterFactory} from "./persisters/memoryPersister";
+import {CURSORS_TABLE} from "./storage/types";
 import {createFakeTransport, type FakeTransport} from "./sync/fakeTransport";
 import {AuthRequiredError, type HttpChannel} from "./sync/httpChannel";
-import type {AuthProvider, SyncDelta, SyncSnapshotResponse} from "./types";
+import type {AuthProvider, SyncDelta, SyncSnapshotResponse, SyncStreamInfo} from "./types";
 
 let nameCounter = 0;
 const uniqueName = (): string => {
@@ -48,21 +49,55 @@ const makeAuthProvider = (initialUserId: string | null = "u1"): FakeAuth => {
   };
 };
 
+/** The single stream the default harness advertises via GET /sync/streams. */
+const DEFAULT_STREAM = "todos|owner:u1";
+
 interface FakeChannel {
   channel: HttpChannel;
-  state: {fetchCount: number; pages: Record<string, SyncSnapshotResponse>};
+  state: {
+    fetchCount: number;
+    streamsCount: number;
+    /** Snapshot pages keyed by stream key. */
+    pages: Record<string, SyncSnapshotResponse>;
+    /** The membership set GET /sync/streams returns; mutate in a test to model join/leave. */
+    streams: SyncStreamInfo[];
+    /** When set, fetchStreams throws this instead of returning (401/transport tests). */
+    streamsError?: Error;
+  };
 }
 
+/** An empty snapshot page carrying the C1/C7 fields (no more data, no retention gap). */
+const emptyPage = (stream: string, cursor = 0): SyncSnapshotResponse => ({
+  cursor,
+  entities: [],
+  frontierSeq: cursor,
+  hasMore: false,
+  oldestRetainedSeq: 0,
+  stream,
+});
+
 const makeChannel = (): FakeChannel => {
-  const state: FakeChannel["state"] = {fetchCount: 0, pages: {}};
+  const state: FakeChannel["state"] = {
+    fetchCount: 0,
+    pages: {},
+    streams: [{collection: "todos", stream: DEFAULT_STREAM}],
+    streamsCount: 0,
+  };
   return {
     channel: {
       fetchKeyMaterial: async () => {
         throw new Error("key material not expected in this test");
       },
-      fetchSnapshotPage: async ({collection}) => {
+      fetchSnapshotPage: async ({stream}) => {
         state.fetchCount += 1;
-        return state.pages[collection] ?? {cursor: 0, entities: [], hasMore: false};
+        return state.pages[stream] ?? emptyPage(stream);
+      },
+      fetchStreams: async () => {
+        state.streamsCount += 1;
+        if (state.streamsError) {
+          throw state.streamsError;
+        }
+        return state.streams;
       },
       sendMutation: async () => {
         throw new Error("HTTP mutate not expected in this test");
@@ -369,6 +404,164 @@ describe("createSyncDb", () => {
       const client = createSyncDb({...harness.config, httpChannel: undefined});
       await client.start();
       await expect(client.reconcile()).resolves.toBeUndefined();
+      await client.stop();
+    });
+  });
+
+  describe("stream discovery, join & leave (C2)", () => {
+    it("join: a newly-returned stream is bootstrapped from 0 and recorded as known", async () => {
+      const harness = makeHarness();
+      const joined = "todos|tenant:org1";
+      // Server advertises the default owner stream plus a new tenant stream, and serves a
+      // one-entity page for the joined stream.
+      harness.http.state.streams = [
+        {collection: "todos", stream: DEFAULT_STREAM},
+        {collection: "todos", stream: joined},
+      ];
+      harness.http.state.pages[joined] = {
+        cursor: 4,
+        entities: [{data: {title: "tenant doc"}, deleted: false, id: "tj", seq: 4}],
+        frontierSeq: 4,
+        hasMore: false,
+        oldestRetainedSeq: 0,
+        stream: joined,
+      };
+      const client = createSyncDb(harness.config);
+      await client.start();
+      await flush();
+
+      expect(client.store.getKnownStreams().sort()).toEqual([DEFAULT_STREAM, joined].sort());
+      expect(client.store.getEntity({collection: "todos", id: "tj"})?.data).toEqual({
+        title: "tenant doc",
+      });
+      await client.stop();
+    });
+
+    it("leave (HTTP 200): a stream absent from the server set is purged locally", async () => {
+      const harness = makeHarness();
+      const leaving = "todos|tenant:org1";
+      // First discovery advertises both streams so org1 becomes known and its entity lands.
+      harness.http.state.streams = [
+        {collection: "todos", stream: DEFAULT_STREAM},
+        {collection: "todos", stream: leaving},
+      ];
+      harness.http.state.pages[leaving] = {
+        cursor: 2,
+        entities: [{data: {title: "org doc"}, deleted: false, id: "og", seq: 2}],
+        frontierSeq: 2,
+        hasMore: false,
+        oldestRetainedSeq: 0,
+        stream: leaving,
+      };
+      const client = createSyncDb(harness.config);
+      await client.start();
+      await flush();
+      expect(client.store.getEntity({collection: "todos", id: "og"})?.data).toEqual({
+        title: "org doc",
+      });
+      expect(client.store.getKnownStreams()).toContain(leaving);
+
+      // Membership changes: org1 is gone. A successful (HTTP 200) discovery purges it.
+      harness.http.state.streams = [{collection: "todos", stream: DEFAULT_STREAM}];
+      await client.reconcile();
+      await flush();
+
+      expect(client.store.getEntity({collection: "todos", id: "og"})).toBeUndefined();
+      expect(client.store.getKnownStreams()).not.toContain(leaving);
+      await client.stop();
+    });
+
+    it("leave under 401 (INV-2): NO purge, auth-pause, local data intact", async () => {
+      const harness = makeHarness();
+      const stream = "todos|tenant:org1";
+      harness.http.state.streams = [
+        {collection: "todos", stream: DEFAULT_STREAM},
+        {collection: "todos", stream},
+      ];
+      harness.http.state.pages[stream] = {
+        cursor: 2,
+        entities: [{data: {title: "org doc"}, deleted: false, id: "og", seq: 2}],
+        frontierSeq: 2,
+        hasMore: false,
+        oldestRetainedSeq: 0,
+        stream,
+      };
+      const client = createSyncDb(harness.config);
+      await client.start();
+      await flush();
+      expect(client.store.getEntity({collection: "todos", id: "og"})).toBeDefined();
+
+      // A 401 during discovery is NOT a membership change: pause, purge NOTHING.
+      harness.http.state.streamsError = new AuthRequiredError();
+      await client.reconcile();
+      await flush();
+
+      expect(client.getSyncStatus().paused).toBe("auth");
+      expect(client.store.getEntity({collection: "todos", id: "og"})?.data).toEqual({
+        title: "org doc",
+      });
+      expect(client.store.getKnownStreams()).toContain(stream);
+      await client.stop();
+    });
+
+    it("transport error during discovery: NO purge, data intact (not a membership change)", async () => {
+      const harness = makeHarness();
+      const stream = "todos|tenant:org1";
+      harness.http.state.streams = [
+        {collection: "todos", stream: DEFAULT_STREAM},
+        {collection: "todos", stream},
+      ];
+      harness.http.state.pages[stream] = {
+        cursor: 1,
+        entities: [{data: {x: 1}, deleted: false, id: "og", seq: 1}],
+        frontierSeq: 1,
+        hasMore: false,
+        oldestRetainedSeq: 0,
+        stream,
+      };
+      const client = createSyncDb(harness.config);
+      await client.start();
+      await flush();
+      expect(client.store.getEntity({collection: "todos", id: "og"})).toBeDefined();
+
+      harness.http.state.streamsError = new Error("network down");
+      // reconcile rethrows a transport error; the client's warn() wrapper swallows it, but
+      // either way no purge happens and the pause state is NOT auth.
+      await client.reconcile().catch(() => {});
+      await flush();
+
+      expect(client.store.getEntity({collection: "todos", id: "og"})).toBeDefined();
+      expect(client.store.getKnownStreams()).toContain(stream);
+      expect(client.getSyncStatus().paused).toBeUndefined();
+      await client.stop();
+    });
+
+    it("legacy migration: a snapshot:{collection} cursor is dropped and streams re-bootstrap", async () => {
+      const harness = makeHarness();
+      harness.http.state.pages[DEFAULT_STREAM] = {
+        cursor: 3,
+        entities: [{data: {title: "fresh"}, deleted: false, id: "f1", seq: 3}],
+        frontierSeq: 3,
+        hasMore: false,
+        oldestRetainedSeq: 0,
+        stream: DEFAULT_STREAM,
+      };
+      const client = createSyncDb(harness.config);
+      // Seed a legacy snapshot cursor + a stale known-stream entry BEFORE start(), as a
+      // deployed client would hold. (The store is shared with the client instance.)
+      client.store.raw.setRow(CURSORS_TABLE, "snapshot:todos", {seq: 42, updatedAt: "old"});
+      client.store.addKnownStream({collection: "todos", stream: "todos|owner:stale"});
+
+      await client.start();
+      await flush();
+
+      // The legacy pseudo-cursor is gone...
+      expect(client.store.raw.hasRow(CURSORS_TABLE, "snapshot:todos")).toBe(false);
+      // ...and the streams were re-bootstrapped from the current membership set.
+      expect(client.store.getEntity({collection: "todos", id: "f1"})?.data).toEqual({
+        title: "fresh",
+      });
+      expect(client.store.getKnownStreams()).toContain(DEFAULT_STREAM);
       await client.stop();
     });
   });
@@ -777,6 +970,7 @@ describe("createSyncDb", () => {
     const http: HttpChannel = {
       fetchKeyMaterial: harness.http.channel.fetchKeyMaterial,
       fetchSnapshotPage: harness.http.channel.fetchSnapshotPage,
+      fetchStreams: harness.http.channel.fetchStreams,
       sendMutation: async (request) => {
         httpMutations += 1;
         return {ack: {id: request.id ?? "", mutationId: request.mutationId, seq: 5}, type: "ack"};

--- a/syncdb/src/client.test.ts
+++ b/syncdb/src/client.test.ts
@@ -1264,6 +1264,99 @@ describe("createSyncDb", () => {
     });
   });
 
+  describe("socket session re-validation sweep mapping into auth-pause (D1)", () => {
+    it("sync:auth-expired disconnect pauses sync with the outbox intact and zero budget consumed", async () => {
+      const harness = makeHarness();
+      const client = createSyncDb(harness.config);
+      await client.start();
+      harness.transport.setConnected(true);
+      await flush();
+
+      harness.transport.disconnectWithAuthExpired();
+      await flush();
+      expect(client.getSyncStatus().paused).toBe("auth");
+      expect(client.getSyncStatus().isOnline).toBe(false);
+
+      // A mutation enqueued WHILE paused must stay queued untouched — replay
+      // stands down entirely until the pause clears (INV-2).
+      const {mutationId} = client.mutate({
+        collection: "todos",
+        data: {title: "x"},
+        operation: "create",
+      });
+      await flush();
+      const mutation = client.outbox.getMutation({mutationId});
+      expect(mutation?.status).toBe("queued");
+      expect(mutation?.errorNackCount).toBe(0);
+      expect(mutation?.attemptCount).toBe(0);
+      await client.stop();
+    });
+
+    it("a plain disconnect (no auth-expired tag) does NOT enter the auth-pause state", async () => {
+      const harness = makeHarness();
+      const client = createSyncDb(harness.config);
+      await client.start();
+      harness.transport.setConnected(true);
+      await flush();
+
+      harness.transport.setConnected(false);
+      await flush();
+
+      expect(client.getSyncStatus().paused).toBeUndefined();
+      expect(client.getSyncStatus().isOnline).toBe(false);
+      await client.stop();
+    });
+
+    it("same-user re-auth after a sync:auth-expired pause resumes replay with the outbox intact", async () => {
+      const harness = makeHarness();
+      const client = createSyncDb(harness.config);
+      await client.start();
+      harness.transport.setConnected(true);
+      await flush();
+
+      harness.transport.disconnectWithAuthExpired();
+      await flush();
+      expect(client.getSyncStatus().paused).toBe("auth");
+
+      // Enqueued while paused — stays queued (INV-2) until the pause clears.
+      const {id, mutationId} = client.mutate({
+        collection: "todos",
+        data: {title: "x"},
+        operation: "create",
+      });
+      await flush();
+      expect(client.outbox.getMutation({mutationId})?.status).toBe("queued");
+
+      // Same-user re-auth clears the pause; the transport reconnects and drains
+      // the queue fully (the fake transport auto-acks by default).
+      harness.auth.emitAuthChange();
+      harness.transport.setConnected(true);
+      await flush();
+
+      expect(client.getSyncStatus().paused).toBeUndefined();
+      expect(client.outbox.getMutation({mutationId})).toBeUndefined();
+      expect(client.store.getEntity({collection: "todos", id})?.pendingMutationId).toBeUndefined();
+      await client.stop();
+    });
+
+    it("no reconcile/replay is issued while paused from a sync:auth-expired disconnect", async () => {
+      const harness = makeHarness();
+      const client = createSyncDb(harness.config);
+      await client.start();
+      harness.transport.setConnected(true);
+      await flush();
+
+      harness.transport.disconnectWithAuthExpired();
+      await flush();
+      expect(client.getSyncStatus().paused).toBe("auth");
+
+      const baseline = harness.http.state.fetchCount;
+      await client.reconcile();
+      expect(harness.http.state.fetchCount).toBe(baseline);
+      await client.stop();
+    });
+  });
+
   describe("signOut() (A4)", () => {
     it("clears the current user without wiping when wipeOnSignOut is not set", async () => {
       const harness = makeHarness();

--- a/syncdb/src/client.test.ts
+++ b/syncdb/src/client.test.ts
@@ -8,9 +8,11 @@ import {getConflict} from "./mutations/conflicts";
 import {createDefaultPersisterFactory as createWebPersisterFactory} from "./persisters/defaultPersisterFactory.web";
 import {memoryPersisterFactory} from "./persisters/memoryPersister";
 import {idbGet} from "./storage/idb";
+import {SYNC_SCHEMA_VERSION} from "./storage/schema";
+import {CURSORS_TABLE} from "./storage/types";
 import {createFakeTransport, type FakeTransport} from "./sync/fakeTransport";
 import {AuthRequiredError, type HttpChannel} from "./sync/httpChannel";
-import type {AuthProvider, SyncDelta, SyncSnapshotResponse} from "./types";
+import type {AuthProvider, SyncDelta, SyncSnapshotResponse, SyncStreamInfo} from "./types";
 
 let nameCounter = 0;
 const uniqueName = (): string => {
@@ -53,21 +55,55 @@ const makeAuthProvider = (initialUserId: string | null = "u1"): FakeAuth => {
   };
 };
 
+/** The single stream the default harness advertises via GET /sync/streams. */
+const DEFAULT_STREAM = "todos|owner:u1";
+
 interface FakeChannel {
   channel: HttpChannel;
-  state: {fetchCount: number; pages: Record<string, SyncSnapshotResponse>};
+  state: {
+    fetchCount: number;
+    streamsCount: number;
+    /** Snapshot pages keyed by stream key. */
+    pages: Record<string, SyncSnapshotResponse>;
+    /** The membership set GET /sync/streams returns; mutate in a test to model join/leave. */
+    streams: SyncStreamInfo[];
+    /** When set, fetchStreams throws this instead of returning (401/transport tests). */
+    streamsError?: Error;
+  };
 }
 
+/** An empty snapshot page carrying the C1/C7 fields (no more data, no retention gap). */
+const emptyPage = (stream: string, cursor = 0): SyncSnapshotResponse => ({
+  cursor,
+  entities: [],
+  frontierSeq: cursor,
+  hasMore: false,
+  oldestRetainedSeq: 0,
+  stream,
+});
+
 const makeChannel = (): FakeChannel => {
-  const state: FakeChannel["state"] = {fetchCount: 0, pages: {}};
+  const state: FakeChannel["state"] = {
+    fetchCount: 0,
+    pages: {},
+    streams: [{collection: "todos", stream: DEFAULT_STREAM}],
+    streamsCount: 0,
+  };
   return {
     channel: {
       fetchKeyMaterial: async () => {
         throw new Error("key material not expected in this test");
       },
-      fetchSnapshotPage: async ({collection}) => {
+      fetchSnapshotPage: async ({stream}) => {
         state.fetchCount += 1;
-        return state.pages[collection] ?? {cursor: 0, entities: [], hasMore: false};
+        return state.pages[stream] ?? emptyPage(stream);
+      },
+      fetchStreams: async () => {
+        state.streamsCount += 1;
+        if (state.streamsError) {
+          throw state.streamsError;
+        }
+        return state.streams;
       },
       sendMutation: async () => {
         throw new Error("HTTP mutate not expected in this test");
@@ -375,6 +411,164 @@ describe("createSyncDb", () => {
       const client = createSyncDb({...harness.config, httpChannel: undefined});
       await client.start();
       await expect(client.reconcile()).resolves.toBeUndefined();
+      await client.stop();
+    });
+  });
+
+  describe("stream discovery, join & leave (C2)", () => {
+    it("join: a newly-returned stream is bootstrapped from 0 and recorded as known", async () => {
+      const harness = makeHarness();
+      const joined = "todos|tenant:org1";
+      // Server advertises the default owner stream plus a new tenant stream, and serves a
+      // one-entity page for the joined stream.
+      harness.http.state.streams = [
+        {collection: "todos", stream: DEFAULT_STREAM},
+        {collection: "todos", stream: joined},
+      ];
+      harness.http.state.pages[joined] = {
+        cursor: 4,
+        entities: [{data: {title: "tenant doc"}, deleted: false, id: "tj", seq: 4}],
+        frontierSeq: 4,
+        hasMore: false,
+        oldestRetainedSeq: 0,
+        stream: joined,
+      };
+      const client = createSyncDb(harness.config);
+      await client.start();
+      await flush();
+
+      expect(client.store.getKnownStreams().sort()).toEqual([DEFAULT_STREAM, joined].sort());
+      expect(client.store.getEntity({collection: "todos", id: "tj"})?.data).toEqual({
+        title: "tenant doc",
+      });
+      await client.stop();
+    });
+
+    it("leave (HTTP 200): a stream absent from the server set is purged locally", async () => {
+      const harness = makeHarness();
+      const leaving = "todos|tenant:org1";
+      // First discovery advertises both streams so org1 becomes known and its entity lands.
+      harness.http.state.streams = [
+        {collection: "todos", stream: DEFAULT_STREAM},
+        {collection: "todos", stream: leaving},
+      ];
+      harness.http.state.pages[leaving] = {
+        cursor: 2,
+        entities: [{data: {title: "org doc"}, deleted: false, id: "og", seq: 2}],
+        frontierSeq: 2,
+        hasMore: false,
+        oldestRetainedSeq: 0,
+        stream: leaving,
+      };
+      const client = createSyncDb(harness.config);
+      await client.start();
+      await flush();
+      expect(client.store.getEntity({collection: "todos", id: "og"})?.data).toEqual({
+        title: "org doc",
+      });
+      expect(client.store.getKnownStreams()).toContain(leaving);
+
+      // Membership changes: org1 is gone. A successful (HTTP 200) discovery purges it.
+      harness.http.state.streams = [{collection: "todos", stream: DEFAULT_STREAM}];
+      await client.reconcile();
+      await flush();
+
+      expect(client.store.getEntity({collection: "todos", id: "og"})).toBeUndefined();
+      expect(client.store.getKnownStreams()).not.toContain(leaving);
+      await client.stop();
+    });
+
+    it("leave under 401 (INV-2): NO purge, auth-pause, local data intact", async () => {
+      const harness = makeHarness();
+      const stream = "todos|tenant:org1";
+      harness.http.state.streams = [
+        {collection: "todos", stream: DEFAULT_STREAM},
+        {collection: "todos", stream},
+      ];
+      harness.http.state.pages[stream] = {
+        cursor: 2,
+        entities: [{data: {title: "org doc"}, deleted: false, id: "og", seq: 2}],
+        frontierSeq: 2,
+        hasMore: false,
+        oldestRetainedSeq: 0,
+        stream,
+      };
+      const client = createSyncDb(harness.config);
+      await client.start();
+      await flush();
+      expect(client.store.getEntity({collection: "todos", id: "og"})).toBeDefined();
+
+      // A 401 during discovery is NOT a membership change: pause, purge NOTHING.
+      harness.http.state.streamsError = new AuthRequiredError();
+      await client.reconcile();
+      await flush();
+
+      expect(client.getSyncStatus().paused).toBe("auth");
+      expect(client.store.getEntity({collection: "todos", id: "og"})?.data).toEqual({
+        title: "org doc",
+      });
+      expect(client.store.getKnownStreams()).toContain(stream);
+      await client.stop();
+    });
+
+    it("transport error during discovery: NO purge, data intact (not a membership change)", async () => {
+      const harness = makeHarness();
+      const stream = "todos|tenant:org1";
+      harness.http.state.streams = [
+        {collection: "todos", stream: DEFAULT_STREAM},
+        {collection: "todos", stream},
+      ];
+      harness.http.state.pages[stream] = {
+        cursor: 1,
+        entities: [{data: {x: 1}, deleted: false, id: "og", seq: 1}],
+        frontierSeq: 1,
+        hasMore: false,
+        oldestRetainedSeq: 0,
+        stream,
+      };
+      const client = createSyncDb(harness.config);
+      await client.start();
+      await flush();
+      expect(client.store.getEntity({collection: "todos", id: "og"})).toBeDefined();
+
+      harness.http.state.streamsError = new Error("network down");
+      // reconcile rethrows a transport error; the client's warn() wrapper swallows it, but
+      // either way no purge happens and the pause state is NOT auth.
+      await client.reconcile().catch(() => {});
+      await flush();
+
+      expect(client.store.getEntity({collection: "todos", id: "og"})).toBeDefined();
+      expect(client.store.getKnownStreams()).toContain(stream);
+      expect(client.getSyncStatus().paused).toBeUndefined();
+      await client.stop();
+    });
+
+    it("legacy migration: a snapshot:{collection} cursor is dropped and streams re-bootstrap", async () => {
+      const harness = makeHarness();
+      harness.http.state.pages[DEFAULT_STREAM] = {
+        cursor: 3,
+        entities: [{data: {title: "fresh"}, deleted: false, id: "f1", seq: 3}],
+        frontierSeq: 3,
+        hasMore: false,
+        oldestRetainedSeq: 0,
+        stream: DEFAULT_STREAM,
+      };
+      const client = createSyncDb(harness.config);
+      // Seed a legacy snapshot cursor + a stale known-stream entry BEFORE start(), as a
+      // deployed client would hold. (The store is shared with the client instance.)
+      client.store.raw.setRow(CURSORS_TABLE, "snapshot:todos", {seq: 42, updatedAt: "old"});
+      client.store.addKnownStream({collection: "todos", stream: "todos|owner:stale"});
+
+      await client.start();
+      await flush();
+
+      // The legacy pseudo-cursor is gone...
+      expect(client.store.raw.hasRow(CURSORS_TABLE, "snapshot:todos")).toBe(false);
+      // ...and the streams were re-bootstrapped from the current membership set.
+      expect(client.store.getEntity({collection: "todos", id: "f1"})?.data).toEqual({
+        title: "fresh",
+      });
+      expect(client.store.getKnownStreams()).toContain(DEFAULT_STREAM);
       await client.stop();
     });
   });
@@ -834,6 +1028,7 @@ describe("createSyncDb", () => {
     const http: HttpChannel = {
       fetchKeyMaterial: harness.http.channel.fetchKeyMaterial,
       fetchSnapshotPage: harness.http.channel.fetchSnapshotPage,
+      fetchStreams: harness.http.channel.fetchStreams,
       sendMutation: async (request) => {
         httpMutations += 1;
         return {ack: {id: request.id ?? "", mutationId: request.mutationId, seq: 5}, type: "ack"};
@@ -1555,13 +1750,17 @@ describe("createSyncDb", () => {
       await flush();
       await client.stop();
 
-      // Seed a snapshot page so the re-bootstrap after the wipe has something
-      // to fetch and the test can prove it actually ran.
+      // Seed a snapshot page (keyed by the discovered stream — C2) so the
+      // re-bootstrap after the wipe has something to fetch and the test can
+      // prove it actually ran.
       const second = makeHarness({name});
-      second.http.state.pages.todos = {
+      second.http.state.pages[DEFAULT_STREAM] = {
         cursor: 5,
         entities: [{data: {title: "from server"}, deleted: false, id: "server-1", seq: 5}],
+        frontierSeq: 5,
         hasMore: false,
+        oldestRetainedSeq: 0,
+        stream: DEFAULT_STREAM,
       };
       const reopened = createSyncDb(second.config);
       await reopened.start();
@@ -1573,7 +1772,7 @@ describe("createSyncDb", () => {
       expect(reopened.store.getEntity({collection: "todos", id: "server-1"})?.data).toEqual({
         title: "from server",
       });
-      expect(reopened.store.getSchemaVersion()).toBe(1);
+      expect(reopened.store.getSchemaVersion()).toBe(SYNC_SCHEMA_VERSION);
       await reopened.stop();
     });
 
@@ -1594,7 +1793,7 @@ describe("createSyncDb", () => {
       expect(reopened.store.getEntity({collection: "todos", id: "t1"})?.data).toEqual({
         title: "current",
       });
-      expect(reopened.store.getSchemaVersion()).toBe(1);
+      expect(reopened.store.getSchemaVersion()).toBe(SYNC_SCHEMA_VERSION);
       await reopened.stop();
     });
 
@@ -1602,7 +1801,7 @@ describe("createSyncDb", () => {
       const harness = makeHarness();
       const client = createSyncDb(harness.config);
       await client.start();
-      expect(client.store.getSchemaVersion()).toBe(1);
+      expect(client.store.getSchemaVersion()).toBe(SYNC_SCHEMA_VERSION);
       await client.stop();
     });
   });

--- a/syncdb/src/client.test.ts
+++ b/syncdb/src/client.test.ts
@@ -187,7 +187,39 @@ describe("createSyncDb", () => {
   });
 
   it("start() rejects without an authenticated user", async () => {
-    const harness = makeHarness();
+    // startAuthRetryAttempts: 1 disables retrying so this stays instant — the
+    // no-retry-attempts contract is tested here; retry behavior is tested below.
+    const harness = makeHarness({startAuthRetryAttempts: 1});
+    harness.auth.setUserId(null);
+    const client = createSyncDb(harness.config);
+    await expect(client.start()).rejects.toThrow("requires an authenticated user");
+  });
+
+  it("start() retries auth resolution before giving up", async () => {
+    const harness = makeHarness({startAuthRetryAttempts: 3, startAuthRetryDelayMs: 1});
+    harness.auth.setUserId(null);
+    const client = createSyncDb(harness.config);
+
+    // Transient failure: getUserId() only resolves on the 2nd attempt — start()
+    // should not throw on the first null, matching a host app that calls start()
+    // right after its own login flow resolved (see client.ts start() doc).
+    let calls = 0;
+    const originalGetUserId = harness.config.authProvider.getUserId;
+    harness.config.authProvider.getUserId = async () => {
+      calls += 1;
+      if (calls === 1) {
+        return null;
+      }
+      return originalGetUserId();
+    };
+    harness.auth.setUserId("retry-user");
+
+    await client.start();
+    expect(calls).toBeGreaterThanOrEqual(2);
+  });
+
+  it("start() rejects when auth never resolves after exhausting retries", async () => {
+    const harness = makeHarness({startAuthRetryAttempts: 2, startAuthRetryDelayMs: 1});
     harness.auth.setUserId(null);
     const client = createSyncDb(harness.config);
     await expect(client.start()).rejects.toThrow("requires an authenticated user");

--- a/syncdb/src/client.test.ts
+++ b/syncdb/src/client.test.ts
@@ -4,7 +4,7 @@ import {createSyncDb, type SyncDbConfig} from "./client";
 import {getConflict} from "./mutations/conflicts";
 import {memoryPersisterFactory} from "./persisters/memoryPersister";
 import {createFakeTransport, type FakeTransport} from "./sync/fakeTransport";
-import type {HttpChannel} from "./sync/httpChannel";
+import {AuthRequiredError, type HttpChannel} from "./sync/httpChannel";
 import type {AuthProvider, SyncDelta, SyncSnapshotResponse} from "./types";
 
 let nameCounter = 0;
@@ -132,6 +132,7 @@ describe("createSyncDb", () => {
     });
     expect(client.getSyncStatus()).toEqual({
       conflictCount: 0,
+      failedCount: 0,
       isOnline: false,
       isSyncing: false,
       queuedCount: 0,
@@ -437,6 +438,10 @@ describe("createSyncDb", () => {
       await flush();
       expect(client.getSyncStatus().queuedCount).toBe(1);
 
+      // The failed send armed a jittered transport-failure backoff (A3,
+      // unlimited retries) — advance past its cap so the retry is eligible
+      // again before the auth-change replay trigger runs.
+      harness.clock.value += 30_000;
       harness.transport.setDefaultResponder();
       harness.auth.emitAuthChange();
       await flush();
@@ -706,6 +711,409 @@ describe("createSyncDb", () => {
       expect(conflict?.ok).toBe(false);
       expect(conflict?.detail?.serverSeq).toBe(7);
       await client.stop();
+    });
+
+    it("skips the debug-only listQueued scan in replayOutbox() when debug is disabled (A3)", async () => {
+      const countListQueuedCalls = async (debug: boolean): Promise<number> => {
+        const harness = makeHarness({debug});
+        const client = createSyncDb(harness.config);
+        await client.start();
+        await flush();
+        const originalListQueued = client.outbox.listQueued;
+        let calls = 0;
+        // biome-ignore lint/suspicious/noExplicitAny: test-only spy shim
+        (client.outbox as any).listQueued = (...args: any[]) => {
+          calls += 1;
+          return originalListQueued(...(args as [{collection?: string; userId: string}]));
+        };
+        await client.replayOutbox();
+        await client.stop();
+        return calls;
+      };
+
+      const withoutDebug = await countListQueuedCalls(false);
+      const withDebug = await countListQueuedCalls(true);
+      // The debug label adds exactly one extra listQueued scan (the drain
+      // itself still calls listQueued to find work) — proving the debug-only
+      // scan is conditional, not unconditional.
+      expect(withDebug).toBe(withoutDebug + 1);
+    });
+  });
+
+  describe("startup recovery (A1)", () => {
+    it("recovers a stranded inFlight row on start(): it replays and the entity receives deltas again", async () => {
+      const name = uniqueName();
+      const harness = makeHarness({name});
+      // Hold every send indefinitely so the mutation is still inFlight when
+      // stop() is called (simulating a crash mid-send, not a clean stop).
+      harness.transport.respondWith(() => new Promise(() => {}));
+      const client = createSyncDb(harness.config);
+      await client.start();
+      const {id, mutationId} = client.mutate({
+        collection: "todos",
+        data: {title: "stranded"},
+        operation: "create",
+      });
+      await flush();
+      expect(client.outbox.getMutation({mutationId})?.status).toBe("inFlight");
+      // stop() itself never repairs outbox state (only start() does) — a
+      // clean stop() here still leaves the row inFlight in persisted content,
+      // standing in for a hard crash that never ran a graceful shutdown.
+      await client.stop();
+
+      const second = makeHarness({name});
+      const reopened = createSyncDb(second.config);
+      await reopened.start();
+      await flush();
+      // Recovered to queued and replayed against the fresh (auto-acking)
+      // transport: the row acks and — per A5 — is pruned immediately, so its
+      // resolution shows up as a successful send, not a lingering outbox row.
+      expect(reopened.outbox.getMutation({mutationId})).toBeUndefined();
+      expect(second.transport.sentMutations.map((m) => m.mutationId)).toContain(mutationId);
+      expect(
+        reopened.store.getEntity({collection: "todos", id})?.pendingMutationId
+      ).toBeUndefined();
+      // The entity's pendingMutationId was released — a subsequent delta applies.
+      second.transport.deliverDelta({
+        collection: "todos",
+        data: {title: "from server"},
+        id,
+        method: "update",
+        seq: 99,
+        stream: "todos|owner:u1",
+      });
+      expect(reopened.store.getEntity({collection: "todos", id})?.data).toEqual({
+        title: "from server",
+      });
+      await reopened.stop();
+    });
+
+    it("clears a stale pendingMutationId for an acked-with-pending row on start()", async () => {
+      const name = uniqueName();
+      const harness = makeHarness({name});
+      const client = createSyncDb(harness.config);
+      await client.start();
+      client.store.upsertEntity({
+        collection: "todos",
+        data: {title: "x"},
+        id: "t1",
+        pendingMutationId: "m1",
+      });
+      client.outbox.enqueue({
+        args: {title: "x"},
+        collection: "todos",
+        entityId: "t1",
+        mutationId: "m1",
+        operation: "create",
+        userId: "u1",
+      });
+      client.outbox.markInFlight({mutationId: "m1"});
+      client.outbox.markAcked({mutationId: "m1"});
+      // Simulate a crash between markAcked and releaseEntity.
+      await flush();
+      await client.stop();
+
+      const second = makeHarness({name});
+      const reopened = createSyncDb(second.config);
+      await reopened.start();
+      expect(
+        reopened.store.getEntity({collection: "todos", id: "t1"})?.pendingMutationId
+      ).toBeUndefined();
+      await reopened.stop();
+    });
+
+    it("writes a missing conflict row for a conflicted mutation on start()", async () => {
+      const name = uniqueName();
+      const harness = makeHarness({name});
+      const client = createSyncDb(harness.config);
+      await client.start();
+      client.store.upsertEntity({
+        collection: "todos",
+        data: {title: "local"},
+        id: "t1",
+        pendingMutationId: "m1",
+      });
+      client.outbox.enqueue({
+        args: {title: "local"},
+        collection: "todos",
+        entityId: "t1",
+        mutationId: "m1",
+        operation: "create",
+        userId: "u1",
+      });
+      client.outbox.markInFlight({mutationId: "m1"});
+      client.outbox.markConflicted({mutationId: "m1"});
+      // Simulate a crash between markConflicted and writeConflict: no row yet.
+      expect(getConflict({mutationId: "m1", store: client.store})).toBeUndefined();
+      await flush();
+      await client.stop();
+
+      const second = makeHarness({name});
+      const reopened = createSyncDb(second.config);
+      await reopened.start();
+      const conflict = getConflict({mutationId: "m1", store: reopened.store});
+      expect(conflict?.entityId).toBe("t1");
+      expect(conflict?.serverSeq).toBe(0);
+      await reopened.stop();
+    });
+  });
+
+  describe("outbox hygiene (A5)", () => {
+    it("prunes acked rows after a successful drain pass, driven end-to-end through mutate()", async () => {
+      const harness = makeHarness();
+      harness.transport.respondWithAck({seq: 1});
+      const client = createSyncDb(harness.config);
+      await client.start();
+
+      const {mutationId} = client.mutate({
+        collection: "todos",
+        data: {title: "x"},
+        operation: "create",
+      });
+      await flush();
+      // The mutation acked and was pruned in the same drain pass — no lingering row.
+      expect(client.outbox.getMutation({mutationId})).toBeUndefined();
+      expect(client.getSyncStatus().queuedCount).toBe(0);
+      await client.stop();
+    });
+
+    it("keeps failed rows visible in failedCount until pruned past the retention window", async () => {
+      const harness = makeHarness();
+      harness.transport.setDefaultResponder((request) => ({
+        nack: {code: "validation", mutationId: request.mutationId},
+        type: "nack",
+      }));
+      const client = createSyncDb(harness.config);
+      await client.start();
+      client.mutate({collection: "todos", data: {title: "bad"}, operation: "create"});
+      await flush();
+      expect(client.getSyncStatus().failedCount).toBe(1);
+      await client.stop();
+    });
+  });
+
+  describe("auth-pause pipeline (A4)", () => {
+    /** Force sendMutation through the HTTP channel (offline transport) so AuthRequiredError surfaces. */
+    const makeAuthPauseHarness = (
+      overrides: Partial<SyncDbConfig> = {}
+    ): Harness & {offlineTransport: FakeTransport} => {
+      const harness = makeHarness(overrides);
+      const offlineTransport: FakeTransport = {
+        ...harness.transport,
+        connect: async () => {
+          throw new Error("no network");
+        },
+      };
+      harness.config.transport = offlineTransport;
+      return {...harness, offlineTransport};
+    };
+
+    it("AuthRequiredError from the HTTP channel pauses sync, leaves the outbox untouched, burns zero budget, and fires onAuthRequired once", async () => {
+      const harness = makeAuthPauseHarness();
+      let authRequiredCount = 0;
+      harness.config.onAuthRequired = () => {
+        authRequiredCount += 1;
+      };
+      harness.http.channel.sendMutation = async () => {
+        throw new AuthRequiredError();
+      };
+      const client = createSyncDb(harness.config);
+      await client.start();
+
+      const {mutationId} = client.mutate({
+        collection: "todos",
+        data: {title: "x"},
+        operation: "create",
+      });
+      await flush();
+
+      expect(client.getSyncStatus().paused).toBe("auth");
+      const mutation = client.outbox.getMutation({mutationId});
+      expect(mutation?.status).toBe("queued");
+      expect(mutation?.errorNackCount).toBe(0);
+      expect(authRequiredCount).toBe(1);
+
+      // A second replay trigger while still paused must not re-fire the hook.
+      await client.replayOutbox();
+      expect(authRequiredCount).toBe(1);
+      await client.stop();
+    });
+
+    it("same-user re-auth clears the pause and drains the queue fully, entity converges", async () => {
+      const harness = makeAuthPauseHarness();
+      harness.http.channel.sendMutation = async () => {
+        throw new AuthRequiredError();
+      };
+      const client = createSyncDb(harness.config);
+      await client.start();
+      const {id, mutationId} = client.mutate({
+        collection: "todos",
+        data: {title: "x"},
+        operation: "create",
+      });
+      await flush();
+      expect(client.getSyncStatus().paused).toBe("auth");
+
+      // Re-authenticate as the SAME user with a channel that now works.
+      harness.http.channel.sendMutation = async (request) => ({
+        ack: {id: request.id ?? "", mutationId: request.mutationId, seq: 1},
+        type: "ack",
+      });
+      harness.auth.emitAuthChange();
+      await flush();
+
+      expect(client.getSyncStatus().paused).toBeUndefined();
+      expect(client.getSyncStatus().queuedCount).toBe(0);
+      expect(client.outbox.getMutation({mutationId})).toBeUndefined();
+      expect(client.store.getEntity({collection: "todos", id})?.pendingMutationId).toBeUndefined();
+      await client.stop();
+    });
+
+    it("logout (userId -> undefined) retains local data; a later same-user login drains the queue", async () => {
+      const harness = makeAuthPauseHarness();
+      const client = createSyncDb(harness.config);
+      await client.start();
+      client.store.upsertEntity({collection: "todos", data: {title: "kept"}, id: "t1"});
+
+      harness.auth.setUserId(null);
+      harness.auth.emitAuthChange();
+      await flush();
+      expect(client.store.listEntities({collection: "todos"})).toHaveLength(1);
+      expect(client.getSyncStatus().paused).toBe("auth");
+
+      // Same user comes back — resumes fully, no wipe occurred.
+      harness.auth.setUserId("u1");
+      harness.auth.emitAuthChange();
+      await flush();
+      expect(client.getSyncStatus().paused).toBeUndefined();
+      expect(client.store.listEntities({collection: "todos"})).toHaveLength(1);
+      await client.stop();
+    });
+
+    it("a different-user login still wipes local data (regression)", async () => {
+      const name = uniqueName();
+      const harness = makeAuthPauseHarness({name});
+      const client = createSyncDb(harness.config);
+      await client.start();
+      client.store.upsertEntity({collection: "todos", data: {title: "mine"}, id: "t1", seq: 1});
+
+      harness.auth.setUserId("u2");
+      harness.auth.emitAuthChange();
+      await flush();
+      expect(client.store.listEntities({collection: "todos"})).toEqual([]);
+      expect(client.store.getLastUserId()).toBe("u2");
+      await client.stop();
+    });
+
+    it("no reconcile/snapshot requests are issued while paused", async () => {
+      const harness = makeAuthPauseHarness();
+      harness.http.channel.sendMutation = async () => {
+        throw new AuthRequiredError();
+      };
+      const client = createSyncDb(harness.config);
+      await client.start();
+      client.mutate({collection: "todos", data: {title: "x"}, operation: "create"});
+      await flush();
+      expect(client.getSyncStatus().paused).toBe("auth");
+
+      const baseline = harness.http.state.fetchCount;
+      await client.reconcile();
+      expect(harness.http.state.fetchCount).toBe(baseline);
+      await client.stop();
+    });
+
+    it("betterAuthAdapter's refresh() gets one silent attempt per pause episode, and a successful refresh resumes replay immediately", async () => {
+      const harness = makeAuthPauseHarness();
+      let refreshCalls = 0;
+      let shouldSucceed = false;
+      harness.config.authProvider = {
+        ...harness.auth.provider,
+        refresh: async () => {
+          refreshCalls += 1;
+          if (shouldSucceed) {
+            // A real adapter's refresh() renews the underlying token in place;
+            // simulate that by making the channel work again before reporting success.
+            harness.http.channel.sendMutation = async (request) => ({
+              ack: {id: request.id ?? "", mutationId: request.mutationId, seq: 1},
+              type: "ack",
+            });
+          }
+          return shouldSucceed;
+        },
+      };
+      harness.http.channel.sendMutation = async () => {
+        throw new AuthRequiredError();
+      };
+      const client = createSyncDb(harness.config);
+      await client.start();
+      const {mutationId} = client.mutate({
+        collection: "todos",
+        data: {title: "x"},
+        operation: "create",
+      });
+      await flush();
+      expect(refreshCalls).toBe(1);
+      expect(client.getSyncStatus().paused).toBe("auth");
+
+      // Further replay triggers within the SAME episode never re-attempt refresh.
+      await client.replayOutbox();
+      await client.replayOutbox();
+      expect(refreshCalls).toBe(1);
+
+      // The episode ends via same-user re-auth (not refresh) — the outbox is
+      // still intact and unpaused replay drains it.
+      harness.http.channel.sendMutation = async (request) => ({
+        ack: {id: request.id ?? "", mutationId: request.mutationId, seq: 1},
+        type: "ack",
+      });
+      harness.auth.emitAuthChange();
+      await flush();
+      expect(client.getSyncStatus().paused).toBeUndefined();
+      expect(client.outbox.getMutation({mutationId})).toBeUndefined();
+
+      // A FRESH pause episode (new failing mutation) gets its own refresh
+      // attempt, and this time a successful refresh resumes replay immediately.
+      shouldSucceed = true;
+      harness.http.channel.sendMutation = async () => {
+        throw new AuthRequiredError();
+      };
+      const {mutationId: secondMutationId} = client.mutate({
+        collection: "todos",
+        data: {title: "y"},
+        operation: "create",
+      });
+      await flush();
+      expect(refreshCalls).toBe(2);
+      // The refresh succeeded, so the pause clears and replay retried with the
+      // (now-working) channel rather than staying surfaced to the app.
+      expect(client.getSyncStatus().paused).toBeUndefined();
+      expect(client.outbox.getMutation({mutationId: secondMutationId})).toBeUndefined();
+      await client.stop();
+    });
+  });
+
+  describe("signOut() (A4)", () => {
+    it("clears the current user without wiping when wipeOnSignOut is not set", async () => {
+      const harness = makeHarness();
+      const client = createSyncDb(harness.config);
+      await client.start();
+      client.store.upsertEntity({collection: "todos", data: {title: "kept"}, id: "t1"});
+
+      await client.signOut();
+      expect(client.store.listEntities({collection: "todos"})).toHaveLength(1);
+      expect(() => client.mutate({collection: "todos", operation: "create"})).toThrow(
+        "requires start()"
+      );
+    });
+
+    it("wipes local data when wipeOnSignOut is configured", async () => {
+      const harness = makeHarness({wipeOnSignOut: true});
+      const client = createSyncDb(harness.config);
+      await client.start();
+      client.store.upsertEntity({collection: "todos", data: {title: "gone"}, id: "t1"});
+
+      await client.signOut();
+      expect(client.store.listEntities({collection: "todos", includeDeleted: true})).toEqual([]);
     });
   });
 });

--- a/syncdb/src/client.ts
+++ b/syncdb/src/client.ts
@@ -14,11 +14,12 @@ import {applyDelta} from "./sync/deltaApplier";
 import {AuthRequiredError, createHttpChannel, type HttpChannel} from "./sync/httpChannel";
 import {createReplayCoordinator, type ReplayCoordinator} from "./sync/replayCoordinator";
 import {createSocketTransport} from "./sync/socketTransport";
-import type {SendMutationResult, SyncTransport} from "./sync/transport";
+import type {SendMutationBatchResult, SendMutationResult, SyncTransport} from "./sync/transport";
 import type {
   AuthProvider,
   ConflictResolutionStrategy,
   SyncDelta,
+  SyncMutateBatchRequest,
   SyncMutateRequest,
   SyncMutationOperation,
   SyncStatus,
@@ -74,6 +75,14 @@ export interface SyncDbConfig {
    * this explicit, host-app-initiated opt-in.
    */
   wipeOnSignOut?: boolean;
+  /** Max mutations per batched drain send (B3, default 50; server caps at 100). */
+  batchSize?: number;
+  /**
+   * B4: when true, a conflict halts the ENTIRE drain instead of just blocking
+   * its entity. Default false (per-entity blocking — see README "Conflict
+   * handling modes").
+   */
+  haltQueueOnConflict?: boolean;
 }
 
 export interface MutateArgs {
@@ -125,6 +134,13 @@ export interface SyncDb {
   replayOutbox: () => Promise<void>;
   /** Resolve a recorded conflict with the given strategy. */
   resolveConflict: (args: {mutationId: string; strategy: ConflictResolutionStrategy}) => void;
+  /**
+   * B4: re-enable an entity's queued successors after a terminal validation
+   * failure blocked them. Does not touch unresolved conflicts (those clear
+   * via `resolveConflict`); kicks off a replay so the re-enabled mutations
+   * drain immediately rather than waiting for the next trigger.
+   */
+  retryFailed: (args: {entityId: string}) => void;
   /**
    * Explicit, host-app-initiated sign-out. Always clears the in-memory
    * current-user pointer; wipes local data ONLY when `wipeOnSignOut` is
@@ -232,6 +248,22 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     return httpChannel.sendMutation(request);
   };
 
+  // B3: batched sends mirror the same socket-preferred/HTTP-fallback selection.
+  // Omitted entirely when neither channel supports batching, so the
+  // coordinator falls back to sendMutation for every send.
+  const sendMutationBatch =
+    transport.sendMutationBatch || httpChannel?.sendMutationBatch
+      ? async (request: SyncMutateBatchRequest): Promise<SendMutationBatchResult> => {
+          if ((connected || !httpChannel) && transport.sendMutationBatch) {
+            return transport.sendMutationBatch(request);
+          }
+          if (httpChannel?.sendMutationBatch) {
+            return httpChannel.sendMutationBatch(request);
+          }
+          return {type: "unsupported"};
+        }
+      : undefined;
+
   const setAuthPaused = (value: boolean): void => {
     if (authPaused === value) {
       return;
@@ -253,7 +285,9 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
   };
 
   const coordinator: ReplayCoordinator = createReplayCoordinator({
+    batchSize: config.batchSize,
     debug: debugLog,
+    haltQueueOnConflict: config.haltQueueOnConflict,
     now,
     onAuthPause: () => {
       setAuthPaused(true);
@@ -268,9 +302,16 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     onDrainPass: ({userId}) => {
       outbox.prune({userId});
     },
+    onProgress: () => {
+      // B5: drain progress (sentThisDrain/totalThisDrain) is exposed through
+      // getSyncStatus() — nudge status listeners so a progress UI re-renders
+      // as each chunk/mutation resolves, not just at the start/end of replay.
+      notifyStatusChange();
+    },
     outbox,
     random: config.random,
     sendMutation,
+    sendMutationBatch,
     // Internally-scheduled drains (armed wake-up timers, the mid-drain-enqueue
     // recheck) must respect the same gating as an external replayOutbox()
     // call: never send while simulated-offline or auth-paused.
@@ -441,6 +482,11 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     if (!isConnected) {
       return;
     }
+    // B3: re-probe batch support on every reconnect — a previous
+    // `batchUnsupported` determination may have been against an old server
+    // that has since been upgraded, or the reconnect landed on a different
+    // instance behind a load balancer.
+    coordinator.notifyReconnect();
     void reconcile().catch(warn("reconnect reconcile failed"));
     void replayOutbox().catch(warn("reconnect replay failed"));
   };
@@ -662,17 +708,39 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     void replayOutbox().catch(warn("post-resolve replay failed"));
   };
 
-  const getSyncStatus = (): SyncStatus => ({
-    conflictCount: listConflicts({store}).length,
-    failedCount: currentUserId
-      ? outbox.countByStatus({status: "failed", userId: currentUserId})
-      : 0,
-    isOnline: connected,
-    isSyncing: syncingCount > 0,
-    ...(authPaused ? {paused: "auth" as const} : {}),
-    queuedCount: currentUserId ? outbox.listQueued({userId: currentUserId}).length : 0,
-    streams: getAllCursors({store}),
-  });
+  const retryFailed = ({entityId}: {entityId: string}): void => {
+    coordinator.retryFailed({entityId});
+    debugLog?.record({
+      detail: {entityId},
+      direction: "local",
+      label: `retry failed (${entityId})`,
+      type: "resolve",
+    });
+    void replayOutbox().catch(warn("post-retryFailed replay failed"));
+  };
+
+  const getSyncStatus = (): SyncStatus => {
+    const drainProgress = currentUserId
+      ? coordinator.getDrainProgress({userId: currentUserId})
+      : {draining: false, sentThisDrain: 0, totalThisDrain: 0};
+    return {
+      blockedEntities: currentUserId
+        ? coordinator.getBlockedEntities({userId: currentUserId}).length
+        : 0,
+      conflictCount: listConflicts({store}).length,
+      draining: drainProgress.draining,
+      failedCount: currentUserId
+        ? outbox.countByStatus({status: "failed", userId: currentUserId})
+        : 0,
+      isOnline: connected,
+      isSyncing: syncingCount > 0,
+      ...(authPaused ? {paused: "auth" as const} : {}),
+      queuedCount: currentUserId ? outbox.listQueued({userId: currentUserId}).length : 0,
+      sentThisDrain: drainProgress.sentThisDrain,
+      streams: getAllCursors({store}),
+      totalThisDrain: drainProgress.totalThisDrain,
+    };
+  };
 
   const onStatusChange = (callback: () => void): (() => void) => {
     statusListeners.add(callback);
@@ -703,6 +771,7 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     reconcile,
     replayOutbox,
     resolveConflict,
+    retryFailed,
     signOut,
     start,
     stop,

--- a/syncdb/src/client.ts
+++ b/syncdb/src/client.ts
@@ -39,6 +39,20 @@ export const DEFAULT_SEQ_JUMP_RECONCILE_MIN_INTERVAL_MS = 30_000;
 /** E5: default local tombstone retention window (90 days), matching the server's (C7). */
 export const DEFAULT_TOMBSTONE_RETENTION_MS = 90 * 24 * 60 * 60 * 1_000;
 
+/**
+ * `start()` auth-resolution retry defaults. A host app only calls `start()` once it
+ * already believes the user is authenticated (e.g. right after its own login flow
+ * resolved), so a `null` from `authProvider.getUserId()` on the first attempt is far
+ * more likely a transient hiccup — the session cookie/token not yet queryable, or a
+ * one-off fetch failure racing a just-completed navigation — than a genuine
+ * logged-out state. Retrying briefly avoids `start()` giving up permanently on a call
+ * site that (by design, see the client.ts start() doc) never retries itself.
+ */
+export const DEFAULT_START_AUTH_RETRY_ATTEMPTS = 3;
+export const DEFAULT_START_AUTH_RETRY_DELAY_MS = 250;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
 export interface SyncDbConfig {
   /** App/store name; used as the persisted database name. */
   name: string;
@@ -118,6 +132,18 @@ export interface SyncDbConfig {
    * missing a delete it hasn't converged on yet. 0 disables compaction.
    */
   tombstoneRetentionMs?: number;
+  /**
+   * Number of `authProvider.getUserId()` attempts `start()` makes before giving up
+   * with "requires an authenticated user" (default {@link DEFAULT_START_AUTH_RETRY_ATTEMPTS}).
+   * A host app calls `start()` only once it believes the user is signed in, so an
+   * initial `null` is usually a transient auth-provider hiccup (e.g. a session fetch
+   * racing a just-completed login) rather than a real logged-out state — retrying
+   * a few times avoids `start()` permanently failing on that race. Set to 1 to
+   * disable retrying.
+   */
+  startAuthRetryAttempts?: number;
+  /** Delay between `start()` auth-resolution retries (default {@link DEFAULT_START_AUTH_RETRY_DELAY_MS}). */
+  startAuthRetryDelayMs?: number;
 }
 
 export interface MutateArgs {
@@ -986,7 +1012,24 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
       }
       generation += 1;
       const myGeneration = generation;
-      const userId = await config.authProvider.getUserId();
+      const authRetryAttempts = Math.max(
+        1,
+        config.startAuthRetryAttempts ?? DEFAULT_START_AUTH_RETRY_ATTEMPTS
+      );
+      const authRetryDelayMs = config.startAuthRetryDelayMs ?? DEFAULT_START_AUTH_RETRY_DELAY_MS;
+      let userId: string | null = null;
+      for (let attempt = 1; attempt <= authRetryAttempts; attempt += 1) {
+        userId = await config.authProvider.getUserId();
+        if (userId || attempt === authRetryAttempts) {
+          break;
+        }
+        await sleep(authRetryDelayMs);
+        if (generation !== myGeneration) {
+          // A stop() (or another start()) ran while we were retrying auth
+          // resolution — abandon this attempt, see the generation check below.
+          return;
+        }
+      }
       if (!userId) {
         throw new Error("createSyncDb.start() requires an authenticated user");
       }

--- a/syncdb/src/client.ts
+++ b/syncdb/src/client.ts
@@ -1,11 +1,15 @@
-import {createServerKeyProvider} from "./crypto/keyProviders";
+import {DateTime} from "luxon";
+import type {AnyPersister} from "tinybase/persisters";
+
+import {createServerKeyProvider, DEFAULT_KEY_CACHE_DB_NAME} from "./crypto/keyProviders";
 import type {KeyProvider} from "./crypto/types";
 import {resolveDebugLog, type SyncDebugLog, type SyncDebugLogOptions} from "./debug/debugLog";
 import {listConflicts} from "./mutations/conflicts";
 import {createOutbox, generateMutationId, type Outbox} from "./mutations/outbox";
 import {resolveConflict as applyConflictResolution} from "./mutations/resolveConflict";
 import {createDefaultPersisterFactory} from "./persisters/defaultPersisterFactory";
-import type {PersisterFactory} from "./persisters/types";
+import type {DefaultPersisterFactoryConfig, PersisterFactory} from "./persisters/types";
+import {SYNC_SCHEMA_VERSION} from "./storage/schema";
 import {createSyncStore, type SyncStore} from "./storage/store";
 import {wipeLocalData} from "./storage/wipe";
 import {bootstrapCollections} from "./sync/bootstrap";
@@ -31,6 +35,9 @@ export const DEFAULT_RECONCILE_INTERVAL_MS = 5 * 60_000;
 /** Minimum interval between seq-jump-triggered reconciles per stream (30s). */
 export const DEFAULT_SEQ_JUMP_RECONCILE_MIN_INTERVAL_MS = 30_000;
 
+/** E5: default local tombstone retention window (90 days), matching the server's (C7). */
+export const DEFAULT_TOMBSTONE_RETENTION_MS = 90 * 24 * 60 * 60 * 1_000;
+
 export interface SyncDbConfig {
   /** App/store name; used as the persisted database name. */
   name: string;
@@ -47,6 +54,14 @@ export interface SyncDbConfig {
   persisterFactory?: PersisterFactory;
   /** Encryption key provider forwarded to the default persister factory (web). */
   keyProvider?: KeyProvider;
+  /**
+   * Test-only IndexedDB read/write overrides forwarded to the default web
+   * persister factory (e.g. to simulate a read error or a quota-exceeded
+   * write in tests without a real broken IndexedDB). Ignored on native and
+   * ignored entirely when `persisterFactory` is overridden.
+   */
+  idbGetImpl?: DefaultPersisterFactoryConfig["idbGetImpl"];
+  idbSetImpl?: DefaultPersisterFactoryConfig["idbSetImpl"];
   /** Periodic reconcile interval in ms; 0 disables (default 5 minutes). */
   reconcileIntervalMs?: number;
   /** Rate limit for seq-jump-triggered reconciles per stream (default 30s). */
@@ -83,6 +98,25 @@ export interface SyncDbConfig {
    * handling modes").
    */
   haltQueueOnConflict?: boolean;
+  /**
+   * E3(b): invoked when persisted local data cannot be decrypted (web only —
+   * corrupt data, or a rotated/lost encryption key). DEFAULT BEHAVIOR when
+   * omitted: wipe all local data for the current user, re-stamp the schema
+   * version, and run a full snapshot re-bootstrap — always preceded by a
+   * `console.warn`. Pass this to override that default (e.g. to prompt the
+   * user before wiping); when provided, the client's own wipe/re-bootstrap is
+   * skipped and the host app is fully responsible for recovery.
+   */
+  onDecryptFailure?: () => void;
+  /**
+   * E5: client-side compaction — local tombstone rows (`deleted: true`) older
+   * than this window (from their `deletedAt` stamp) are deleted after each
+   * successful reconcile. Default 90 days, matching the server's own
+   * tombstone retention (C7); keep the two in sync — compacting locally
+   * before the server's retention window elapses risks a client permanently
+   * missing a delete it hasn't converged on yet. 0 disables compaction.
+   */
+  tombstoneRetentionMs?: number;
 }
 
 export interface MutateArgs {
@@ -193,7 +227,10 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
       ? createHttpChannel({authProvider: config.authProvider, baseUrl: config.baseUrl})
       : undefined);
 
-  const store = createSyncStore({collections: config.collections});
+  const store = createSyncStore({
+    collections: config.collections,
+    now: () => DateTime.fromMillis(now()).toISO() ?? new Date(now()).toISOString(),
+  });
   const outbox = createOutbox({store});
   const debugLog = resolveDebugLog(config.debug);
 
@@ -212,6 +249,39 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
   // refresh has already run for the CURRENT pause episode.
   let authPaused = false;
   let refreshAttempted = false;
+  // E1: lifecycle serialization. `generation` bumps on every start()/stop() so
+  // an in-flight operation that resumes after an await can detect it has been
+  // superseded (a rapid stop()-then-start() for a new user) and abort instead
+  // of mutating state (persister, currentUserId, listeners) that a LATER
+  // operation already owns. `lifecycle` is a promise-chain mutex: every call
+  // to start()/stop()/handleAuthChange()/runUserCheck() (the latter only ever
+  // invoked FROM start()/handleAuthChange(), never directly) is appended to it
+  // so at most one of these runs at a time, in call order — this is what
+  // prevents the interleaving the mutex exists to fix, not the generation
+  // check alone (the generation check only guards against a stale resume
+  // AFTER an await; the chain prevents two lifecycle ops from running
+  // concurrently in the first place).
+  let generation = 0;
+  let lifecycle: Promise<void> = Promise.resolve();
+  /** True once a start() has completed without a matching stop() (E1 double-start guard). */
+  let isStarted = false;
+
+  /**
+   * Queue `op` onto the lifecycle mutex; resolves/rejects with `op`'s own
+   * outcome once every previously-queued op has settled. `lifecycle` itself
+   * NEVER rejects (see below), so chaining with a plain `.then` is safe — a
+   * prior op's failure never wedges the mutex or blocks later queued calls.
+   */
+  const withLifecycle = <T>(op: () => Promise<T>): Promise<T> => {
+    const result = lifecycle.then(op);
+    // Keep the chain alive regardless of this op's outcome; `result` itself
+    // (returned below) carries the outcome to THIS call's caller.
+    lifecycle = result.then(
+      () => {},
+      () => {}
+    );
+    return result;
+  };
 
   const notifyStatusChange = (): void => {
     for (const listener of statusListeners) {
@@ -336,6 +406,24 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     });
     try {
       await bootstrapCollections({channel: httpChannel, collections: config.collections, store});
+      // E5: client-side compaction runs only after a successful reconcile —
+      // reconcile just proved the local store caught up with the server via
+      // a real network round trip, which is the signal that it is safe to
+      // age out old tombstones (never on a failed/incomplete reconcile).
+      const retentionMs = config.tombstoneRetentionMs ?? DEFAULT_TOMBSTONE_RETENTION_MS;
+      if (retentionMs > 0) {
+        // No explicit `now` override here — compactTombstones defaults to
+        // the same injected clock the store itself was created with above.
+        const {removed} = store.compactTombstones({olderThanMs: retentionMs});
+        if (removed > 0) {
+          debugLog?.record({
+            detail: {removed},
+            direction: "system",
+            label: `compacted ${removed} tombstone(s)`,
+            type: "reconcile",
+          });
+        }
+      }
     } catch (error) {
       if (error instanceof AuthRequiredError) {
         setAuthPaused(true);
@@ -415,7 +503,25 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     }
   };
 
+  /**
+   * E3(c): the web factory (`persisters/defaultPersisterFactory.web.ts`) falls
+   * back to the in-memory persister when `globalThis.indexedDB` is absent
+   * (private browsing / a locked-down embedded webview), emitting a one-time
+   * console.warn. That fallback is invisible to the caller unless it inspects
+   * the returned persister — surface it on the client's status instead so a
+   * host app can tell durable persistence apart from a session that silently
+   * never survives reload. Defaults to "durable"; a persister factory may
+   * report "memory" via `persister.persistenceMode` (see
+   * `defaultPersisterFactory.web.ts`), and a load failure (E3a) downgrades to
+   * "error" for the remainder of the session.
+   */
+  let persistenceMode: "durable" | "memory" | "error" = "durable";
+
   const createAndStartPersister = async (userId: string): Promise<void> => {
+    // Reset per-call: a fresh persister/load attempt starts optimistic even
+    // if a PRIOR persister instance (e.g. before a wipe-and-rebuild) had
+    // flagged a load failure.
+    persistenceMode = "durable";
     // Default key provider is SERVER-DERIVED (HKDF over GET /sync/key material) so the
     // server can rotate/revoke; pass keyProvider: createLocalKeyProvider() for a purely
     // device-local key with no server-side copy of the material.
@@ -427,16 +533,123 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
             fetchKeyMaterial: httpChannel.fetchKeyMaterial,
           })
         : undefined);
-    const factory = config.persisterFactory ?? createDefaultPersisterFactory({keyProvider, userId});
-    persister = factory({databaseName: config.name, store: store.raw});
+    // E3(b): decrypt/corrupt-data failures wipe + re-bootstrap by default
+    // (documented behavior) unless the host app overrides via
+    // `config.onDecryptFailure`. Either way it always warns.
+    const onDecryptFailure = (): void => {
+      console.warn(
+        `[syncdb] persisted data for "${config.name}" could not be decrypted; wiping and re-bootstrapping`
+      );
+      if (config.onDecryptFailure) {
+        config.onDecryptFailure();
+        return;
+      }
+      void wipeAndRebootstrap(userId).catch(warn("post-decrypt-failure wipe/rebootstrap failed"));
+    };
+    // E3(a): a read ERROR (not "no data") must never be treated as a fresh
+    // store — flag it so the caller skips autosave (which would otherwise
+    // overwrite the still-good persisted blob with an empty in-memory store).
+    const onLoadFailure = (): void => {
+      persistenceMode = "error";
+      console.warn(
+        `[syncdb] failed to read persisted data for "${config.name}"; leaving the stored snapshot untouched this session`
+      );
+      notifyStatusChange();
+    };
+    // E3(a): a save (write) failure — e.g. IndexedDB quota exceeded — is
+    // surfaced the same way: local writes are no longer reliably durable this
+    // session, so the host app should warn the user rather than silently
+    // losing data. Unlike a load failure this does NOT skip future save
+    // attempts (a transient quota issue may clear once the user frees space).
+    const onSaveFailure = (error: unknown): void => {
+      persistenceMode = "error";
+      console.warn(`[syncdb] failed to persist local data for "${config.name}"`, error);
+      notifyStatusChange();
+    };
+    const factory =
+      config.persisterFactory ??
+      createDefaultPersisterFactory({
+        idbGetImpl: config.idbGetImpl,
+        idbSetImpl: config.idbSetImpl,
+        keyProvider,
+        onDecryptFailure,
+        onLoadFailure,
+        onSaveFailure,
+        userId,
+      });
+    // `hooks` is always passed (even to a custom persisterFactory) so a host
+    // app supplying its own storage backend can still opt into E3 SyncStatus
+    // surfacing; the default factory already received the same callbacks
+    // above (at creation time) and ignores this second copy.
+    persister = factory({
+      databaseName: config.name,
+      hooks: {onDecryptFailure, onLoadFailure, onSaveFailure},
+      store: store.raw,
+    });
     await persister.startAutoLoad();
+    // Read through a function call: `onLoadFailure` (invoked synchronously
+    // from inside `startAutoLoad()`, not after it returns) mutates
+    // `persistenceMode` by closure, which TypeScript's control-flow narrowing
+    // cannot see across the awaited call above — without this indirection it
+    // would (wrongly) treat the "durable" assignment at the top of this
+    // function as still in effect here.
+    const getPersistenceMode = (): typeof persistenceMode => persistenceMode;
+    if (getPersistenceMode() === "error") {
+      // Do NOT startAutoSave(): the in-memory store is empty (load bailed out
+      // before touching it) and autosaving now would clobber the real blob.
+      return;
+    }
+    // E3(c): the web factory tags its returned persister with a
+    // `persistenceMode` marker when it fell back to in-memory (no
+    // globalThis.indexedDB) — surface that on SyncStatus.
+    const reportedMode = (persister as AnyPersister & {persistenceMode?: "durable" | "memory"})
+      .persistenceMode;
+    if (reportedMode === "memory") {
+      persistenceMode = "memory";
+      notifyStatusChange();
+    }
     await persister.startAutoSave();
+  };
+
+  /**
+   * Sanctioned wipe + fresh start for `userId`: clears every local table and
+   * the persisted databases (including cached encryption keys — E3f), stamps
+   * the current schema version and userId on the now-empty store, rebuilds
+   * the persister, and — when an HTTP channel is available — runs a full
+   * snapshot re-bootstrap so the app is immediately usable again rather than
+   * waiting for the next reconcile trigger. Shared by the E2 schema-mismatch
+   * path and the E3(b) decrypt-failure default handler; NOT used for the
+   * different-user wipe (that path's re-bootstrap comes from the caller's own
+   * subsequent reconcile()/replayOutbox() calls, matching pre-E2 behavior).
+   */
+  const wipeAndRebootstrap = async (userId: string): Promise<void> => {
+    coordinator.reset();
+    await wipeLocalData({
+      databaseNames: [config.name],
+      keyCacheDbNames: [DEFAULT_KEY_CACHE_DB_NAME],
+      persister,
+      store,
+    });
+    lastSeqJumpReconcileAt.clear();
+    persistenceMode = "durable";
+    await createAndStartPersister(userId);
+    store.raw.setValue("schemaVersion", SYNC_SCHEMA_VERSION);
+    store.setLastUserId({userId});
+    currentUserId = userId;
+    if (httpChannel) {
+      await bootstrapCollections({channel: httpChannel, collections: config.collections, store});
+    }
   };
 
   /**
    * Wipe-on-user-change: when the persisted `lastUserId` differs from the
    * authenticated user, destroy all local data (entities, outbox, cursors,
    * conflicts, persisted databases) and start fresh for the new user.
+   *
+   * E2: also checked here (after the persister's autoload has populated the
+   * store from disk) is the persisted schema version — a mismatch is a
+   * sanctioned wipe (schema migration, not an auth event) distinct from the
+   * user-change wipe above, so it runs regardless of whether the user changed.
    */
   const runUserCheck = async (userId: string): Promise<void> => {
     const lastUserId = store.getLastUserId();
@@ -447,10 +660,32 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
       // armed timers) leak into the new user's session — reset before the
       // new user's persister/outbox come online.
       coordinator.reset();
-      await wipeLocalData({databaseNames: [config.name], persister, store});
+      // E3(f): also clear the cached derived encryption key for the key-cache
+      // database — the same rationale as wiping local data: nothing from the
+      // previous user's session should linger once a different user has
+      // authenticated (the new user's persister derives/caches its own key
+      // fresh via createAndStartPersister below).
+      await wipeLocalData({
+        databaseNames: [config.name],
+        keyCacheDbNames: [DEFAULT_KEY_CACHE_DB_NAME],
+        persister,
+        store,
+      });
       lastSeqJumpReconcileAt.clear();
       await createAndStartPersister(userId);
     }
+    // E2: schema version check. `getSchemaVersion()` reads the persisted
+    // value with a same-as-current default (so a genuinely fresh store never
+    // trips this), meaning a real mismatch can only come from a persisted
+    // store written under an OLDER `SYNC_SCHEMA_VERSION`. Always stamp the
+    // current version afterward so a fresh store (and one just wiped above)
+    // is never mistaken for stale on the next start().
+    const persistedVersion = store.getSchemaVersion();
+    if (persistedVersion !== SYNC_SCHEMA_VERSION) {
+      await wipeAndRebootstrap(userId);
+      return;
+    }
+    store.raw.setValue("schemaVersion", SYNC_SCHEMA_VERSION);
     store.setLastUserId({userId});
     currentUserId = userId;
   };
@@ -512,9 +747,27 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     void replayOutbox().catch(warn("reconnect replay failed"));
   };
 
+  /**
+   * E1: `handleAuthChange` goes through the SAME lifecycle mutex as
+   * `start`/`stop` — it mutates the same shared state (`currentUserId`,
+   * `persister` via `runUserCheck`) that a concurrent stop()/start() would.
+   * Queuing it here means a rapid stop()-then-start() for a new user can
+   * never interleave with an in-flight auth-change handler from the OLD
+   * user's session; whichever queued first fully completes before the next
+   * runs. The generation check additionally covers the case where THIS
+   * handler itself is stale — e.g. it was queued behind a stop() while
+   * `getUserId()` resolves, and by the time it runs a fresh generation has
+   * already started up for a different user.
+   */
   const handleAuthChange = (): void => {
-    void (async (): Promise<void> => {
+    void withLifecycle(async (): Promise<void> => {
+      const myGeneration = generation;
       const userId = await config.authProvider.getUserId();
+      if (generation !== myGeneration) {
+        // Superseded by a stop()/start() while awaiting the auth provider —
+        // that operation now owns currentUserId/persister; do nothing.
+        return;
+      }
       if (!userId) {
         // Logged out: NEVER wipe (INV-2). Keep all local data, clear the
         // current-user pointer (mutate() requires start() again), and remain
@@ -535,10 +788,13 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
       // login after a logout (currentUserId undefined) — either way this is a
       // confirmed identity change, never inferred from a bare 401.
       await runUserCheck(userId);
+      if (generation !== myGeneration) {
+        return;
+      }
       setAuthPaused(false);
       void reconcile().catch(warn("post-auth reconcile failed"));
       void replayOutbox().catch(warn("post-auth replay failed"));
-    })().catch(warn("auth change handling failed"));
+    }).catch(warn("auth change handling failed"));
   };
 
   const startReconcileTimer = (): void => {
@@ -559,62 +815,112 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     }
   };
 
-  const start = async (): Promise<void> => {
-    const userId = await config.authProvider.getUserId();
-    if (!userId) {
-      throw new Error("createSyncDb.start() requires an authenticated user");
-    }
-    simulatedOffline = false;
-    setAuthPaused(false);
-    await createAndStartPersister(userId);
-    await runUserCheck(userId);
+  /**
+   * E1: lifecycle serialization. `start`/`stop` both queue through the same
+   * `lifecycle` mutex as `handleAuthChange`, so at most one of these ever
+   * runs at a time, in call order — the bug this fixes was a `stop()`
+   * re-reading the module-level `persister` after awaiting a debounced
+   * `save()`, by which point an interleaved `start()` for a new user had
+   * already replaced it, destroying the NEW user's persister instead of the
+   * old one. On top of mutual exclusion, every operation captures its own
+   * `myGeneration` and re-checks `generation === myGeneration` after each
+   * `await` — belt-and-suspenders against any future call site that manages
+   * to bypass the mutex (e.g. a direct call from a test), and cheap enough to
+   * always do.
+   */
+  const start = async (): Promise<void> =>
+    withLifecycle(async (): Promise<void> => {
+      if (isStarted) {
+        // E1: double-start() is a no-op rather than a second full
+        // initialization — calling start() again would double-register the
+        // transport/auth-change listeners and leak a second reconcile timer.
+        // A caller that wants a hard restart should stop() first.
+        return;
+      }
+      generation += 1;
+      const myGeneration = generation;
+      const userId = await config.authProvider.getUserId();
+      if (!userId) {
+        throw new Error("createSyncDb.start() requires an authenticated user");
+      }
+      if (generation !== myGeneration) {
+        // A stop() (or another start()) ran while awaiting the auth
+        // provider — that operation now owns the lifecycle; abandon this one
+        // rather than initializing state a newer generation doesn't expect.
+        return;
+      }
+      simulatedOffline = false;
+      setAuthPaused(false);
+      await createAndStartPersister(userId);
+      if (generation !== myGeneration) {
+        return;
+      }
+      await runUserCheck(userId);
+      if (generation !== myGeneration) {
+        return;
+      }
 
-    // A1: startup crash recovery, before the first replayOutbox() — repair
-    // any outbox rows stranded mid-lifecycle by a prior crash/reload (inFlight
-    // never resolved, acked-with-still-pending entity, conflicted with no
-    // conflict row written).
-    const recovery = outbox.recoverStartupState({userId});
-    debugLog?.record({
-      detail: {...recovery},
-      direction: "system",
-      label: `startup recovery (${recovery.recoveredInFlight.length} inFlight, ${recovery.releasedEntities.length} released, ${recovery.repairedConflicts.length} conflicts repaired)`,
-      type: "reconcile",
+      // A1: startup crash recovery, before the first replayOutbox() — repair
+      // any outbox rows stranded mid-lifecycle by a prior crash/reload (inFlight
+      // never resolved, acked-with-still-pending entity, conflicted with no
+      // conflict row written).
+      const recovery = outbox.recoverStartupState({userId});
+      debugLog?.record({
+        detail: {...recovery},
+        direction: "system",
+        label: `startup recovery (${recovery.recoveredInFlight.length} inFlight, ${recovery.releasedEntities.length} released, ${recovery.repairedConflicts.length} conflicts repaired)`,
+        type: "reconcile",
+      });
+
+      unsubscribers.push(transport.onDelta(handleDelta));
+      unsubscribers.push(transport.onStatusChange(handleStatusChange));
+      unsubscribers.push(config.authProvider.onAuthChange(handleAuthChange));
+
+      try {
+        await transport.connect();
+      } catch (error) {
+        // Local-first: start succeeds offline; reconnection/status events pick
+        // up syncing when connectivity returns.
+        warn("transport connect failed; starting offline")(error);
+      }
+      if (generation !== myGeneration) {
+        return;
+      }
+      transport.subscribe(config.collections);
+      startReconcileTimer();
+      isStarted = true;
+      void replayOutbox().catch(warn("startup replay failed"));
     });
 
-    unsubscribers.push(transport.onDelta(handleDelta));
-    unsubscribers.push(transport.onStatusChange(handleStatusChange));
-    unsubscribers.push(config.authProvider.onAuthChange(handleAuthChange));
-
-    try {
-      await transport.connect();
-    } catch (error) {
-      // Local-first: start succeeds offline; reconnection/status events pick
-      // up syncing when connectivity returns.
-      warn("transport connect failed; starting offline")(error);
-    }
-    transport.subscribe(config.collections);
-    startReconcileTimer();
-    void replayOutbox().catch(warn("startup replay failed"));
-  };
-
-  const stop = async (): Promise<void> => {
-    stopReconcileTimer();
-    simulatedOffline = false;
-    for (const unsubscribe of unsubscribers) {
-      unsubscribe();
-    }
-    unsubscribers = [];
-    transport.disconnect();
-    setConnected(false);
-    coordinator.dispose(currentUserId ? {userId: currentUserId} : undefined);
-    if (persister) {
-      // Flush any pending autosave so a clean stop never loses local writes.
-      await persister.save();
-      await persister.destroy();
+  const stop = async (): Promise<void> =>
+    withLifecycle(async (): Promise<void> => {
+      generation += 1;
+      isStarted = false;
+      stopReconcileTimer();
+      simulatedOffline = false;
+      for (const unsubscribe of unsubscribers) {
+        unsubscribe();
+      }
+      unsubscribers = [];
+      transport.disconnect();
+      setConnected(false);
+      coordinator.dispose(currentUserId ? {userId: currentUserId} : undefined);
+      // Capture the persister into a local BEFORE the awaits below: this is
+      // the exact fix for the original bug (a later start() calling
+      // createAndStartPersister() reassigns the module-level `persister`
+      // binding, so re-reading it after the await would destroy the NEW
+      // user's persister instead of this stop()'s). The mutex already
+      // prevents that interleaving, but capturing the local costs nothing and
+      // remains correct even if that invariant is ever relaxed.
+      const persisterToStop = persister;
       persister = undefined;
-    }
-    currentUserId = undefined;
-  };
+      currentUserId = undefined;
+      if (persisterToStop) {
+        // Flush any pending autosave so a clean stop never loses local writes.
+        await persisterToStop.save();
+        await persisterToStop.destroy();
+      }
+    });
 
   const goOffline = (): void => {
     if (simulatedOffline) {
@@ -756,6 +1062,7 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
       isOnline: connected,
       isSyncing: syncingCount > 0,
       ...(authPaused ? {paused: "auth" as const} : {}),
+      persistence: persistenceMode,
       queuedCount: currentUserId ? outbox.listQueued({userId: currentUserId}).length : 0,
       sentThisDrain: drainProgress.sentThisDrain,
       streams: getAllCursors({store}),

--- a/syncdb/src/client.ts
+++ b/syncdb/src/client.ts
@@ -7,8 +7,9 @@ import {resolveConflict as applyConflictResolution} from "./mutations/resolveCon
 import {createDefaultPersisterFactory} from "./persisters/defaultPersisterFactory";
 import type {PersisterFactory} from "./persisters/types";
 import {createSyncStore, type SyncStore} from "./storage/store";
+import {CURSORS_TABLE} from "./storage/types";
 import {wipeLocalData} from "./storage/wipe";
-import {bootstrapCollections} from "./sync/bootstrap";
+import {bootstrapStream} from "./sync/bootstrap";
 import {getAllCursors} from "./sync/cursor";
 import {applyDelta} from "./sync/deltaApplier";
 import {AuthRequiredError, createHttpChannel, type HttpChannel} from "./sync/httpChannel";
@@ -319,6 +320,72 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     store,
   });
 
+  /**
+   * C2: discover the streams the user currently belongs to (`GET /sync/streams`), then
+   * diff against the persisted `_knownStreams` set to detect joins and leaves.
+   *
+   * INV-2 (the whole ballgame): the leave-purge only runs when `fetchStreams` returned
+   * HTTP 200. A 401 (AuthRequiredError) or any transport error is NOT a membership
+   * change — it enters auth-pause (401) or is rethrown (transport) with every local
+   * entity, cursor, and known-stream entry left intact. Joins backfill from cursor 0;
+   * leaves purge that stream's local entities + cursor + known-stream entry.
+   *
+   * Returns the current membership set (stream → collection) on success so the caller
+   * can bootstrap each; returns `undefined` when auth-paused (no membership known).
+   */
+  const syncStreams = async (): Promise<Map<string, string> | undefined> => {
+    if (!httpChannel) {
+      // No HTTP channel: fall back to the configured collections' streams are unknown;
+      // bootstrap cannot run. Callers treat undefined as "skip stream sync".
+      return undefined;
+    }
+    let serverStreams: {stream: string; collection: string}[];
+    try {
+      serverStreams = await httpChannel.fetchStreams();
+    } catch (error) {
+      if (error instanceof AuthRequiredError) {
+        // INV-2: a 401 is NOT a leave. Pause; leave every stream/entity intact.
+        setAuthPaused(true);
+        return undefined;
+      }
+      // Transport error: also not a membership change — leave data intact, rethrow so
+      // the caller's catch handles retry/backoff.
+      throw error;
+    }
+
+    const serverSet = new Map<string, string>();
+    for (const {stream, collection} of serverStreams) {
+      serverSet.set(stream, collection);
+    }
+    const known = new Set(store.getKnownStreams());
+
+    // Leaves: known locally but absent from the (HTTP-200) server set → purge.
+    for (const stream of known) {
+      if (!serverSet.has(stream)) {
+        const purged = store.purgeStream({stream});
+        debugLog?.record({
+          detail: {purged, stream},
+          direction: "system",
+          label: `stream leave: purged ${stream} (${purged} entities)`,
+          type: "reconcile",
+        });
+      }
+    }
+    // Joins: in the server set but not yet known → mark known (cursor 0 bootstrap follows).
+    for (const [stream, collection] of serverSet) {
+      if (!known.has(stream)) {
+        store.addKnownStream({collection, stream});
+        debugLog?.record({
+          detail: {collection, stream},
+          direction: "system",
+          label: `stream join: ${stream}`,
+          type: "reconcile",
+        });
+      }
+    }
+    return serverSet;
+  };
+
   const reconcile = async (): Promise<void> => {
     // Simulated offline severs all network activity, including the HTTP
     // channel; an auth pause stands down every network trigger (INV-2) until
@@ -335,7 +402,14 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
       type: "reconcile",
     });
     try {
-      await bootstrapCollections({channel: httpChannel, collections: config.collections, store});
+      const streams = await syncStreams();
+      if (!streams) {
+        // Auth-paused during discovery (401) — stand down (INV-2).
+        return;
+      }
+      for (const [stream, collection] of streams) {
+        await bootstrapStream({channel: httpChannel, collection, store, stream});
+      }
     } catch (error) {
       if (error instanceof AuthRequiredError) {
         setAuthPaused(true);
@@ -349,6 +423,42 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
         durationMs: now() - startedAt,
         label: "reconcile end",
         phase: "end",
+        type: "reconcile",
+      });
+    }
+  };
+
+  /**
+   * C2 migration: deployed clients hold legacy `snapshot:{collection}` pseudo-cursors.
+   * On start, delete all of them and clear `_knownStreams` so the normal discovery path
+   * re-bootstraps every stream from cursor 0. Idempotent upserts + seq guards make
+   * re-bootstrap cheap and non-destructive (existing entities keep their data). Runs once.
+   *
+   * NOTE (Phase E merge): Phase E is adding the schema-version wipe machinery in the main
+   * worktree. Ideally this migration gates behind that version bump so it runs exactly
+   * once. That hook does not exist in this worktree, so this implements the minimal
+   * standalone cursor-migration path — it is self-idempotent (after the first run there
+   * are no `snapshot:` keys left, so subsequent runs are no-ops). When merging, this can
+   * be moved behind the E2 version bump.
+   */
+  const migrateLegacySnapshotCursors = (): void => {
+    const cursorRows = store.raw.getTable(CURSORS_TABLE);
+    let migrated = 0;
+    for (const key of Object.keys(cursorRows)) {
+      if (key.startsWith("snapshot:")) {
+        store.raw.delRow(CURSORS_TABLE, key);
+        migrated += 1;
+      }
+    }
+    if (migrated > 0) {
+      // Clear the known-streams set so discovery re-bootstraps every stream from 0.
+      for (const stream of store.getKnownStreams()) {
+        store.removeKnownStream({stream});
+      }
+      debugLog?.record({
+        detail: {migrated},
+        direction: "system",
+        label: `migrated ${migrated} legacy snapshot cursors`,
         type: "reconcile",
       });
     }
@@ -569,6 +679,10 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     await createAndStartPersister(userId);
     await runUserCheck(userId);
 
+    // C2: migrate any legacy snapshot:{collection} cursors before the first discovery so
+    // the per-stream bootstrap path starts from a clean cursor set.
+    migrateLegacySnapshotCursors();
+
     // A1: startup crash recovery, before the first replayOutbox() — repair
     // any outbox rows stranded mid-lifecycle by a prior crash/reload (inFlight
     // never resolved, acked-with-still-pending entity, conflicted with no
@@ -593,6 +707,10 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
       warn("transport connect failed; starting offline")(error);
     }
     transport.subscribe(config.collections);
+    // C2: run an initial stream discovery + per-stream bootstrap on start (not only via
+    // the reconnect status event) so a client that starts offline-then-online, or with a
+    // warm socket, still backfills newly-joined streams and drains legacy cursors.
+    void reconcile().catch(warn("startup reconcile failed"));
     startReconcileTimer();
     void replayOutbox().catch(warn("startup replay failed"));
   };

--- a/syncdb/src/client.ts
+++ b/syncdb/src/client.ts
@@ -11,7 +11,7 @@ import {wipeLocalData} from "./storage/wipe";
 import {bootstrapCollections} from "./sync/bootstrap";
 import {getAllCursors} from "./sync/cursor";
 import {applyDelta} from "./sync/deltaApplier";
-import {createHttpChannel, type HttpChannel} from "./sync/httpChannel";
+import {AuthRequiredError, createHttpChannel, type HttpChannel} from "./sync/httpChannel";
 import {createReplayCoordinator, type ReplayCoordinator} from "./sync/replayCoordinator";
 import {createSocketTransport} from "./sync/socketTransport";
 import type {SendMutationResult, SyncTransport} from "./sync/transport";
@@ -52,6 +52,8 @@ export interface SyncDbConfig {
   seqJumpReconcileMinIntervalMs?: number;
   /** Millisecond clock, injectable for deterministic rate-limit tests. */
   now?: () => number;
+  /** Random source in [0, 1), injectable for deterministic backoff-jitter tests. */
+  random?: () => number;
   /**
    * Enable the in-memory debug event log (patches, mutations, acks/nacks,
    * conflicts, reconcile/replay, connectivity). `true` uses defaults; pass
@@ -59,6 +61,19 @@ export interface SyncDbConfig {
    * Powers the sync debugger UI and the future MCP introspection surface.
    */
   debug?: boolean | SyncDebugLogOptions;
+  /**
+   * Fired at most once per auth-pause episode when the client enters
+   * `paused: "auth"` (INV-2), so the host app can show a re-login prompt.
+   * Clears and can fire again after a subsequent pause episode.
+   */
+  onAuthRequired?: () => void;
+  /**
+   * When true, `client.signOut()` wipes local data for the current user (in
+   * addition to clearing auth state). Local data is otherwise NEVER wiped on
+   * logout or 401 (INV-2) — only on a confirmed different-user login, or via
+   * this explicit, host-app-initiated opt-in.
+   */
+  wipeOnSignOut?: boolean;
 }
 
 export interface MutateArgs {
@@ -110,6 +125,13 @@ export interface SyncDb {
   replayOutbox: () => Promise<void>;
   /** Resolve a recorded conflict with the given strategy. */
   resolveConflict: (args: {mutationId: string; strategy: ConflictResolutionStrategy}) => void;
+  /**
+   * Explicit, host-app-initiated sign-out. Always clears the in-memory
+   * current-user pointer; wipes local data ONLY when `wipeOnSignOut` is
+   * configured (INV-2 — a bare 401/logout event never triggers this on its
+   * own). Safe to call whether or not the client is currently paused.
+   */
+  signOut: () => Promise<void>;
   /** Aggregate sync state for status UI. */
   getSyncStatus: () => SyncStatus;
   /**
@@ -168,6 +190,12 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
   let unsubscribers: (() => void)[] = [];
   const lastSeqJumpReconcileAt = new Map<string, number>();
   const statusListeners = new Set<() => void>();
+  // A4: auth-pause state. `authPaused` gates reconcile/replay/timer triggers
+  // (INV-2 — nothing else may unpause except a same-user auth change).
+  // `refreshAttempted` tracks whether the auth adapter's one-shot silent
+  // refresh has already run for the CURRENT pause episode.
+  let authPaused = false;
+  let refreshAttempted = false;
 
   const notifyStatusChange = (): void => {
     for (const listener of statusListeners) {
@@ -204,17 +232,57 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     return httpChannel.sendMutation(request);
   };
 
+  const setAuthPaused = (value: boolean): void => {
+    if (authPaused === value) {
+      return;
+    }
+    authPaused = value;
+    if (value) {
+      refreshAttempted = false;
+      config.onAuthRequired?.();
+    } else {
+      refreshAttempted = false;
+    }
+    notifyStatusChange();
+  };
+
+  const warn = (message: string): ((error: unknown) => void) => {
+    return (error: unknown): void => {
+      console.warn(`[syncdb] ${message}`, error);
+    };
+  };
+
   const coordinator: ReplayCoordinator = createReplayCoordinator({
     debug: debugLog,
     now,
+    onAuthPause: () => {
+      setAuthPaused(true);
+      // Fire from the coordinator hook (not a replayOutbox() return-value
+      // check): drain-until-empty's internal recheck/wake-timer continuations
+      // can be the call that actually observes the auth failure, orphaned
+      // from whichever replayOutbox() wrapper kicked off the original drain.
+      // The hook fires exactly once per new pause episode regardless of which
+      // internal call triggered it.
+      void attemptAuthRecovery();
+    },
+    onDrainPass: ({userId}) => {
+      outbox.prune({userId});
+    },
     outbox,
+    random: config.random,
     sendMutation,
+    // Internally-scheduled drains (armed wake-up timers, the mid-drain-enqueue
+    // recheck) must respect the same gating as an external replayOutbox()
+    // call: never send while simulated-offline or auth-paused.
+    shouldDrain: () => !simulatedOffline && !authPaused,
     store,
   });
 
   const reconcile = async (): Promise<void> => {
-    // Simulated offline severs all network activity, including the HTTP channel.
-    if (!httpChannel || simulatedOffline) {
+    // Simulated offline severs all network activity, including the HTTP
+    // channel; an auth pause stands down every network trigger (INV-2) until
+    // the same user re-authenticates.
+    if (!httpChannel || simulatedOffline || authPaused) {
       return;
     }
     addSyncing(1);
@@ -227,6 +295,12 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     });
     try {
       await bootstrapCollections({channel: httpChannel, collections: config.collections, store});
+    } catch (error) {
+      if (error instanceof AuthRequiredError) {
+        setAuthPaused(true);
+        return;
+      }
+      throw error;
     } finally {
       addSyncing(-1);
       debugLog?.record({
@@ -240,22 +314,32 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
   };
 
   const replayOutbox = async (): Promise<void> => {
-    // While simulated-offline, mutations stay queued in the durable outbox
-    // (replay would otherwise fall back to the HTTP channel and succeed).
-    if (!currentUserId || simulatedOffline) {
+    // While simulated-offline or auth-paused, mutations stay queued in the
+    // durable outbox (INV-2: an auth pause stands down replay until the same
+    // user re-authenticates).
+    if (!currentUserId || simulatedOffline || authPaused) {
       return;
     }
     addSyncing(1);
     const startedAt = now();
-    const queued = outbox.listQueued({userId: currentUserId}).length;
-    debugLog?.record({
-      detail: {queued},
-      direction: "system",
-      label: `replay start (${queued} queued)`,
-      phase: "start",
-      type: "replay",
-    });
+    // A3: this listQueued scan exists purely to label a debug event — never
+    // pay for it when debug logging is disabled (the common case).
+    if (debugLog) {
+      const queued = outbox.listQueued({userId: currentUserId}).length;
+      debugLog.record({
+        detail: {queued},
+        direction: "system",
+        label: `replay start (${queued} queued)`,
+        phase: "start",
+        type: "replay",
+      });
+    }
     try {
+      // Auth-pause recovery (the one-shot silent refresh) is wired through
+      // the coordinator's onAuthPause hook, not this return value — it fires
+      // reliably regardless of which internal call (this one, the wake
+      // timer, or the mid-drain recheck) is the one that actually observes
+      // the auth failure.
       await coordinator.replay({userId: currentUserId});
     } finally {
       addSyncing(-1);
@@ -269,10 +353,25 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     }
   };
 
-  const warn = (message: string): ((error: unknown) => void) => {
-    return (error: unknown): void => {
-      console.warn(`[syncdb] ${message}`, error);
-    };
+  /**
+   * Give the auth adapter one chance to silently refresh before the pause is
+   * fully surfaced to the app (A4 step 5). Runs at most once per pause
+   * episode; a successful refresh immediately retries replay.
+   */
+  const attemptAuthRecovery = async (): Promise<void> => {
+    if (refreshAttempted || !config.authProvider.refresh) {
+      return;
+    }
+    refreshAttempted = true;
+    try {
+      const refreshed = await config.authProvider.refresh();
+      if (refreshed && authPaused) {
+        setAuthPaused(false);
+        void replayOutbox().catch(warn("post-refresh replay failed"));
+      }
+    } catch (error) {
+      warn("auth refresh attempt failed")(error);
+    }
   };
 
   const createAndStartPersister = async (userId: string): Promise<void> => {
@@ -350,13 +449,27 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     void (async (): Promise<void> => {
       const userId = await config.authProvider.getUserId();
       if (!userId) {
+        // Logged out: NEVER wipe (INV-2). Keep all local data, clear the
+        // current-user pointer (mutate() requires start() again), and remain
+        // paused — reconcile/replay stand down until the same user (or a
+        // different one, via the wipe path below) re-authenticates.
         currentUserId = undefined;
+        setAuthPaused(true);
         return;
       }
-      if (userId !== currentUserId) {
-        await runUserCheck(userId);
-        void reconcile().catch(warn("post-auth reconcile failed"));
+      if (userId === currentUserId) {
+        // Same-user re-auth: the pause (if any) clears fully and replay
+        // resumes with the outbox completely intact.
+        setAuthPaused(false);
+        void replayOutbox().catch(warn("post-auth replay failed"));
+        return;
       }
+      // Different userId: existing wipe-on-user-change behavior, or a first
+      // login after a logout (currentUserId undefined) — either way this is a
+      // confirmed identity change, never inferred from a bare 401.
+      await runUserCheck(userId);
+      setAuthPaused(false);
+      void reconcile().catch(warn("post-auth reconcile failed"));
       void replayOutbox().catch(warn("post-auth replay failed"));
     })().catch(warn("auth change handling failed"));
   };
@@ -385,8 +498,21 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
       throw new Error("createSyncDb.start() requires an authenticated user");
     }
     simulatedOffline = false;
+    setAuthPaused(false);
     await createAndStartPersister(userId);
     await runUserCheck(userId);
+
+    // A1: startup crash recovery, before the first replayOutbox() — repair
+    // any outbox rows stranded mid-lifecycle by a prior crash/reload (inFlight
+    // never resolved, acked-with-still-pending entity, conflicted with no
+    // conflict row written).
+    const recovery = outbox.recoverStartupState({userId});
+    debugLog?.record({
+      detail: {...recovery},
+      direction: "system",
+      label: `startup recovery (${recovery.recoveredInFlight.length} inFlight, ${recovery.releasedEntities.length} released, ${recovery.repairedConflicts.length} conflicts repaired)`,
+      type: "reconcile",
+    });
 
     unsubscribers.push(transport.onDelta(handleDelta));
     unsubscribers.push(transport.onStatusChange(handleStatusChange));
@@ -401,6 +527,7 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     }
     transport.subscribe(config.collections);
     startReconcileTimer();
+    void replayOutbox().catch(warn("startup replay failed"));
   };
 
   const stop = async (): Promise<void> => {
@@ -412,6 +539,7 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     unsubscribers = [];
     transport.disconnect();
     setConnected(false);
+    coordinator.dispose(currentUserId ? {userId: currentUserId} : undefined);
     if (persister) {
       // Flush any pending autosave so a clean stop never loses local writes.
       await persister.save();
@@ -536,8 +664,12 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
 
   const getSyncStatus = (): SyncStatus => ({
     conflictCount: listConflicts({store}).length,
+    failedCount: currentUserId
+      ? outbox.countByStatus({status: "failed", userId: currentUserId})
+      : 0,
     isOnline: connected,
     isSyncing: syncingCount > 0,
+    ...(authPaused ? {paused: "auth" as const} : {}),
     queuedCount: currentUserId ? outbox.listQueued({userId: currentUserId}).length : 0,
     streams: getAllCursors({store}),
   });
@@ -547,6 +679,17 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     return () => {
       statusListeners.delete(callback);
     };
+  };
+
+  const signOut = async (): Promise<void> => {
+    const userId = currentUserId;
+    setAuthPaused(false);
+    currentUserId = undefined;
+    if (userId && config.wipeOnSignOut) {
+      coordinator.dispose({userId});
+      await wipeLocalData({databaseNames: [config.name], persister, store});
+      lastSeqJumpReconcileAt.clear();
+    }
   };
 
   return {
@@ -560,6 +703,7 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     reconcile,
     replayOutbox,
     resolveConflict,
+    signOut,
     start,
     stop,
     store,

--- a/syncdb/src/client.ts
+++ b/syncdb/src/client.ts
@@ -477,9 +477,24 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     void reconcile().catch(warn("seq-jump reconcile failed"));
   };
 
-  const handleStatusChange = ({connected: isConnected}: {connected: boolean}): void => {
+  const handleStatusChange = ({
+    connected: isConnected,
+    authExpired,
+  }: {
+    connected: boolean;
+    authExpired?: boolean;
+  }): void => {
     setConnected(isConnected);
     if (!isConnected) {
+      // D1: the server's session re-validation sweep disconnected this socket
+      // (sync:auth-expired). Map straight into the existing A4 auth-pause path —
+      // INV-2: no wipe, outbox untouched, zero retry budget consumed. The
+      // reconnect attempt Socket.io makes on its own will keep failing the
+      // handshake with the same expired/invalid credentials until the host app
+      // re-authenticates (handleAuthChange clears the pause on same-user re-auth).
+      if (authExpired) {
+        setAuthPaused(true);
+      }
       return;
     }
     // B3: re-probe batch support on every reconnect — a previous

--- a/syncdb/src/client.ts
+++ b/syncdb/src/client.ts
@@ -11,8 +11,9 @@ import {createDefaultPersisterFactory} from "./persisters/defaultPersisterFactor
 import type {DefaultPersisterFactoryConfig, PersisterFactory} from "./persisters/types";
 import {SYNC_SCHEMA_VERSION} from "./storage/schema";
 import {createSyncStore, type SyncStore} from "./storage/store";
+import {CURSORS_TABLE} from "./storage/types";
 import {wipeLocalData} from "./storage/wipe";
-import {bootstrapCollections} from "./sync/bootstrap";
+import {bootstrapStream} from "./sync/bootstrap";
 import {getAllCursors} from "./sync/cursor";
 import {applyDelta} from "./sync/deltaApplier";
 import {AuthRequiredError, createHttpChannel, type HttpChannel} from "./sync/httpChannel";
@@ -389,6 +390,87 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     store,
   });
 
+  /**
+   * C2: discover the streams the user currently belongs to (`GET /sync/streams`), then
+   * diff against the persisted `_knownStreams` set to detect joins and leaves.
+   *
+   * INV-2 (the whole ballgame): the leave-purge only runs when `fetchStreams` returned
+   * HTTP 200. A 401 (AuthRequiredError) or any transport error is NOT a membership
+   * change — it enters auth-pause (401) or is rethrown (transport) with every local
+   * entity, cursor, and known-stream entry left intact. Joins backfill from cursor 0;
+   * leaves purge that stream's local entities + cursor + known-stream entry.
+   *
+   * Returns the current membership set (stream → collection) on success so the caller
+   * can bootstrap each; returns `undefined` when auth-paused (no membership known).
+   */
+  const syncStreams = async ({
+    isSuperseded,
+  }: {
+    /**
+     * Optional lifecycle guard checked AFTER the network fetch resolves but BEFORE any
+     * store mutation. A fired-and-forgotten reconcile's `fetchStreams()` await can straddle
+     * a stop()/start() or different-user wipe; without this, the post-await store reads and
+     * purges/joins below run against the swapped-in store and can resurrect wiped rows via
+     * TinyBase's mergeable-schema re-materialization. Returns undefined when superseded.
+     */
+    isSuperseded?: () => boolean;
+  } = {}): Promise<Map<string, string> | undefined> => {
+    if (!httpChannel) {
+      // No HTTP channel: fall back to the configured collections' streams are unknown;
+      // bootstrap cannot run. Callers treat undefined as "skip stream sync".
+      return undefined;
+    }
+    let serverStreams: {stream: string; collection: string}[];
+    try {
+      serverStreams = await httpChannel.fetchStreams();
+    } catch (error) {
+      if (error instanceof AuthRequiredError) {
+        // INV-2: a 401 is NOT a leave. Pause; leave every stream/entity intact.
+        setAuthPaused(true);
+        return undefined;
+      }
+      // Transport error: also not a membership change — leave data intact, rethrow so
+      // the caller's catch handles retry/backoff.
+      throw error;
+    }
+    if (isSuperseded?.()) {
+      // A newer lifecycle/user took over during the fetch — do not touch the store.
+      return undefined;
+    }
+
+    const serverSet = new Map<string, string>();
+    for (const {stream, collection} of serverStreams) {
+      serverSet.set(stream, collection);
+    }
+    const known = new Set(store.getKnownStreams());
+
+    // Leaves: known locally but absent from the (HTTP-200) server set → purge.
+    for (const stream of known) {
+      if (!serverSet.has(stream)) {
+        const purged = store.purgeStream({stream});
+        debugLog?.record({
+          detail: {purged, stream},
+          direction: "system",
+          label: `stream leave: purged ${stream} (${purged} entities)`,
+          type: "reconcile",
+        });
+      }
+    }
+    // Joins: in the server set but not yet known → mark known (cursor 0 bootstrap follows).
+    for (const [stream, collection] of serverSet) {
+      if (!known.has(stream)) {
+        store.addKnownStream({collection, stream});
+        debugLog?.record({
+          detail: {collection, stream},
+          direction: "system",
+          label: `stream join: ${stream}`,
+          type: "reconcile",
+        });
+      }
+    }
+    return serverSet;
+  };
+
   const reconcile = async (): Promise<void> => {
     // Simulated offline severs all network activity, including the HTTP
     // channel; an auth pause stands down every network trigger (INV-2) until
@@ -396,6 +478,16 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     if (!httpChannel || simulatedOffline || authPaused) {
       return;
     }
+    // E1 + C2: reconcile is fired-and-forgotten (startup, reconnect, periodic,
+    // post-auth) and its network awaits below can straddle a stop()/start() (bumps
+    // `generation`) or a different-user switch (changes `currentUserId` + swaps the
+    // persister, via runUserCheck). Capture both at entry and re-check after every await
+    // so a stale reconcile never writes discovered streams or snapshot pages into a store
+    // that now belongs to a different lifecycle or user — the resurrection bug where an
+    // in-flight reconcile for the previous user re-materialized purged rows after a wipe.
+    const myGeneration = generation;
+    const myUserId = currentUserId;
+    const isSuperseded = (): boolean => generation !== myGeneration || currentUserId !== myUserId;
     addSyncing(1);
     const startedAt = now();
     debugLog?.record({
@@ -405,15 +497,26 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
       type: "reconcile",
     });
     try {
-      await bootstrapCollections({channel: httpChannel, collections: config.collections, store});
-      // E5: client-side compaction runs only after a successful reconcile —
-      // reconcile just proved the local store caught up with the server via
-      // a real network round trip, which is the signal that it is safe to
-      // age out old tombstones (never on a failed/incomplete reconcile).
+      const streams = await syncStreams({isSuperseded});
+      if (!streams || isSuperseded()) {
+        // Auth-paused during discovery (401 → INV-2), or superseded by a newer
+        // lifecycle/user while awaiting discovery.
+        return;
+      }
+      for (const [stream, collection] of streams) {
+        await bootstrapStream({channel: httpChannel, collection, store, stream});
+        if (isSuperseded()) {
+          return;
+        }
+      }
+      // E5: client-side compaction runs only after a successful per-stream reconcile —
+      // reconcile just proved the local store caught up with the server via real network
+      // round trips (discovery + each stream), which is the signal that it is safe to age
+      // out old tombstones (never on a failed/incomplete reconcile).
       const retentionMs = config.tombstoneRetentionMs ?? DEFAULT_TOMBSTONE_RETENTION_MS;
       if (retentionMs > 0) {
-        // No explicit `now` override here — compactTombstones defaults to
-        // the same injected clock the store itself was created with above.
+        // No explicit `now` override here — compactTombstones defaults to the same
+        // injected clock the store itself was created with above.
         const {removed} = store.compactTombstones({olderThanMs: retentionMs});
         if (removed > 0) {
           debugLog?.record({
@@ -437,6 +540,42 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
         durationMs: now() - startedAt,
         label: "reconcile end",
         phase: "end",
+        type: "reconcile",
+      });
+    }
+  };
+
+  /**
+   * C2 migration: deployed clients hold legacy `snapshot:{collection}` pseudo-cursors.
+   * On start, delete all of them and clear `_knownStreams` so the normal discovery path
+   * re-bootstraps every stream from cursor 0. Idempotent upserts + seq guards make
+   * re-bootstrap cheap and non-destructive (existing entities keep their data). Runs once.
+   *
+   * NOTE (Phase E merge): Phase E is adding the schema-version wipe machinery in the main
+   * worktree. Ideally this migration gates behind that version bump so it runs exactly
+   * once. That hook does not exist in this worktree, so this implements the minimal
+   * standalone cursor-migration path — it is self-idempotent (after the first run there
+   * are no `snapshot:` keys left, so subsequent runs are no-ops). When merging, this can
+   * be moved behind the E2 version bump.
+   */
+  const migrateLegacySnapshotCursors = (): void => {
+    const cursorRows = store.raw.getTable(CURSORS_TABLE);
+    let migrated = 0;
+    for (const key of Object.keys(cursorRows)) {
+      if (key.startsWith("snapshot:")) {
+        store.raw.delRow(CURSORS_TABLE, key);
+        migrated += 1;
+      }
+    }
+    if (migrated > 0) {
+      // Clear the known-streams set so discovery re-bootstraps every stream from 0.
+      for (const stream of store.getKnownStreams()) {
+        store.removeKnownStream({stream});
+      }
+      debugLog?.record({
+        detail: {migrated},
+        direction: "system",
+        label: `migrated ${migrated} legacy snapshot cursors`,
         type: "reconcile",
       });
     }
@@ -637,7 +776,15 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
     store.setLastUserId({userId});
     currentUserId = userId;
     if (httpChannel) {
-      await bootstrapCollections({channel: httpChannel, collections: config.collections, store});
+      // C2: after a wipe the known-streams set is empty, so discover the user's current
+      // stream membership and bootstrap each from cursor 0. syncStreams() handles the
+      // INV-2 auth-pause case (returns undefined on a 401) — skip bootstrap then.
+      const streams = await syncStreams();
+      if (streams) {
+        for (const [stream, collection] of streams) {
+          await bootstrapStream({channel: httpChannel, collection, store, stream});
+        }
+      }
     }
   };
 
@@ -860,6 +1007,15 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
         return;
       }
 
+      // C2: migrate any legacy snapshot:{collection} cursors before the first discovery
+      // so the per-stream bootstrap path starts from a clean cursor set. This is a cheap,
+      // idempotent fast-path — Phase E's schema-version wipe (runUserCheck ->
+      // wipeAndRebootstrap) already re-bootstraps any store still on v1, so in practice no
+      // v2 store carries legacy `snapshot:` cursors. Kept because it costs one table scan
+      // and lets a v2-with-legacy-cursors store (which should not exist) recover without a
+      // full wipe; after the first run there are no `snapshot:` keys left, so it no-ops.
+      migrateLegacySnapshotCursors();
+
       // A1: startup crash recovery, before the first replayOutbox() — repair
       // any outbox rows stranded mid-lifecycle by a prior crash/reload (inFlight
       // never resolved, acked-with-still-pending entity, conflicted with no
@@ -887,6 +1043,10 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
         return;
       }
       transport.subscribe(config.collections);
+      // C2: run an initial stream discovery + per-stream bootstrap on start (not only via
+      // the reconnect status event) so a client that starts offline-then-online, or with a
+      // warm socket, still backfills newly-joined streams and drains legacy cursors.
+      void reconcile().catch(warn("startup reconcile failed"));
       startReconcileTimer();
       isStarted = true;
       void replayOutbox().catch(warn("startup replay failed"));

--- a/syncdb/src/client.ts
+++ b/syncdb/src/client.ts
@@ -441,6 +441,12 @@ export const createSyncDb = (config: SyncDbConfig): SyncDb => {
   const runUserCheck = async (userId: string): Promise<void> => {
     const lastUserId = store.getLastUserId();
     if (lastUserId !== undefined && lastUserId !== userId) {
+      // FIX 3: a different-user login must not let the PREVIOUS user's
+      // in-memory coordinator state (validationBlockedEntities keyed
+      // user-scoped, retry/backoff bookkeeping, the batch-capability latch,
+      // armed timers) leak into the new user's session — reset before the
+      // new user's persister/outbox come online.
+      coordinator.reset();
       await wipeLocalData({databaseNames: [config.name], persister, store});
       lastSeqJumpReconcileAt.clear();
       await createAndStartPersister(userId);

--- a/syncdb/src/debug/debugLog.test.ts
+++ b/syncdb/src/debug/debugLog.test.ts
@@ -55,8 +55,62 @@ describe("createSyncDebugLog", () => {
     log.clear();
     expect(log.getRevision()).toBe(2);
     expect(log.getEvents()).toHaveLength(0);
-    // total is a lifetime counter and survives clear.
-    expect(log.getStats().total).toBe(1);
+    // E6: clear() resets every derived stat coherently — total (and
+    // everything else getStats() reports) describes only what happened
+    // since the last clear, not a lifetime count that would otherwise be
+    // inconsistent with retained: 0.
+    expect(log.getStats().total).toBe(0);
+  });
+
+  it("clear() resets total/dropped/byType/firstEventAt/lastEventAt, not just retained (E6)", () => {
+    const log = createSyncDebugLog({capacity: 2});
+    log.record({direction: "local", label: "a", type: "mutate"});
+    log.record({direction: "inbound", label: "b", type: "delta"});
+    // Overflow past capacity to also populate `dropped`.
+    log.record({direction: "inbound", label: "c", type: "ack"});
+
+    const beforeClear = log.getStats();
+    expect(beforeClear.total).toBe(3);
+    expect(beforeClear.dropped).toBe(1);
+    expect(beforeClear.byType.mutate).toBe(1);
+    expect(beforeClear.firstEventAt).toBeDefined();
+    expect(beforeClear.lastEventAt).toBeDefined();
+
+    log.clear();
+    const afterClear = log.getStats();
+    expect(afterClear).toEqual({
+      byType: {
+        ack: 0,
+        conflict: 0,
+        connect: 0,
+        delta: 0,
+        disconnect: 0,
+        failed: 0,
+        mutate: 0,
+        nack: 0,
+        reconcile: 0,
+        replay: 0,
+        resolve: 0,
+        retry: 0,
+        send: 0,
+      },
+      dropped: 0,
+      firstEventAt: undefined,
+      lastEventAt: undefined,
+      retained: 0,
+      total: 0,
+    });
+
+    // A fresh record after clear reports as if the log were brand new, and
+    // ids stay monotonic (not reset) across the clear.
+    const next = log.record({direction: "local", label: "d", type: "mutate"});
+    expect(next.id).toBe(4);
+    expect(log.getStats()).toMatchObject({
+      byType: {mutate: 1},
+      dropped: 0,
+      retained: 1,
+      total: 1,
+    });
   });
 
   it("snapshot returns a serializable events + stats view", () => {

--- a/syncdb/src/debug/debugLog.ts
+++ b/syncdb/src/debug/debugLog.ts
@@ -108,7 +108,15 @@ export interface SyncDebugLog {
   getStats: () => SyncDebugStats;
   /** Serializable snapshot (events + stats) — safe to return over MCP. */
   snapshot: () => SyncDebugSnapshot;
-  /** Drop all retained events (stats.total is preserved as a lifetime counter). */
+  /**
+   * Drop all retained events AND reset every derived stat (`total`,
+   * `dropped`, `byType`, `firstEventAt`, `lastEventAt`) to match the
+   * now-empty buffer — `getStats()` immediately after `clear()` always
+   * describes exactly what the log currently holds (nothing), never a
+   * lifetime total left over from before the clear. The event id sequence
+   * (`nextId`) is the only thing that survives a clear, so ids stay
+   * monotonic across it.
+   */
   clear: () => void;
 }
 
@@ -224,6 +232,20 @@ export const createSyncDebugLog = (options: SyncDebugLogOptions = {}): SyncDebug
     buffer.fill(undefined);
     writeIndex = 0;
     retained = 0;
+    // E6: reset every derived stat to match the now-empty buffer, not just
+    // `retained` — leaving `total`/`dropped`/`byType`/`firstEventAt`/
+    // `lastEventAt` at their pre-clear values produced an incoherent
+    // snapshot (e.g. `retained: 0` alongside `byType.mutate: 5` and a
+    // `total` that no longer describes anything the log still holds).
+    // `nextId` is NOT reset: ids stay monotonic across a clear so a listener
+    // that cached an event by id never collides with a later one.
+    total = 0;
+    dropped = 0;
+    for (const type of Object.keys(byType) as SyncDebugEventType[]) {
+      byType[type] = 0;
+    }
+    firstEventAt = undefined;
+    lastEventAt = undefined;
     revision++;
   };
 

--- a/syncdb/src/mutations/outbox.test.ts
+++ b/syncdb/src/mutations/outbox.test.ts
@@ -532,6 +532,56 @@ describe("prune (A5)", () => {
   });
 });
 
+describe("hasAnyRowForEntity (FIX 4)", () => {
+  it("returns true for a queued row matching user/collection/entity", () => {
+    const outbox = makeOutbox();
+    enqueueDefault(outbox, {entityId: "e1", mutationId: "m1", userId: "user-1"});
+    expect(outbox.hasAnyRowForEntity({collection: "todos", entityId: "e1", userId: "user-1"})).toBe(
+      true
+    );
+  });
+
+  it("returns true for a failed (not yet pruned) row", () => {
+    const outbox = makeOutbox();
+    enqueueDefault(outbox, {entityId: "e1", mutationId: "m1", userId: "user-1"});
+    outbox.markInFlight({mutationId: "m1"});
+    outbox.markFailed({mutationId: "m1"});
+    expect(outbox.hasAnyRowForEntity({collection: "todos", entityId: "e1", userId: "user-1"})).toBe(
+      true
+    );
+  });
+
+  it("returns false once the only row for the entity is pruned", () => {
+    const outbox = makeOutbox();
+    enqueueDefault(outbox, {entityId: "e1", mutationId: "m1", userId: "user-1"});
+    outbox.markInFlight({mutationId: "m1"});
+    outbox.markFailed({mutationId: "m1"});
+    outbox.prune({keepFailed: 0, userId: "user-1"});
+    expect(outbox.hasAnyRowForEntity({collection: "todos", entityId: "e1", userId: "user-1"})).toBe(
+      false
+    );
+  });
+
+  it("is scoped by userId, collection, and entityId — no cross-matching", () => {
+    const outbox = makeOutbox();
+    enqueueDefault(outbox, {
+      collection: "todos",
+      entityId: "e1",
+      mutationId: "m1",
+      userId: "user-1",
+    });
+    expect(outbox.hasAnyRowForEntity({collection: "todos", entityId: "e1", userId: "user-2"})).toBe(
+      false
+    );
+    expect(outbox.hasAnyRowForEntity({collection: "notes", entityId: "e1", userId: "user-1"})).toBe(
+      false
+    );
+    expect(outbox.hasAnyRowForEntity({collection: "todos", entityId: "e2", userId: "user-1"})).toBe(
+      false
+    );
+  });
+});
+
 describe("enqueueOrder persistence (A5)", () => {
   it("survives a store reload via the outboxMaxEnqueueOrder meta cell", () => {
     const store = makeStore();

--- a/syncdb/src/mutations/outbox.test.ts
+++ b/syncdb/src/mutations/outbox.test.ts
@@ -1,8 +1,10 @@
 import {describe, expect, it} from "bun:test";
 
 import {createSyncStore, type SyncStore} from "../storage/store";
+import {CONFLICTS_TABLE} from "../storage/types";
 import type {OutboxStatus} from "../types";
-import {createOutbox, generateMutationId, type Outbox} from "./outbox";
+import {getConflict} from "./conflicts";
+import {createOutbox, DEFAULT_KEEP_FAILED, generateMutationId, type Outbox} from "./outbox";
 
 const makeStore = (): SyncStore => createSyncStore({collections: ["todos"]});
 
@@ -51,6 +53,7 @@ describe("enqueue / getMutation", () => {
       collection: "todos",
       createdAt: "2026-07-04T00:00:00.000Z",
       entityId: "t1",
+      errorNackCount: 0,
       mutationId: "m1",
       operation: "update",
       status: "queued",
@@ -88,23 +91,7 @@ describe("enqueue / getMutation", () => {
 });
 
 describe("listQueued", () => {
-  it("returns queued mutations FIFO by createdAt", () => {
-    const timestamps = ["2026-07-04T00:00:02Z", "2026-07-04T00:00:01Z", "2026-07-04T00:00:03Z"];
-    let call = 0;
-    const outbox = makeOutbox({
-      now: () => timestamps[call++] ?? "2026-07-04T00:00:09Z",
-    });
-    enqueueDefault(outbox, {mutationId: "m-second"});
-    enqueueDefault(outbox, {mutationId: "m-first"});
-    enqueueDefault(outbox, {mutationId: "m-third"});
-    expect(outbox.listQueued({userId: "user-1"}).map((mutation) => mutation.mutationId)).toEqual([
-      "m-first",
-      "m-second",
-      "m-third",
-    ]);
-  });
-
-  it("breaks createdAt ties by insertion order", () => {
+  it("returns queued mutations FIFO by enqueueOrder (insertion order)", () => {
     const outbox = makeOutbox({now: () => "2026-07-04T00:00:00Z"});
     enqueueDefault(outbox, {mutationId: "m-a"});
     enqueueDefault(outbox, {mutationId: "m-b"});
@@ -113,6 +100,41 @@ describe("listQueued", () => {
       "m-a",
       "m-b",
       "m-c",
+    ]);
+  });
+
+  it("enqueueOrder is the primary sort key — immune to createdAt traveling backward (DST/timezone offset changes)", () => {
+    // A locale-offset ISO createdAt can go "backward" across a DST transition
+    // even though real insertion order is forward; enqueueOrder (a monotonic
+    // integer) must still win so an update never sorts before its create.
+    const timestamps = ["2026-07-04T00:00:02Z", "2026-07-04T00:00:01Z", "2026-07-04T00:00:03Z"];
+    let call = 0;
+    const outbox = makeOutbox({
+      now: () => timestamps[call++] ?? "2026-07-04T00:00:09Z",
+    });
+    enqueueDefault(outbox, {mutationId: "m-first"});
+    enqueueDefault(outbox, {mutationId: "m-second"});
+    enqueueDefault(outbox, {mutationId: "m-third"});
+    expect(outbox.listQueued({userId: "user-1"}).map((mutation) => mutation.mutationId)).toEqual([
+      "m-first",
+      "m-second",
+      "m-third",
+    ]);
+  });
+
+  it("breaks enqueueOrder ties (legacy rows predating the cell) by createdAt", () => {
+    const store = makeStore();
+    const outbox = makeOutbox({now: () => "2026-07-04T00:00:00Z", store});
+    enqueueDefault(outbox, {mutationId: "m-a"});
+    enqueueDefault(outbox, {mutationId: "m-b"});
+    // Simulate two legacy rows that both default to enqueueOrder 0.
+    store.raw.setCell("_outbox", "m-a", "enqueueOrder", 0);
+    store.raw.setCell("_outbox", "m-a", "createdAt", "2026-07-04T00:00:02Z");
+    store.raw.setCell("_outbox", "m-b", "enqueueOrder", 0);
+    store.raw.setCell("_outbox", "m-b", "createdAt", "2026-07-04T00:00:01Z");
+    expect(outbox.listQueued({userId: "user-1"}).map((mutation) => mutation.mutationId)).toEqual([
+      "m-b",
+      "m-a",
     ]);
   });
 
@@ -290,5 +312,269 @@ describe("clearForUser", () => {
     expect(outbox.getMutation({mutationId: "m-queued"})).toBeUndefined();
     expect(outbox.getMutation({mutationId: "m-flying"})).toBeUndefined();
     expect(outbox.getMutation({mutationId: "m-other"})).toBeDefined();
+  });
+});
+
+describe("recoverStartupState (A1)", () => {
+  it("transitions stranded inFlight rows back to queued without incrementing attemptCount", () => {
+    const store = makeStore();
+    const outbox = createOutbox({store});
+    enqueueDefault(outbox, {mutationId: "m1"});
+    outbox.markInFlight({mutationId: "m1"});
+    expect(outbox.getMutation({mutationId: "m1"})?.attemptCount).toBe(1);
+
+    const result = outbox.recoverStartupState({userId: "user-1"});
+    expect(result.recoveredInFlight).toEqual(["m1"]);
+    const mutation = outbox.getMutation({mutationId: "m1"});
+    expect(mutation?.status).toBe("queued");
+    // Recovery is not an attempt: attemptCount stays at its pre-crash value.
+    expect(mutation?.attemptCount).toBe(1);
+    // The mutation replays: it can transition inFlight again immediately.
+    expect(() => outbox.markInFlight({mutationId: "m1"})).not.toThrow();
+  });
+
+  it("clears a stale pendingMutationId when an acked row's entity is still pending", () => {
+    const store = makeStore();
+    const outbox = createOutbox({store});
+    enqueueDefault(outbox, {mutationId: "m1"});
+    store.upsertEntity({
+      collection: "todos",
+      data: {title: "Buy milk"},
+      id: "t1",
+      pendingMutationId: "m1",
+    });
+    outbox.markInFlight({mutationId: "m1"});
+    outbox.markAcked({mutationId: "m1"});
+    // Simulate a crash between markAcked and releaseEntity: the entity still
+    // thinks m1 is pending even though the outbox row is already acked.
+    expect(store.getEntity({collection: "todos", id: "t1"})?.pendingMutationId).toBe("m1");
+
+    const result = outbox.recoverStartupState({userId: "user-1"});
+    expect(result.releasedEntities).toEqual(["t1"]);
+    expect(store.getEntity({collection: "todos", id: "t1"})?.pendingMutationId).toBeUndefined();
+  });
+
+  it("does not touch an acked row's entity when a NEWER mutation owns pendingMutationId", () => {
+    const store = makeStore();
+    const outbox = createOutbox({store});
+    enqueueDefault(outbox, {mutationId: "m1"});
+    store.upsertEntity({
+      collection: "todos",
+      data: {title: "v1"},
+      id: "t1",
+      pendingMutationId: "m1",
+    });
+    outbox.markInFlight({mutationId: "m1"});
+    outbox.markAcked({mutationId: "m1"});
+    // A second optimistic edit re-protects the entity before recovery runs.
+    store.upsertEntity({
+      collection: "todos",
+      data: {title: "v2"},
+      id: "t1",
+      pendingMutationId: "m2",
+    });
+
+    const result = outbox.recoverStartupState({userId: "user-1"});
+    expect(result.releasedEntities).toEqual([]);
+    expect(store.getEntity({collection: "todos", id: "t1"})?.pendingMutationId).toBe("m2");
+  });
+
+  it("writes a missing conflict row for a conflicted mutation with no matching _conflicts row", () => {
+    const store = makeStore();
+    const outbox = createOutbox({store});
+    enqueueDefault(outbox, {mutationId: "m1"});
+    store.upsertEntity({
+      collection: "todos",
+      data: {title: "local edit"},
+      id: "t1",
+      pendingMutationId: "m1",
+    });
+    outbox.markInFlight({mutationId: "m1"});
+    outbox.markConflicted({mutationId: "m1"});
+    // Simulate a crash between markConflicted and writeConflict: no row yet.
+    expect(store.raw.hasRow(CONFLICTS_TABLE, "m1")).toBe(false);
+
+    const result = outbox.recoverStartupState({userId: "user-1"});
+    expect(result.repairedConflicts).toEqual(["m1"]);
+    const conflict = getConflict({mutationId: "m1", store});
+    expect(conflict).toEqual({
+      collection: "todos",
+      dismissed: false,
+      entityId: "t1",
+      localData: JSON.stringify({title: "local edit"}),
+      mutationId: "m1",
+      serverData: JSON.stringify(null),
+      serverSeq: 0,
+    });
+  });
+
+  it("leaves an existing conflict row untouched (repair is idempotent)", () => {
+    const store = makeStore();
+    const outbox = createOutbox({store});
+    enqueueDefault(outbox, {mutationId: "m1"});
+    outbox.markInFlight({mutationId: "m1"});
+    outbox.markConflicted({mutationId: "m1"});
+    store.raw.setRow(CONFLICTS_TABLE, "m1", {
+      collection: "todos",
+      dismissed: false,
+      entityId: "t1",
+      localData: JSON.stringify({title: "already recorded"}),
+      serverData: JSON.stringify({title: "server"}),
+      serverSeq: 5,
+    });
+
+    const result = outbox.recoverStartupState({userId: "user-1"});
+    expect(result.repairedConflicts).toEqual([]);
+    expect(getConflict({mutationId: "m1", store})?.serverSeq).toBe(5);
+  });
+
+  it("only recovers rows belonging to the requested user", () => {
+    const store = makeStore();
+    const outbox = createOutbox({store});
+    enqueueDefault(outbox, {mutationId: "m-mine", userId: "user-1"});
+    outbox.markInFlight({mutationId: "m-mine"});
+    enqueueDefault(outbox, {mutationId: "m-theirs", userId: "user-2"});
+    outbox.markInFlight({mutationId: "m-theirs"});
+
+    const result = outbox.recoverStartupState({userId: "user-1"});
+    expect(result.recoveredInFlight).toEqual(["m-mine"]);
+    expect(outbox.getMutation({mutationId: "m-theirs"})?.status).toBe("inFlight");
+  });
+
+  it("leaves queued, acked-without-pending, and failed rows untouched", () => {
+    const outbox = makeOutbox();
+    enqueueDefault(outbox, {mutationId: "m-queued"});
+    enqueueDefault(outbox, {mutationId: "m-acked"});
+    outbox.markInFlight({mutationId: "m-acked"});
+    outbox.markAcked({mutationId: "m-acked"});
+    enqueueDefault(outbox, {mutationId: "m-failed"});
+    outbox.markInFlight({mutationId: "m-failed"});
+    outbox.markFailed({mutationId: "m-failed"});
+
+    const result = outbox.recoverStartupState({userId: "user-1"});
+    expect(result).toEqual({recoveredInFlight: [], releasedEntities: [], repairedConflicts: []});
+    expect(outbox.getMutation({mutationId: "m-queued"})?.status).toBe("queued");
+    expect(outbox.getMutation({mutationId: "m-acked"})?.status).toBe("acked");
+    expect(outbox.getMutation({mutationId: "m-failed"})?.status).toBe("failed");
+  });
+});
+
+describe("prune (A5)", () => {
+  it("deletes acked rows for the user", () => {
+    const outbox = makeOutbox();
+    enqueueDefault(outbox, {mutationId: "m-acked"});
+    outbox.markInFlight({mutationId: "m-acked"});
+    outbox.markAcked({mutationId: "m-acked"});
+    enqueueDefault(outbox, {mutationId: "m-queued"});
+
+    outbox.prune({userId: "user-1"});
+    expect(outbox.getMutation({mutationId: "m-acked"})).toBeUndefined();
+    expect(outbox.getMutation({mutationId: "m-queued"})).toBeDefined();
+  });
+
+  it("keeps only the most recent `keepFailed` failed rows, oldest first deleted", () => {
+    const outbox = makeOutbox();
+    for (let i = 0; i < 5; i += 1) {
+      const mutationId = `m-failed-${i}`;
+      enqueueDefault(outbox, {mutationId});
+      outbox.markInFlight({mutationId});
+      outbox.markFailed({mutationId});
+    }
+    outbox.prune({keepFailed: 2, userId: "user-1"});
+    expect(outbox.getMutation({mutationId: "m-failed-0"})).toBeUndefined();
+    expect(outbox.getMutation({mutationId: "m-failed-1"})).toBeUndefined();
+    expect(outbox.getMutation({mutationId: "m-failed-2"})).toBeUndefined();
+    // The two most recently enqueued (highest enqueueOrder) survive.
+    expect(outbox.getMutation({mutationId: "m-failed-3"})).toBeDefined();
+    expect(outbox.getMutation({mutationId: "m-failed-4"})).toBeDefined();
+  });
+
+  it("defaults keepFailed to DEFAULT_KEEP_FAILED", () => {
+    const outbox = makeOutbox();
+    for (let i = 0; i < DEFAULT_KEEP_FAILED + 3; i += 1) {
+      const mutationId = `m-failed-${i}`;
+      enqueueDefault(outbox, {mutationId});
+      outbox.markInFlight({mutationId});
+      outbox.markFailed({mutationId});
+    }
+    outbox.prune({userId: "user-1"});
+    let remaining = 0;
+    for (let i = 0; i < DEFAULT_KEEP_FAILED + 3; i += 1) {
+      if (outbox.getMutation({mutationId: `m-failed-${i}`})) {
+        remaining += 1;
+      }
+    }
+    expect(remaining).toBe(DEFAULT_KEEP_FAILED);
+  });
+
+  it("never prunes conflicted rows", () => {
+    const outbox = makeOutbox();
+    enqueueDefault(outbox, {mutationId: "m-conflicted"});
+    outbox.markInFlight({mutationId: "m-conflicted"});
+    outbox.markConflicted({mutationId: "m-conflicted"});
+
+    outbox.prune({keepFailed: 0, userId: "user-1"});
+    expect(outbox.getMutation({mutationId: "m-conflicted"})?.status).toBe("conflicted");
+  });
+
+  it("only prunes rows belonging to the requested user", () => {
+    const outbox = makeOutbox();
+    enqueueDefault(outbox, {mutationId: "m-mine", userId: "user-1"});
+    outbox.markInFlight({mutationId: "m-mine"});
+    outbox.markAcked({mutationId: "m-mine"});
+    enqueueDefault(outbox, {mutationId: "m-theirs", userId: "user-2"});
+    outbox.markInFlight({mutationId: "m-theirs"});
+    outbox.markAcked({mutationId: "m-theirs"});
+
+    outbox.prune({userId: "user-1"});
+    expect(outbox.getMutation({mutationId: "m-mine"})).toBeUndefined();
+    expect(outbox.getMutation({mutationId: "m-theirs"})).toBeDefined();
+  });
+});
+
+describe("enqueueOrder persistence (A5)", () => {
+  it("survives a store reload via the outboxMaxEnqueueOrder meta cell", () => {
+    const store = makeStore();
+    const outbox = createOutbox({store});
+    enqueueDefault(outbox, {mutationId: "m1"});
+    enqueueDefault(outbox, {mutationId: "m2"});
+
+    const rebound = createOutbox({store});
+    const mutation = rebound.enqueue({
+      args: {},
+      collection: "todos",
+      entityId: "t3",
+      mutationId: "m3",
+      operation: "create",
+      userId: "user-1",
+    });
+    // The rebound outbox must not restart the counter — m3 sorts after m1/m2.
+    expect(
+      rebound.listQueued({userId: "user-1"}).map((mutationEntry) => mutationEntry.mutationId)
+    ).toEqual(["m1", "m2", "m3"]);
+    expect(mutation.mutationId).toBe("m3");
+  });
+
+  it("rebuilds the counter from a table scan when the meta cell is absent (pre-A5 persisted store)", () => {
+    const store = makeStore();
+    const outbox = createOutbox({store});
+    enqueueDefault(outbox, {mutationId: "m1"});
+    enqueueDefault(outbox, {mutationId: "m2"});
+    // Simulate a store persisted before the meta cell existed.
+    store.raw.setValue("outboxMaxEnqueueOrder", 0);
+
+    const rebound = createOutbox({store});
+    const mutation = rebound.enqueue({
+      args: {},
+      collection: "todos",
+      entityId: "t3",
+      mutationId: "m3",
+      operation: "create",
+      userId: "user-1",
+    });
+    expect(
+      rebound.listQueued({userId: "user-1"}).map((mutationEntry) => mutationEntry.mutationId)
+    ).toEqual(["m1", "m2", "m3"]);
+    expect(mutation.mutationId).toBe("m3");
   });
 });

--- a/syncdb/src/mutations/outbox.ts
+++ b/syncdb/src/mutations/outbox.ts
@@ -118,6 +118,17 @@ export interface Outbox {
   prune: (args: {userId: string; keepFailed?: number}) => void;
   /** Count of the user's mutations currently in the given status. */
   countByStatus: (args: {userId: string; status: OutboxStatus}) => number;
+  /**
+   * True when ANY outbox row (any status — queued, inFlight, conflicted, or
+   * failed) still exists for the given user/collection/entity. Used by the
+   * replay coordinator's FIX 4 GC to distinguish "the entity's failed row was
+   * pruned with nothing queued behind it" (block should be dropped) from "a
+   * successor is queued but the failed row itself was already pruned" (block
+   * must still hold) — checking queued-only would wrongly treat the latter
+   * as already-cleared during the narrow window between a validation failure
+   * and its successor's enqueue.
+   */
+  hasAnyRowForEntity: (args: {userId: string; collection: string; entityId: string}) => boolean;
 }
 
 /**
@@ -417,11 +428,34 @@ export const createOutbox = ({
     return count;
   };
 
+  const hasAnyRowForEntity = ({
+    userId,
+    collection,
+    entityId,
+  }: {
+    userId: string;
+    collection: string;
+    entityId: string;
+  }): boolean => {
+    for (const row of Object.values(store.raw.getTable(OUTBOX_TABLE))) {
+      const typedRow = row as Partial<OutboxRow>;
+      if (
+        (typedRow.userId ?? "") === userId &&
+        typedRow.collection === collection &&
+        typedRow.entityId === entityId
+      ) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   return {
     clearForUser,
     countByStatus,
     enqueue,
     getMutation,
+    hasAnyRowForEntity,
     listQueued,
     markAcked,
     markConflicted,

--- a/syncdb/src/mutations/outbox.ts
+++ b/syncdb/src/mutations/outbox.ts
@@ -2,10 +2,13 @@ import {DateTime} from "luxon";
 import type {Row} from "tinybase";
 
 import type {SyncStore} from "../storage/store";
-import {OUTBOX_TABLE, type OutboxRow} from "../storage/types";
+import {CONFLICTS_TABLE, OUTBOX_TABLE, type OutboxRow} from "../storage/types";
 import type {OutboxMutation, OutboxStatus, SyncMutationOperation} from "../types";
 
 const defaultNow = (): string => DateTime.now().toISO();
+
+/** Default number of failed rows retained by `prune()` for debugging/UI. */
+export const DEFAULT_KEEP_FAILED = 50;
 
 /** Generate a stable client mutation id (idempotency key). */
 export const generateMutationId = (): string => {
@@ -31,6 +34,7 @@ const rowToMutation = (mutationId: string, row: Partial<OutboxRow>): OutboxMutat
   collection: row.collection ?? "",
   createdAt: row.createdAt ?? "",
   entityId: row.entityId ?? "",
+  errorNackCount: row.errorNackCount ?? 0,
   mutationId,
   operation: (row.operation ?? "update") as SyncMutationOperation,
   status: (row.status ?? "queued") as OutboxStatus,
@@ -51,10 +55,19 @@ export interface EnqueueArgs {
   mutationId?: string;
 }
 
+export interface RecoverStartupStateResult {
+  /** mutationIds that were stranded `inFlight` and moved back to `queued`. */
+  recoveredInFlight: string[];
+  /** entityIds whose stale `pendingMutationId` was cleared (acked-with-pending). */
+  releasedEntities: string[];
+  /** mutationIds that were `conflicted` with no matching `_conflicts` row, now repaired. */
+  repairedConflicts: string[];
+}
+
 export interface Outbox {
   enqueue: (args: EnqueueArgs) => OutboxMutation;
   getMutation: (args: {mutationId: string}) => OutboxMutation | undefined;
-  /** Queued mutations for a user, FIFO by createdAt then insertion order. */
+  /** Queued mutations for a user, global FIFO by enqueueOrder (createdAt tiebreak). */
   listQueued: (args: {collection?: string; userId: string}) => OutboxMutation[];
   /** queued → inFlight; increments attemptCount. */
   markInFlight: (args: {mutationId: string}) => void;
@@ -67,6 +80,12 @@ export interface Outbox {
   /** inFlight → failed (terminal, non-retryable rejection). */
   markFailed: (args: {mutationId: string}) => void;
   /**
+   * inFlight → queued after a server error-nack; increments the dedicated
+   * `errorNackCount` retry-budget cell (NOT `attemptCount`, which stays a
+   * diagnostic total across every send attempt including transport failures).
+   */
+  markQueuedAfterErrorNack: (args: {mutationId: string}) => void;
+  /**
    * Re-enqueue a conflicted mutation under a FRESH mutationId with the given
    * baseVersion (keepMine resolution). The server's idempotency ledger records
    * a terminal outcome per mutationId, so retrying with the original id would
@@ -76,6 +95,29 @@ export interface Outbox {
   requeue: (args: {mutationId: string; baseVersion?: number}) => OutboxMutation;
   /** Remove every mutation belonging to the given user (wipe-on-user-change). */
   clearForUser: (args: {userId: string}) => void;
+  /**
+   * Startup crash recovery (A1): repair rows stranded by a crash mid-lifecycle.
+   * Must run once at client start, before the first replay.
+   *
+   * - Every `inFlight` row for the user → back to `queued` (NOT an attempt —
+   *   attemptCount/errorNackCount are untouched).
+   * - Every `acked` row for the user whose entity still has
+   *   `pendingMutationId === mutationId` → clear the entity's
+   *   `pendingMutationId` (replays the missing `releaseEntity`).
+   * - Every `conflicted` row for the user with no matching `_conflicts` row →
+   *   write the conflict row now (localData from the entity, serverData null,
+   *   serverSeq 0) so the UI can surface it.
+   */
+  recoverStartupState: (args: {userId: string}) => RecoverStartupStateResult;
+  /**
+   * Delete `acked` rows (no future value once acked — the server ledger owns
+   * idempotency) and trim `failed` rows to the most recent `keepFailed`
+   * (default {@link DEFAULT_KEEP_FAILED}). `conflicted` rows are never pruned
+   * automatically. Call after each successful drain pass.
+   */
+  prune: (args: {userId: string; keepFailed?: number}) => void;
+  /** Count of the user's mutations currently in the given status. */
+  countByStatus: (args: {userId: string; status: OutboxStatus}) => number;
 }
 
 /**
@@ -108,15 +150,31 @@ export const createOutbox = ({
     return row;
   };
 
+  /**
+   * O(1) FIFO ordering: the max enqueueOrder is cached in a `_meta` value cell
+   * (`outboxMaxEnqueueOrder`) so enqueue never scans the whole table. TinyBase's
+   * ValuesSchema always supplies a default of 0 for an unset cell, so "absent"
+   * is indistinguishable from "genuinely zero" at the storage layer — treat a
+   * cached 0 as unknown and rebuild once from a table scan (covers both a
+   * fresh store, where the scan is a cheap no-op, and a store persisted before
+   * this cell existed, where the scan recovers the true max). Once the cache
+   * is non-zero it is trusted from then on.
+   */
   const nextEnqueueOrder = (): number => {
-    let max = 0;
-    for (const row of Object.values(store.raw.getTable(OUTBOX_TABLE))) {
-      const order = (row as Partial<OutboxRow>).enqueueOrder ?? 0;
-      if (order > max) {
-        max = order;
+    const cached = store.raw.getValue("outboxMaxEnqueueOrder");
+    let max = typeof cached === "number" && cached > 0 ? cached : undefined;
+    if (max === undefined) {
+      max = 0;
+      for (const row of Object.values(store.raw.getTable(OUTBOX_TABLE))) {
+        const order = (row as Partial<OutboxRow>).enqueueOrder ?? 0;
+        if (order > max) {
+          max = order;
+        }
       }
     }
-    return max + 1;
+    const next = max + 1;
+    store.raw.setValue("outboxMaxEnqueueOrder", next);
+    return next;
   };
 
   const enqueue = (args: EnqueueArgs): OutboxMutation => {
@@ -128,6 +186,7 @@ export const createOutbox = ({
       createdAt: now(),
       enqueueOrder: nextEnqueueOrder(),
       entityId: args.entityId,
+      errorNackCount: 0,
       operation: args.operation,
       status: "queued",
       userId: args.userId,
@@ -174,8 +233,11 @@ export const createOutbox = ({
         order: typedRow.enqueueOrder ?? 0,
       });
     }
+    // enqueueOrder is the durable FIFO key (a monotonic integer, immune to
+    // locale/timezone drift); createdAt is only a tiebreak for legacy rows
+    // that predate the cell (order defaults to 0).
     entries.sort(
-      (a, b) => a.mutation.createdAt.localeCompare(b.mutation.createdAt) || a.order - b.order
+      (a, b) => a.order - b.order || a.mutation.createdAt.localeCompare(b.mutation.createdAt)
     );
     return entries.map((entry) => entry.mutation);
   };
@@ -187,6 +249,11 @@ export const createOutbox = ({
 
   const markQueued = ({mutationId}: {mutationId: string}): void => {
     transition(mutationId, "queued");
+  };
+
+  const markQueuedAfterErrorNack = ({mutationId}: {mutationId: string}): void => {
+    const row = transition(mutationId, "queued");
+    store.raw.setCell(OUTBOX_TABLE, mutationId, "errorNackCount", (row.errorNackCount ?? 0) + 1);
   };
 
   const markAcked = ({mutationId}: {mutationId: string}): void => {
@@ -223,6 +290,7 @@ export const createOutbox = ({
       createdAt: row.createdAt ?? now(),
       enqueueOrder: row.enqueueOrder ?? 0,
       entityId: row.entityId ?? "",
+      errorNackCount: 0,
       operation: row.operation ?? "update",
       status: "queued",
       userId: row.userId ?? "",
@@ -245,8 +313,113 @@ export const createOutbox = ({
     }
   };
 
+  const recoverStartupState = ({userId}: {userId: string}): RecoverStartupStateResult => {
+    const result: RecoverStartupStateResult = {
+      recoveredInFlight: [],
+      releasedEntities: [],
+      repairedConflicts: [],
+    };
+    const table = store.raw.getTable(OUTBOX_TABLE);
+    for (const [mutationId, row] of Object.entries(table)) {
+      const typedRow = row as Partial<OutboxRow>;
+      if ((typedRow.userId ?? "") !== userId) {
+        continue;
+      }
+
+      if (typedRow.status === "inFlight") {
+        // Recovery is not an attempt: transition directly, bypassing
+        // markQueued's semantics (which is reserved for post-send retries).
+        store.raw.setCell(OUTBOX_TABLE, mutationId, "status", "queued");
+        result.recoveredInFlight.push(mutationId);
+        continue;
+      }
+
+      if (typedRow.status === "acked") {
+        const collection = typedRow.collection ?? "";
+        const entityId = typedRow.entityId ?? "";
+        if (!collection || !entityId) {
+          continue;
+        }
+        const entity = store.getEntity({collection, id: entityId});
+        if (entity?.pendingMutationId === mutationId) {
+          store.upsertEntity({
+            collection,
+            data: entity.data,
+            id: entityId,
+            pendingMutationId: "",
+          });
+          result.releasedEntities.push(entityId);
+        }
+        continue;
+      }
+
+      if (typedRow.status === "conflicted") {
+        if (store.raw.hasRow(CONFLICTS_TABLE, mutationId)) {
+          continue;
+        }
+        const collection = typedRow.collection ?? "";
+        const entityId = typedRow.entityId ?? "";
+        const entity = store.getEntity({collection, id: entityId});
+        store.raw.setRow(CONFLICTS_TABLE, mutationId, {
+          collection,
+          dismissed: false,
+          entityId,
+          localData: JSON.stringify(entity?.data ?? null),
+          serverData: JSON.stringify(null),
+          serverSeq: 0,
+        });
+        result.repairedConflicts.push(mutationId);
+      }
+    }
+    return result;
+  };
+
+  const prune = ({
+    userId,
+    keepFailed = DEFAULT_KEEP_FAILED,
+  }: {
+    userId: string;
+    keepFailed?: number;
+  }): void => {
+    const table = store.raw.getTable(OUTBOX_TABLE);
+    const failedRows: {mutationId: string; order: number}[] = [];
+    for (const [mutationId, row] of Object.entries(table)) {
+      const typedRow = row as Partial<OutboxRow>;
+      if ((typedRow.userId ?? "") !== userId) {
+        continue;
+      }
+      if (typedRow.status === "acked") {
+        store.raw.delRow(OUTBOX_TABLE, mutationId);
+        continue;
+      }
+      if (typedRow.status === "failed") {
+        failedRows.push({mutationId, order: typedRow.enqueueOrder ?? 0});
+      }
+    }
+    if (failedRows.length <= keepFailed) {
+      return;
+    }
+    // Keep the most recent `keepFailed` (highest enqueueOrder); delete the rest.
+    failedRows.sort((a, b) => b.order - a.order);
+    for (const {mutationId} of failedRows.slice(keepFailed)) {
+      store.raw.delRow(OUTBOX_TABLE, mutationId);
+    }
+  };
+
+  const countByStatus = ({userId, status}: {userId: string; status: OutboxStatus}): number => {
+    let count = 0;
+    for (const row of Object.values(store.raw.getTable(OUTBOX_TABLE))) {
+      const typedRow = row as Partial<OutboxRow>;
+      if ((typedRow.userId ?? "") === userId && typedRow.status === status) {
+        count += 1;
+      }
+    }
+    return count;
+  };
+
   return {
     clearForUser,
+    countByStatus,
     enqueue,
     getMutation,
     listQueued,
@@ -255,6 +428,9 @@ export const createOutbox = ({
     markFailed,
     markInFlight,
     markQueued,
+    markQueuedAfterErrorNack,
+    prune,
+    recoverStartupState,
     requeue,
   };
 };

--- a/syncdb/src/persisters/defaultPersisterFactory.test.ts
+++ b/syncdb/src/persisters/defaultPersisterFactory.test.ts
@@ -121,4 +121,46 @@ describe("createDefaultPersisterFactory (web)", () => {
     expect(onDecryptFailure).toHaveBeenCalledTimes(1);
     expect(target.listEntities({collection: "todos"})).toEqual([]);
   });
+
+  it("tags the returned persister with persistenceMode: 'durable' when IndexedDB is available", () => {
+    const persister = createWebFactory({saveDebounceMs: 0})({
+      databaseName: uniqueDbName(),
+      store: makeStore().raw,
+    });
+    expect((persister as unknown as {persistenceMode?: string}).persistenceMode).toBe("durable");
+  });
+
+  it("falls back to the in-memory persister and tags persistenceMode: 'memory' when indexedDB is unavailable (E3c)", async () => {
+    const originalIndexedDb = globalThis.indexedDB;
+    // Simulating an environment with no IndexedDB at all.
+    delete (globalThis as {indexedDB?: unknown}).indexedDB;
+    try {
+      const databaseName = uniqueDbName();
+      const source = makeStore();
+      source.upsertEntity({collection: "todos", data: {title: "memory only"}, id: "t1"});
+      const persister = createWebFactory({saveDebounceMs: 0})({
+        databaseName,
+        store: source.raw,
+      });
+      expect((persister as unknown as {persistenceMode?: string}).persistenceMode).toBe("memory");
+      await persister.save();
+
+      // The same databaseName round-trips through the in-memory backing —
+      // proving the fallback is a real, working persister, not a stub.
+      const target = makeStore();
+      const targetPersister = createWebFactory({saveDebounceMs: 0})({
+        databaseName,
+        store: target.raw,
+      });
+      expect((targetPersister as unknown as {persistenceMode?: string}).persistenceMode).toBe(
+        "memory"
+      );
+      await targetPersister.load();
+      expect(target.getEntity({collection: "todos", id: "t1"})?.data).toEqual({
+        title: "memory only",
+      });
+    } finally {
+      globalThis.indexedDB = originalIndexedDb;
+    }
+  });
 });

--- a/syncdb/src/persisters/defaultPersisterFactory.web.ts
+++ b/syncdb/src/persisters/defaultPersisterFactory.web.ts
@@ -1,27 +1,78 @@
+import type {AnyPersister} from "tinybase/persisters";
+
 import {createKeyProviderCodec, createLocalKeyProvider} from "../crypto/keyProviders";
 import {createEncryptedIndexedDbPersister} from "./encryptedIndexedDbPersister";
+import {memoryPersisterFactory} from "./memoryPersister";
 import type {DefaultPersisterFactoryConfig, PersisterFactory} from "./types";
 
 /** Key scope used when the caller has not (yet) supplied a user id. */
 const DEFAULT_KEY_SCOPE_USER_ID = "local";
 
 /**
+ * E3(c): true once the one-time "no IndexedDB, falling back to memory
+ * persistence" warning has fired for this session — module-level so the
+ * warning is emitted at most once per page load even across multiple
+ * `createSyncDb` instances (e.g. tests, or an app with more than one store).
+ */
+let hasWarnedNoIndexedDb = false;
+
+/**
  * Web default persister: the encrypted IndexedDB persister with encryption
  * default-on. Without explicit config the key is a device-local random
  * non-extractable key; production apps pass a `createServerKeyProvider`-backed
  * `keyProvider` + `userId` so the key derives from server key material.
+ *
+ * E3(c): when `globalThis.indexedDB` is unavailable (private-browsing modes
+ * that disable it, a locked-down embedded webview), falls back to the
+ * in-memory persister rather than throwing — local-first apps should still
+ * start, just without durable persistence for this session — and warns once.
+ * The returned persister carries a `persistenceMode` marker
+ * (`"durable" | "memory"`) so callers (see `client.ts`) can surface the
+ * degraded mode on `SyncStatus` instead of it being silently invisible.
  */
 export const createDefaultPersisterFactory = (
   config: DefaultPersisterFactoryConfig = {}
 ): PersisterFactory => {
   const keyProvider = config.keyProvider ?? createLocalKeyProvider();
   const userId = config.userId ?? DEFAULT_KEY_SCOPE_USER_ID;
-  return ({store, databaseName}) =>
-    createEncryptedIndexedDbPersister({
+  return ({store, databaseName, hooks}) => {
+    // Call-time `hooks` (see `PersisterFactory`) and config-time callbacks
+    // are the same closures in the real client.ts flow; call-time wins when
+    // both are present so a caller building this factory directly (tests, or
+    // a host app not going through createSyncDb's config-time wiring) can
+    // rely on `hooks` alone.
+    const onDecryptFailure = hooks?.onDecryptFailure ?? config.onDecryptFailure;
+    const onLoadFailure = hooks?.onLoadFailure ?? config.onLoadFailure;
+    const onSaveFailure = hooks?.onSaveFailure ?? config.onSaveFailure;
+    if (typeof globalThis.indexedDB === "undefined") {
+      if (!hasWarnedNoIndexedDb) {
+        hasWarnedNoIndexedDb = true;
+        console.warn(
+          "[syncdb] IndexedDB is unavailable in this environment; falling back to in-memory persistence (data will not survive a reload)"
+        );
+      }
+      const memoryPersister = memoryPersisterFactory({databaseName, store});
+      // Spreading a frozen Persister into a plain object is safe (copies
+      // enumerable own properties) and lets callers detect the fallback via
+      // `persistenceMode` without needing an isSynchronizer-style branch at
+      // every call site.
+      return {...memoryPersister, persistenceMode: "memory"} as AnyPersister & {
+        persistenceMode: "memory";
+      };
+    }
+    const persister = createEncryptedIndexedDbPersister({
       codec: createKeyProviderCodec({keyProvider, userId}),
       databaseName,
-      onDecryptFailure: config.onDecryptFailure,
+      idbGetImpl: config.idbGetImpl,
+      idbSetImpl: config.idbSetImpl,
+      onDecryptFailure,
+      onLoadFailure,
+      onSaveFailure,
       saveDebounceMs: config.saveDebounceMs,
       store,
     });
+    return {...persister, persistenceMode: "durable"} as AnyPersister & {
+      persistenceMode: "durable";
+    };
+  };
 };

--- a/syncdb/src/persisters/encryptedIndexedDbPersister.test.ts
+++ b/syncdb/src/persisters/encryptedIndexedDbPersister.test.ts
@@ -6,6 +6,7 @@ import {createAesGcmCodec} from "../crypto/aesGcmCodec";
 import {identityCodec} from "../crypto/identityCodec";
 import type {PayloadCodec} from "../crypto/types";
 import {idbSet} from "../storage/idb";
+import {SYNC_SCHEMA_VERSION} from "../storage/schema";
 import {createSyncStore, type SyncStore} from "../storage/store";
 import {createEncryptedIndexedDbPersister} from "./encryptedIndexedDbPersister";
 
@@ -375,6 +376,6 @@ describe("createEncryptedIndexedDbPersister", () => {
       saveDebounceMs: 0,
       store: target.raw,
     }).load();
-    expect(target.getSchemaVersion()).toBe(1);
+    expect(target.getSchemaVersion()).toBe(SYNC_SCHEMA_VERSION);
   });
 });

--- a/syncdb/src/persisters/encryptedIndexedDbPersister.test.ts
+++ b/syncdb/src/persisters/encryptedIndexedDbPersister.test.ts
@@ -139,6 +139,78 @@ describe("createEncryptedIndexedDbPersister", () => {
     expect(onDecryptFailure).not.toHaveBeenCalled();
   });
 
+  describe("load failure (E3a)", () => {
+    it("a rejecting idbGet at load leaves the stored blob intact and reports onLoadFailure, not onDecryptFailure", async () => {
+      const databaseName = uniqueDbName();
+      const codec = createAesGcmCodec({key: await generateKey()});
+      const source = makeStore();
+      source.upsertEntity({collection: "todos", data: {title: "still here"}, id: "t1", seq: 3});
+      await createEncryptedIndexedDbPersister({
+        codec,
+        databaseName,
+        saveDebounceMs: 0,
+        store: source.raw,
+      }).save();
+
+      const onDecryptFailure = mock(() => {});
+      const onLoadFailure = mock(() => {});
+      const target = makeStore();
+      await createEncryptedIndexedDbPersister({
+        codec,
+        databaseName,
+        idbGetImpl: async () => {
+          throw new Error("simulated IndexedDB read failure");
+        },
+        onDecryptFailure,
+        onLoadFailure,
+        saveDebounceMs: 0,
+        store: target.raw,
+      }).load();
+
+      // The distinct load-failure hook fired, NOT the decrypt-failure one — a
+      // read error is not "corrupt/undecryptable data".
+      expect(onLoadFailure).toHaveBeenCalledTimes(1);
+      expect(onDecryptFailure).not.toHaveBeenCalled();
+      // The target store was never populated (load bailed out before
+      // touching it) — this is the state a caller must check before deciding
+      // to autosave (autosaving now would write this empty content over the
+      // still-good blob).
+      expect(target.listEntities({collection: "todos"})).toEqual([]);
+
+      // The persisted blob itself is untouched: reading it back normally
+      // (real idbGet) with a fresh store still recovers the original data —
+      // proving nothing was overwritten during the failed load.
+      const recovered = makeStore();
+      await createEncryptedIndexedDbPersister({
+        codec,
+        databaseName,
+        saveDebounceMs: 0,
+        store: recovered.raw,
+      }).load();
+      expect(recovered.getEntity({collection: "todos", id: "t1"})?.data).toEqual({
+        title: "still here",
+      });
+      expect(recovered.getEntity({collection: "todos", id: "t1"})?.seq).toBe(3);
+    });
+
+    it("treats a genuinely missing record (no read error) as a fresh store, not a load failure", async () => {
+      const onLoadFailure = mock(() => {});
+      const onDecryptFailure = mock(() => {});
+      const store = makeStore();
+      await createEncryptedIndexedDbPersister({
+        codec: createAesGcmCodec({key: await generateKey()}),
+        databaseName: uniqueDbName(),
+        onDecryptFailure,
+        onLoadFailure,
+        saveDebounceMs: 0,
+        store: store.raw,
+      }).load();
+      expect(onLoadFailure).not.toHaveBeenCalled();
+      expect(onDecryptFailure).not.toHaveBeenCalled();
+      expect(store.listEntities({collection: "todos"})).toEqual([]);
+    });
+  });
+
   it("invokes onDecryptFailure and yields an empty store on undecryptable data", async () => {
     const databaseName = uniqueDbName();
     await idbSet({
@@ -228,6 +300,46 @@ describe("createEncryptedIndexedDbPersister", () => {
       store: target.raw,
     }).load();
     expect(target.getEntity({collection: "todos", id: "t1"})?.data).toEqual({title: "three"});
+  });
+
+  it("destroy() cancels a pending debounced save and writes nothing after (E3e)", async () => {
+    const databaseName = uniqueDbName();
+    let encodeCount = 0;
+    const countingCodec: PayloadCodec = {
+      decode: identityCodec.decode,
+      encode: (plaintext) => {
+        encodeCount += 1;
+        return identityCodec.encode(plaintext);
+      },
+    };
+    const source = makeStore();
+    const persister = createEncryptedIndexedDbPersister({
+      codec: countingCodec,
+      databaseName,
+      saveDebounceMs: 50,
+      store: source.raw,
+    });
+    await persister.startAutoSave();
+    const encodeCountAfterInitialSave = encodeCount;
+    source.upsertEntity({collection: "todos", data: {title: "pending"}, id: "t1"});
+    // The autosave listener's write is now debounced (50ms) and still
+    // pending — destroy immediately, before it can fire.
+    await persister.destroy();
+    // Wait well past the debounce window: if the timer were still armed
+    // (E3e regression), it would fire here and write "pending".
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(encodeCount).toBe(encodeCountAfterInitialSave);
+
+    const target = makeStore();
+    await createEncryptedIndexedDbPersister({
+      codec: countingCodec,
+      databaseName,
+      saveDebounceMs: 0,
+      store: target.raw,
+    }).load();
+    // Nothing was ever written after the initial (pre-mutation) autosave —
+    // the mutated content never landed.
+    expect(target.getEntity({collection: "todos", id: "t1"})).toBeUndefined();
   });
 
   it("propagates encode failures to the caller of save()", async () => {

--- a/syncdb/src/persisters/encryptedIndexedDbPersister.test.ts
+++ b/syncdb/src/persisters/encryptedIndexedDbPersister.test.ts
@@ -6,6 +6,7 @@ import {createAesGcmCodec} from "../crypto/aesGcmCodec";
 import {identityCodec} from "../crypto/identityCodec";
 import type {PayloadCodec} from "../crypto/types";
 import {idbSet} from "../storage/idb";
+import {SYNC_SCHEMA_VERSION} from "../storage/schema";
 import {createSyncStore, type SyncStore} from "../storage/store";
 import {createEncryptedIndexedDbPersister} from "./encryptedIndexedDbPersister";
 
@@ -263,6 +264,6 @@ describe("createEncryptedIndexedDbPersister", () => {
       saveDebounceMs: 0,
       store: target.raw,
     }).load();
-    expect(target.getSchemaVersion()).toBe(1);
+    expect(target.getSchemaVersion()).toBe(SYNC_SCHEMA_VERSION);
   });
 });

--- a/syncdb/src/persisters/encryptedIndexedDbPersister.ts
+++ b/syncdb/src/persisters/encryptedIndexedDbPersister.ts
@@ -23,6 +23,15 @@ interface PendingSave {
  * (AES-GCM) → put blob. Corrupt or undecryptable data is treated as a fresh
  * store — `onDecryptFailure` fires so the caller can wipe and re-bootstrap.
  *
+ * A READ error from IndexedDB itself (as opposed to "no record yet") is a
+ * different failure mode (E3a): the blob may well still be intact, so it must
+ * NOT be treated as "fresh store" (which would let a subsequent autosave
+ * clobber it with empty content). `onLoadFailure` fires in that case instead
+ * of `onDecryptFailure`, and the underlying read error is re-thrown so
+ * TinyBase's own `getPersisted` error handling leaves the in-memory store
+ * exactly as it was (never calls `setContentOrChanges`) — callers key off
+ * `onLoadFailure` to additionally skip `startAutoSave()` for this session.
+ *
  * Saves are debounced with a trailing edge (default 500ms) since TinyBase's
  * autosave fires on every transaction: each write waits out the debounce
  * window, and follow-up saves whose serialized content matches the last
@@ -34,24 +43,52 @@ export const createEncryptedIndexedDbPersister = ({
   databaseName,
   codec,
   onDecryptFailure,
+  onLoadFailure,
+  onSaveFailure,
   saveDebounceMs = DEFAULT_SAVE_DEBOUNCE_MS,
+  idbGetImpl = idbGet,
+  idbSetImpl = idbSet,
 }: {
   store: MergeableStore;
   databaseName: string;
   codec: PayloadCodec;
   onDecryptFailure?: () => void;
+  onLoadFailure?: () => void;
+  /**
+   * E3(a): invoked whenever a write to IndexedDB ultimately fails (e.g. a
+   * quota-exceeded `DOMException`) — TinyBase's own autosave scheduler
+   * otherwise swallows `setPersisted` errors silently via its internal
+   * `onIgnoredError`, so without this hook a failing save would be invisible.
+   */
+  onSaveFailure?: (error: unknown) => void;
   saveDebounceMs?: number;
+  /** Test-only override for the IndexedDB read (default: the real `idbGet`). */
+  idbGetImpl?: typeof idbGet;
+  /** Test-only override for the IndexedDB write (default: the real `idbSet`). */
+  idbSetImpl?: typeof idbSet;
 }): Persister<Persists.MergeableStoreOnly> => {
   let lastWrittenJson: string | undefined;
   let pendingSave: PendingSave | undefined;
+  // E3(e): the debounce timer scheduling `flushPendingSave` — tracked so
+  // `destroy()` can cancel it. Without this, a pending debounced save would
+  // still fire (and write) after destroy(), which is exactly the kind of
+  // "wrote something after we thought we were done" bug destroy() must
+  // prevent (e.g. a wipe immediately followed by destroy()).
+  let pendingSaveTimer: ReturnType<typeof setTimeout> | undefined;
+  let destroyed = false;
   // Serializes writes so a slow encode/put can never land after (and clobber)
   // a newer snapshot's write.
   let writeChain: Promise<void> = Promise.resolve();
 
   const writeJson = (json: string): Promise<void> => {
     const write = writeChain.then(async () => {
+      // E3(e): destroy() may have run while this write was already chained
+      // behind an earlier one — never let it land after destroy() completes.
+      if (destroyed) {
+        return;
+      }
       const payload = await codec.encode(json);
-      await idbSet({databaseName, key: RECORD_KEY, value: payload});
+      await idbSetImpl({databaseName, key: RECORD_KEY, value: payload});
       lastWrittenJson = json;
     });
     // Keep the chain alive after a failed write; the failure still propagates
@@ -77,7 +114,20 @@ export const createEncryptedIndexedDbPersister = ({
   };
 
   const getPersisted = async (): Promise<MergeableContent | undefined> => {
-    const payload = await idbGet<unknown>({databaseName, key: RECORD_KEY});
+    let payload: unknown;
+    try {
+      payload = await idbGetImpl<unknown>({databaseName, key: RECORD_KEY});
+    } catch (error) {
+      // E3(a): the READ itself failed (IndexedDB unavailable/blocked/thrown) —
+      // this is NOT "no data" (undefined) and must not be treated as a fresh
+      // store: onDecryptFailure (whose default wipes and re-bootstraps) would
+      // be actively harmful here since the persisted blob may still be
+      // perfectly intact. Signal the distinct failure and re-throw so
+      // TinyBase's own error handling leaves the in-memory store untouched
+      // rather than defaulting it to empty.
+      onLoadFailure?.();
+      throw error;
+    }
     if (payload === undefined) {
       return undefined;
     }
@@ -95,7 +145,12 @@ export const createEncryptedIndexedDbPersister = ({
   const setPersisted = async (getContent: () => MergeableContent): Promise<void> => {
     const json = JSON.stringify(getContent());
     if (saveDebounceMs <= 0) {
-      await writeJson(json);
+      try {
+        await writeJson(json);
+      } catch (error) {
+        onSaveFailure?.(error);
+        throw error;
+      }
       return;
     }
     // TinyBase serializes setPersisted calls, so per-transaction autosaves
@@ -112,14 +167,20 @@ export const createEncryptedIndexedDbPersister = ({
         rejectPending = rej;
       });
       pendingSave = {promise, reject: rejectPending, resolve: resolvePending};
-      setTimeout(() => {
+      pendingSaveTimer = setTimeout(() => {
+        pendingSaveTimer = undefined;
         void flushPendingSave();
       }, saveDebounceMs);
     }
-    await pendingSave.promise;
+    try {
+      await pendingSave.promise;
+    } catch (error) {
+      onSaveFailure?.(error);
+      throw error;
+    }
   };
 
-  return createCustomPersister<number, Persists.MergeableStoreOnly>(
+  const persister = createCustomPersister<number, Persists.MergeableStoreOnly>(
     store,
     getPersisted,
     setPersisted,
@@ -130,4 +191,28 @@ export const createEncryptedIndexedDbPersister = ({
     undefined,
     Persists.MergeableStoreOnly
   );
+
+  // E3(e): wrap destroy() to cancel the debounce timer and drop (without
+  // writing) any pending save — TinyBase's own destroy()/stopAutoPersisting()
+  // has no idea this persister keeps its own setTimeout-based debounce state,
+  // so without this override a pending write fires (and lands in IndexedDB)
+  // even after the caller believes destroy() fully tore everything down.
+  const originalDestroy = persister.destroy.bind(persister);
+  return {
+    ...persister,
+    destroy: (): ReturnType<typeof originalDestroy> => {
+      destroyed = true;
+      if (pendingSaveTimer !== undefined) {
+        clearTimeout(pendingSaveTimer);
+        pendingSaveTimer = undefined;
+      }
+      // A pending save's awaiters (if any) must still settle — resolve
+      // rather than reject, since "destroyed before its debounce elapsed" is
+      // an expected lifecycle event, not a failure the caller needs to
+      // handle specially.
+      pendingSave?.resolve();
+      pendingSave = undefined;
+      return originalDestroy();
+    },
+  };
 };

--- a/syncdb/src/persisters/types.ts
+++ b/syncdb/src/persisters/types.ts
@@ -2,19 +2,34 @@ import type {MergeableStore} from "tinybase";
 import type {AnyPersister} from "tinybase/persisters";
 
 import type {KeyProvider} from "../crypto/types";
+import type {idbGet, idbSet} from "../storage/idb";
 
 /**
  * Binds a TinyBase persister to a specific store + logical database name. The
  * returned persister must support MergeableStore content (TinyBase
  * `Persists.MergeableStoreOnly` or `Persists.StoreOrMergeableStore`) so CRDT
  * metadata survives the round trip.
+ *
+ * `hooks` carries the client's E3 failure-surfacing callbacks
+ * (`onDecryptFailure`/`onLoadFailure`/`onSaveFailure`) — always passed
+ * through regardless of whether the default or a custom factory is in use, so
+ * a host app supplying its own `persisterFactory` (e.g. a different storage
+ * backend) can still opt into the same SyncStatus surfacing by wiring these
+ * into its own persister. Optional to consume; a factory that ignores
+ * `hooks` simply forgoes that surfacing (matches pre-E3 behavior).
  */
 export type PersisterFactory = ({
   store,
   databaseName,
+  hooks,
 }: {
   store: MergeableStore;
   databaseName: string;
+  hooks?: {
+    onDecryptFailure?: () => void;
+    onLoadFailure?: () => void;
+    onSaveFailure?: (error: unknown) => void;
+  };
 }) => AnyPersister;
 
 /**
@@ -32,8 +47,25 @@ export interface DefaultPersisterFactoryConfig {
   userId?: string;
   /** Invoked when persisted data cannot be decrypted (web only). */
   onDecryptFailure?: () => void;
+  /**
+   * E3(a): invoked when the underlying storage READ itself fails (distinct
+   * from "no data" and from a decrypt/parse failure) — a signal that the
+   * persisted blob might still be intact and must not be autosaved over
+   * (web only).
+   */
+  onLoadFailure?: () => void;
+  /**
+   * E3(a): invoked when a WRITE to storage ultimately fails (e.g. a
+   * quota-exceeded error) — TinyBase's autosave scheduler otherwise swallows
+   * this silently (web only).
+   */
+  onSaveFailure?: (error: unknown) => void;
   /** Trailing save debounce in ms; 0 disables debouncing (web only). */
   saveDebounceMs?: number;
   /** SQLite table name holding the JSON-serialized store (native only). */
   storeTableName?: string;
+  /** Test-only override for the IndexedDB read (web only; default: the real `idbGet`). */
+  idbGetImpl?: typeof idbGet;
+  /** Test-only override for the IndexedDB write (web only; default: the real `idbSet`). */
+  idbSetImpl?: typeof idbSet;
 }

--- a/syncdb/src/react/hooks.test.tsx
+++ b/syncdb/src/react/hooks.test.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import {createSyncDb, type SyncDb} from "../client";
 import {memoryPersisterFactory} from "../persisters/memoryPersister";
 import {createFakeTransport, type FakeTransport} from "../sync/fakeTransport";
+import {AuthRequiredError} from "../sync/httpChannel";
 import type {AuthProvider, SyncDelta} from "../types";
 import {useConflicts, useEntity, useMutate, useQuery, useSyncStatus} from "./hooks";
 import {SyncDbProvider, useSyncDbClient} from "./provider";
@@ -24,22 +25,37 @@ const flush = async (): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, 5));
 };
 
-const makeAuthProvider = (userId: string): AuthProvider => ({
-  getToken: async () => "token",
-  getUserId: async () => userId,
-  onAuthChange: () => () => {},
-});
+const makeAuthProvider = (userId: string): AuthProvider & {emitAuthChange: () => void} => {
+  const listeners = new Set<() => void>();
+  return {
+    emitAuthChange: (): void => {
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+    getToken: async () => "token",
+    getUserId: async () => userId,
+    onAuthChange: (callback: () => void): (() => void) => {
+      listeners.add(callback);
+      return () => {
+        listeners.delete(callback);
+      };
+    },
+  };
+};
 
 interface Harness {
   client: SyncDb;
   transport: FakeTransport;
+  auth: ReturnType<typeof makeAuthProvider>;
   wrapper: React.FC<{children: React.ReactNode}>;
 }
 
 const setup = async (): Promise<Harness> => {
   const transport = createFakeTransport();
+  const auth = makeAuthProvider("u1");
   const client = createSyncDb({
-    authProvider: makeAuthProvider("u1"),
+    authProvider: auth,
     collections: ["todos"],
     name: uniqueName(),
     persisterFactory: memoryPersisterFactory,
@@ -50,7 +66,7 @@ const setup = async (): Promise<Harness> => {
   const wrapper: React.FC<{children: React.ReactNode}> = ({children}) => (
     <SyncDbProvider client={client}>{children}</SyncDbProvider>
   );
-  return {client, transport, wrapper};
+  return {auth, client, transport, wrapper};
 };
 
 const makeDelta = (overrides: Partial<SyncDelta> = {}): SyncDelta => ({
@@ -323,6 +339,32 @@ describe("useSyncStatus", () => {
       await flush();
     });
     expect(result.current.conflictCount).toBe(1);
+    await act(async () => {
+      await client.stop();
+    });
+  });
+
+  it("reflects the auth-pause state reactively (A4)", async () => {
+    const {auth, client, transport, wrapper} = await setup();
+    transport.setDefaultResponder(() => {
+      throw new AuthRequiredError();
+    });
+    const {result} = renderHook(() => useSyncStatus(), {wrapper});
+    expect(result.current.paused).toBeUndefined();
+
+    await act(async () => {
+      client.mutate({collection: "todos", data: {title: "x"}, operation: "create"});
+      await flush();
+    });
+    expect(result.current.paused).toBe("auth");
+
+    // Same-user re-auth is the unpause path (no refresh() configured here).
+    transport.setDefaultResponder();
+    await act(async () => {
+      auth.emitAuthChange();
+      await flush();
+    });
+    expect(result.current.paused).toBeUndefined();
     await act(async () => {
       await client.stop();
     });

--- a/syncdb/src/react/hooks.test.tsx
+++ b/syncdb/src/react/hooks.test.tsx
@@ -230,6 +230,32 @@ describe("useQuery", () => {
       await client.stop();
     });
   });
+
+  it("skips a corrupt row (undecodable data) instead of throwing (E4)", async () => {
+    const {client, wrapper} = await setup();
+    act(() => {
+      client.store.upsertEntity({collection: "todos", data: {title: "healthy"}, id: "t1"});
+      // Write a raw row whose `data` cell is not valid JSON, bypassing the
+      // encoder — this is what a corrupt/legacy row looks like on disk.
+      // store.ts's decodeData already swallows the JSON.parse failure and
+      // returns null (with a console.warn) rather than throwing; useQuery
+      // must additionally skip that row from its results rather than handing
+      // list consumers a `null` entry that crashes on first field access.
+      client.store.raw.setRow("todos", "corrupt-1", {
+        data: "{not valid json",
+        deleted: false,
+        pendingMutationId: "",
+        seq: 1,
+      });
+    });
+    const {result} = renderHook(() => useQuery<TodoData>("todos"), {wrapper});
+    expect(() => result.current).not.toThrow();
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]?.title).toBe("healthy");
+    await act(async () => {
+      await client.stop();
+    });
+  });
 });
 
 describe("useMutate", () => {
@@ -445,6 +471,56 @@ describe("useConflicts", () => {
       .find((mutation) => mutation.entityId === "t1");
     expect(retry?.status).toBe("queued");
     expect(retry?.baseVersion).toBe(7);
+    await act(async () => {
+      await client.stop();
+    });
+  });
+});
+
+describe("listener cleanup on unmount (E4)", () => {
+  it("useEntity removes its row listener on unmount", async () => {
+    const {client, wrapper} = await setup();
+    const baseline = client.store.raw.getListenerStats();
+    const {unmount} = renderHook(() => useEntity<TodoData>("todos", "t1"), {wrapper});
+    expect(client.store.raw.getListenerStats().row).toBe(baseline.row + 1);
+    unmount();
+    expect(client.store.raw.getListenerStats()).toEqual(baseline);
+    await act(async () => {
+      await client.stop();
+    });
+  });
+
+  it("useQuery removes its table listener on unmount", async () => {
+    const {client, wrapper} = await setup();
+    const baseline = client.store.raw.getListenerStats();
+    const {unmount} = renderHook(() => useQuery<TodoData>("todos"), {wrapper});
+    expect(client.store.raw.getListenerStats().table).toBe(baseline.table + 1);
+    unmount();
+    expect(client.store.raw.getListenerStats()).toEqual(baseline);
+    await act(async () => {
+      await client.stop();
+    });
+  });
+
+  it("useSyncStatus removes its outbox/conflicts/cursors table listeners on unmount", async () => {
+    const {client, wrapper} = await setup();
+    const baseline = client.store.raw.getListenerStats();
+    const {unmount} = renderHook(() => useSyncStatus(), {wrapper});
+    expect(client.store.raw.getListenerStats().table).toBe(baseline.table + 3);
+    unmount();
+    expect(client.store.raw.getListenerStats()).toEqual(baseline);
+    await act(async () => {
+      await client.stop();
+    });
+  });
+
+  it("useConflicts removes its conflicts table listener on unmount", async () => {
+    const {client, wrapper} = await setup();
+    const baseline = client.store.raw.getListenerStats();
+    const {unmount} = renderHook(() => useConflicts(), {wrapper});
+    expect(client.store.raw.getListenerStats().table).toBe(baseline.table + 1);
+    unmount();
+    expect(client.store.raw.getListenerStats()).toEqual(baseline);
     await act(async () => {
       await client.stop();
     });

--- a/syncdb/src/react/hooks.ts
+++ b/syncdb/src/react/hooks.ts
@@ -10,7 +10,7 @@
  * (and RNW) compatible.
  */
 
-import {useCallback, useRef, useSyncExternalStore} from "react";
+import {useCallback, useLayoutEffect, useRef, useSyncExternalStore} from "react";
 
 import type {SyncDebugEvent, SyncDebugLog, SyncDebugStats} from "../debug/debugLog";
 import {listConflicts} from "../mutations/conflicts";
@@ -108,7 +108,15 @@ export const useQuery = <TData = Record<string, unknown>>(
   // reading them through a ref keeps `select` stable so the snapshot cache and
   // the store subscription survive re-renders.
   const optionsRef = useRef(options);
-  optionsRef.current = options;
+  // E4: assigning a ref during render is a side effect against React's render
+  // model (StrictMode double-invokes render bodies specifically to surface
+  // this class of bug) — moved into a layout effect, which still runs before
+  // the browser paints (and before any synchronous store-listener callback
+  // triggered by an event between render and the passive-effect phase could
+  // observe a stale ref).
+  useLayoutEffect(() => {
+    optionsRef.current = options;
+  });
 
   const subscribe = useCallback(
     (onChange: () => void): (() => void) => {
@@ -126,7 +134,11 @@ export const useQuery = <TData = Record<string, unknown>>(
       collection,
       includeDeleted: current?.includeDeleted,
     });
-    let results = entities.map((entity) => entity.data);
+    // E4: a corrupt/legacy row decodes to `data: null` (store.ts's decodeData
+    // swallows JSON.parse failures and returns null rather than throwing) —
+    // skip it here rather than letting it crash list consumers that assume
+    // every row's data matches TData (e.g. destructuring a field off it).
+    let results = entities.filter((entity) => entity.data !== null).map((entity) => entity.data);
     if (current?.filter) {
       results = results.filter(current.filter);
     }
@@ -250,7 +262,7 @@ export interface UseSyncDebugLogResult {
   stats: SyncDebugStats | undefined;
   /** The underlying log, for `snapshot()`/`clear()` (undefined when disabled). */
   log: SyncDebugLog | undefined;
-  /** Drop all retained events. */
+  /** Drop all retained events and reset `stats` to describe the now-empty log (a no-op when disabled). */
   clear: () => void;
 }
 

--- a/syncdb/src/storage/schema.ts
+++ b/syncdb/src/storage/schema.ts
@@ -8,6 +8,8 @@ export const SYNC_SCHEMA_VERSION = 1;
 const ENTITY_TABLE_SCHEMA: Record<string, CellSchema> = {
   data: {type: "string"},
   deleted: {default: false, type: "boolean"},
+  /** E5: stamped when a tombstone is first applied; "" otherwise. */
+  deletedAt: {default: "", type: "string"},
   pendingMutationId: {default: "", type: "string"},
   seq: {default: 0, type: "number"},
 };

--- a/syncdb/src/storage/schema.ts
+++ b/syncdb/src/storage/schema.ts
@@ -1,15 +1,19 @@
 import type {CellSchema, TablesSchema, ValuesSchema} from "tinybase";
 
-import {CONFLICTS_TABLE, CURSORS_TABLE, OUTBOX_TABLE} from "./types";
+import {CONFLICTS_TABLE, CURSORS_TABLE, KNOWN_STREAMS_TABLE, OUTBOX_TABLE} from "./types";
 
-/** Current local schema version. Bump when the table shapes change. */
-export const SYNC_SCHEMA_VERSION = 1;
+/**
+ * Current local schema version. Bump when the table shapes change.
+ * v2 (C2): entity rows gained a `stream` column; added the `_knownStreams` table.
+ */
+export const SYNC_SCHEMA_VERSION = 2;
 
 const ENTITY_TABLE_SCHEMA: Record<string, CellSchema> = {
   data: {type: "string"},
   deleted: {default: false, type: "boolean"},
   pendingMutationId: {default: "", type: "string"},
   seq: {default: 0, type: "number"},
+  stream: {default: "", type: "string"},
 };
 
 /**
@@ -31,6 +35,10 @@ export const buildTablesSchema = ({collections}: {collections: string[]}): Table
     [CURSORS_TABLE]: {
       seq: {default: 0, type: "number"},
       updatedAt: {type: "string"},
+    },
+    [KNOWN_STREAMS_TABLE]: {
+      addedAt: {type: "string"},
+      collection: {type: "string"},
     },
     [OUTBOX_TABLE]: {
       args: {type: "string"},

--- a/syncdb/src/storage/schema.ts
+++ b/syncdb/src/storage/schema.ts
@@ -40,6 +40,7 @@ export const buildTablesSchema = ({collections}: {collections: string[]}): Table
       createdAt: {type: "string"},
       enqueueOrder: {default: 0, type: "number"},
       entityId: {type: "string"},
+      errorNackCount: {default: 0, type: "number"},
       operation: {type: "string"},
       status: {default: "queued", type: "string"},
       userId: {default: "", type: "string"},
@@ -54,5 +55,7 @@ export const buildTablesSchema = ({collections}: {collections: string[]}): Table
 /** Store-level values schema: schema version + last authenticated user. */
 export const SYNC_VALUES_SCHEMA: ValuesSchema = {
   lastUserId: {default: "", type: "string"},
+  /** O(1) FIFO ordering cell: the highest `enqueueOrder` handed out so far. */
+  outboxMaxEnqueueOrder: {default: 0, type: "number"},
   schemaVersion: {default: SYNC_SCHEMA_VERSION, type: "number"},
 };

--- a/syncdb/src/storage/schema.ts
+++ b/syncdb/src/storage/schema.ts
@@ -1,9 +1,12 @@
 import type {CellSchema, TablesSchema, ValuesSchema} from "tinybase";
 
-import {CONFLICTS_TABLE, CURSORS_TABLE, OUTBOX_TABLE} from "./types";
+import {CONFLICTS_TABLE, CURSORS_TABLE, KNOWN_STREAMS_TABLE, OUTBOX_TABLE} from "./types";
 
-/** Current local schema version. Bump when the table shapes change. */
-export const SYNC_SCHEMA_VERSION = 1;
+/**
+ * Current local schema version. Bump when the table shapes change.
+ * v2 (C2): entity rows gained a `stream` column; added the `_knownStreams` table.
+ */
+export const SYNC_SCHEMA_VERSION = 2;
 
 const ENTITY_TABLE_SCHEMA: Record<string, CellSchema> = {
   data: {type: "string"},
@@ -12,6 +15,7 @@ const ENTITY_TABLE_SCHEMA: Record<string, CellSchema> = {
   deletedAt: {default: "", type: "string"},
   pendingMutationId: {default: "", type: "string"},
   seq: {default: 0, type: "number"},
+  stream: {default: "", type: "string"},
 };
 
 /**
@@ -33,6 +37,10 @@ export const buildTablesSchema = ({collections}: {collections: string[]}): Table
     [CURSORS_TABLE]: {
       seq: {default: 0, type: "number"},
       updatedAt: {type: "string"},
+    },
+    [KNOWN_STREAMS_TABLE]: {
+      addedAt: {type: "string"},
+      collection: {type: "string"},
     },
     [OUTBOX_TABLE]: {
       args: {type: "string"},

--- a/syncdb/src/storage/store.test.ts
+++ b/syncdb/src/storage/store.test.ts
@@ -56,6 +56,7 @@ describe("upsertEntity / getEntity", () => {
       id: "t1",
       pendingMutationId: undefined,
       seq: 3,
+      stream: undefined,
     });
   });
 
@@ -206,5 +207,49 @@ describe("clearCollection", () => {
     expect(() => store.clearCollection({collection: CONFLICTS_TABLE})).toThrow(
       /Unknown collection/
     );
+  });
+});
+
+describe("known streams + purgeStream (C2)", () => {
+  it("round-trips known streams (add / get / remove)", () => {
+    const store = makeStore();
+    expect(store.getKnownStreams()).toEqual([]);
+    store.addKnownStream({collection: "todos", stream: "todos|owner:u1"});
+    store.addKnownStream({collection: "todos", stream: "todos|tenant:org1"});
+    expect(store.getKnownStreams().sort()).toEqual(["todos|owner:u1", "todos|tenant:org1"]);
+    store.removeKnownStream({stream: "todos|owner:u1"});
+    expect(store.getKnownStreams()).toEqual(["todos|tenant:org1"]);
+  });
+
+  it("purgeStream deletes only the matching stream's entities, its cursor, and its known-stream row", () => {
+    const store = makeStore();
+    const leaving = "todos|tenant:org1";
+    const staying = "todos|owner:u1";
+    // Two entities on the leaving stream (one in each collection), one on the staying stream.
+    store.upsertEntity({collection: "todos", data: {t: 1}, id: "a", seq: 3, stream: leaving});
+    store.upsertEntity({collection: "notes", data: {n: 1}, id: "b", seq: 4, stream: leaving});
+    store.upsertEntity({collection: "todos", data: {t: 2}, id: "c", seq: 5, stream: staying});
+    store.addKnownStream({collection: "todos", stream: leaving});
+    store.addKnownStream({collection: "todos", stream: staying});
+    store.raw.setRow(CURSORS_TABLE, leaving, {seq: 3, updatedAt: "x"});
+    store.raw.setRow(CURSORS_TABLE, staying, {seq: 5, updatedAt: "y"});
+
+    const purged = store.purgeStream({stream: leaving});
+
+    expect(purged).toBe(2);
+    expect(store.getEntity({collection: "todos", id: "a"})).toBeUndefined();
+    expect(store.getEntity({collection: "notes", id: "b"})).toBeUndefined();
+    // The staying stream's entity and cursor and known-stream row are untouched.
+    expect(store.getEntity({collection: "todos", id: "c"})?.data).toEqual({t: 2});
+    expect(store.raw.getCell(CURSORS_TABLE, staying, "seq")).toBe(5);
+    expect(store.raw.hasRow(CURSORS_TABLE, leaving)).toBe(false);
+    expect(store.getKnownStreams()).toEqual([staying]);
+  });
+
+  it("purgeStream returns 0 and is a no-op for a stream with no entities", () => {
+    const store = makeStore();
+    store.addKnownStream({collection: "todos", stream: "todos|owner:ghost"});
+    expect(store.purgeStream({stream: "todos|owner:ghost"})).toBe(0);
+    expect(store.getKnownStreams()).toEqual([]);
   });
 });

--- a/syncdb/src/storage/store.test.ts
+++ b/syncdb/src/storage/store.test.ts
@@ -56,6 +56,7 @@ describe("upsertEntity / getEntity", () => {
       id: "t1",
       pendingMutationId: undefined,
       seq: 3,
+      stream: undefined,
     });
   });
 
@@ -289,5 +290,49 @@ describe("compactTombstones (E5)", () => {
     });
     expect(result.removed).toBe(0);
     expect(store.getEntity({collection: "todos", id: "t1"})).toBeDefined();
+  });
+});
+
+describe("known streams + purgeStream (C2)", () => {
+  it("round-trips known streams (add / get / remove)", () => {
+    const store = makeStore();
+    expect(store.getKnownStreams()).toEqual([]);
+    store.addKnownStream({collection: "todos", stream: "todos|owner:u1"});
+    store.addKnownStream({collection: "todos", stream: "todos|tenant:org1"});
+    expect(store.getKnownStreams().sort()).toEqual(["todos|owner:u1", "todos|tenant:org1"]);
+    store.removeKnownStream({stream: "todos|owner:u1"});
+    expect(store.getKnownStreams()).toEqual(["todos|tenant:org1"]);
+  });
+
+  it("purgeStream deletes only the matching stream's entities, its cursor, and its known-stream row", () => {
+    const store = makeStore();
+    const leaving = "todos|tenant:org1";
+    const staying = "todos|owner:u1";
+    // Two entities on the leaving stream (one in each collection), one on the staying stream.
+    store.upsertEntity({collection: "todos", data: {t: 1}, id: "a", seq: 3, stream: leaving});
+    store.upsertEntity({collection: "notes", data: {n: 1}, id: "b", seq: 4, stream: leaving});
+    store.upsertEntity({collection: "todos", data: {t: 2}, id: "c", seq: 5, stream: staying});
+    store.addKnownStream({collection: "todos", stream: leaving});
+    store.addKnownStream({collection: "todos", stream: staying});
+    store.raw.setRow(CURSORS_TABLE, leaving, {seq: 3, updatedAt: "x"});
+    store.raw.setRow(CURSORS_TABLE, staying, {seq: 5, updatedAt: "y"});
+
+    const purged = store.purgeStream({stream: leaving});
+
+    expect(purged).toBe(2);
+    expect(store.getEntity({collection: "todos", id: "a"})).toBeUndefined();
+    expect(store.getEntity({collection: "notes", id: "b"})).toBeUndefined();
+    // The staying stream's entity and cursor and known-stream row are untouched.
+    expect(store.getEntity({collection: "todos", id: "c"})?.data).toEqual({t: 2});
+    expect(store.raw.getCell(CURSORS_TABLE, staying, "seq")).toBe(5);
+    expect(store.raw.hasRow(CURSORS_TABLE, leaving)).toBe(false);
+    expect(store.getKnownStreams()).toEqual([staying]);
+  });
+
+  it("purgeStream returns 0 and is a no-op for a stream with no entities", () => {
+    const store = makeStore();
+    store.addKnownStream({collection: "todos", stream: "todos|owner:ghost"});
+    expect(store.purgeStream({stream: "todos|owner:ghost"})).toBe(0);
+    expect(store.getKnownStreams()).toEqual([]);
   });
 });

--- a/syncdb/src/storage/store.test.ts
+++ b/syncdb/src/storage/store.test.ts
@@ -208,3 +208,86 @@ describe("clearCollection", () => {
     );
   });
 });
+
+describe("deletedAt stamping (E5)", () => {
+  it("upsertEntity stamps deletedAt on the transition into a tombstone, and only then", () => {
+    const store = makeStore();
+    store.upsertEntity({collection: "todos", data: {title: "a"}, id: "t1"});
+    expect(store.getEntity({collection: "todos", id: "t1"})?.deletedAt).toBeUndefined();
+
+    store.softDeleteEntity({collection: "todos", id: "t1"});
+    const firstStampedAt = store.getEntity({collection: "todos", id: "t1"})?.deletedAt;
+    expect(firstStampedAt).toBeTruthy();
+
+    // A second upsert that keeps deleted: true must NOT re-stamp deletedAt.
+    store.upsertEntity({collection: "todos", data: {title: "a"}, deleted: true, id: "t1"});
+    expect(store.getEntity({collection: "todos", id: "t1"})?.deletedAt).toBe(firstStampedAt);
+  });
+
+  it("clears deletedAt on a resurrection (upsert back to deleted: false)", () => {
+    const store = makeStore();
+    store.upsertEntity({collection: "todos", data: {title: "a"}, id: "t1"});
+    store.softDeleteEntity({collection: "todos", id: "t1"});
+    expect(store.getEntity({collection: "todos", id: "t1"})?.deletedAt).toBeTruthy();
+
+    store.upsertEntity({collection: "todos", data: {title: "a"}, deleted: false, id: "t1"});
+    expect(store.getEntity({collection: "todos", id: "t1"})?.deletedAt).toBeUndefined();
+  });
+});
+
+describe("compactTombstones (E5)", () => {
+  it("removes tombstones older than the retention window, across all collections", () => {
+    const clock = {value: 1_000_000};
+    const store = createSyncStore({
+      collections: ["todos", "notes"],
+      now: () => new Date(clock.value).toISOString(),
+    });
+    store.upsertEntity({collection: "todos", data: {title: "old"}, id: "t1"});
+    store.upsertEntity({collection: "todos", data: {title: "recent"}, id: "t2"});
+    store.upsertEntity({collection: "notes", data: {body: "old note"}, id: "n1"});
+    store.upsertEntity({collection: "todos", data: {title: "kept, not deleted"}, id: "t3"});
+
+    // t1/n1 tombstoned "long ago"; t2 tombstoned "recently", relative to the
+    // clock the compaction call itself uses below.
+    store.upsertEntity({collection: "todos", data: null, deleted: true, id: "t1"});
+    store.upsertEntity({collection: "notes", data: null, deleted: true, id: "n1"});
+    clock.value += 100 * 24 * 60 * 60 * 1_000; // +100 days
+    store.upsertEntity({collection: "todos", data: null, deleted: true, id: "t2"});
+
+    // Advance the clock another 10 days: t1/n1 are now ~110 days old, t2 is
+    // ~10 days old. A 90-day retention window compacts t1/n1 but keeps t2.
+    clock.value += 10 * 24 * 60 * 60 * 1_000;
+    const result = store.compactTombstones({olderThanMs: 90 * 24 * 60 * 60 * 1_000});
+
+    expect(result.removed).toBe(2);
+    expect(store.getEntity({collection: "todos", id: "t1"})).toBeUndefined();
+    expect(store.getEntity({collection: "notes", id: "n1"})).toBeUndefined();
+    expect(store.getEntity({collection: "todos", id: "t2"})?.deleted).toBe(true);
+    expect(store.getEntity({collection: "todos", id: "t3"})?.deleted).toBe(false);
+  });
+
+  it("leaves tombstones with no deletedAt (pre-E5 rows) untouched", () => {
+    const store = makeStore();
+    store.upsertEntity({collection: "todos", data: {title: "legacy"}, id: "t1"});
+    // Simulate a tombstone written before deletedAt existed: set the cell
+    // directly, bypassing the stamping logic in upsertEntity/softDeleteEntity.
+    store.raw.setCell("todos", "t1", "deleted", true);
+    expect(store.getEntity({collection: "todos", id: "t1"})?.deletedAt).toBeUndefined();
+
+    const result = store.compactTombstones({olderThanMs: 0});
+    expect(result.removed).toBe(0);
+    expect(store.getEntity({collection: "todos", id: "t1"})).toBeDefined();
+  });
+
+  it("never removes non-tombstone rows regardless of age", () => {
+    const store = makeStore();
+    const clock = {value: 1_000_000};
+    store.upsertEntity({collection: "todos", data: {title: "alive"}, id: "t1"});
+    const result = store.compactTombstones({
+      now: () => new Date(clock.value + 1_000 * 60 * 60 * 24 * 365).toISOString(),
+      olderThanMs: 0,
+    });
+    expect(result.removed).toBe(0);
+    expect(store.getEntity({collection: "todos", id: "t1"})).toBeDefined();
+  });
+});

--- a/syncdb/src/storage/store.ts
+++ b/syncdb/src/storage/store.ts
@@ -2,7 +2,13 @@ import {DateTime} from "luxon";
 import {createMergeableStore, type MergeableStore, type Row} from "tinybase";
 
 import {buildTablesSchema, SYNC_SCHEMA_VERSION, SYNC_VALUES_SCHEMA} from "./schema";
-import {type EntityRow, RESERVED_TABLE_PREFIX, type SyncEntity} from "./types";
+import {
+  CURSORS_TABLE,
+  type EntityRow,
+  KNOWN_STREAMS_TABLE,
+  RESERVED_TABLE_PREFIX,
+  type SyncEntity,
+} from "./types";
 
 const defaultNow = (): string => DateTime.now().toISO();
 
@@ -28,6 +34,7 @@ const rowToEntity = <TData>(id: string, row: Partial<EntityRow>): SyncEntity<TDa
   id,
   pendingMutationId: row.pendingMutationId ? row.pendingMutationId : undefined,
   seq: row.seq ?? 0,
+  stream: row.stream ? row.stream : undefined,
 });
 
 export interface UpsertEntityArgs {
@@ -40,6 +47,8 @@ export interface UpsertEntityArgs {
   deleted?: boolean;
   /** Protecting outbox mutation; omitted = preserve existing, "" = clear. */
   pendingMutationId?: string;
+  /** C2: the stream this entity was written under; omitted = preserve existing. */
+  stream?: string;
 }
 
 export interface CompactTombstonesResult {
@@ -75,6 +84,18 @@ export interface SyncStore {
    * client hasn't actually converged on yet.
    */
   compactTombstones: (args: {olderThanMs: number; now?: () => string}) => CompactTombstonesResult;
+  /** C2: stream keys the client has bootstrapped (the persisted membership set). */
+  getKnownStreams: () => string[];
+  /** C2: record a stream as bootstrapped (join). */
+  addKnownStream: (args: {stream: string; collection: string}) => void;
+  /** C2: forget a bootstrapped stream (leave). */
+  removeKnownStream: (args: {stream: string}) => void;
+  /**
+   * C2 leave-purge: delete every local entity written under `stream` (matched on the
+   * entity `stream` column) across all collections, and its cursor + known-stream entry.
+   * Returns the number of entities purged.
+   */
+  purgeStream: (args: {stream: string}) => number;
 }
 
 /**
@@ -131,6 +152,7 @@ export const createSyncStore = ({
       deletedAt: deleted ? existing?.deletedAt || now() : "",
       pendingMutationId: args.pendingMutationId ?? existing?.pendingMutationId ?? "",
       seq: args.seq ?? existing?.seq ?? 0,
+      stream: args.stream ?? existing?.stream ?? "",
     };
     raw.setRow(args.collection, args.id, row as unknown as Row);
     return rowToEntity(args.id, row);
@@ -228,15 +250,50 @@ export const createSyncStore = ({
     });
   };
 
+  const getKnownStreams = (): string[] => Object.keys(raw.getTable(KNOWN_STREAMS_TABLE));
+
+  const addKnownStream = ({stream, collection}: {stream: string; collection: string}): void => {
+    raw.setRow(KNOWN_STREAMS_TABLE, stream, {
+      addedAt: now(),
+      collection,
+    } as unknown as Row);
+  };
+
+  const removeKnownStream = ({stream}: {stream: string}): void => {
+    raw.delRow(KNOWN_STREAMS_TABLE, stream);
+  };
+
+  const purgeStream = ({stream}: {stream: string}): number => {
+    // C2 leave-purge deletes rows outright, so E5 deletedAt tombstone semantics
+    // do not apply here — a purged stream is gone locally, not soft-deleted.
+    let purged = 0;
+    for (const collection of collections) {
+      const table = raw.getTable(collection);
+      for (const [id, row] of Object.entries(table)) {
+        if ((row as Partial<EntityRow>).stream === stream) {
+          raw.delRow(collection, id);
+          purged += 1;
+        }
+      }
+    }
+    raw.delRow(CURSORS_TABLE, stream);
+    removeKnownStream({stream});
+    return purged;
+  };
+
   return {
+    addKnownStream,
     clearCollection,
     collections,
     compactTombstones,
     getEntity,
+    getKnownStreams,
     getLastUserId,
     getSchemaVersion,
     listEntities,
+    purgeStream,
     raw,
+    removeKnownStream,
     setLastUserId,
     softDeleteEntity,
     upsertEntity,

--- a/syncdb/src/storage/store.ts
+++ b/syncdb/src/storage/store.ts
@@ -1,7 +1,10 @@
+import {DateTime} from "luxon";
 import {createMergeableStore, type MergeableStore, type Row} from "tinybase";
 
 import {buildTablesSchema, SYNC_SCHEMA_VERSION, SYNC_VALUES_SCHEMA} from "./schema";
 import {type EntityRow, RESERVED_TABLE_PREFIX, type SyncEntity} from "./types";
+
+const defaultNow = (): string => DateTime.now().toISO();
 
 const encodeData = (data: unknown): string => JSON.stringify(data ?? null);
 
@@ -21,6 +24,7 @@ const decodeData = <TData>(raw: string | undefined): TData => {
 const rowToEntity = <TData>(id: string, row: Partial<EntityRow>): SyncEntity<TData> => ({
   data: decodeData<TData>(row.data),
   deleted: Boolean(row.deleted),
+  deletedAt: row.deletedAt ? row.deletedAt : undefined,
   id,
   pendingMutationId: row.pendingMutationId ? row.pendingMutationId : undefined,
   seq: row.seq ?? 0,
@@ -36,6 +40,11 @@ export interface UpsertEntityArgs {
   deleted?: boolean;
   /** Protecting outbox mutation; omitted = preserve existing, "" = clear. */
   pendingMutationId?: string;
+}
+
+export interface CompactTombstonesResult {
+  /** Number of tombstone rows removed (across all configured collections). */
+  removed: number;
 }
 
 export interface SyncStore {
@@ -57,6 +66,15 @@ export interface SyncStore {
   getSchemaVersion: () => number;
   getLastUserId: () => string | undefined;
   setLastUserId: (args: {userId: string}) => void;
+  /**
+   * E5: delete local tombstone rows (`deleted: true`) whose `deletedAt` is
+   * older than `olderThanMs` (from `now`), across every configured
+   * collection, in one transaction. Tombstones with no `deletedAt` (applied
+   * before this cell existed) are left alone — there is no reliable age to
+   * compare, and it is safer to under-compact than to drop a tombstone a
+   * client hasn't actually converged on yet.
+   */
+  compactTombstones: (args: {olderThanMs: number; now?: () => string}) => CompactTombstonesResult;
 }
 
 /**
@@ -66,7 +84,14 @@ export interface SyncStore {
  * Every accessor validates its collection against the configured list so a
  * typo'd collection fails loudly instead of silently writing to a stray table.
  */
-export const createSyncStore = ({collections}: {collections: string[]}): SyncStore => {
+export const createSyncStore = ({
+  collections,
+  now = defaultNow,
+}: {
+  collections: string[];
+  /** ISO clock, injectable for deterministic E5 tombstone-retention tests. */
+  now?: () => string;
+}): SyncStore => {
   for (const collection of collections) {
     if (collection.startsWith(RESERVED_TABLE_PREFIX)) {
       throw new Error(
@@ -94,9 +119,16 @@ export const createSyncStore = ({collections}: {collections: string[]}): SyncSto
     const existing = raw.hasRow(args.collection, args.id)
       ? (raw.getRow(args.collection, args.id) as Partial<EntityRow>)
       : undefined;
+    const deleted = args.deleted ?? existing?.deleted ?? false;
     const row: EntityRow = {
       data: encodeData(args.data),
-      deleted: args.deleted ?? existing?.deleted ?? false,
+      deleted,
+      // E5: stamp deletedAt the moment a row FIRST becomes a tombstone (not
+      // on every subsequent upsert while it stays deleted, and never on a
+      // resurrection back to deleted: false — clear it instead). Empty
+      // string (the schema default for a never-deleted row) must be treated
+      // the same as "absent" here — `??` alone does not do that.
+      deletedAt: deleted ? existing?.deletedAt || now() : "",
       pendingMutationId: args.pendingMutationId ?? existing?.pendingMutationId ?? "",
       seq: args.seq ?? existing?.seq ?? 0,
     };
@@ -137,7 +169,16 @@ export const createSyncStore = ({collections}: {collections: string[]}): SyncSto
     if (!raw.hasRow(args.collection, args.id)) {
       return;
     }
-    raw.setCell(args.collection, args.id, "deleted", true);
+    raw.transaction(() => {
+      raw.setCell(args.collection, args.id, "deleted", true);
+      // E5: stamp deletedAt only on the transition into a tombstone — a
+      // second softDeleteEntity call on an already-deleted row (idempotent)
+      // must not push the age-out clock forward.
+      const currentDeletedAt = raw.getCell(args.collection, args.id, "deletedAt");
+      if (!currentDeletedAt) {
+        raw.setCell(args.collection, args.id, "deletedAt", now());
+      }
+    });
   };
 
   const clearCollection = (args: {collection: string}): void => {
@@ -159,9 +200,38 @@ export const createSyncStore = ({collections}: {collections: string[]}): SyncSto
     raw.setValue("lastUserId", userId);
   };
 
+  const compactTombstones = ({
+    olderThanMs,
+    now: compactionNow = now,
+  }: {
+    olderThanMs: number;
+    now?: () => string;
+  }): CompactTombstonesResult => {
+    const cutoff = DateTime.fromISO(compactionNow()).minus({milliseconds: olderThanMs});
+    return raw.transaction(() => {
+      let removed = 0;
+      for (const collection of collections) {
+        const table = raw.getTable(collection);
+        for (const [id, row] of Object.entries(table)) {
+          const typedRow = row as Partial<EntityRow>;
+          if (!typedRow.deleted || !typedRow.deletedAt) {
+            continue;
+          }
+          const deletedAt = DateTime.fromISO(typedRow.deletedAt);
+          if (!deletedAt.isValid || deletedAt < cutoff) {
+            raw.delRow(collection, id);
+            removed += 1;
+          }
+        }
+      }
+      return {removed};
+    });
+  };
+
   return {
     clearCollection,
     collections,
+    compactTombstones,
     getEntity,
     getLastUserId,
     getSchemaVersion,

--- a/syncdb/src/storage/store.ts
+++ b/syncdb/src/storage/store.ts
@@ -1,7 +1,14 @@
+import {DateTime} from "luxon";
 import {createMergeableStore, type MergeableStore, type Row} from "tinybase";
 
 import {buildTablesSchema, SYNC_SCHEMA_VERSION, SYNC_VALUES_SCHEMA} from "./schema";
-import {type EntityRow, RESERVED_TABLE_PREFIX, type SyncEntity} from "./types";
+import {
+  CURSORS_TABLE,
+  type EntityRow,
+  KNOWN_STREAMS_TABLE,
+  RESERVED_TABLE_PREFIX,
+  type SyncEntity,
+} from "./types";
 
 const encodeData = (data: unknown): string => JSON.stringify(data ?? null);
 
@@ -24,6 +31,7 @@ const rowToEntity = <TData>(id: string, row: Partial<EntityRow>): SyncEntity<TDa
   id,
   pendingMutationId: row.pendingMutationId ? row.pendingMutationId : undefined,
   seq: row.seq ?? 0,
+  stream: row.stream ? row.stream : undefined,
 });
 
 export interface UpsertEntityArgs {
@@ -36,6 +44,8 @@ export interface UpsertEntityArgs {
   deleted?: boolean;
   /** Protecting outbox mutation; omitted = preserve existing, "" = clear. */
   pendingMutationId?: string;
+  /** C2: the stream this entity was written under; omitted = preserve existing. */
+  stream?: string;
 }
 
 export interface SyncStore {
@@ -57,6 +67,18 @@ export interface SyncStore {
   getSchemaVersion: () => number;
   getLastUserId: () => string | undefined;
   setLastUserId: (args: {userId: string}) => void;
+  /** C2: stream keys the client has bootstrapped (the persisted membership set). */
+  getKnownStreams: () => string[];
+  /** C2: record a stream as bootstrapped (join). */
+  addKnownStream: (args: {stream: string; collection: string}) => void;
+  /** C2: forget a bootstrapped stream (leave). */
+  removeKnownStream: (args: {stream: string}) => void;
+  /**
+   * C2 leave-purge: delete every local entity written under `stream` (matched on the
+   * entity `stream` column) across all collections, and its cursor + known-stream entry.
+   * Returns the number of entities purged.
+   */
+  purgeStream: (args: {stream: string}) => number;
 }
 
 /**
@@ -99,6 +121,7 @@ export const createSyncStore = ({collections}: {collections: string[]}): SyncSto
       deleted: args.deleted ?? existing?.deleted ?? false,
       pendingMutationId: args.pendingMutationId ?? existing?.pendingMutationId ?? "",
       seq: args.seq ?? existing?.seq ?? 0,
+      stream: args.stream ?? existing?.stream ?? "",
     };
     raw.setRow(args.collection, args.id, row as unknown as Row);
     return rowToEntity(args.id, row);
@@ -159,14 +182,47 @@ export const createSyncStore = ({collections}: {collections: string[]}): SyncSto
     raw.setValue("lastUserId", userId);
   };
 
+  const getKnownStreams = (): string[] => Object.keys(raw.getTable(KNOWN_STREAMS_TABLE));
+
+  const addKnownStream = ({stream, collection}: {stream: string; collection: string}): void => {
+    raw.setRow(KNOWN_STREAMS_TABLE, stream, {
+      addedAt: DateTime.now().toISO(),
+      collection,
+    } as unknown as Row);
+  };
+
+  const removeKnownStream = ({stream}: {stream: string}): void => {
+    raw.delRow(KNOWN_STREAMS_TABLE, stream);
+  };
+
+  const purgeStream = ({stream}: {stream: string}): number => {
+    let purged = 0;
+    for (const collection of collections) {
+      const table = raw.getTable(collection);
+      for (const [id, row] of Object.entries(table)) {
+        if ((row as Partial<EntityRow>).stream === stream) {
+          raw.delRow(collection, id);
+          purged += 1;
+        }
+      }
+    }
+    raw.delRow(CURSORS_TABLE, stream);
+    removeKnownStream({stream});
+    return purged;
+  };
+
   return {
+    addKnownStream,
     clearCollection,
     collections,
     getEntity,
+    getKnownStreams,
     getLastUserId,
     getSchemaVersion,
     listEntities,
+    purgeStream,
     raw,
+    removeKnownStream,
     setLastUserId,
     softDeleteEntity,
     upsertEntity,

--- a/syncdb/src/storage/types.ts
+++ b/syncdb/src/storage/types.ts
@@ -40,7 +40,14 @@ export interface EntityRow {
 export interface OutboxRow {
   /** JSON-encoded mutation args. */
   args: string;
+  /** Diagnostic total attempt count across every send (transport + error-nack). */
   attemptCount: number;
+  /**
+   * Retry budget counter incremented ONLY on server error-nacks; transport
+   * failures never touch this cell (they get unlimited retries). Terminality
+   * (`MAX_ERROR_NACK_ATTEMPTS`) is checked against this, not `attemptCount`.
+   */
+  errorNackCount: number;
   /** Absent when the mutation carries no base version (e.g. creates). */
   baseVersion?: number;
   collection: string;

--- a/syncdb/src/storage/types.ts
+++ b/syncdb/src/storage/types.ts
@@ -30,6 +30,16 @@ export interface EntityRow {
   data: string;
   /** Soft-delete tombstone flag. */
   deleted: boolean;
+  /**
+   * ISO-8601 timestamp stamped the moment a tombstone (`deleted: true`) is
+   * first applied locally (empty string when not a tombstone, or for
+   * tombstones applied before this cell existed). E5's client-side
+   * compaction ages tombstones out from this timestamp, not `updated`/
+   * `created`, since a tombstone's local arrival time is what determines when
+   * it is safe to drop (it must survive at least as long as the server's own
+   * retention window, C7).
+   */
+  deletedAt: string;
   /** Outbox mutation currently protecting this entity's optimistic state ("" = none). */
   pendingMutationId: string;
   /** Highest server seq applied to this entity (0 = local-only, never synced). */
@@ -85,6 +95,8 @@ export interface SyncEntity<TData = unknown> {
   data: TData;
   /** Soft-delete tombstone flag. */
   deleted: boolean;
+  /** ISO-8601 timestamp the tombstone was first applied; undefined when not a tombstone. */
+  deletedAt?: string;
   /** Entity id (the TinyBase row id). */
   id: string;
   /** Outbox mutation currently protecting this entity, if any. */

--- a/syncdb/src/storage/types.ts
+++ b/syncdb/src/storage/types.ts
@@ -21,6 +21,13 @@ export const CURSORS_TABLE = "_cursors";
 /** Reserved table holding unresolved conflicts; rowId = mutationId. */
 export const CONFLICTS_TABLE = "_conflicts";
 
+/**
+ * C2: reserved table recording the streams the client has bootstrapped (membership set);
+ * rowId = stream key. Diffed against `GET /sync/streams` to detect joins (backfill) and
+ * leaves (purge), the latter only on a confirmed HTTP-200 membership change (INV-2).
+ */
+export const KNOWN_STREAMS_TABLE = "_knownStreams";
+
 /** Prefix marking reserved (non-collection) tables. */
 export const RESERVED_TABLE_PREFIX = "_";
 
@@ -44,6 +51,20 @@ export interface EntityRow {
   pendingMutationId: string;
   /** Highest server seq applied to this entity (0 = local-only, never synced). */
   seq: number;
+  /**
+   * C2: the stream key this entity was last written under (delta/snapshot). Recorded at
+   * apply time so leave-purge can drop a stream's entities in O(stream) without
+   * recomputing scope. "" for local-only entities never synced from the server.
+   */
+  stream: string;
+}
+
+/** Primitive row shape for the `_knownStreams` table; rowId = stream key. */
+export interface KnownStreamRow {
+  /** The collection tag the stream belongs to. */
+  collection: string;
+  /** When the stream was first bootstrapped. */
+  addedAt: string;
 }
 
 /** Primitive row shape for the `_outbox` table; rowId = mutationId. */
@@ -103,4 +124,6 @@ export interface SyncEntity<TData = unknown> {
   pendingMutationId?: string;
   /** Highest server seq applied to this entity (0 = local-only). */
   seq: number;
+  /** C2: the stream key this entity was last written under ("" for local-only). */
+  stream?: string;
 }

--- a/syncdb/src/storage/types.ts
+++ b/syncdb/src/storage/types.ts
@@ -21,6 +21,13 @@ export const CURSORS_TABLE = "_cursors";
 /** Reserved table holding unresolved conflicts; rowId = mutationId. */
 export const CONFLICTS_TABLE = "_conflicts";
 
+/**
+ * C2: reserved table recording the streams the client has bootstrapped (membership set);
+ * rowId = stream key. Diffed against `GET /sync/streams` to detect joins (backfill) and
+ * leaves (purge), the latter only on a confirmed HTTP-200 membership change (INV-2).
+ */
+export const KNOWN_STREAMS_TABLE = "_knownStreams";
+
 /** Prefix marking reserved (non-collection) tables. */
 export const RESERVED_TABLE_PREFIX = "_";
 
@@ -34,6 +41,20 @@ export interface EntityRow {
   pendingMutationId: string;
   /** Highest server seq applied to this entity (0 = local-only, never synced). */
   seq: number;
+  /**
+   * C2: the stream key this entity was last written under (delta/snapshot). Recorded at
+   * apply time so leave-purge can drop a stream's entities in O(stream) without
+   * recomputing scope. "" for local-only entities never synced from the server.
+   */
+  stream: string;
+}
+
+/** Primitive row shape for the `_knownStreams` table; rowId = stream key. */
+export interface KnownStreamRow {
+  /** The collection tag the stream belongs to. */
+  collection: string;
+  /** When the stream was first bootstrapped. */
+  addedAt: string;
 }
 
 /** Primitive row shape for the `_outbox` table; rowId = mutationId. */
@@ -91,4 +112,6 @@ export interface SyncEntity<TData = unknown> {
   pendingMutationId?: string;
   /** Highest server seq applied to this entity (0 = local-only). */
   seq: number;
+  /** C2: the stream key this entity was last written under ("" for local-only). */
+  stream?: string;
 }

--- a/syncdb/src/storage/wipe.ts
+++ b/syncdb/src/storage/wipe.ts
@@ -1,3 +1,4 @@
+import {createMergeableStore} from "tinybase";
 import type {AnyPersister} from "tinybase/persisters";
 
 import {clearMemoryPersisterData} from "../persisters/memoryPersister";
@@ -30,6 +31,14 @@ export const wipeLocalData = async ({
 }): Promise<void> => {
   store.raw.delTables();
   store.raw.delValues();
+  // A MergeableStore records CRDT (HLC) metadata for every cell it has ever held, and
+  // `delTables()` only tombstones rows — it does not drop that metadata. When the SAME
+  // store object is reused across a wipe (the different-user switch path, unlike the
+  // schema-mismatch/decrypt paths that build a fresh client), the residual metadata can be
+  // re-materialized as empty default rows the next time a persister loads and merges into
+  // the store. Reset the mergeable content outright so a wiped store carries no ghost rows
+  // into the next user's session.
+  store.raw.setMergeableContent(createMergeableStore().getMergeableContent());
   if (persister) {
     // Overwrite the snapshot with the emptied content (covers persisters whose
     // backing store is not named in databaseNames, e.g. native SQLite), then

--- a/syncdb/src/sync/bootstrap.test.ts
+++ b/syncdb/src/sync/bootstrap.test.ts
@@ -175,4 +175,40 @@ describe("bootstrapCollections", () => {
       {applied: 1, collection: "todos", cursor: 2, fetched: 2, hasMore: false},
     ]);
   });
+
+  it("applies a whole page inside one transaction: exactly one table-listener fire per page (E4)", async () => {
+    const store = makeStore();
+    const channel = makeChannel({
+      todos: {
+        0: {
+          cursor: 3,
+          entities: [
+            {data: {title: "a"}, deleted: false, id: "t1", seq: 1},
+            {data: {title: "b"}, deleted: false, id: "t2", seq: 2},
+            {data: {title: "c"}, deleted: false, id: "t3", seq: 3},
+          ],
+          hasMore: true,
+        },
+        3: {
+          cursor: 5,
+          entities: [
+            {data: {title: "d"}, deleted: false, id: "t4", seq: 4},
+            {data: {title: "e"}, deleted: false, id: "t5", seq: 5},
+          ],
+          hasMore: false,
+        },
+      },
+    });
+    let fireCount = 0;
+    const listenerId = store.raw.addTableListener("todos", () => {
+      fireCount += 1;
+    });
+    await bootstrapCollections({channel, collections: ["todos"], store});
+    store.raw.delListener(listenerId);
+    // Two pages fetched (hasMore then a final page) — one listener fire per
+    // page, not per row (5 entities total across both pages would mean 5
+    // fires if each upsert were its own transaction).
+    expect(fireCount).toBe(2);
+    expect(store.listEntities({collection: "todos"})).toHaveLength(5);
+  });
 });

--- a/syncdb/src/sync/bootstrap.test.ts
+++ b/syncdb/src/sync/bootstrap.test.ts
@@ -2,15 +2,37 @@ import {describe, expect, it} from "bun:test";
 
 import {createSyncStore, type SyncStore} from "../storage/store";
 import type {SyncSnapshotResponse} from "../types";
-import {type BootstrapProgress, bootstrapCollections, snapshotCursorStream} from "./bootstrap";
+import {type BootstrapProgress, bootstrapStream} from "./bootstrap";
 import {getCursor, setCursor} from "./cursor";
 import type {FetchSnapshotPageArgs} from "./httpChannel";
 
+const STREAM = "todos|owner:u1";
+
 const makeStore = (): SyncStore => createSyncStore({collections: ["notes", "todos"]});
 
-/** Channel stub serving canned pages per collection, keyed by request cursor. */
+/**
+ * Build a snapshot page with the C1/C7 fields defaulted so tests only specify what they
+ * care about. `frontierSeq` defaults to the page cursor (fully committed), and
+ * `oldestRetainedSeq` to 0 (no retention gap).
+ */
+const page = (
+  overrides: Partial<SyncSnapshotResponse> & {cursor: number}
+): SyncSnapshotResponse => ({
+  entities: [],
+  frontierSeq: overrides.frontierSeq ?? overrides.cursor,
+  hasMore: false,
+  oldestRetainedSeq: 0,
+  stream: STREAM,
+  ...overrides,
+});
+
+/**
+ * Channel stub serving canned pages for a single stream. Seq pages are keyed by the
+ * request cursor (as a string); legacy-stratum pages are keyed `legacy:{token}` where the
+ * first request (cursor 0, no legacyCursor) maps to `legacy:start`.
+ */
 const makeChannel = (
-  pages: Record<string, Record<number, SyncSnapshotResponse>>
+  byKey: Record<string, SyncSnapshotResponse>
 ): {
   fetchSnapshotPage: (args: FetchSnapshotPageArgs) => Promise<SyncSnapshotResponse>;
   calls: FetchSnapshotPageArgs[];
@@ -19,53 +41,222 @@ const makeChannel = (
   return {
     calls,
     fetchSnapshotPage: async (args: FetchSnapshotPageArgs): Promise<SyncSnapshotResponse> => {
-      calls.push(args);
-      const page = pages[args.collection]?.[args.cursor];
-      if (!page) {
-        throw new Error(`No canned page for ${args.collection}@${args.cursor}`);
+      calls.push({...args});
+      const key =
+        args.legacyCursor !== undefined
+          ? `legacy:${args.legacyCursor}`
+          : args.cursor === 0 && byKey["legacy:start"]
+            ? "legacy:start"
+            : String(args.cursor);
+      const canned = byKey[key];
+      if (!canned) {
+        throw new Error(`No canned page for key ${key} (cursor=${args.cursor})`);
       }
-      return page;
+      return canned;
     },
   };
 };
 
-describe("bootstrapCollections", () => {
-  it("pages a collection to completion and advances the snapshot cursor", async () => {
+describe("bootstrapStream", () => {
+  it("pages a stream to completion and advances the real stream cursor", async () => {
     const store = makeStore();
     const channel = makeChannel({
-      todos: {
-        0: {
-          cursor: 2,
-          entities: [
-            {data: {title: "a"}, deleted: false, id: "t1", seq: 1},
-            {data: {title: "b"}, deleted: false, id: "t2", seq: 2},
-          ],
-          hasMore: true,
-        },
-        2: {
-          cursor: 3,
-          entities: [{data: {title: "c"}, deleted: true, id: "t3", seq: 3}],
-          hasMore: false,
-        },
-      },
+      0: page({
+        cursor: 2,
+        entities: [
+          {data: {title: "a"}, deleted: false, id: "t1", seq: 1},
+          {data: {title: "b"}, deleted: false, id: "t2", seq: 2},
+        ],
+        frontierSeq: 3,
+        hasMore: true,
+      }),
+      2: page({
+        cursor: 3,
+        entities: [{data: {title: "c"}, deleted: true, id: "t3", seq: 3}],
+        frontierSeq: 3,
+        hasMore: false,
+      }),
     });
-    await bootstrapCollections({channel, collections: ["todos"], store});
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
 
     expect(store.getEntity({collection: "todos", id: "t1"})?.data).toEqual({title: "a"});
     expect(store.getEntity({collection: "todos", id: "t2"})?.seq).toBe(2);
     expect(store.getEntity({collection: "todos", id: "t3"})?.deleted).toBe(true);
-    expect(getCursor({store, stream: snapshotCursorStream("todos")})).toBe(3);
+    // Entities record the stream they were bootstrapped under (for leave-purge).
+    expect(store.getEntity({collection: "todos", id: "t1"})?.stream).toBe(STREAM);
+    expect(getCursor({store, stream: STREAM})).toBe(3);
     expect(channel.calls.map((call) => call.cursor)).toEqual([0, 2]);
+    expect(channel.calls.every((call) => call.stream === STREAM)).toBe(true);
   });
 
-  it("resumes from the persisted per-collection cursor", async () => {
+  it("resumes from the persisted per-stream cursor", async () => {
     const store = makeStore();
-    setCursor({seq: 10, store, stream: snapshotCursorStream("todos")});
+    setCursor({seq: 10, store, stream: STREAM});
+    const channel = makeChannel({10: page({cursor: 10, entities: [], frontierSeq: 10})});
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
+    expect(channel.calls).toEqual([
+      {cursor: 10, legacyCursor: undefined, limit: undefined, stream: STREAM},
+    ]);
+  });
+
+  it("C1: never advances the cursor past the stable frontier", async () => {
+    const store = makeStore();
+    // Server returns one committed entity; the frontier equals it. The next seq's owning
+    // write is still in-flight (hasMore false → nothing more to fetch right now).
     const channel = makeChannel({
-      todos: {10: {cursor: 10, entities: [], hasMore: false}},
+      0: page({
+        cursor: 1,
+        entities: [{data: {title: "a"}, deleted: false, id: "t1", seq: 1}],
+        frontierSeq: 1,
+        hasMore: false,
+      }),
     });
-    await bootstrapCollections({channel, collections: ["todos"], store});
-    expect(channel.calls).toEqual([{collection: "todos", cursor: 10, limit: undefined}]);
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
+    expect(getCursor({store, stream: STREAM})).toBe(1);
+  });
+
+  it("C1: clamps a cursor a buggy server reports above its own frontier", async () => {
+    const store = makeStore();
+    const channel = makeChannel({
+      0: page({
+        cursor: 9,
+        entities: [{data: {title: "a"}, deleted: false, id: "t1", seq: 5}],
+        frontierSeq: 5,
+        hasMore: false,
+      }),
+    });
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
+    // page.cursor 9 is clamped down to the frontier 5.
+    expect(getCursor({store, stream: STREAM})).toBe(5);
+  });
+
+  it("C3: drains the legacy stratum by echoing legacyCursor, then proceeds by seq", async () => {
+    const store = makeStore();
+    const channel = makeChannel({
+      // Echo legacyCursor L2 → second legacy page.
+      "legacy:L2": page({
+        cursor: 0,
+        entities: [{data: {title: "l3"}, deleted: false, id: "L3", seq: 0}],
+        hasMore: true,
+        legacyCursor: "L3",
+      }),
+      // Echo legacyCursor L3 → legacy exhausted (no legacyCursor); switch to seq paging.
+      "legacy:L3": page({
+        cursor: 3,
+        entities: [{data: {title: "s1"}, deleted: false, id: "S1", seq: 3}],
+        frontierSeq: 3,
+        hasMore: false,
+      }),
+      // First request (cursor 0, no legacyCursor) → first legacy page.
+      "legacy:start": page({
+        cursor: 0,
+        entities: [
+          {data: {title: "l1"}, deleted: false, id: "L1", seq: 0},
+          {data: {title: "l2"}, deleted: false, id: "L2", seq: 0},
+        ],
+        hasMore: true,
+        legacyCursor: "L2",
+      }),
+    });
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
+
+    // All legacy entities applied.
+    expect(store.getEntity({collection: "todos", id: "L1"})?.data).toEqual({title: "l1"});
+    expect(store.getEntity({collection: "todos", id: "L3"})?.data).toEqual({title: "l3"});
+    // Then the seq-stratum entity.
+    expect(store.getEntity({collection: "todos", id: "S1"})?.seq).toBe(3);
+    expect(getCursor({store, stream: STREAM})).toBe(3);
+    // legacyCursor echoed forward: undefined → L2 → L3, then the final seq page.
+    expect(channel.calls.map((c) => c.legacyCursor)).toEqual([undefined, "L2", "L3"]);
+  });
+
+  it("C3: terminates on a large legacy stratum spanning many pages (loop-guard intact)", async () => {
+    const store = makeStore();
+    // 1201 legacy entities, 500 per page → 3 legacy pages then a terminating seq page.
+    const total = 1201;
+    const limit = 500;
+    const byKey: Record<string, SyncSnapshotResponse> = {};
+    let done = 0;
+    let prevKey = "legacy:start";
+    while (done < total) {
+      const size = Math.min(limit, total - done);
+      const entities = Array.from({length: size}, (_, i) => ({
+        data: {n: done + i},
+        deleted: false,
+        id: `L${done + i}`,
+        seq: 0,
+      }));
+      const lastId = `L${done + size - 1}`;
+      byKey[prevKey] = page({cursor: 0, entities, hasMore: true, legacyCursor: lastId});
+      prevKey = `legacy:${lastId}`;
+      done += size;
+      if (done >= total) {
+        // The request echoing the final legacy id drains into the (empty) seq stratum.
+        byKey[prevKey] = page({cursor: 0, entities: [], frontierSeq: 0, hasMore: false});
+      }
+    }
+    const channel = makeChannel(byKey);
+    await bootstrapStream({channel, collection: "todos", limit, store, stream: STREAM});
+
+    expect(store.listEntities({collection: "todos"}).length).toBe(total);
+    expect(store.getEntity({collection: "todos", id: "L0"})).toBeDefined();
+    expect(store.getEntity({collection: "todos", id: `L${total - 1}`})).toBeDefined();
+    // 3 legacy pages + 1 terminating seq page.
+    expect(channel.calls.length).toBe(4);
+  });
+
+  it("C7: re-bootstraps from 0 when the stored cursor is below oldestRetainedSeq", async () => {
+    const store = makeStore();
+    // Client is at cursor 5 with a stale entity written under this stream.
+    setCursor({seq: 5, store, stream: STREAM});
+    store.upsertEntity({
+      collection: "todos",
+      data: {title: "stale"},
+      id: "old",
+      seq: 5,
+      stream: STREAM,
+    });
+    store.addKnownStream({collection: "todos", stream: STREAM});
+    const channel = makeChannel({
+      // After purge, re-bootstrap from 0.
+      0: page({
+        cursor: 12,
+        entities: [{data: {title: "fresh"}, deleted: false, id: "new", seq: 12}],
+        frontierSeq: 20,
+        hasMore: false,
+        oldestRetainedSeq: 10,
+      }),
+      // First fetch at cursor 5 reports the retained floor is 10 → retention gap.
+      5: page({cursor: 5, entities: [], frontierSeq: 20, oldestRetainedSeq: 10}),
+    });
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
+
+    // Stale entity purged, fresh entity present.
+    expect(store.getEntity({collection: "todos", id: "old"})).toBeUndefined();
+    expect(store.getEntity({collection: "todos", id: "new"})?.data).toEqual({title: "fresh"});
+    // The stream remains known after re-bootstrap.
+    expect(store.getKnownStreams()).toContain(STREAM);
+    expect(getCursor({store, stream: STREAM})).toBe(12);
+    // First call at cursor 5, then re-bootstrap at cursor 0.
+    expect(channel.calls.map((c) => c.cursor)).toEqual([5, 0]);
+  });
+
+  it("C7: no re-bootstrap when the cursor is at or above the retained floor", async () => {
+    const store = makeStore();
+    setCursor({seq: 10, store, stream: STREAM});
+    store.upsertEntity({
+      collection: "todos",
+      data: {title: "kept"},
+      id: "keep",
+      seq: 10,
+      stream: STREAM,
+    });
+    const channel = makeChannel({
+      10: page({cursor: 10, entities: [], frontierSeq: 10, oldestRetainedSeq: 10}),
+    });
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
+    expect(store.getEntity({collection: "todos", id: "keep"})).toBeDefined();
+    expect(channel.calls.map((c) => c.cursor)).toEqual([10]);
   });
 
   it("never overwrites an entity protected by a pending outbox mutation", async () => {
@@ -78,67 +269,42 @@ describe("bootstrapCollections", () => {
       seq: 1,
     });
     const channel = makeChannel({
-      todos: {
-        0: {
-          cursor: 5,
-          entities: [{data: {title: "server"}, deleted: false, id: "t1", seq: 5}],
-          hasMore: false,
-        },
-      },
+      0: page({
+        cursor: 5,
+        entities: [{data: {title: "server"}, deleted: false, id: "t1", seq: 5}],
+        frontierSeq: 5,
+        hasMore: false,
+      }),
     });
-    await bootstrapCollections({channel, collections: ["todos"], store});
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
     const entity = store.getEntity({collection: "todos", id: "t1"});
     expect(entity?.data).toEqual({title: "local edit"});
     expect(entity?.pendingMutationId).toBe("m1");
     // The cursor still advances so the protected entity is not refetched forever.
-    expect(getCursor({store, stream: snapshotCursorStream("todos")})).toBe(5);
+    expect(getCursor({store, stream: STREAM})).toBe(5);
   });
 
   it("skips entities at or below the locally applied seq", async () => {
     const store = makeStore();
     store.upsertEntity({collection: "todos", data: {title: "newer"}, id: "t1", seq: 8});
     const channel = makeChannel({
-      todos: {
-        0: {
-          cursor: 8,
-          entities: [{data: {title: "stale"}, deleted: false, id: "t1", seq: 8}],
-          hasMore: false,
-        },
-      },
+      0: page({
+        cursor: 8,
+        entities: [{data: {title: "stale"}, deleted: false, id: "t1", seq: 8}],
+        frontierSeq: 8,
+        hasMore: false,
+      }),
     });
-    await bootstrapCollections({channel, collections: ["todos"], store});
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
     expect(store.getEntity({collection: "todos", id: "t1"})?.data).toEqual({title: "newer"});
-  });
-
-  it("bootstraps each collection with an independent cursor", async () => {
-    const store = makeStore();
-    const channel = makeChannel({
-      notes: {
-        0: {
-          cursor: 1,
-          entities: [{data: {body: "n"}, deleted: false, id: "n1", seq: 1}],
-          hasMore: false,
-        },
-      },
-      todos: {
-        0: {
-          cursor: 4,
-          entities: [{data: {title: "t"}, deleted: false, id: "t1", seq: 4}],
-          hasMore: false,
-        },
-      },
-    });
-    await bootstrapCollections({channel, collections: ["todos", "notes"], store});
-    expect(getCursor({store, stream: snapshotCursorStream("todos")})).toBe(4);
-    expect(getCursor({store, stream: snapshotCursorStream("notes")})).toBe(1);
   });
 
   it("stops when hasMore is set but the cursor did not advance (server bug guard)", async () => {
     const store = makeStore();
     const channel = makeChannel({
-      todos: {0: {cursor: 0, entities: [], hasMore: true}},
+      0: page({cursor: 0, entities: [], frontierSeq: 0, hasMore: true}),
     });
-    await bootstrapCollections({channel, collections: ["todos"], store});
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
     expect(channel.calls).toHaveLength(1);
   });
 
@@ -151,28 +317,28 @@ describe("bootstrapCollections", () => {
       pendingMutationId: "m9",
     });
     const channel = makeChannel({
-      todos: {
-        0: {
-          cursor: 2,
-          entities: [
-            {data: {title: "a"}, deleted: false, id: "t1", seq: 1},
-            {data: {title: "b"}, deleted: false, id: "t2", seq: 2},
-          ],
-          hasMore: false,
-        },
-      },
+      0: page({
+        cursor: 2,
+        entities: [
+          {data: {title: "a"}, deleted: false, id: "t1", seq: 1},
+          {data: {title: "b"}, deleted: false, id: "t2", seq: 2},
+        ],
+        frontierSeq: 2,
+        hasMore: false,
+      }),
     });
     const progress: BootstrapProgress[] = [];
-    await bootstrapCollections({
+    await bootstrapStream({
       channel,
-      collections: ["todos"],
+      collection: "todos",
       limit: 25,
-      onProgress: (update) => progress.push(update),
+      onProgress: (update: BootstrapProgress) => progress.push(update),
       store,
+      stream: STREAM,
     });
     expect(channel.calls[0]?.limit).toBe(25);
     expect(progress).toEqual([
-      {applied: 1, collection: "todos", cursor: 2, fetched: 2, hasMore: false},
+      {applied: 1, collection: "todos", cursor: 2, fetched: 2, hasMore: false, stream: STREAM},
     ]);
   });
 });

--- a/syncdb/src/sync/bootstrap.test.ts
+++ b/syncdb/src/sync/bootstrap.test.ts
@@ -2,15 +2,37 @@ import {describe, expect, it} from "bun:test";
 
 import {createSyncStore, type SyncStore} from "../storage/store";
 import type {SyncSnapshotResponse} from "../types";
-import {type BootstrapProgress, bootstrapCollections, snapshotCursorStream} from "./bootstrap";
+import {type BootstrapProgress, bootstrapStream} from "./bootstrap";
 import {getCursor, setCursor} from "./cursor";
 import type {FetchSnapshotPageArgs} from "./httpChannel";
 
+const STREAM = "todos|owner:u1";
+
 const makeStore = (): SyncStore => createSyncStore({collections: ["notes", "todos"]});
 
-/** Channel stub serving canned pages per collection, keyed by request cursor. */
+/**
+ * Build a snapshot page with the C1/C7 fields defaulted so tests only specify what they
+ * care about. `frontierSeq` defaults to the page cursor (fully committed), and
+ * `oldestRetainedSeq` to 0 (no retention gap).
+ */
+const page = (
+  overrides: Partial<SyncSnapshotResponse> & {cursor: number}
+): SyncSnapshotResponse => ({
+  entities: [],
+  frontierSeq: overrides.frontierSeq ?? overrides.cursor,
+  hasMore: false,
+  oldestRetainedSeq: 0,
+  stream: STREAM,
+  ...overrides,
+});
+
+/**
+ * Channel stub serving canned pages for a single stream. Seq pages are keyed by the
+ * request cursor (as a string); legacy-stratum pages are keyed `legacy:{token}` where the
+ * first request (cursor 0, no legacyCursor) maps to `legacy:start`.
+ */
 const makeChannel = (
-  pages: Record<string, Record<number, SyncSnapshotResponse>>
+  byKey: Record<string, SyncSnapshotResponse>
 ): {
   fetchSnapshotPage: (args: FetchSnapshotPageArgs) => Promise<SyncSnapshotResponse>;
   calls: FetchSnapshotPageArgs[];
@@ -19,53 +41,222 @@ const makeChannel = (
   return {
     calls,
     fetchSnapshotPage: async (args: FetchSnapshotPageArgs): Promise<SyncSnapshotResponse> => {
-      calls.push(args);
-      const page = pages[args.collection]?.[args.cursor];
-      if (!page) {
-        throw new Error(`No canned page for ${args.collection}@${args.cursor}`);
+      calls.push({...args});
+      const key =
+        args.legacyCursor !== undefined
+          ? `legacy:${args.legacyCursor}`
+          : args.cursor === 0 && byKey["legacy:start"]
+            ? "legacy:start"
+            : String(args.cursor);
+      const canned = byKey[key];
+      if (!canned) {
+        throw new Error(`No canned page for key ${key} (cursor=${args.cursor})`);
       }
-      return page;
+      return canned;
     },
   };
 };
 
-describe("bootstrapCollections", () => {
-  it("pages a collection to completion and advances the snapshot cursor", async () => {
+describe("bootstrapStream", () => {
+  it("pages a stream to completion and advances the real stream cursor", async () => {
     const store = makeStore();
     const channel = makeChannel({
-      todos: {
-        0: {
-          cursor: 2,
-          entities: [
-            {data: {title: "a"}, deleted: false, id: "t1", seq: 1},
-            {data: {title: "b"}, deleted: false, id: "t2", seq: 2},
-          ],
-          hasMore: true,
-        },
-        2: {
-          cursor: 3,
-          entities: [{data: {title: "c"}, deleted: true, id: "t3", seq: 3}],
-          hasMore: false,
-        },
-      },
+      0: page({
+        cursor: 2,
+        entities: [
+          {data: {title: "a"}, deleted: false, id: "t1", seq: 1},
+          {data: {title: "b"}, deleted: false, id: "t2", seq: 2},
+        ],
+        frontierSeq: 3,
+        hasMore: true,
+      }),
+      2: page({
+        cursor: 3,
+        entities: [{data: {title: "c"}, deleted: true, id: "t3", seq: 3}],
+        frontierSeq: 3,
+        hasMore: false,
+      }),
     });
-    await bootstrapCollections({channel, collections: ["todos"], store});
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
 
     expect(store.getEntity({collection: "todos", id: "t1"})?.data).toEqual({title: "a"});
     expect(store.getEntity({collection: "todos", id: "t2"})?.seq).toBe(2);
     expect(store.getEntity({collection: "todos", id: "t3"})?.deleted).toBe(true);
-    expect(getCursor({store, stream: snapshotCursorStream("todos")})).toBe(3);
+    // Entities record the stream they were bootstrapped under (for leave-purge).
+    expect(store.getEntity({collection: "todos", id: "t1"})?.stream).toBe(STREAM);
+    expect(getCursor({store, stream: STREAM})).toBe(3);
     expect(channel.calls.map((call) => call.cursor)).toEqual([0, 2]);
+    expect(channel.calls.every((call) => call.stream === STREAM)).toBe(true);
   });
 
-  it("resumes from the persisted per-collection cursor", async () => {
+  it("resumes from the persisted per-stream cursor", async () => {
     const store = makeStore();
-    setCursor({seq: 10, store, stream: snapshotCursorStream("todos")});
+    setCursor({seq: 10, store, stream: STREAM});
+    const channel = makeChannel({10: page({cursor: 10, entities: [], frontierSeq: 10})});
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
+    expect(channel.calls).toEqual([
+      {cursor: 10, legacyCursor: undefined, limit: undefined, stream: STREAM},
+    ]);
+  });
+
+  it("C1: never advances the cursor past the stable frontier", async () => {
+    const store = makeStore();
+    // Server returns one committed entity; the frontier equals it. The next seq's owning
+    // write is still in-flight (hasMore false → nothing more to fetch right now).
     const channel = makeChannel({
-      todos: {10: {cursor: 10, entities: [], hasMore: false}},
+      0: page({
+        cursor: 1,
+        entities: [{data: {title: "a"}, deleted: false, id: "t1", seq: 1}],
+        frontierSeq: 1,
+        hasMore: false,
+      }),
     });
-    await bootstrapCollections({channel, collections: ["todos"], store});
-    expect(channel.calls).toEqual([{collection: "todos", cursor: 10, limit: undefined}]);
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
+    expect(getCursor({store, stream: STREAM})).toBe(1);
+  });
+
+  it("C1: clamps a cursor a buggy server reports above its own frontier", async () => {
+    const store = makeStore();
+    const channel = makeChannel({
+      0: page({
+        cursor: 9,
+        entities: [{data: {title: "a"}, deleted: false, id: "t1", seq: 5}],
+        frontierSeq: 5,
+        hasMore: false,
+      }),
+    });
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
+    // page.cursor 9 is clamped down to the frontier 5.
+    expect(getCursor({store, stream: STREAM})).toBe(5);
+  });
+
+  it("C3: drains the legacy stratum by echoing legacyCursor, then proceeds by seq", async () => {
+    const store = makeStore();
+    const channel = makeChannel({
+      // Echo legacyCursor L2 → second legacy page.
+      "legacy:L2": page({
+        cursor: 0,
+        entities: [{data: {title: "l3"}, deleted: false, id: "L3", seq: 0}],
+        hasMore: true,
+        legacyCursor: "L3",
+      }),
+      // Echo legacyCursor L3 → legacy exhausted (no legacyCursor); switch to seq paging.
+      "legacy:L3": page({
+        cursor: 3,
+        entities: [{data: {title: "s1"}, deleted: false, id: "S1", seq: 3}],
+        frontierSeq: 3,
+        hasMore: false,
+      }),
+      // First request (cursor 0, no legacyCursor) → first legacy page.
+      "legacy:start": page({
+        cursor: 0,
+        entities: [
+          {data: {title: "l1"}, deleted: false, id: "L1", seq: 0},
+          {data: {title: "l2"}, deleted: false, id: "L2", seq: 0},
+        ],
+        hasMore: true,
+        legacyCursor: "L2",
+      }),
+    });
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
+
+    // All legacy entities applied.
+    expect(store.getEntity({collection: "todos", id: "L1"})?.data).toEqual({title: "l1"});
+    expect(store.getEntity({collection: "todos", id: "L3"})?.data).toEqual({title: "l3"});
+    // Then the seq-stratum entity.
+    expect(store.getEntity({collection: "todos", id: "S1"})?.seq).toBe(3);
+    expect(getCursor({store, stream: STREAM})).toBe(3);
+    // legacyCursor echoed forward: undefined → L2 → L3, then the final seq page.
+    expect(channel.calls.map((c) => c.legacyCursor)).toEqual([undefined, "L2", "L3"]);
+  });
+
+  it("C3: terminates on a large legacy stratum spanning many pages (loop-guard intact)", async () => {
+    const store = makeStore();
+    // 1201 legacy entities, 500 per page → 3 legacy pages then a terminating seq page.
+    const total = 1201;
+    const limit = 500;
+    const byKey: Record<string, SyncSnapshotResponse> = {};
+    let done = 0;
+    let prevKey = "legacy:start";
+    while (done < total) {
+      const size = Math.min(limit, total - done);
+      const entities = Array.from({length: size}, (_, i) => ({
+        data: {n: done + i},
+        deleted: false,
+        id: `L${done + i}`,
+        seq: 0,
+      }));
+      const lastId = `L${done + size - 1}`;
+      byKey[prevKey] = page({cursor: 0, entities, hasMore: true, legacyCursor: lastId});
+      prevKey = `legacy:${lastId}`;
+      done += size;
+      if (done >= total) {
+        // The request echoing the final legacy id drains into the (empty) seq stratum.
+        byKey[prevKey] = page({cursor: 0, entities: [], frontierSeq: 0, hasMore: false});
+      }
+    }
+    const channel = makeChannel(byKey);
+    await bootstrapStream({channel, collection: "todos", limit, store, stream: STREAM});
+
+    expect(store.listEntities({collection: "todos"}).length).toBe(total);
+    expect(store.getEntity({collection: "todos", id: "L0"})).toBeDefined();
+    expect(store.getEntity({collection: "todos", id: `L${total - 1}`})).toBeDefined();
+    // 3 legacy pages + 1 terminating seq page.
+    expect(channel.calls.length).toBe(4);
+  });
+
+  it("C7: re-bootstraps from 0 when the stored cursor is below oldestRetainedSeq", async () => {
+    const store = makeStore();
+    // Client is at cursor 5 with a stale entity written under this stream.
+    setCursor({seq: 5, store, stream: STREAM});
+    store.upsertEntity({
+      collection: "todos",
+      data: {title: "stale"},
+      id: "old",
+      seq: 5,
+      stream: STREAM,
+    });
+    store.addKnownStream({collection: "todos", stream: STREAM});
+    const channel = makeChannel({
+      // After purge, re-bootstrap from 0.
+      0: page({
+        cursor: 12,
+        entities: [{data: {title: "fresh"}, deleted: false, id: "new", seq: 12}],
+        frontierSeq: 20,
+        hasMore: false,
+        oldestRetainedSeq: 10,
+      }),
+      // First fetch at cursor 5 reports the retained floor is 10 → retention gap.
+      5: page({cursor: 5, entities: [], frontierSeq: 20, oldestRetainedSeq: 10}),
+    });
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
+
+    // Stale entity purged, fresh entity present.
+    expect(store.getEntity({collection: "todos", id: "old"})).toBeUndefined();
+    expect(store.getEntity({collection: "todos", id: "new"})?.data).toEqual({title: "fresh"});
+    // The stream remains known after re-bootstrap.
+    expect(store.getKnownStreams()).toContain(STREAM);
+    expect(getCursor({store, stream: STREAM})).toBe(12);
+    // First call at cursor 5, then re-bootstrap at cursor 0.
+    expect(channel.calls.map((c) => c.cursor)).toEqual([5, 0]);
+  });
+
+  it("C7: no re-bootstrap when the cursor is at or above the retained floor", async () => {
+    const store = makeStore();
+    setCursor({seq: 10, store, stream: STREAM});
+    store.upsertEntity({
+      collection: "todos",
+      data: {title: "kept"},
+      id: "keep",
+      seq: 10,
+      stream: STREAM,
+    });
+    const channel = makeChannel({
+      10: page({cursor: 10, entities: [], frontierSeq: 10, oldestRetainedSeq: 10}),
+    });
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
+    expect(store.getEntity({collection: "todos", id: "keep"})).toBeDefined();
+    expect(channel.calls.map((c) => c.cursor)).toEqual([10]);
   });
 
   it("never overwrites an entity protected by a pending outbox mutation", async () => {
@@ -78,67 +269,42 @@ describe("bootstrapCollections", () => {
       seq: 1,
     });
     const channel = makeChannel({
-      todos: {
-        0: {
-          cursor: 5,
-          entities: [{data: {title: "server"}, deleted: false, id: "t1", seq: 5}],
-          hasMore: false,
-        },
-      },
+      0: page({
+        cursor: 5,
+        entities: [{data: {title: "server"}, deleted: false, id: "t1", seq: 5}],
+        frontierSeq: 5,
+        hasMore: false,
+      }),
     });
-    await bootstrapCollections({channel, collections: ["todos"], store});
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
     const entity = store.getEntity({collection: "todos", id: "t1"});
     expect(entity?.data).toEqual({title: "local edit"});
     expect(entity?.pendingMutationId).toBe("m1");
     // The cursor still advances so the protected entity is not refetched forever.
-    expect(getCursor({store, stream: snapshotCursorStream("todos")})).toBe(5);
+    expect(getCursor({store, stream: STREAM})).toBe(5);
   });
 
   it("skips entities at or below the locally applied seq", async () => {
     const store = makeStore();
     store.upsertEntity({collection: "todos", data: {title: "newer"}, id: "t1", seq: 8});
     const channel = makeChannel({
-      todos: {
-        0: {
-          cursor: 8,
-          entities: [{data: {title: "stale"}, deleted: false, id: "t1", seq: 8}],
-          hasMore: false,
-        },
-      },
+      0: page({
+        cursor: 8,
+        entities: [{data: {title: "stale"}, deleted: false, id: "t1", seq: 8}],
+        frontierSeq: 8,
+        hasMore: false,
+      }),
     });
-    await bootstrapCollections({channel, collections: ["todos"], store});
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
     expect(store.getEntity({collection: "todos", id: "t1"})?.data).toEqual({title: "newer"});
-  });
-
-  it("bootstraps each collection with an independent cursor", async () => {
-    const store = makeStore();
-    const channel = makeChannel({
-      notes: {
-        0: {
-          cursor: 1,
-          entities: [{data: {body: "n"}, deleted: false, id: "n1", seq: 1}],
-          hasMore: false,
-        },
-      },
-      todos: {
-        0: {
-          cursor: 4,
-          entities: [{data: {title: "t"}, deleted: false, id: "t1", seq: 4}],
-          hasMore: false,
-        },
-      },
-    });
-    await bootstrapCollections({channel, collections: ["todos", "notes"], store});
-    expect(getCursor({store, stream: snapshotCursorStream("todos")})).toBe(4);
-    expect(getCursor({store, stream: snapshotCursorStream("notes")})).toBe(1);
   });
 
   it("stops when hasMore is set but the cursor did not advance (server bug guard)", async () => {
     const store = makeStore();
     const channel = makeChannel({
-      todos: {0: {cursor: 0, entities: [], hasMore: true}},
+      0: page({cursor: 0, entities: [], frontierSeq: 0, hasMore: true}),
     });
-    await bootstrapCollections({channel, collections: ["todos"], store});
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
     expect(channel.calls).toHaveLength(1);
   });
 
@@ -151,59 +317,59 @@ describe("bootstrapCollections", () => {
       pendingMutationId: "m9",
     });
     const channel = makeChannel({
-      todos: {
-        0: {
-          cursor: 2,
-          entities: [
-            {data: {title: "a"}, deleted: false, id: "t1", seq: 1},
-            {data: {title: "b"}, deleted: false, id: "t2", seq: 2},
-          ],
-          hasMore: false,
-        },
-      },
+      0: page({
+        cursor: 2,
+        entities: [
+          {data: {title: "a"}, deleted: false, id: "t1", seq: 1},
+          {data: {title: "b"}, deleted: false, id: "t2", seq: 2},
+        ],
+        frontierSeq: 2,
+        hasMore: false,
+      }),
     });
     const progress: BootstrapProgress[] = [];
-    await bootstrapCollections({
+    await bootstrapStream({
       channel,
-      collections: ["todos"],
+      collection: "todos",
       limit: 25,
-      onProgress: (update) => progress.push(update),
+      onProgress: (update: BootstrapProgress) => progress.push(update),
       store,
+      stream: STREAM,
     });
     expect(channel.calls[0]?.limit).toBe(25);
     expect(progress).toEqual([
-      {applied: 1, collection: "todos", cursor: 2, fetched: 2, hasMore: false},
+      {applied: 1, collection: "todos", cursor: 2, fetched: 2, hasMore: false, stream: STREAM},
     ]);
   });
 
   it("applies a whole page inside one transaction: exactly one table-listener fire per page (E4)", async () => {
     const store = makeStore();
     const channel = makeChannel({
-      todos: {
-        0: {
-          cursor: 3,
-          entities: [
-            {data: {title: "a"}, deleted: false, id: "t1", seq: 1},
-            {data: {title: "b"}, deleted: false, id: "t2", seq: 2},
-            {data: {title: "c"}, deleted: false, id: "t3", seq: 3},
-          ],
-          hasMore: true,
-        },
-        3: {
-          cursor: 5,
-          entities: [
-            {data: {title: "d"}, deleted: false, id: "t4", seq: 4},
-            {data: {title: "e"}, deleted: false, id: "t5", seq: 5},
-          ],
-          hasMore: false,
-        },
-      },
+      0: page({
+        cursor: 3,
+        entities: [
+          {data: {title: "a"}, deleted: false, id: "t1", seq: 1},
+          {data: {title: "b"}, deleted: false, id: "t2", seq: 2},
+          {data: {title: "c"}, deleted: false, id: "t3", seq: 3},
+        ],
+        frontierSeq: 5,
+        hasMore: true,
+      }),
+      3: page({
+        cursor: 5,
+        entities: [
+          {data: {title: "d"}, deleted: false, id: "t4", seq: 4},
+          {data: {title: "e"}, deleted: false, id: "t5", seq: 5},
+        ],
+        frontierSeq: 5,
+        hasMore: false,
+      }),
     });
     let fireCount = 0;
     const listenerId = store.raw.addTableListener("todos", () => {
       fireCount += 1;
     });
-    await bootstrapCollections({channel, collections: ["todos"], store});
+    await bootstrapStream({channel, collection: "todos", store, stream: STREAM});
     store.raw.delListener(listenerId);
     // Two pages fetched (hasMore then a final page) — one listener fire per
     // page, not per row (5 entities total across both pages would mean 5

--- a/syncdb/src/sync/bootstrap.ts
+++ b/syncdb/src/sync/bootstrap.ts
@@ -1,19 +1,27 @@
 /**
- * Snapshot bootstrap: page `GET /sync/snapshot` per collection into the local
- * store until the server reports no more pages.
+ * Snapshot bootstrap: page `GET /sync/snapshot` per STREAM into the local store until
+ * the server reports no more pages.
  *
- * ## Cursor semantics — snapshot vs stream cursors
+ * ## Cursor semantics (C2 — per-stream cursors)
  *
- * Deltas carry a `stream` key (e.g. "todos|owner:123") and advance per-stream
- * cursors in `_cursors`, but snapshot entities do NOT carry their stream — the
- * server pages a whole collection (already scope-filtered to the caller) by
- * `_syncSeq` ascending. Bootstrap therefore keeps its own per-collection
- * resume cursor in `_cursors` under the reserved key `snapshot:{collection}`,
- * a namespace disjoint from real delta stream keys (which are
- * `{collection}|{scope}:{value}` shaped). Snapshot entities are applied
- * directly through the store
- * accessors with the same protections as `applyDelta`: entities protected by a
- * pending outbox mutation are never overwritten, and stale seqs are skipped.
+ * Bootstrap pages one stream per request (the server resolves the stream's scope from
+ * the stream key and pages by `_syncSeq`). The resume cursor is kept in `_cursors` keyed
+ * by the REAL stream key (the same key deltas advance) — the old `snapshot:{collection}`
+ * pseudo-cursors are gone. Snapshot entities are applied with the same protections as
+ * `applyDelta`: entities protected by a pending outbox mutation are never overwritten,
+ * and stale seqs are skipped.
+ *
+ * ## Frontier & retention (C1/C7)
+ *
+ * The client never advances a stream's cursor past the server-reported `frontierSeq`.
+ * If the stored cursor is below the response's `oldestRetainedSeq`, compacted tombstones
+ * may have been missed → the stream is purged and re-bootstrapped from 0 (a sanctioned
+ * retention-gap wipe, distinct from an auth wipe — INV-2).
+ *
+ * ## Legacy stratum (C3)
+ *
+ * While the server returns a `legacyCursor`, bootstrap echoes it back verbatim to drain
+ * the seq-0 (unstamped) stratum by `_id` before proceeding to seq paging.
  */
 
 import type {SyncStore} from "../storage/store";
@@ -21,36 +29,39 @@ import type {SyncSnapshotEntity} from "../types";
 import {getCursor, setCursor} from "./cursor";
 import type {HttpChannel} from "./httpChannel";
 
-/** The `_cursors` row key holding a collection's snapshot resume cursor. */
-export const snapshotCursorStream = (collection: string): string => `snapshot:${collection}`;
-
 export interface BootstrapProgress {
+  /** The stream just paged. */
+  stream: string;
   collection: string;
   /** Entities in the page just fetched. */
   fetched: number;
   /** Entities from that page actually written locally (rest were protected/stale). */
   applied: number;
-  /** The collection's snapshot cursor after this page. */
+  /** The stream's cursor after this page. */
   cursor: number;
-  /** True when more pages remain for this collection. */
+  /** True when more pages remain for this stream. */
   hasMore: boolean;
 }
 
 /**
- * Apply one snapshot entity with `applyDelta`-equivalent protections. Returns
- * true when the entity was written locally.
+ * Apply one snapshot entity with `applyDelta`-equivalent protections. Returns true when
+ * the entity was written locally. Records the stream so leave-purge is O(stream).
  */
 const applySnapshotEntity = ({
   store,
   collection,
+  stream,
   entity,
 }: {
   store: SyncStore;
   collection: string;
+  stream: string;
   entity: SyncSnapshotEntity;
 }): boolean => {
   const existing = store.getEntity({collection, id: entity.id});
-  if (existing && entity.seq <= existing.seq) {
+  // Seq-0 legacy entities always apply on first sight (existing seq is also 0); a stamped
+  // entity at or below the applied seq is a stale/duplicate page and is skipped.
+  if (existing && entity.seq > 0 && entity.seq <= existing.seq) {
     return false;
   }
   if (existing?.pendingMutationId) {
@@ -64,60 +75,106 @@ const applySnapshotEntity = ({
     id: entity.id,
     pendingMutationId: "",
     seq: entity.seq,
+    stream,
   });
   return true;
 };
 
 /**
- * Page every listed collection from its current snapshot cursor to the head of
- * the server's data. Used for the initial bootstrap and for reconcile
- * (snapshot-from-cursor); both are incremental because the cursor persists.
+ * Page a single stream from its current cursor to the server's head. Handles the C3
+ * legacy stratum (echoing `legacyCursor`), C1 frontier clamping, and C7 retention-gap
+ * re-bootstrap. Idempotent and incremental — safe to call for both initial bootstrap and
+ * reconcile.
  */
-export const bootstrapCollections = async ({
+export const bootstrapStream = async ({
   store,
   channel,
-  collections,
+  stream,
+  collection,
   limit,
   onProgress,
   now,
 }: {
   store: SyncStore;
   channel: Pick<HttpChannel, "fetchSnapshotPage">;
-  collections: string[];
-  /** Page size forwarded to the server (server default when omitted). */
+  stream: string;
+  collection: string;
   limit?: number;
   onProgress?: (progress: BootstrapProgress) => void;
   now?: () => string;
 }): Promise<void> => {
-  for (const collection of collections) {
-    const stream = snapshotCursorStream(collection);
-    let cursor = getCursor({store, stream});
-    let hasMore = true;
-    while (hasMore) {
-      const page = await channel.fetchSnapshotPage({collection, cursor, limit});
-      // E4: apply the whole page inside one store transaction — TinyBase
-      // batches listener notifications (and the autosave persister's
-      // did-finish-transaction write) to fire ONCE per transaction rather
-      // than once per row. Without this, a page of N entities triggers N
-      // table-listener calls (and N autosave attempts) instead of one,
-      // which is O(N²) work across a full bootstrap of many pages.
+  let cursor = getCursor({store, stream});
+  let legacyCursor: string | undefined;
+  let hasMore = true;
+  let retentionChecked = false;
+
+  while (hasMore) {
+    const page = await channel.fetchSnapshotPage({cursor, legacyCursor, limit, stream});
+
+    // C7: a stored cursor below the retained floor means compacted tombstones were
+    // missed — purge and re-bootstrap this stream from 0 exactly once.
+    if (!retentionChecked) {
+      retentionChecked = true;
+      if (cursor > 0 && cursor < page.oldestRetainedSeq) {
+        store.purgeStream({stream});
+        store.addKnownStream({collection, stream});
+        cursor = 0;
+        legacyCursor = undefined;
+        continue;
+      }
+    }
+
+    if (page.legacyCursor !== undefined) {
+      // C3: still draining the seq-0 stratum — echo the token, cursor stays 0. Apply the
+      // whole page in one transaction (E4) so listeners/autosave fire once per page.
       const applied = store.raw.transaction(() => {
         let count = 0;
         for (const entity of page.entities) {
-          if (applySnapshotEntity({collection, entity, store})) {
+          if (applySnapshotEntity({collection, entity, store, stream})) {
             count += 1;
           }
         }
-        if (page.cursor > cursor) {
-          setCursor({now, seq: page.cursor, store, stream});
-        }
         return count;
       });
-      // Guard against a server bug reporting hasMore without advancing the
-      // cursor, which would loop forever re-fetching the same page.
-      hasMore = page.hasMore && page.cursor > cursor;
-      cursor = Math.max(cursor, page.cursor);
-      onProgress?.({applied, collection, cursor, fetched: page.entities.length, hasMore});
+      const advanced = page.legacyCursor !== legacyCursor;
+      legacyCursor = page.legacyCursor;
+      hasMore = advanced;
+      onProgress?.({
+        applied,
+        collection,
+        cursor: 0,
+        fetched: page.entities.length,
+        hasMore,
+        stream,
+      });
+      continue;
     }
+    // Legacy stratum done (or never present) — proceed by seq.
+    legacyCursor = undefined;
+
+    // C1: never advance past the stable frontier; the server already clamped page.cursor.
+    const clampedCursor = Math.min(page.cursor, page.frontierSeq);
+    const madeProgress = clampedCursor > cursor;
+    // E4: apply the whole page plus its cursor advance inside ONE store transaction —
+    // TinyBase batches listener notifications (and the autosave persister's
+    // did-finish-transaction write) to fire ONCE per transaction rather than once per
+    // row. Without this, a page of N entities triggers N table-listener calls (and N
+    // autosave attempts) instead of one, which is O(N²) across a full bootstrap.
+    const applied = store.raw.transaction(() => {
+      let count = 0;
+      for (const entity of page.entities) {
+        if (applySnapshotEntity({collection, entity, store, stream})) {
+          count += 1;
+        }
+      }
+      if (madeProgress) {
+        setCursor({now, seq: clampedCursor, store, stream});
+      }
+      return count;
+    });
+    // Guard against a server reporting hasMore without advancing (would loop forever).
+    hasMore = page.hasMore && madeProgress;
+    cursor = Math.max(cursor, clampedCursor);
+    onProgress?.({applied, collection, cursor, fetched: page.entities.length, hasMore, stream});
   }
 };

--- a/syncdb/src/sync/bootstrap.ts
+++ b/syncdb/src/sync/bootstrap.ts
@@ -1,19 +1,27 @@
 /**
- * Snapshot bootstrap: page `GET /sync/snapshot` per collection into the local
- * store until the server reports no more pages.
+ * Snapshot bootstrap: page `GET /sync/snapshot` per STREAM into the local store until
+ * the server reports no more pages.
  *
- * ## Cursor semantics — snapshot vs stream cursors
+ * ## Cursor semantics (C2 — per-stream cursors)
  *
- * Deltas carry a `stream` key (e.g. "todos|owner:123") and advance per-stream
- * cursors in `_cursors`, but snapshot entities do NOT carry their stream — the
- * server pages a whole collection (already scope-filtered to the caller) by
- * `_syncSeq` ascending. Bootstrap therefore keeps its own per-collection
- * resume cursor in `_cursors` under the reserved key `snapshot:{collection}`,
- * a namespace disjoint from real delta stream keys (which are
- * `{collection}|{scope}:{value}` shaped). Snapshot entities are applied
- * directly through the store
- * accessors with the same protections as `applyDelta`: entities protected by a
- * pending outbox mutation are never overwritten, and stale seqs are skipped.
+ * Bootstrap pages one stream per request (the server resolves the stream's scope from
+ * the stream key and pages by `_syncSeq`). The resume cursor is kept in `_cursors` keyed
+ * by the REAL stream key (the same key deltas advance) — the old `snapshot:{collection}`
+ * pseudo-cursors are gone. Snapshot entities are applied with the same protections as
+ * `applyDelta`: entities protected by a pending outbox mutation are never overwritten,
+ * and stale seqs are skipped.
+ *
+ * ## Frontier & retention (C1/C7)
+ *
+ * The client never advances a stream's cursor past the server-reported `frontierSeq`.
+ * If the stored cursor is below the response's `oldestRetainedSeq`, compacted tombstones
+ * may have been missed → the stream is purged and re-bootstrapped from 0 (a sanctioned
+ * retention-gap wipe, distinct from an auth wipe — INV-2).
+ *
+ * ## Legacy stratum (C3)
+ *
+ * While the server returns a `legacyCursor`, bootstrap echoes it back verbatim to drain
+ * the seq-0 (unstamped) stratum by `_id` before proceeding to seq paging.
  */
 
 import type {SyncStore} from "../storage/store";
@@ -21,36 +29,39 @@ import type {SyncSnapshotEntity} from "../types";
 import {getCursor, setCursor} from "./cursor";
 import type {HttpChannel} from "./httpChannel";
 
-/** The `_cursors` row key holding a collection's snapshot resume cursor. */
-export const snapshotCursorStream = (collection: string): string => `snapshot:${collection}`;
-
 export interface BootstrapProgress {
+  /** The stream just paged. */
+  stream: string;
   collection: string;
   /** Entities in the page just fetched. */
   fetched: number;
   /** Entities from that page actually written locally (rest were protected/stale). */
   applied: number;
-  /** The collection's snapshot cursor after this page. */
+  /** The stream's cursor after this page. */
   cursor: number;
-  /** True when more pages remain for this collection. */
+  /** True when more pages remain for this stream. */
   hasMore: boolean;
 }
 
 /**
- * Apply one snapshot entity with `applyDelta`-equivalent protections. Returns
- * true when the entity was written locally.
+ * Apply one snapshot entity with `applyDelta`-equivalent protections. Returns true when
+ * the entity was written locally. Records the stream so leave-purge is O(stream).
  */
 const applySnapshotEntity = ({
   store,
   collection,
+  stream,
   entity,
 }: {
   store: SyncStore;
   collection: string;
+  stream: string;
   entity: SyncSnapshotEntity;
 }): boolean => {
   const existing = store.getEntity({collection, id: entity.id});
-  if (existing && entity.seq <= existing.seq) {
+  // Seq-0 legacy entities always apply on first sight (existing seq is also 0); a stamped
+  // entity at or below the applied seq is a stale/duplicate page and is skipped.
+  if (existing && entity.seq > 0 && entity.seq <= existing.seq) {
     return false;
   }
   if (existing?.pendingMutationId) {
@@ -64,51 +75,89 @@ const applySnapshotEntity = ({
     id: entity.id,
     pendingMutationId: "",
     seq: entity.seq,
+    stream,
   });
   return true;
 };
 
 /**
- * Page every listed collection from its current snapshot cursor to the head of
- * the server's data. Used for the initial bootstrap and for reconcile
- * (snapshot-from-cursor); both are incremental because the cursor persists.
+ * Page a single stream from its current cursor to the server's head. Handles the C3
+ * legacy stratum (echoing `legacyCursor`), C1 frontier clamping, and C7 retention-gap
+ * re-bootstrap. Idempotent and incremental — safe to call for both initial bootstrap and
+ * reconcile.
  */
-export const bootstrapCollections = async ({
+export const bootstrapStream = async ({
   store,
   channel,
-  collections,
+  stream,
+  collection,
   limit,
   onProgress,
   now,
 }: {
   store: SyncStore;
   channel: Pick<HttpChannel, "fetchSnapshotPage">;
-  collections: string[];
-  /** Page size forwarded to the server (server default when omitted). */
+  stream: string;
+  collection: string;
   limit?: number;
   onProgress?: (progress: BootstrapProgress) => void;
   now?: () => string;
 }): Promise<void> => {
-  for (const collection of collections) {
-    const stream = snapshotCursorStream(collection);
-    let cursor = getCursor({store, stream});
-    let hasMore = true;
-    while (hasMore) {
-      const page = await channel.fetchSnapshotPage({collection, cursor, limit});
-      let applied = 0;
-      for (const entity of page.entities) {
-        if (applySnapshotEntity({collection, entity, store})) {
-          applied += 1;
-        }
+  let cursor = getCursor({store, stream});
+  let legacyCursor: string | undefined;
+  let hasMore = true;
+  let retentionChecked = false;
+
+  while (hasMore) {
+    const page = await channel.fetchSnapshotPage({cursor, legacyCursor, limit, stream});
+
+    // C7: a stored cursor below the retained floor means compacted tombstones were
+    // missed — purge and re-bootstrap this stream from 0 exactly once.
+    if (!retentionChecked) {
+      retentionChecked = true;
+      if (cursor > 0 && cursor < page.oldestRetainedSeq) {
+        store.purgeStream({stream});
+        store.addKnownStream({collection, stream});
+        cursor = 0;
+        legacyCursor = undefined;
+        continue;
       }
-      if (page.cursor > cursor) {
-        setCursor({now, seq: page.cursor, store, stream});
-      }
-      // Guard against a server bug reporting hasMore without advancing the
-      // cursor, which would loop forever re-fetching the same page.
-      hasMore = page.hasMore && page.cursor > cursor;
-      cursor = Math.max(cursor, page.cursor);
-      onProgress?.({applied, collection, cursor, fetched: page.entities.length, hasMore});
     }
+
+    let applied = 0;
+    for (const entity of page.entities) {
+      if (applySnapshotEntity({collection, entity, store, stream})) {
+        applied += 1;
+      }
+    }
+
+    if (page.legacyCursor !== undefined) {
+      // C3: still draining the seq-0 stratum — echo the token, cursor stays 0.
+      const advanced = page.legacyCursor !== legacyCursor;
+      legacyCursor = page.legacyCursor;
+      hasMore = advanced;
+      onProgress?.({
+        applied,
+        collection,
+        cursor: 0,
+        fetched: page.entities.length,
+        hasMore,
+        stream,
+      });
+      continue;
+    }
+    // Legacy stratum done (or never present) — proceed by seq.
+    legacyCursor = undefined;
+
+    // C1: never advance past the stable frontier; the server already clamped page.cursor.
+    const clampedCursor = Math.min(page.cursor, page.frontierSeq);
+    if (clampedCursor > cursor) {
+      setCursor({now, seq: clampedCursor, store, stream});
+    }
+    // Guard against a server reporting hasMore without advancing (would loop forever).
+    const madeProgress = clampedCursor > cursor;
+    hasMore = page.hasMore && madeProgress;
+    cursor = Math.max(cursor, clampedCursor);
+    onProgress?.({applied, collection, cursor, fetched: page.entities.length, hasMore, stream});
   }
 };

--- a/syncdb/src/sync/bootstrap.ts
+++ b/syncdb/src/sync/bootstrap.ts
@@ -95,15 +95,24 @@ export const bootstrapCollections = async ({
     let hasMore = true;
     while (hasMore) {
       const page = await channel.fetchSnapshotPage({collection, cursor, limit});
-      let applied = 0;
-      for (const entity of page.entities) {
-        if (applySnapshotEntity({collection, entity, store})) {
-          applied += 1;
+      // E4: apply the whole page inside one store transaction — TinyBase
+      // batches listener notifications (and the autosave persister's
+      // did-finish-transaction write) to fire ONCE per transaction rather
+      // than once per row. Without this, a page of N entities triggers N
+      // table-listener calls (and N autosave attempts) instead of one,
+      // which is O(N²) work across a full bootstrap of many pages.
+      const applied = store.raw.transaction(() => {
+        let count = 0;
+        for (const entity of page.entities) {
+          if (applySnapshotEntity({collection, entity, store})) {
+            count += 1;
+          }
         }
-      }
-      if (page.cursor > cursor) {
-        setCursor({now, seq: page.cursor, store, stream});
-      }
+        if (page.cursor > cursor) {
+          setCursor({now, seq: page.cursor, store, stream});
+        }
+        return count;
+      });
       // Guard against a server bug reporting hasMore without advancing the
       // cursor, which would loop forever re-fetching the same page.
       hasMore = page.hasMore && page.cursor > cursor;

--- a/syncdb/src/sync/deltaApplier.test.ts
+++ b/syncdb/src/sync/deltaApplier.test.ts
@@ -30,6 +30,7 @@ describe("applyDelta", () => {
       id: "t1",
       pendingMutationId: undefined,
       seq: 1,
+      stream: STREAM,
     });
     expect(getCursor({store, stream: STREAM})).toBe(1);
   });
@@ -181,6 +182,47 @@ describe("applyDelta", () => {
     const store = makeStore();
     applyDelta({delta: makeDelta(), now: () => "2026-07-04T12:00:00Z", store});
     expect(store.raw.getCell("_cursors", STREAM, "updatedAt")).toBe("2026-07-04T12:00:00Z");
+  });
+
+  it("C1: clamps the cursor to min(seq, frontierSeq) when the frontier lags the seq", () => {
+    const store = makeStore();
+    // The delta is for seq 5 but the stream frontier sits at 3 (seq 4's owning write is
+    // still uncommitted) — the entity applies at seq 5, but the cursor must not advance
+    // past the frontier or catch-up would skip the still-pending hole at 4.
+    const result = applyDelta({delta: makeDelta({frontierSeq: 3, seq: 5}), store});
+    expect(result.applied).toBe(true);
+    expect(store.getEntity({collection: "todos", id: "t1"})?.seq).toBe(5);
+    expect(getCursor({store, stream: STREAM})).toBe(3);
+  });
+
+  it("C1: advances the cursor to the delta seq when frontierSeq is absent (older server)", () => {
+    const store = makeStore();
+    const result = applyDelta({delta: makeDelta({seq: 4}), store});
+    expect(result.applied).toBe(true);
+    expect(getCursor({store, stream: STREAM})).toBe(4);
+  });
+
+  it("C1: clamps the cursor even on a skipped (pending-protected) delta", () => {
+    const store = makeStore();
+    store.upsertEntity({
+      collection: "todos",
+      data: {title: "optimistic"},
+      id: "t1",
+      pendingMutationId: "m1",
+      seq: 1,
+    });
+    const result = applyDelta({
+      delta: makeDelta({frontierSeq: 2, method: "update", seq: 6}),
+      store,
+    });
+    expect(result.applied).toBe(false);
+    expect(getCursor({store, stream: STREAM})).toBe(2);
+  });
+
+  it("C2: records the stream on the entity so leave-purge can find it", () => {
+    const store = makeStore();
+    applyDelta({delta: makeDelta({stream: "todos|tenant:org7"}), store});
+    expect(store.getEntity({collection: "todos", id: "t1"})?.stream).toBe("todos|tenant:org7");
   });
 
   it("throws for a delta targeting an unknown collection", () => {

--- a/syncdb/src/sync/deltaApplier.ts
+++ b/syncdb/src/sync/deltaApplier.ts
@@ -34,9 +34,15 @@ export const applyDelta = ({
   delta: SyncDelta;
   now?: () => string;
 }): ApplyDeltaResult => {
+  // C1: never advance the cursor past the stream's stable frontier. A delta can arrive
+  // for seq N while N-1's claim is still uncommitted (out-of-commit-order); clamping to
+  // min(seq, frontierSeq) means the cursor never skips the still-pending hole. Older
+  // servers omit frontierSeq — treat it as the delta's own seq (no clamp).
+  const frontier = typeof delta.frontierSeq === "number" ? delta.frontierSeq : delta.seq;
+  const cursorTarget = Math.min(delta.seq, frontier);
   const seqJump = delta.seq > getCursor({store, stream: delta.stream}) + 1;
   const advanceCursor = (): void => {
-    setCursor({now, seq: delta.seq, store, stream: delta.stream});
+    setCursor({now, seq: cursorTarget, store, stream: delta.stream});
   };
 
   const existing = store.getEntity({collection: delta.collection, id: delta.id});
@@ -58,6 +64,8 @@ export const applyDelta = ({
     id: delta.id,
     pendingMutationId: "",
     seq: delta.seq,
+    // C2: record the stream so leave-purge can drop this entity in O(stream).
+    stream: delta.stream,
   });
   advanceCursor();
   return {applied: true, seqJump};

--- a/syncdb/src/sync/deltaApplier.ts
+++ b/syncdb/src/sync/deltaApplier.ts
@@ -33,32 +33,37 @@ export const applyDelta = ({
   store: SyncStore;
   delta: SyncDelta;
   now?: () => string;
-}): ApplyDeltaResult => {
-  const seqJump = delta.seq > getCursor({store, stream: delta.stream}) + 1;
-  const advanceCursor = (): void => {
-    setCursor({now, seq: delta.seq, store, stream: delta.stream});
-  };
+}): ApplyDeltaResult =>
+  // E4: one transaction per delta — the entity upsert and cursor advance land
+  // as a single store commit (one listener notification, one autosave
+  // attempt) instead of two, and the two writes can never be observed
+  // half-applied by a listener firing between them.
+  store.raw.transaction(() => {
+    const seqJump = delta.seq > getCursor({store, stream: delta.stream}) + 1;
+    const advanceCursor = (): void => {
+      setCursor({now, seq: delta.seq, store, stream: delta.stream});
+    };
 
-  const existing = store.getEntity({collection: delta.collection, id: delta.id});
-  if (existing && delta.seq <= existing.seq) {
-    advanceCursor();
-    return {applied: false, seqJump};
-  }
-  if (existing?.pendingMutationId) {
-    advanceCursor();
-    return {applied: false, seqJump};
-  }
+    const existing = store.getEntity({collection: delta.collection, id: delta.id});
+    if (existing && delta.seq <= existing.seq) {
+      advanceCursor();
+      return {applied: false, seqJump};
+    }
+    if (existing?.pendingMutationId) {
+      advanceCursor();
+      return {applied: false, seqJump};
+    }
 
-  const deleted = delta.deleted === true || delta.method === "delete";
-  store.upsertEntity({
-    collection: delta.collection,
-    // Tombstone deltas omit data; keep the last known payload for conflict UIs.
-    data: delta.data !== undefined ? delta.data : (existing?.data ?? null),
-    deleted,
-    id: delta.id,
-    pendingMutationId: "",
-    seq: delta.seq,
+    const deleted = delta.deleted === true || delta.method === "delete";
+    store.upsertEntity({
+      collection: delta.collection,
+      // Tombstone deltas omit data; keep the last known payload for conflict UIs.
+      data: delta.data !== undefined ? delta.data : (existing?.data ?? null),
+      deleted,
+      id: delta.id,
+      pendingMutationId: "",
+      seq: delta.seq,
+    });
+    advanceCursor();
+    return {applied: true, seqJump};
   });
-  advanceCursor();
-  return {applied: true, seqJump};
-};

--- a/syncdb/src/sync/deltaApplier.ts
+++ b/syncdb/src/sync/deltaApplier.ts
@@ -39,9 +39,15 @@ export const applyDelta = ({
   // attempt) instead of two, and the two writes can never be observed
   // half-applied by a listener firing between them.
   store.raw.transaction(() => {
+    // C1: never advance the cursor past the stream's stable frontier. A delta can
+    // arrive for seq N while N-1's claim is still uncommitted (out-of-commit-order);
+    // clamping to min(seq, frontierSeq) means the cursor never skips the still-pending
+    // hole. Older servers omit frontierSeq — treat it as the delta's own seq (no clamp).
+    const frontier = typeof delta.frontierSeq === "number" ? delta.frontierSeq : delta.seq;
+    const cursorTarget = Math.min(delta.seq, frontier);
     const seqJump = delta.seq > getCursor({store, stream: delta.stream}) + 1;
     const advanceCursor = (): void => {
-      setCursor({now, seq: delta.seq, store, stream: delta.stream});
+      setCursor({now, seq: cursorTarget, store, stream: delta.stream});
     };
 
     const existing = store.getEntity({collection: delta.collection, id: delta.id});
@@ -63,6 +69,8 @@ export const applyDelta = ({
       id: delta.id,
       pendingMutationId: "",
       seq: delta.seq,
+      // C2: record the stream so leave-purge can drop this entity in O(stream).
+      stream: delta.stream,
     });
     advanceCursor();
     return {applied: true, seqJump};

--- a/syncdb/src/sync/fakeTransport.ts
+++ b/syncdb/src/sync/fakeTransport.ts
@@ -34,6 +34,12 @@ export interface FakeTransport extends SyncTransport {
   deliverDelta: (delta: SyncDelta) => void;
   /** Simulate a connect/disconnect; notifies status listeners on change. */
   setConnected: (connected: boolean) => void;
+  /**
+   * Simulate the D1 server-side session re-validation sweep disconnecting this
+   * socket: a disconnect tagged `authExpired: true`, mirroring the real socket
+   * transport's `sync:auth-expired` + `disconnect` sequence.
+   */
+  disconnectWithAuthExpired: () => void;
   /** Queue an ack for the next sendMutation (mutationId/id filled from the request). */
   respondWithAck: (overrides?: Partial<SyncAck>) => void;
   /** Queue a nack for the next sendMutation (mutationId filled from the request). */
@@ -116,6 +122,12 @@ export const createFakeTransport = (): FakeTransport => {
     },
     disconnect: (): void => {
       setConnected(false);
+    },
+    disconnectWithAuthExpired: (): void => {
+      connected = false;
+      for (const listener of statusListeners) {
+        listener({authExpired: true, connected: false});
+      }
     },
     onDelta: (callback: (delta: SyncDelta) => void): (() => void) => {
       deltaListeners.add(callback);

--- a/syncdb/src/sync/fakeTransport.ts
+++ b/syncdb/src/sync/fakeTransport.ts
@@ -1,15 +1,33 @@
-import type {SyncAck, SyncDelta, SyncMutateRequest, SyncNack} from "../types";
-import type {SendMutationResult, SyncTransport, TransportStatus} from "./transport";
+import type {
+  SyncAck,
+  SyncDelta,
+  SyncMutateBatchRequest,
+  SyncMutateRequest,
+  SyncNack,
+} from "../types";
+import type {
+  SendMutationBatchResult,
+  SendMutationResult,
+  SyncTransport,
+  TransportStatus,
+} from "./transport";
 
 /** Computes the reply for a sent mutation (may reject to simulate transport failure). */
 export type FakeMutationResponder = (
   request: SyncMutateRequest
 ) => SendMutationResult | Promise<SendMutationResult>;
 
+/** Computes the reply for a sent batch (may reject to simulate transport failure). */
+export type FakeBatchResponder = (
+  request: SyncMutateBatchRequest
+) => SendMutationBatchResult | Promise<SendMutationBatchResult>;
+
 /** Test-facing controls layered on top of the {@link SyncTransport} contract. */
 export interface FakeTransport extends SyncTransport {
   /** Every mutation sent through the transport, in order. */
   readonly sentMutations: SyncMutateRequest[];
+  /** Every batch sent through the transport (as arrays of mutationIds), in order. */
+  readonly sentBatches: string[][];
   /** Distinct collections subscribed so far (union across subscribe calls). */
   readonly subscribedCollections: string[];
   /** Deliver a server delta to all onDelta listeners. */
@@ -24,6 +42,15 @@ export interface FakeTransport extends SyncTransport {
   respondWith: (responder: FakeMutationResponder) => void;
   /** Replace the fallback responder used when the queue is empty (undefined = auto-ack). */
   setDefaultResponder: (responder?: FakeMutationResponder) => void;
+  /**
+   * Replace the batch responder (undefined = auto-ack every mutation in the
+   * batch with monotonically increasing seqs, sharing the same counter as
+   * single-send auto-ack). Set to a responder returning `{type:
+   * "unsupported"}` to simulate an old server without batch support.
+   */
+  setBatchResponder: (responder?: FakeBatchResponder) => void;
+  /** Queue a one-shot responder for the next sendMutationBatch call only. */
+  respondBatchWith: (responder: FakeBatchResponder) => void;
 }
 
 /**
@@ -34,6 +61,7 @@ export interface FakeTransport extends SyncTransport {
  */
 export const createFakeTransport = (): FakeTransport => {
   const sentMutations: SyncMutateRequest[] = [];
+  const sentBatches: string[][] = [];
   const subscribed = new Set<string>();
   const deltaListeners = new Set<(delta: SyncDelta) => void>();
   const statusListeners = new Set<(status: TransportStatus) => void>();
@@ -49,6 +77,23 @@ export const createFakeTransport = (): FakeTransport => {
     };
   };
   let defaultResponder: FakeMutationResponder = autoAck;
+
+  const autoAckBatch: FakeBatchResponder = (request) => ({
+    results: request.mutations.map((mutation) => {
+      nextSeq += 1;
+      return {
+        ack: {
+          id: mutation.id ?? `server-${nextSeq}`,
+          mutationId: mutation.mutationId,
+          seq: nextSeq,
+        },
+        type: "ack" as const,
+      };
+    }),
+    type: "results",
+  });
+  let batchResponder: FakeBatchResponder = autoAckBatch;
+  const batchResponderQueue: FakeBatchResponder[] = [];
 
   const setConnected = (value: boolean): void => {
     if (connected === value) {
@@ -84,6 +129,9 @@ export const createFakeTransport = (): FakeTransport => {
         statusListeners.delete(callback);
       };
     },
+    respondBatchWith: (responder: FakeBatchResponder): void => {
+      batchResponderQueue.push(responder);
+    },
     respondWith: (responder: FakeMutationResponder): void => {
       responderQueue.push(responder);
     },
@@ -112,7 +160,18 @@ export const createFakeTransport = (): FakeTransport => {
       const responder = responderQueue.shift() ?? defaultResponder;
       return responder(request);
     },
+    sendMutationBatch: async (
+      request: SyncMutateBatchRequest
+    ): Promise<SendMutationBatchResult> => {
+      sentBatches.push(request.mutations.map((mutation) => mutation.mutationId));
+      const responder = batchResponderQueue.shift() ?? batchResponder;
+      return responder(request);
+    },
+    sentBatches,
     sentMutations,
+    setBatchResponder: (responder?: FakeBatchResponder): void => {
+      batchResponder = responder ?? autoAckBatch;
+    },
     setConnected,
     setDefaultResponder: (responder?: FakeMutationResponder): void => {
       defaultResponder = responder ?? autoAck;

--- a/syncdb/src/sync/httpChannel.test.ts
+++ b/syncdb/src/sync/httpChannel.test.ts
@@ -31,48 +31,89 @@ const json = (body: unknown, status = 200): Response =>
 
 describe("createHttpChannel", () => {
   describe("fetchSnapshotPage", () => {
-    it("requests the snapshot with bearer token, collection, cursor, and limit", async () => {
-      const page = {cursor: 5, entities: [], hasMore: false};
+    it("requests the snapshot with bearer token, stream, cursor, and limit", async () => {
+      const page = {
+        cursor: 5,
+        entities: [],
+        frontierSeq: 5,
+        hasMore: false,
+        oldestRetainedSeq: 0,
+        stream: "todos|owner:u1",
+      };
       const {fetchImpl, requests} = makeFetch(() => json(page));
       const channel = createHttpChannel({authProvider, baseUrl: "http://api", fetchImpl});
-      const result = await channel.fetchSnapshotPage({collection: "todos", cursor: 3, limit: 10});
+      const result = await channel.fetchSnapshotPage({
+        cursor: 3,
+        limit: 10,
+        stream: "todos|owner:u1",
+      });
       expect(result).toEqual(page);
       expect(requests[0]?.input).toBe(
-        "http://api/sync/snapshot?collection=todos&cursor=3&limit=10"
+        "http://api/sync/snapshot?cursor=3&stream=todos%7Cowner%3Au1&limit=10"
       );
       expect((requests[0]?.init?.headers as Record<string, string>).Authorization).toBe(
         "Bearer token-123"
       );
     });
 
+    it("forwards the legacyCursor token (C3) when provided", async () => {
+      const page = {
+        cursor: 0,
+        entities: [],
+        frontierSeq: 0,
+        hasMore: true,
+        legacyCursor: "abc123",
+        oldestRetainedSeq: 0,
+        stream: "todos|owner:u1",
+      };
+      const {fetchImpl, requests} = makeFetch(() => json(page));
+      const channel = createHttpChannel({authProvider, baseUrl: "http://api", fetchImpl});
+      const result = await channel.fetchSnapshotPage({
+        cursor: 0,
+        legacyCursor: "prev-id",
+        stream: "todos|owner:u1",
+      });
+      expect(result.legacyCursor).toBe("abc123");
+      expect(requests[0]?.input).toContain("legacyCursor=prev-id");
+    });
+
     it("omits the limit parameter and the auth header when absent", async () => {
       const {fetchImpl, requests} = makeFetch(() =>
-        json({cursor: 0, entities: [], hasMore: false})
+        json({
+          cursor: 0,
+          entities: [],
+          frontierSeq: 0,
+          hasMore: false,
+          oldestRetainedSeq: 0,
+          stream: "todos|owner:u1",
+        })
       );
       const channel = createHttpChannel({
         authProvider: {getToken: async () => null},
         baseUrl: "http://api",
         fetchImpl,
       });
-      await channel.fetchSnapshotPage({collection: "todos", cursor: 0});
-      expect(requests[0]?.input).toBe("http://api/sync/snapshot?collection=todos&cursor=0");
+      await channel.fetchSnapshotPage({cursor: 0, stream: "todos|owner:u1"});
+      expect(requests[0]?.input).toBe(
+        "http://api/sync/snapshot?cursor=0&stream=todos%7Cowner%3Au1"
+      );
       expect((requests[0]?.init?.headers as Record<string, string>).Authorization).toBeUndefined();
     });
 
     it("rejects with AuthRequiredError on 401", async () => {
       const {fetchImpl} = makeFetch(() => json({}, 401));
       const channel = createHttpChannel({authProvider, baseUrl: "http://api", fetchImpl});
-      await expect(channel.fetchSnapshotPage({collection: "todos", cursor: 0})).rejects.toThrow(
-        AuthRequiredError
-      );
+      await expect(
+        channel.fetchSnapshotPage({cursor: 0, stream: "todos|owner:u1"})
+      ).rejects.toThrow(AuthRequiredError);
     });
 
     it("rejects on non-ok statuses", async () => {
       const {fetchImpl} = makeFetch(() => json({}, 404));
       const channel = createHttpChannel({authProvider, baseUrl: "http://api", fetchImpl});
-      await expect(channel.fetchSnapshotPage({collection: "todos", cursor: 0})).rejects.toThrow(
-        "status 404"
-      );
+      await expect(
+        channel.fetchSnapshotPage({cursor: 0, stream: "todos|owner:u1"})
+      ).rejects.toThrow("status 404");
     });
 
     it("propagates network errors", async () => {
@@ -80,9 +121,43 @@ describe("createHttpChannel", () => {
         throw new Error("offline");
       });
       const channel = createHttpChannel({authProvider, baseUrl: "http://api", fetchImpl});
-      await expect(channel.fetchSnapshotPage({collection: "todos", cursor: 0})).rejects.toThrow(
-        "offline"
+      await expect(
+        channel.fetchSnapshotPage({cursor: 0, stream: "todos|owner:u1"})
+      ).rejects.toThrow("offline");
+    });
+  });
+
+  describe("fetchStreams", () => {
+    it("GETs /sync/streams and returns the membership set", async () => {
+      const streams = [
+        {collection: "todos", stream: "todos|owner:u1"},
+        {collection: "todos", stream: "todos|tenant:org1"},
+      ];
+      const {fetchImpl, requests} = makeFetch(() => json({streams}));
+      const channel = createHttpChannel({authProvider, baseUrl: "http://api", fetchImpl});
+      await expect(channel.fetchStreams()).resolves.toEqual(streams);
+      expect(requests[0]?.input).toBe("http://api/sync/streams");
+      expect((requests[0]?.init?.headers as Record<string, string>).Authorization).toBe(
+        "Bearer token-123"
       );
+    });
+
+    it("returns an empty array when the body has no streams field", async () => {
+      const {fetchImpl} = makeFetch(() => json({}));
+      const channel = createHttpChannel({authProvider, baseUrl: "http://api", fetchImpl});
+      await expect(channel.fetchStreams()).resolves.toEqual([]);
+    });
+
+    it("rejects with AuthRequiredError on 401 (INV-2: never treated as a leave)", async () => {
+      const {fetchImpl} = makeFetch(() => json({}, 401));
+      const channel = createHttpChannel({authProvider, baseUrl: "http://api", fetchImpl});
+      await expect(channel.fetchStreams()).rejects.toBeInstanceOf(AuthRequiredError);
+    });
+
+    it("rejects on non-ok statuses", async () => {
+      const {fetchImpl} = makeFetch(() => json({}, 500));
+      const channel = createHttpChannel({authProvider, baseUrl: "http://api", fetchImpl});
+      await expect(channel.fetchStreams()).rejects.toThrow("status 500");
     });
   });
 
@@ -152,7 +227,9 @@ describe("createHttpChannel", () => {
       // Port 9 (discard) is never listening locally; fetch fails fast.
       baseUrl: "http://127.0.0.1:9",
     });
-    await expect(channel.fetchSnapshotPage({collection: "todos", cursor: 0})).rejects.toThrow();
+    await expect(
+      channel.fetchSnapshotPage({cursor: 0, stream: "todos|owner:u1"})
+    ).rejects.toThrow();
   });
 
   describe("fetchKeyMaterial", () => {

--- a/syncdb/src/sync/httpChannel.ts
+++ b/syncdb/src/sync/httpChannel.ts
@@ -1,11 +1,12 @@
 import type {
   AuthProvider,
   SyncAck,
+  SyncMutateBatchRequest,
   SyncMutateRequest,
   SyncNack,
   SyncSnapshotResponse,
 } from "../types";
-import type {SendMutationResult} from "./transport";
+import type {SendMutationBatchResult, SendMutationResult} from "./transport";
 
 /**
  * Thrown when the server answers 401: the bearer token is missing or expired.
@@ -39,6 +40,13 @@ export interface HttpChannel {
    * rejects with {@link AuthRequiredError}, anything else rejects.
    */
   sendMutation: (request: SyncMutateRequest) => Promise<SendMutationResult>;
+  /**
+   * POST the batch to `/sync/mutate/batch`; resolves `{type: "results", results}`
+   * on 200/422 (both carry a `results` array — see server contract), resolves
+   * `{type: "unsupported"}` on 404 (older server with no batch route), 401
+   * rejects with {@link AuthRequiredError}, anything else rejects.
+   */
+  sendMutationBatch?: (request: SyncMutateBatchRequest) => Promise<SendMutationBatchResult>;
   /**
    * Fetch the caller's per-user key material from `GET /sync/key` — feeds the
    * default server-derived encryption KeyProvider.
@@ -117,6 +125,29 @@ export const createHttpChannel = ({
     throw new Error(`Sync mutate failed with status ${response.status}`);
   };
 
+  const sendMutationBatch = async (
+    batch: SyncMutateBatchRequest
+  ): Promise<SendMutationBatchResult> => {
+    const response = await request("/sync/mutate/batch", {
+      body: JSON.stringify(batch),
+      method: "POST",
+    });
+    if (response.status === 404) {
+      return {type: "unsupported"};
+    }
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      throw new Error(`Sync mutate batch returned a non-JSON response (status ${response.status})`);
+    }
+    const parsed = body as {results?: SendMutationResult[]};
+    if (!Array.isArray(parsed.results)) {
+      throw new Error(`Sync mutate batch failed with status ${response.status}`);
+    }
+    return {results: parsed.results, type: "results"};
+  };
+
   const fetchKeyMaterial = async (): Promise<string> => {
     const response = await request("/sync/key");
     if (!response.ok) {
@@ -129,5 +160,5 @@ export const createHttpChannel = ({
     return body.keyMaterial;
   };
 
-  return {fetchKeyMaterial, fetchSnapshotPage, sendMutation};
+  return {fetchKeyMaterial, fetchSnapshotPage, sendMutation, sendMutationBatch};
 };

--- a/syncdb/src/sync/httpChannel.ts
+++ b/syncdb/src/sync/httpChannel.ts
@@ -5,6 +5,7 @@ import type {
   SyncMutateRequest,
   SyncNack,
   SyncSnapshotResponse,
+  SyncStreamInfo,
 } from "../types";
 import type {SendMutationBatchResult, SendMutationResult} from "./transport";
 
@@ -21,11 +22,14 @@ export class AuthRequiredError extends Error {
 }
 
 export interface FetchSnapshotPageArgs {
-  collection: string;
+  /** C2: the stream key to page (e.g. "todos|owner:123"), not a collection. */
+  stream: string;
   /** Resume cursor (highest seq already applied); 0 = from the beginning. */
   cursor: number;
   /** Page size; server default applies when omitted. */
   limit?: number;
+  /** C3: opaque legacy-stratum token echoed back from a prior page. */
+  legacyCursor?: string;
 }
 
 /**
@@ -34,6 +38,13 @@ export interface FetchSnapshotPageArgs {
  */
 export interface HttpChannel {
   fetchSnapshotPage: (args: FetchSnapshotPageArgs) => Promise<SyncSnapshotResponse>;
+  /**
+   * C2: the authoritative set of streams the caller currently belongs to
+   * (`GET /sync/streams`). Drives join-backfill / leave-purge diffs; 401 rejects with
+   * {@link AuthRequiredError} so a transport/auth error is never mistaken for a
+   * membership change (INV-2).
+   */
+  fetchStreams: () => Promise<SyncStreamInfo[]>;
   /**
    * POST the mutation; 200 resolves `{type: "ack"}`, nack statuses
    * (409/403/422/500 with a `{nack}` body) resolve `{type: "nack"}`, 401
@@ -89,19 +100,32 @@ export const createHttpChannel = ({
   };
 
   const fetchSnapshotPage = async ({
-    collection,
+    stream,
     cursor,
     limit,
+    legacyCursor,
   }: FetchSnapshotPageArgs): Promise<SyncSnapshotResponse> => {
-    const query = new URLSearchParams({collection, cursor: String(cursor)});
+    const query = new URLSearchParams({cursor: String(cursor), stream});
     if (limit !== undefined) {
       query.set("limit", String(limit));
     }
+    if (legacyCursor !== undefined) {
+      query.set("legacyCursor", legacyCursor);
+    }
     const response = await request(`/sync/snapshot?${query.toString()}`);
     if (!response.ok) {
-      throw new Error(`Snapshot request for ${collection} failed with status ${response.status}`);
+      throw new Error(`Snapshot request for ${stream} failed with status ${response.status}`);
     }
     return (await response.json()) as SyncSnapshotResponse;
+  };
+
+  const fetchStreams = async (): Promise<SyncStreamInfo[]> => {
+    const response = await request("/sync/streams");
+    if (!response.ok) {
+      throw new Error(`Sync streams request failed with status ${response.status}`);
+    }
+    const body = (await response.json()) as {streams?: SyncStreamInfo[]};
+    return Array.isArray(body.streams) ? body.streams : [];
   };
 
   const sendMutation = async (mutation: SyncMutateRequest): Promise<SendMutationResult> => {
@@ -160,5 +184,5 @@ export const createHttpChannel = ({
     return body.keyMaterial;
   };
 
-  return {fetchKeyMaterial, fetchSnapshotPage, sendMutation, sendMutationBatch};
+  return {fetchKeyMaterial, fetchSnapshotPage, fetchStreams, sendMutation, sendMutationBatch};
 };

--- a/syncdb/src/sync/replayCoordinator.test.ts
+++ b/syncdb/src/sync/replayCoordinator.test.ts
@@ -39,6 +39,23 @@ const makeHarness = (): Harness => {
   return {clock, coordinator, outbox, store, transport};
 };
 
+/** Harness variant with the batch transport wired in (B3), plus optional overrides. */
+const makeBatchHarness = (overrides: Partial<CreateReplayCoordinatorArgs> = {}): Harness => {
+  const store = createSyncStore({collections: ["notes", "todos"]});
+  const outbox = createOutbox({store});
+  const transport = createFakeTransport();
+  const clock = {value: 1_000_000};
+  const coordinator = createReplayCoordinator({
+    now: () => clock.value,
+    outbox,
+    sendMutation: transport.sendMutation,
+    sendMutationBatch: transport.sendMutationBatch,
+    store,
+    ...overrides,
+  });
+  return {clock, coordinator, outbox, store, transport};
+};
+
 /** A fake, controllable timer queue: setTimeoutFn/clearTimeoutFn injectable into the coordinator. */
 interface FakeTimers {
   /** Fire every timer whose delay has elapsed at the current clock value, in schedule order. */
@@ -746,6 +763,419 @@ describe("createReplayCoordinator", () => {
       // No debug log was configured for this harness; replay must not throw or
       // require one — the debug-only scan path is conditional on its presence.
       await harness.coordinator.replay({userId: USER});
+    });
+  });
+
+  describe("batched drain on top of the global FIFO (B3)", () => {
+    const enqueueN = (
+      harness: Harness,
+      count: number,
+      {collection = "todos", prefix = "m"}: {collection?: string; prefix?: string} = {}
+    ): void => {
+      for (let i = 0; i < count; i++) {
+        enqueue(harness, {collection, entityId: `${prefix}-e${i}`, mutationId: `${prefix}-${i}`});
+      }
+    };
+
+    it("120 queued across 2 collections drains in exactly 3 batch round-trips, order preserved", async () => {
+      const harness = makeBatchHarness();
+      // Interleave two collections in enqueue order so global FIFO ordering is
+      // actually exercised, not just per-collection ordering.
+      for (let i = 0; i < 60; i++) {
+        enqueue(harness, {collection: "todos", entityId: `t-e${i}`, mutationId: `t-${i}`});
+        enqueue(harness, {collection: "notes", entityId: `n-e${i}`, mutationId: `n-${i}`});
+      }
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.transport.sentBatches).toHaveLength(3);
+      // Default batchSize is 50: 120 mutations drain as 50 + 50 + 20.
+      expect(harness.transport.sentBatches.map((batch) => batch.length)).toEqual([50, 50, 20]);
+      // Global enqueue order preserved across the whole drain, not just within
+      // a chunk — assert via server-assigned seq order.
+      const allMutationIds = harness.transport.sentBatches.flat();
+      expect(allMutationIds).toHaveLength(120);
+      for (const id of allMutationIds) {
+        expect(harness.outbox.getMutation({mutationId: id})?.status).toBe("acked");
+      }
+      // Cross-check enqueue order: the Nth mutation sent must be the Nth
+      // enqueued (t-0, n-0, t-1, n-1, ...).
+      const expectedOrder: string[] = [];
+      for (let i = 0; i < 60; i++) {
+        expectedOrder.push(`t-${i}`, `n-${i}`);
+      }
+      expect(allMutationIds).toEqual(expectedOrder);
+    });
+
+    it("at most one mutation per entity per chunk: a second mutation for an already-included entity cuts the chunk short", async () => {
+      const harness = makeBatchHarness();
+      enqueue(harness, {entityId: "a", mutationId: "m1", operation: "create"});
+      enqueue(harness, {entityId: "shared", mutationId: "m2", operation: "create"});
+      harness.outbox.enqueue({
+        args: {title: "v2"},
+        collection: "todos",
+        entityId: "shared",
+        mutationId: "m3",
+        operation: "update",
+        userId: USER,
+      });
+      enqueue(harness, {entityId: "other", mutationId: "m4"});
+
+      await harness.coordinator.replay({userId: USER});
+      // m1 and m2 (distinct entities) fill the first chunk; m3 (second
+      // mutation for "shared", already in this chunk via m2) cuts it short —
+      // m4 is deferred behind the cut too, preserving global FIFO order
+      // (INV-1) rather than reordering around it. Once m1/m2 ack, the
+      // remaining queue is [m3, m4] — distinct entities, so they batch
+      // together in a second chunk (m3 now carries the fresh A2 base).
+      expect(harness.transport.sentBatches[0]).toEqual(["m1", "m2"]);
+      expect(harness.transport.sentBatches[1]).toEqual(["m3", "m4"]);
+      for (const id of ["m1", "m2", "m3", "m4"]) {
+        expect(harness.outbox.getMutation({mutationId: id})?.status).toBe("acked");
+      }
+    });
+
+    it("respects a configured batchSize", async () => {
+      const harness = makeBatchHarness({batchSize: 10});
+      enqueueN(harness, 25);
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.transport.sentBatches.map((b) => b.length)).toEqual([10, 10, 5]);
+    });
+
+    it("capability detection: HTTP-style unsupported response falls back to single sends in global order, re-probed after reconnect", async () => {
+      const harness = makeBatchHarness();
+      harness.transport.setBatchResponder(() => ({type: "unsupported"}));
+      enqueueN(harness, 5);
+
+      await harness.coordinator.replay({userId: USER});
+      // The first attempt probes the batch endpoint once (unsupported), then
+      // every mutation falls back to single sends, still in FIFO order.
+      expect(harness.transport.sentBatches).toHaveLength(1);
+      expect(harness.transport.sentMutations.map((m) => m.mutationId)).toEqual([
+        "m-0",
+        "m-1",
+        "m-2",
+        "m-3",
+        "m-4",
+      ]);
+      for (let i = 0; i < 5; i++) {
+        expect(harness.outbox.getMutation({mutationId: `m-${i}`})?.status).toBe("acked");
+      }
+
+      // Further mutations on the SAME connection keep using single sends —
+      // batching is not re-probed until a reconnect.
+      enqueueN(harness, 2, {prefix: "later"});
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.transport.sentBatches).toHaveLength(1);
+
+      // Re-probe after reconnect: batching works again.
+      harness.transport.setBatchResponder();
+      harness.coordinator.notifyReconnect();
+      enqueueN(harness, 3, {prefix: "reconnected"});
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.transport.sentBatches).toHaveLength(2);
+      expect(harness.transport.sentBatches[1]).toEqual([
+        "reconnected-0",
+        "reconnected-1",
+        "reconnected-2",
+      ]);
+    });
+
+    it("short response (server halted mid-batch) requeues the tail untouched, never burning error-nack budget; next drain resends from the halt point", async () => {
+      const harness = makeBatchHarness();
+      enqueueN(harness, 5);
+      harness.transport.respondBatchWith((request) => ({
+        results: request.mutations.slice(0, 2).map((mutation) => ({
+          ack: {id: mutation.id ?? "", mutationId: mutation.mutationId, seq: 1},
+          type: "ack" as const,
+        })),
+        type: "results",
+      }));
+
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "m-0"})?.status).toBe("acked");
+      expect(harness.outbox.getMutation({mutationId: "m-1"})?.status).toBe("acked");
+      // m-2..m-4 got no result: requeued untouched. The short response halts
+      // THIS replay() call (INV-1 — nothing after an unresolved halt point is
+      // attempted this pass) rather than being immediately re-swept within
+      // the same call.
+      for (let i = 2; i < 5; i++) {
+        const mutation = harness.outbox.getMutation({mutationId: `m-${i}`});
+        expect(mutation?.status).toBe("queued");
+        expect(mutation?.attemptCount).toBe(1); // markInFlight counted the attempt
+        expect(mutation?.errorNackCount).toBe(0); // never treated as an error-nack
+      }
+
+      // The next drain (a fresh trigger) resends from the halt point; the
+      // server ledger would dedupe any overlap (INV-3) — here nothing
+      // overlaps since the tail was never actually applied.
+      await harness.coordinator.replay({userId: USER});
+      for (let i = 0; i < 5; i++) {
+        expect(harness.outbox.getMutation({mutationId: `m-${i}`})?.status).toBe("acked");
+      }
+      // Applied exactly once: m-0..m-4 sent in the first (truncated) batch,
+      // m-2..m-4 resent in a second batch — never duplicated in either.
+      const allSent = harness.transport.sentBatches.flat();
+      const counts = new Map<string, number>();
+      for (const id of allSent) {
+        counts.set(id, (counts.get(id) ?? 0) + 1);
+      }
+      for (let i = 0; i < 5; i++) {
+        expect(counts.get(`m-${i}`)).toBe(i < 2 ? 1 : 2);
+      }
+    });
+
+    it("a lone eligible mutation in a chunk is sent as a single send, not a batch of one", async () => {
+      const harness = makeBatchHarness();
+      enqueue(harness, {entityId: "solo", mutationId: "solo-1"});
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.transport.sentBatches).toHaveLength(0);
+      expect(harness.transport.sentMutations.map((m) => m.mutationId)).toEqual(["solo-1"]);
+      expect(harness.outbox.getMutation({mutationId: "solo-1"})?.status).toBe("acked");
+    });
+  });
+
+  describe("stop-the-line policy (B4)", () => {
+    it("mid-batch socket disconnect (transport rejection) re-queues the WHOLE chunk untouched and halts the drain", async () => {
+      const harness = makeBatchHarness();
+      const enqueueThree = (): void => {
+        enqueue(harness, {entityId: "e1", mutationId: "m1"});
+        enqueue(harness, {entityId: "e2", mutationId: "m2"});
+        enqueue(harness, {entityId: "e3", mutationId: "m3"});
+      };
+      enqueueThree();
+      harness.transport.setBatchResponder(() => {
+        throw new Error("socket disconnected mid-batch");
+      });
+
+      await harness.coordinator.replay({userId: USER});
+      for (const id of ["m1", "m2", "m3"]) {
+        expect(harness.outbox.getMutation({mutationId: id})?.status).toBe("queued");
+      }
+
+      harness.transport.setBatchResponder();
+      harness.clock.value += ERROR_NACK_BASE_BACKOFF_MS * 30;
+      await harness.coordinator.replay({userId: USER});
+      for (const id of ["m1", "m2", "m3"]) {
+        expect(harness.outbox.getMutation({mutationId: id})?.status).toBe("acked");
+      }
+      // Applied exactly once: only one ack recorded per mutation across both
+      // drains (the coordinator never double-applies a chunk).
+      expect(harness.transport.sentMutations).toHaveLength(0);
+      expect(harness.transport.sentBatches.flat().filter((id) => id === "m1")).toHaveLength(2);
+    });
+
+    it("a conflict blocks only its entity's later mutations; other entities keep draining", async () => {
+      const harness = makeBatchHarness();
+      // Entity X has two queued mutations (second must be blocked by the first's
+      // conflict); entity Y has one and should proceed independently. Y is
+      // enqueued BEFORE x2 so the first chunk (x1, y1 — distinct entities)
+      // has length ≥ 2 and genuinely exercises the batch path rather than
+      // degenerating into a lone single-send.
+      enqueue(harness, {
+        baseVersion: 1,
+        entityId: "x",
+        mutationId: "x1",
+        operation: "update",
+      });
+      enqueue(harness, {entityId: "y", mutationId: "y1"});
+      harness.outbox.enqueue({
+        args: {title: "x-v2"},
+        baseVersion: 1,
+        collection: "todos",
+        entityId: "x",
+        mutationId: "x2",
+        operation: "update",
+        userId: USER,
+      });
+
+      harness.transport.setBatchResponder((request) => ({
+        results: request.mutations.map((mutation) => {
+          if (mutation.mutationId === "x1") {
+            return {
+              nack: {code: "conflict" as const, mutationId: mutation.mutationId, serverSeq: 9},
+              type: "nack" as const,
+            };
+          }
+          return {
+            ack: {id: mutation.id ?? "", mutationId: mutation.mutationId, seq: 1},
+            type: "ack" as const,
+          };
+        }),
+        type: "results",
+      }));
+
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "x1"})?.status).toBe("conflicted");
+      expect(harness.outbox.getMutation({mutationId: "y1"})?.status).toBe("acked");
+      // x2 stays queued and blocked — it must never have been sent while x1's
+      // conflict is unresolved.
+      expect(harness.outbox.getMutation({mutationId: "x2"})?.status).toBe("queued");
+      expect(harness.transport.sentBatches.flat()).not.toContain("x2");
+      expect(harness.coordinator.getBlockedEntities({userId: USER})).toContain("todos:x");
+
+      // A further replay call still skips x2 — it stays absent from
+      // subsequent batches while the conflict is unresolved.
+      harness.transport.setBatchResponder();
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "x2"})?.status).toBe("queued");
+
+      // Resolve the conflict (keepMine requeues under a fresh mutationId) —
+      // x2 (now unblocked) drains in its original relative position.
+      const {resolveConflict} = await import("../mutations/resolveConflict");
+      resolveConflict({
+        mutationId: "x1",
+        outbox: harness.outbox,
+        store: harness.store,
+        strategy: "keepMine",
+      });
+      expect(harness.coordinator.getBlockedEntities({userId: USER})).not.toContain("todos:x");
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "x2"})?.status).toBe("acked");
+    });
+
+    it("haltQueueOnConflict: true halts the entire drain — nothing after the conflict is sent at all", async () => {
+      const harness = makeBatchHarness({haltQueueOnConflict: true});
+      enqueue(harness, {baseVersion: 1, entityId: "x", mutationId: "x1", operation: "update"});
+      enqueue(harness, {entityId: "y", mutationId: "y1"});
+      enqueue(harness, {entityId: "z", mutationId: "z1"});
+
+      // Realistic server behavior (B2 stop-on-first-non-ack): x1 is first in
+      // the chunk and conflicts, so the server never attempts y1/z1 — the
+      // response is truncated to just x1's nack.
+      harness.transport.setBatchResponder((request) => ({
+        results: [
+          {
+            nack: {
+              code: "conflict" as const,
+              mutationId: request.mutations[0].mutationId,
+              serverSeq: 9,
+            },
+            type: "nack" as const,
+          },
+        ],
+        type: "results",
+      }));
+
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "x1"})?.status).toBe("conflicted");
+      // y1 and z1 got no result (server never attempted them) — requeued
+      // untouched, and haltQueueOnConflict stops the drain from building a
+      // follow-up chunk to retry them immediately.
+      expect(harness.outbox.getMutation({mutationId: "y1"})?.status).toBe("queued");
+      expect(harness.outbox.getMutation({mutationId: "z1"})?.status).toBe("queued");
+      expect(harness.transport.sentBatches).toHaveLength(1);
+    });
+
+    it("haltQueueOnConflict also halts when the conflict is delivered via the single-send fallback (lone chunk)", async () => {
+      // batchSize 1 forces every chunk to be a "lone eligible mutation",
+      // which reuses the single-mutation send path (not a batch of one) —
+      // haltQueueOnConflict must still stop the drain in that path.
+      const harness = makeBatchHarness({batchSize: 1, haltQueueOnConflict: true});
+      enqueue(harness, {baseVersion: 1, entityId: "x", mutationId: "x1", operation: "update"});
+      enqueue(harness, {entityId: "y", mutationId: "y1"});
+      harness.transport.respondWithNack({code: "conflict", serverSeq: 9});
+
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "x1"})?.status).toBe("conflicted");
+      expect(harness.outbox.getMutation({mutationId: "y1"})?.status).toBe("queued");
+      expect(harness.transport.sentMutations.map((m) => m.mutationId)).toEqual(["x1"]);
+    });
+
+    it("validation failure: successors for that entity are skipped and surfaced; retryFailed re-enables them", async () => {
+      const harness = makeBatchHarness();
+      // "good" is enqueued BEFORE b2 so the first chunk (b1, g1 — distinct
+      // entities) has length ≥ 2 and genuinely exercises the batch path.
+      enqueue(harness, {entityId: "bad", mutationId: "b1"});
+      enqueue(harness, {entityId: "good", mutationId: "g1"});
+      harness.outbox.enqueue({
+        args: {title: "b2"},
+        collection: "todos",
+        entityId: "bad",
+        mutationId: "b2",
+        operation: "update",
+        userId: USER,
+      });
+
+      harness.transport.setBatchResponder((request) => ({
+        results: request.mutations.map((mutation) =>
+          mutation.mutationId === "b1"
+            ? {
+                nack: {code: "validation" as const, mutationId: mutation.mutationId},
+                type: "nack" as const,
+              }
+            : {
+                ack: {id: mutation.id ?? "", mutationId: mutation.mutationId, seq: 1},
+                type: "ack" as const,
+              }
+        ),
+        type: "results",
+      }));
+
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "b1"})?.status).toBe("failed");
+      expect(harness.outbox.getMutation({mutationId: "g1"})?.status).toBe("acked");
+      // b2 is skipped-and-surfaced: stays queued, never sent.
+      expect(harness.outbox.getMutation({mutationId: "b2"})?.status).toBe("queued");
+      expect(harness.transport.sentBatches.flat()).not.toContain("b2");
+      expect(harness.coordinator.getBlockedEntities({userId: USER})).toContain("todos:bad");
+
+      // retryFailed re-enables the entity's queued successors.
+      harness.coordinator.retryFailed({entityId: "bad"});
+      expect(harness.coordinator.getBlockedEntities({userId: USER})).not.toContain("todos:bad");
+      harness.transport.setBatchResponder();
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "b2"})?.status).toBe("acked");
+    });
+
+    it("error nack halts the whole drain (transient — retry without user action)", async () => {
+      const harness = makeBatchHarness();
+      enqueue(harness, {entityId: "e1", mutationId: "m1"});
+      enqueue(harness, {entityId: "e2", mutationId: "m2"});
+      harness.transport.setBatchResponder((request) => ({
+        results: request.mutations.map((mutation) => ({
+          nack: {code: "error" as const, mutationId: mutation.mutationId},
+          type: "nack" as const,
+        })),
+        type: "results",
+      }));
+
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "m1"})?.status).toBe("queued");
+      expect(harness.outbox.getMutation({mutationId: "m2"})?.status).toBe("queued");
+
+      harness.transport.setBatchResponder();
+      harness.clock.value += ERROR_NACK_BASE_BACKOFF_MS * 30;
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "m1"})?.status).toBe("acked");
+      expect(harness.outbox.getMutation({mutationId: "m2"})?.status).toBe("acked");
+    });
+
+    it("unauthorized halts everything and enters auth pause with no data touched", async () => {
+      const harness = makeBatchHarness();
+      enqueue(harness, {entityId: "e1", mutationId: "m1"});
+      enqueue(harness, {entityId: "e2", mutationId: "m2"});
+      // Realistic server behavior (B2 stop-on-first-non-ack): the response is
+      // truncated at the first nack — m2 gets no result at all, not a second
+      // nack, since the server never attempted it.
+      harness.transport.setBatchResponder((request) => ({
+        results: [
+          {
+            nack: {code: "unauthorized" as const, mutationId: request.mutations[0].mutationId},
+            type: "nack" as const,
+          },
+        ],
+        type: "results",
+      }));
+
+      const result = await harness.coordinator.replay({userId: USER});
+      expect(result).toEqual({paused: "auth"});
+      expect(harness.outbox.getMutation({mutationId: "m1"})?.status).toBe("queued");
+      expect(harness.outbox.getMutation({mutationId: "m2"})?.status).toBe("queued");
+
+      harness.transport.setBatchResponder();
+      const resumed = await harness.coordinator.replay({userId: USER});
+      expect(resumed).toEqual({});
+      expect(harness.outbox.getMutation({mutationId: "m1"})?.status).toBe("acked");
+      expect(harness.outbox.getMutation({mutationId: "m2"})?.status).toBe("acked");
     });
   });
 });

--- a/syncdb/src/sync/replayCoordinator.test.ts
+++ b/syncdb/src/sync/replayCoordinator.test.ts
@@ -5,9 +5,12 @@ import {createOutbox, type Outbox} from "../mutations/outbox";
 import {createSyncStore, type SyncStore} from "../storage/store";
 import type {SyncMutateRequest} from "../types";
 import {createFakeTransport, type FakeTransport} from "./fakeTransport";
+import {AuthRequiredError} from "./httpChannel";
 import {
+  type CreateReplayCoordinatorArgs,
   createReplayCoordinator,
   ERROR_NACK_BASE_BACKOFF_MS,
+  MAX_BACKOFF_MS,
   MAX_ERROR_NACK_ATTEMPTS,
   type ReplayCoordinator,
 } from "./replayCoordinator";
@@ -34,6 +37,59 @@ const makeHarness = (): Harness => {
     store,
   });
   return {clock, coordinator, outbox, store, transport};
+};
+
+/** A fake, controllable timer queue: setTimeoutFn/clearTimeoutFn injectable into the coordinator. */
+interface FakeTimers {
+  /** Fire every timer whose delay has elapsed at the current clock value, in schedule order. */
+  flush: () => void;
+  /** Number of currently armed (not yet fired/cleared) timers. */
+  armedCount: () => number;
+}
+
+const makeFakeTimers = (clock: {
+  value: number;
+}): {timers: FakeTimers} & Pick<CreateReplayCoordinatorArgs, "setTimeoutFn" | "clearTimeoutFn"> => {
+  interface Entry {
+    id: number;
+    handler: () => void;
+    dueAt: number;
+    cleared: boolean;
+  }
+  const entries = new Map<number, Entry>();
+  let nextId = 1;
+  const setTimeoutFn = (handler: () => void, ms: number): unknown => {
+    const id = nextId++;
+    entries.set(id, {cleared: false, dueAt: clock.value + ms, handler, id});
+    return id;
+  };
+  const clearTimeoutFn = (handle: unknown): void => {
+    const entry = entries.get(handle as number);
+    if (entry) {
+      entry.cleared = true;
+      entries.delete(handle as number);
+    }
+  };
+  const flush = (): void => {
+    const due = [...entries.values()]
+      .filter((entry) => !entry.cleared && entry.dueAt <= clock.value)
+      .sort((a, b) => a.dueAt - b.dueAt || a.id - b.id);
+    for (const entry of due) {
+      if (entries.get(entry.id)?.cleared) {
+        continue;
+      }
+      entries.delete(entry.id);
+      entry.handler();
+    }
+  };
+  return {
+    clearTimeoutFn,
+    setTimeoutFn,
+    timers: {
+      armedCount: () => entries.size,
+      flush,
+    },
+  };
 };
 
 /** Enqueue a mutation plus its optimistic entity state, mirroring client.mutate. */
@@ -138,6 +194,114 @@ describe("createReplayCoordinator", () => {
     });
   });
 
+  describe("send-time baseVersion refresh (A2)", () => {
+    it("chains a create + update to the same entity through one queue with no self-conflict", async () => {
+      const harness = makeHarness();
+      // create: no baseVersion (new entity).
+      enqueue(harness, {
+        data: {title: "v1"},
+        entityId: "t1",
+        mutationId: "m1",
+        operation: "create",
+      });
+      // update enqueued offline BEFORE the create acked: captured baseVersion
+      // is still the stale 0/undefined floor.
+      harness.store.upsertEntity({collection: "todos", data: {title: "v2"}, id: "t1"});
+      harness.outbox.enqueue({
+        args: {title: "v2"},
+        collection: "todos",
+        entityId: "t1",
+        mutationId: "m2",
+        operation: "update",
+        userId: USER,
+      });
+
+      await harness.coordinator.replay({userId: USER});
+      const [createReq, updateReq] = harness.transport.sentMutations;
+      expect(createReq.baseVersion).toBeUndefined();
+      // The create's ack (seq 1) stamped the entity's seq before the update's
+      // request was built — the update carries the FRESH seq, not the stale
+      // enqueue-time floor, so it never manufactures a conflict.
+      expect(updateReq.baseVersion).toBe(1);
+      expect(harness.outbox.getMutation({mutationId: "m1"})?.status).toBe("acked");
+      expect(harness.outbox.getMutation({mutationId: "m2"})?.status).toBe("acked");
+    });
+
+    it("chains update + update through one queue: the second request carries the first's acked seq", async () => {
+      const harness = makeHarness();
+      harness.store.upsertEntity({collection: "todos", data: {title: "v0"}, id: "t1", seq: 5});
+      harness.outbox.enqueue({
+        args: {title: "v1"},
+        baseVersion: 5,
+        collection: "todos",
+        entityId: "t1",
+        mutationId: "m1",
+        operation: "update",
+        userId: USER,
+      });
+      harness.outbox.enqueue({
+        // Enqueued while m1 is still unacked: same stale baseVersion captured.
+        args: {title: "v2"},
+        baseVersion: 5,
+        collection: "todos",
+        entityId: "t1",
+        mutationId: "m2",
+        operation: "update",
+        userId: USER,
+      });
+      harness.transport.respondWithAck({seq: 6});
+
+      await harness.coordinator.replay({userId: USER});
+      const [firstReq, secondReq] = harness.transport.sentMutations;
+      expect(firstReq.baseVersion).toBe(5);
+      // m1's ack (seq 6) stamped the entity's seq before m2's request was
+      // built — m2 carries that fresh seq, not the stale enqueue-time floor.
+      expect(secondReq.baseVersion).toBe(6);
+      expect(harness.outbox.getMutation({mutationId: "m1"})?.status).toBe("acked");
+      expect(harness.outbox.getMutation({mutationId: "m2"})?.status).toBe("acked");
+    });
+
+    it("never sends a baseVersion lower than the one stored at enqueue time (floor)", async () => {
+      const harness = makeHarness();
+      // The entity's live seq (2) is BELOW the stored baseVersion (5) — e.g. a
+      // stale local write raced a delta application. The stored value is the
+      // floor and must win.
+      harness.store.upsertEntity({collection: "todos", data: {title: "v1"}, id: "t1", seq: 2});
+      harness.outbox.enqueue({
+        args: {title: "v1"},
+        baseVersion: 5,
+        collection: "todos",
+        entityId: "t1",
+        mutationId: "m1",
+        operation: "update",
+        userId: USER,
+      });
+
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.transport.sentMutations[0]?.baseVersion).toBe(5);
+    });
+
+    it("regression: a genuinely stale base (server changed underneath) still conflicts", async () => {
+      const harness = makeHarness();
+      enqueue(harness, {
+        baseVersion: 2,
+        data: {title: "local"},
+        entityId: "t1",
+        mutationId: "m1",
+        operation: "update",
+      });
+      harness.transport.respondWithNack({
+        code: "conflict",
+        serverDoc: {title: "server wins"},
+        serverSeq: 9,
+      });
+
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "m1"})?.status).toBe("conflicted");
+      expect(getConflict({mutationId: "m1", store: harness.store})?.serverSeq).toBe(9);
+    });
+  });
+
   it("drains FIFO within a collection", async () => {
     const harness = makeHarness();
     enqueue(harness, {entityId: "t1", mutationId: "m1"});
@@ -148,7 +312,7 @@ describe("createReplayCoordinator", () => {
     expect(harness.transport.sentMutations.map((m) => m.mutationId)).toEqual(["m1", "m2", "m3"]);
   });
 
-  it("a transport rejection stops one collection without blocking the other", async () => {
+  it("a transport rejection halts the ENTIRE global drain (INV-1), not just its collection", async () => {
     const harness = makeHarness();
     enqueue(harness, {entityId: "t1", mutationId: "m1"});
     enqueue(harness, {entityId: "t2", mutationId: "m2"});
@@ -161,18 +325,22 @@ describe("createReplayCoordinator", () => {
     });
 
     await harness.coordinator.replay({userId: USER});
-    // todos: m1 failed to send and went back to queued; m2 never attempted.
+    // m1 (head of the global FIFO) failed to send and went back to queued;
+    // the drain stops the line — m2 AND m3 (a different collection) are never
+    // attempted, even though m3's transport would have acked it.
     expect(harness.outbox.getMutation({mutationId: "m1"})?.status).toBe("queued");
     expect(harness.outbox.getMutation({mutationId: "m2"})?.status).toBe("queued");
-    expect(harness.transport.sentMutations.map((m) => m.mutationId)).not.toContain("m2");
-    // notes drained independently.
-    expect(harness.outbox.getMutation({mutationId: "m3"})?.status).toBe("acked");
+    expect(harness.outbox.getMutation({mutationId: "m3"})?.status).toBe("queued");
+    expect(harness.transport.sentMutations.map((m) => m.mutationId)).toEqual(["m1"]);
 
-    // The next replay resumes the stopped collection.
+    // The next replay resumes the whole queue once the transport recovers and
+    // the jittered backoff has elapsed.
     harness.transport.setDefaultResponder();
+    harness.clock.value += ERROR_NACK_BASE_BACKOFF_MS * 30;
     await harness.coordinator.replay({userId: USER});
     expect(harness.outbox.getMutation({mutationId: "m1"})?.status).toBe("acked");
     expect(harness.outbox.getMutation({mutationId: "m2"})?.status).toBe("acked");
+    expect(harness.outbox.getMutation({mutationId: "m3"})?.status).toBe("acked");
   });
 
   it("conflict nacks record a _conflicts row and leave the optimistic entity in place", async () => {
@@ -228,6 +396,32 @@ describe("createReplayCoordinator", () => {
     expect(harness.outbox.getMutation({mutationId: "m1"})?.status).toBe("acked");
     expect(harness.outbox.getMutation({mutationId: "m2"})?.status).toBe("acked");
     expect(harness.outbox.getMutation({mutationId: "m3"})?.status).toBe("acked");
+  });
+
+  it("AuthRequiredError thrown by the send channel (A4) is treated exactly like an unauthorized nack: requeue, pause, zero budget burn", async () => {
+    const harness = makeHarness();
+    enqueue(harness, {entityId: "t1", mutationId: "m1"});
+    enqueue(harness, {entityId: "t2", mutationId: "m2"});
+    harness.transport.respondWith(() => {
+      throw new AuthRequiredError();
+    });
+
+    const result = await harness.coordinator.replay({userId: USER});
+    expect(result).toEqual({paused: "auth"});
+    const mutation = harness.outbox.getMutation({mutationId: "m1"});
+    expect(mutation?.status).toBe("queued");
+    // No budget consumed at all: neither the diagnostic attemptCount (beyond
+    // the single send attempt already counted by markInFlight) nor the
+    // error-nack terminality counter.
+    expect(mutation?.errorNackCount).toBe(0);
+    expect(harness.outbox.getMutation({mutationId: "m2"})?.status).toBe("queued");
+
+    // Resumable exactly like an unauthorized nack.
+    harness.transport.setDefaultResponder();
+    const resumed = await harness.coordinator.replay({userId: USER});
+    expect(resumed).toEqual({});
+    expect(harness.outbox.getMutation({mutationId: "m1"})?.status).toBe("acked");
+    expect(harness.outbox.getMutation({mutationId: "m2"})?.status).toBe("acked");
   });
 
   it("validation nacks are terminal failures that release the entity", async () => {
@@ -345,5 +539,213 @@ describe("createReplayCoordinator", () => {
 
     await harness.coordinator.replay({userId: USER});
     expect(harness.transport.sentMutations[0]?.data).toEqual({});
+  });
+
+  describe("real scheduler: drain-until-empty + timed wake-ups + jittered backoff (A3)", () => {
+    it("sends a mutation enqueued during an active drain, within the same replay() call", async () => {
+      const store = createSyncStore({collections: ["todos"]});
+      const outbox = createOutbox({store});
+      const transport = createFakeTransport();
+      let armedSecond = false;
+      transport.respondWith(async (request) => {
+        // Enqueue m2 WHILE m1's send is in flight — before the drain loop's
+        // "is the queue now empty" recheck runs.
+        if (!armedSecond) {
+          armedSecond = true;
+          outbox.enqueue({
+            args: {title: "t2"},
+            collection: "todos",
+            entityId: "t2",
+            mutationId: "m2",
+            operation: "create",
+            userId: USER,
+          });
+        }
+        return {ack: {id: request.id ?? "", mutationId: request.mutationId, seq: 1}, type: "ack"};
+      });
+      const coordinator = createReplayCoordinator({
+        outbox,
+        sendMutation: transport.sendMutation,
+        store,
+      });
+      outbox.enqueue({
+        args: {title: "t1"},
+        collection: "todos",
+        entityId: "t1",
+        mutationId: "m1",
+        operation: "create",
+        userId: USER,
+      });
+
+      await coordinator.replay({userId: USER});
+      expect(transport.sentMutations.map((m) => m.mutationId)).toEqual(["m1", "m2"]);
+      expect(outbox.getMutation({mutationId: "m2"})?.status).toBe("acked");
+    });
+
+    it("an error-nack backoff elapsing fires the retry from the armed timer alone (no external trigger)", async () => {
+      const store = createSyncStore({collections: ["todos"]});
+      const outbox = createOutbox({store});
+      const transport = createFakeTransport();
+      const clock = {value: 1_000_000};
+      const {timers, ...timerArgs} = makeFakeTimers(clock);
+      const coordinator = createReplayCoordinator({
+        ...timerArgs,
+        now: () => clock.value,
+        outbox,
+        random: () => 0.999999, // near-max jitter for a deterministic wake delay
+        sendMutation: transport.sendMutation,
+        store,
+      });
+      outbox.enqueue({
+        args: {title: "t1"},
+        collection: "todos",
+        entityId: "t1",
+        mutationId: "m1",
+        operation: "create",
+        userId: USER,
+      });
+      transport.respondWithNack({code: "error"});
+
+      await coordinator.replay({userId: USER});
+      expect(outbox.getMutation({mutationId: "m1"})?.status).toBe("queued");
+      expect(transport.sentMutations).toHaveLength(1);
+      expect(timers.armedCount()).toBe(1);
+
+      // Advance the clock past the backoff and fire the armed timer directly —
+      // no replay()/replayOutbox() call from the test.
+      clock.value += ERROR_NACK_BASE_BACKOFF_MS;
+      timers.flush();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(transport.sentMutations.map((m) => m.mutationId)).toEqual(["m1", "m1"]);
+      expect(outbox.getMutation({mutationId: "m1"})?.status).toBe("acked");
+    });
+
+    it("transport failures get unlimited retries (never terminal) and don't burn the error-nack budget; a subsequent error-nack budget starts at 1", async () => {
+      const harness = makeHarness();
+      enqueue(harness, {entityId: "t1", mutationId: "m1"});
+      harness.transport.setDefaultResponder(() => {
+        throw new Error("network down");
+      });
+
+      // Ten transport failures — still queued, never terminal, attemptCount
+      // climbs but errorNackCount (the terminality budget) stays at 0.
+      for (let i = 0; i < 10; i += 1) {
+        await harness.coordinator.replay({userId: USER});
+        harness.clock.value += MAX_BACKOFF_MS;
+      }
+      const afterTransportFailures = harness.outbox.getMutation({mutationId: "m1"});
+      expect(afterTransportFailures?.status).toBe("queued");
+      expect(afterTransportFailures?.errorNackCount).toBe(0);
+      expect(afterTransportFailures?.attemptCount).toBe(10);
+
+      // Now the server responds with a real error-nack: its budget starts at 1,
+      // not at 10 (proving the two counters are tracked separately).
+      harness.transport.setDefaultResponder((request) => ({
+        nack: {code: "error", mutationId: request.mutationId},
+        type: "nack",
+      }));
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "m1"})?.errorNackCount).toBe(1);
+    });
+
+    it("jitter: two backoffs for the same attempt differ under an injected seeded random source", async () => {
+      const seeds = [0.1, 0.9];
+      let call = 0;
+      const transport = createFakeTransport();
+      const clock = {value: 1_000_000};
+      const delays: number[] = [];
+
+      // A fresh store/outbox/coordinator per mutation isolates each one's
+      // "attempt 1" backoff so both draw from the seeded random source below.
+      for (const id of ["m1", "m2"]) {
+        const store = createSyncStore({collections: ["todos"]});
+        const outbox = createOutbox({store});
+        const coordinator = createReplayCoordinator({
+          now: () => clock.value,
+          outbox,
+          random: () => seeds[call++] ?? 0.5,
+          sendMutation: transport.sendMutation,
+          setTimeoutFn: (_handler, ms) => {
+            delays.push(ms);
+            return 0;
+          },
+          store,
+        });
+        outbox.enqueue({
+          args: {},
+          collection: "todos",
+          entityId: id,
+          mutationId: id,
+          operation: "create",
+          userId: USER,
+        });
+        transport.respondWithNack({code: "error"});
+        await coordinator.replay({userId: USER});
+      }
+      expect(delays).toHaveLength(2);
+      expect(delays[0]).not.toBe(delays[1]);
+    });
+
+    it("global order: mutations across two collections replay strictly in enqueue order", async () => {
+      const harness = makeHarness();
+      enqueue(harness, {collection: "todos", entityId: "t1", mutationId: "m1"});
+      enqueue(harness, {collection: "notes", entityId: "n1", mutationId: "m2"});
+      enqueue(harness, {collection: "todos", entityId: "t2", mutationId: "m3"});
+      enqueue(harness, {collection: "notes", entityId: "n2", mutationId: "m4"});
+
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.transport.sentMutations.map((m) => m.mutationId)).toEqual([
+        "m1",
+        "m2",
+        "m3",
+        "m4",
+      ]);
+    });
+
+    it("dispose() clears armed timers so nothing sends after stop", async () => {
+      const store = createSyncStore({collections: ["todos"]});
+      const outbox = createOutbox({store});
+      const transport = createFakeTransport();
+      const clock = {value: 1_000_000};
+      const {timers, ...timerArgs} = makeFakeTimers(clock);
+      const coordinator = createReplayCoordinator({
+        ...timerArgs,
+        now: () => clock.value,
+        outbox,
+        sendMutation: transport.sendMutation,
+        store,
+      });
+      outbox.enqueue({
+        args: {},
+        collection: "todos",
+        entityId: "t1",
+        mutationId: "m1",
+        operation: "create",
+        userId: USER,
+      });
+      transport.respondWithNack({code: "error"});
+
+      await coordinator.replay({userId: USER});
+      expect(timers.armedCount()).toBe(1);
+
+      coordinator.dispose({userId: USER});
+      expect(timers.armedCount()).toBe(0);
+
+      // Even if the clock advances past the backoff, nothing fires — the
+      // timer was cleared, not just superseded.
+      clock.value += ERROR_NACK_BASE_BACKOFF_MS * 10;
+      timers.flush();
+      await Promise.resolve();
+      expect(transport.sentMutations).toHaveLength(1);
+    });
+
+    it("skips the debug-only listQueued scan when debug logging is disabled", async () => {
+      const harness = makeHarness();
+      expect(harness.coordinator).toBeDefined();
+      // No debug log was configured for this harness; replay must not throw or
+      // require one — the debug-only scan path is conditional on its presence.
+      await harness.coordinator.replay({userId: USER});
+    });
   });
 });

--- a/syncdb/src/sync/replayCoordinator.test.ts
+++ b/syncdb/src/sync/replayCoordinator.test.ts
@@ -7,6 +7,7 @@ import type {SyncMutateRequest} from "../types";
 import {createFakeTransport, type FakeTransport} from "./fakeTransport";
 import {AuthRequiredError} from "./httpChannel";
 import {
+  BATCH_UNSUPPORTED_REPROBE_INTERVAL_MS,
   type CreateReplayCoordinatorArgs,
   createReplayCoordinator,
   ERROR_NACK_BASE_BACKOFF_MS,
@@ -666,6 +667,79 @@ describe("createReplayCoordinator", () => {
       expect(harness.outbox.getMutation({mutationId: "m1"})?.errorNackCount).toBe(1);
     });
 
+    it("rate_limited nacks are treated exactly like a transport failure: unlimited retries, zero errorNackCount burn (FIX 1)", async () => {
+      const harness = makeHarness();
+      enqueue(harness, {entityId: "t1", mutationId: "m1"});
+      harness.transport.setDefaultResponder((request) => ({
+        nack: {code: "rate_limited", mutationId: request.mutationId, retryAfterMs: 500},
+        type: "nack",
+      }));
+
+      // Five-plus rate-limit nacks — more than MAX_ERROR_NACK_ATTEMPTS would
+      // ever tolerate for a real error-nack — must never go terminal.
+      for (let i = 0; i < 6; i += 1) {
+        const result = await harness.coordinator.replay({userId: USER});
+        expect(result).toEqual({});
+        harness.clock.value += MAX_BACKOFF_MS;
+      }
+      const mutation = harness.outbox.getMutation({mutationId: "m1"});
+      expect(mutation?.status).toBe("queued");
+      expect(mutation?.errorNackCount).toBe(0);
+
+      // Once the server allows it through, the mutation drains successfully.
+      harness.transport.setDefaultResponder();
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "m1"})?.status).toBe("acked");
+    });
+
+    it("rate_limited respects retryAfterMs as a backoff floor — no retry before the server's window clears", async () => {
+      const harness = makeHarness();
+      enqueue(harness, {entityId: "t1", mutationId: "m1"});
+      harness.transport.respondWithNack({code: "rate_limited", retryAfterMs: 10_000});
+
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "m1"})?.status).toBe("queued");
+      expect(harness.transport.sentMutations).toHaveLength(1);
+
+      // A jittered backoff well under the server's floor must not fire yet.
+      harness.transport.setDefaultResponder();
+      harness.clock.value += 1_000;
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.transport.sentMutations).toHaveLength(1);
+
+      // Past the 10s floor, the armed wake-up (or an explicit replay) retries.
+      harness.clock.value += 10_000;
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "m1"})?.status).toBe("acked");
+    });
+
+    it("a rate_limited chunk response requeues the WHOLE batch untouched and halts the drain (FIX 1, batch path)", async () => {
+      const harness = makeBatchHarness();
+      enqueue(harness, {entityId: "e1", mutationId: "m1"});
+      enqueue(harness, {entityId: "e2", mutationId: "m2"});
+      harness.transport.setBatchResponder((request) => ({
+        results: request.mutations.map((mutation) => ({
+          nack: {code: "rate_limited" as const, mutationId: mutation.mutationId, retryAfterMs: 200},
+          type: "nack" as const,
+        })),
+        type: "results",
+      }));
+
+      await harness.coordinator.replay({userId: USER});
+      for (const id of ["m1", "m2"]) {
+        const mutation = harness.outbox.getMutation({mutationId: id});
+        expect(mutation?.status).toBe("queued");
+        expect(mutation?.errorNackCount).toBe(0);
+      }
+
+      harness.transport.setBatchResponder();
+      harness.clock.value += 1_000;
+      await harness.coordinator.replay({userId: USER});
+      for (const id of ["m1", "m2"]) {
+        expect(harness.outbox.getMutation({mutationId: id})?.status).toBe("acked");
+      }
+    });
+
     it("jitter: two backoffs for the same attempt differ under an injected seeded random source", async () => {
       const seeds = [0.1, 0.9];
       let call = 0;
@@ -840,15 +914,16 @@ describe("createReplayCoordinator", () => {
       expect(harness.transport.sentBatches.map((b) => b.length)).toEqual([10, 10, 5]);
     });
 
-    it("capability detection: HTTP-style unsupported response falls back to single sends in global order, re-probed after reconnect", async () => {
+    it("capability detection: HTTP-style unsupported response falls back to single sends after 2 CONSECUTIVE strikes (FIX 5), re-probed after reconnect", async () => {
       const harness = makeBatchHarness();
       harness.transport.setBatchResponder(() => ({type: "unsupported"}));
       enqueueN(harness, 5);
 
       await harness.coordinator.replay({userId: USER});
-      // The first attempt probes the batch endpoint once (unsupported), then
-      // every mutation falls back to single sends, still in FIFO order.
-      expect(harness.transport.sentBatches).toHaveLength(1);
+      // FIX 5: a single unsupported result must not latch — it takes 2
+      // CONSECUTIVE unsupported results (the same 5-mutation chunk retried
+      // once) before falling back to single sends, still in FIFO order.
+      expect(harness.transport.sentBatches).toHaveLength(2);
       expect(harness.transport.sentMutations.map((m) => m.mutationId)).toEqual([
         "m-0",
         "m-1",
@@ -861,22 +936,138 @@ describe("createReplayCoordinator", () => {
       }
 
       // Further mutations on the SAME connection keep using single sends —
-      // batching is not re-probed until a reconnect.
+      // batching is not re-probed until a reconnect (or the 60s timer).
       enqueueN(harness, 2, {prefix: "later"});
       await harness.coordinator.replay({userId: USER});
-      expect(harness.transport.sentBatches).toHaveLength(1);
+      expect(harness.transport.sentBatches).toHaveLength(2);
 
       // Re-probe after reconnect: batching works again.
       harness.transport.setBatchResponder();
       harness.coordinator.notifyReconnect();
       enqueueN(harness, 3, {prefix: "reconnected"});
       await harness.coordinator.replay({userId: USER});
-      expect(harness.transport.sentBatches).toHaveLength(2);
-      expect(harness.transport.sentBatches[1]).toEqual([
+      expect(harness.transport.sentBatches).toHaveLength(3);
+      expect(harness.transport.sentBatches[2]).toEqual([
         "reconnected-0",
         "reconnected-1",
         "reconnected-2",
       ]);
+    });
+
+    it("a single stray unsupported result does not latch — the very next batch send on the same connection succeeds normally (FIX 5)", async () => {
+      const harness = makeBatchHarness();
+      enqueueN(harness, 4);
+      let calls = 0;
+      harness.transport.setBatchResponder((request) => {
+        calls += 1;
+        if (calls === 1) {
+          return {type: "unsupported"};
+        }
+        return {
+          results: request.mutations.map((mutation) => ({
+            ack: {id: mutation.id ?? "", mutationId: mutation.mutationId, seq: 1},
+            type: "ack" as const,
+          })),
+          type: "results",
+        };
+      });
+
+      await harness.coordinator.replay({userId: USER});
+      // Two batch sends: the stray unsupported one, then a real one that
+      // succeeds — never falling back to single sends.
+      expect(harness.transport.sentBatches).toHaveLength(2);
+      expect(harness.transport.sentMutations).toHaveLength(0);
+      for (let i = 0; i < 4; i++) {
+        expect(harness.outbox.getMutation({mutationId: `m-${i}`})?.status).toBe("acked");
+      }
+
+      // A later stray unsupported result also doesn't latch, since the
+      // counter reset after the successful batch above.
+      enqueueN(harness, 2, {prefix: "later"});
+      calls = 0;
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.transport.sentMutations).toHaveLength(0);
+    });
+
+    it("FIX 5: while latched, batching is re-probed on a 60s timer even without a reconnect", async () => {
+      const store = createSyncStore({collections: ["todos"]});
+      const outbox = createOutbox({store});
+      const transport = createFakeTransport();
+      const clock = {value: 1_000_000};
+      const {timers, ...timerArgs} = makeFakeTimers(clock);
+      transport.setBatchResponder(() => ({type: "unsupported"}));
+      const coordinator = createReplayCoordinator({
+        ...timerArgs,
+        now: () => clock.value,
+        outbox,
+        sendMutation: transport.sendMutation,
+        sendMutationBatch: transport.sendMutationBatch,
+        store,
+      });
+      for (let i = 0; i < 3; i++) {
+        outbox.enqueue({
+          args: {title: `t${i}`},
+          collection: "todos",
+          entityId: `t${i}`,
+          mutationId: `m${i}`,
+          operation: "create",
+          userId: USER,
+        });
+      }
+
+      // Two consecutive unsupported batch sends latch batchUnsupported —
+      // the coordinator falls back to single sends for the same mutations
+      // (auto-ack default responder handles the single-send fallback).
+      await coordinator.replay({userId: USER});
+      expect(outbox.getMutation({mutationId: "m0"})?.status).toBe("acked");
+      expect(transport.sentBatches).toHaveLength(2);
+      expect(transport.sentMutations.map((m) => m.mutationId)).toEqual(["m0", "m1", "m2"]);
+
+      // Latched: further mutations on this connection use single sends only.
+      outbox.enqueue({
+        args: {title: "later"},
+        collection: "todos",
+        entityId: "later",
+        mutationId: "m-later",
+        operation: "create",
+        userId: USER,
+      });
+      await coordinator.replay({userId: USER});
+      expect(transport.sentBatches).toHaveLength(2);
+
+      // Advance past the 60s re-probe interval with NO reconnect — the armed
+      // timer clears the latch on its own.
+      clock.value += BATCH_UNSUPPORTED_REPROBE_INTERVAL_MS;
+      timers.flush();
+      transport.setBatchResponder((request) => ({
+        results: request.mutations.map((mutation) => ({
+          ack: {id: mutation.id ?? "", mutationId: mutation.mutationId, seq: 1},
+          type: "ack" as const,
+        })),
+        type: "results",
+      }));
+      // Two mutations so the chunk genuinely exercises the batch path
+      // (a lone eligible mutation reuses the single-send path regardless of
+      // batchUnsupported — see the "lone chunk" comment in drainOnce).
+      outbox.enqueue({
+        args: {title: "reprobed-a"},
+        collection: "todos",
+        entityId: "reprobed-a",
+        mutationId: "m-reprobed-a",
+        operation: "create",
+        userId: USER,
+      });
+      outbox.enqueue({
+        args: {title: "reprobed-b"},
+        collection: "todos",
+        entityId: "reprobed-b",
+        mutationId: "m-reprobed-b",
+        operation: "create",
+        userId: USER,
+      });
+      await coordinator.replay({userId: USER});
+      expect(transport.sentBatches).toHaveLength(3);
+      expect(transport.sentBatches[2]).toEqual(["m-reprobed-a", "m-reprobed-b"]);
     });
 
     it("short response (server halted mid-batch) requeues the tail untouched, never burning error-nack budget; next drain resends from the halt point", async () => {
@@ -1124,6 +1315,246 @@ describe("createReplayCoordinator", () => {
       harness.transport.setBatchResponder();
       await harness.coordinator.replay({userId: USER});
       expect(harness.outbox.getMutation({mutationId: "b2"})?.status).toBe("acked");
+    });
+
+    it("FIX 2: a cross-collection reference to a blocked entity's id is also blocked, and unblocks with its root", async () => {
+      // P (create project, conflicts) and T (create todo in another collection,
+      // args reference P's id) — T must never drain while P is blocked, even
+      // though T's own entity has no conflict of its own. Y is an unrelated
+      // entity enqueued alongside P so P's own chunk has length >= 2 and
+      // genuinely exercises the batch path rather than degenerating into a
+      // lone single-send (the FIX 2 same-batch guard excludes T from P's
+      // chunk since T references P, whose outcome isn't known yet).
+      const harness = makeBatchHarness();
+      enqueue(harness, {collection: "notes", entityId: "p", mutationId: "p1"});
+      enqueue(harness, {entityId: "y", mutationId: "y1"});
+      harness.outbox.enqueue({
+        args: {projectId: "p", title: "todo referencing p"},
+        collection: "todos",
+        entityId: "t",
+        mutationId: "t1",
+        operation: "create",
+        userId: USER,
+      });
+      harness.store.upsertEntity({
+        collection: "todos",
+        data: {projectId: "p", title: "todo referencing p"},
+        id: "t",
+        pendingMutationId: "t1",
+      });
+
+      harness.transport.setBatchResponder((request) => ({
+        results: request.mutations.map((mutation) =>
+          mutation.mutationId === "p1"
+            ? {
+                nack: {code: "conflict" as const, mutationId: mutation.mutationId, serverSeq: 3},
+                type: "nack" as const,
+              }
+            : {
+                ack: {id: mutation.id ?? "", mutationId: mutation.mutationId, seq: 1},
+                type: "ack" as const,
+              }
+        ),
+        type: "results",
+      }));
+
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "p1"})?.status).toBe("conflicted");
+      expect(harness.outbox.getMutation({mutationId: "y1"})?.status).toBe("acked");
+      // t1 was never sent — it stays queued, budgets untouched.
+      expect(harness.outbox.getMutation({mutationId: "t1"})?.status).toBe("queued");
+      expect(harness.outbox.getMutation({mutationId: "t1"})?.errorNackCount).toBe(0);
+      expect(harness.transport.sentBatches.flat()).not.toContain("t1");
+      expect(harness.coordinator.getBlockedEntities({userId: USER})).toContain("notes:p");
+      expect(harness.coordinator.getBlockedEntities({userId: USER})).toContain("todos:t");
+
+      // A further replay still skips t1 while p is blocked.
+      harness.transport.setBatchResponder();
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "t1"})?.status).toBe("queued");
+
+      // Resolving p (keepMine requeues under a fresh mutationId) naturally
+      // unblocks t on the next drain — no persisted dependency graph needed.
+      const {resolveConflict} = await import("../mutations/resolveConflict");
+      resolveConflict({
+        mutationId: "p1",
+        outbox: harness.outbox,
+        store: harness.store,
+        strategy: "keepMine",
+      });
+      expect(harness.coordinator.getBlockedEntities({userId: USER})).not.toContain("todos:t");
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "t1"})?.status).toBe("acked");
+    });
+
+    it("FIX 2: reference blocking is conservative — a nested/array reference to a blocked id is also caught", async () => {
+      const harness = makeBatchHarness();
+      enqueue(harness, {collection: "notes", entityId: "p", mutationId: "p1"});
+      enqueue(harness, {entityId: "y", mutationId: "y1"});
+      harness.outbox.enqueue({
+        args: {meta: {tags: ["x", "p"]}, title: "nested ref"},
+        collection: "todos",
+        entityId: "t",
+        mutationId: "t1",
+        operation: "create",
+        userId: USER,
+      });
+
+      harness.transport.setBatchResponder((request) => ({
+        results: request.mutations.map((mutation) =>
+          mutation.mutationId === "p1"
+            ? {
+                nack: {code: "conflict" as const, mutationId: mutation.mutationId, serverSeq: 3},
+                type: "nack" as const,
+              }
+            : {
+                ack: {id: mutation.id ?? "", mutationId: mutation.mutationId, seq: 1},
+                type: "ack" as const,
+              }
+        ),
+        type: "results",
+      }));
+
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "t1"})?.status).toBe("queued");
+    });
+
+    it("FIX 3: coordinator lifecycle scoping — reset() clears all state so a different user reusing a blocked entity id is unaffected", async () => {
+      const harness = makeHarness();
+      enqueue(harness, {entityId: "singleton", mutationId: "m1"});
+      harness.transport.respondWithNack({code: "validation", message: "bad"});
+      await harness.coordinator.replay({userId: USER});
+      // A queued successor keeps the block observable (FIX 4: a block with no
+      // queued successor is GC'd immediately — see the FIX 4 tests below).
+      harness.outbox.enqueue({
+        args: {title: "v2"},
+        collection: "todos",
+        entityId: "singleton",
+        mutationId: "m1b",
+        operation: "update",
+        userId: USER,
+      });
+      expect(harness.coordinator.getBlockedEntities({userId: USER})).toContain("todos:singleton");
+
+      // Lifecycle boundary: dispose()/reset() as client.ts wires on a
+      // different-user login wipe path.
+      harness.coordinator.reset();
+
+      // A brand-new user reusing the same deterministic entity id must never
+      // be falsely blocked by the previous user's stale in-memory state.
+      const OTHER_USER = "user-2";
+      harness.outbox.enqueue({
+        args: {title: "fresh"},
+        collection: "todos",
+        entityId: "singleton",
+        mutationId: "m2",
+        operation: "create",
+        userId: OTHER_USER,
+      });
+      harness.transport.respondWithAck({seq: 1});
+      await harness.coordinator.replay({userId: OTHER_USER});
+      expect(harness.outbox.getMutation({mutationId: "m2"})?.status).toBe("acked");
+      expect(harness.coordinator.getBlockedEntities({userId: OTHER_USER})).toHaveLength(0);
+    });
+
+    it("FIX 3: validationBlockedEntities is keyed per-user — one user's block never leaks to another", async () => {
+      const harness = makeHarness();
+      const OTHER_USER = "user-2";
+      enqueue(harness, {entityId: "shared-id", mutationId: "m1", userId: USER});
+      harness.transport.respondWithNack({code: "validation", message: "bad"});
+      await harness.coordinator.replay({userId: USER});
+      // A queued successor keeps USER's block observable (FIX 4).
+      harness.outbox.enqueue({
+        args: {title: "v2"},
+        collection: "todos",
+        entityId: "shared-id",
+        mutationId: "m1b",
+        operation: "update",
+        userId: USER,
+      });
+      expect(harness.coordinator.getBlockedEntities({userId: USER})).toContain("todos:shared-id");
+
+      // Same entity id, different user: must drain freely, unaffected by
+      // USER's block, and must not appear in USER's blocked list.
+      harness.outbox.enqueue({
+        args: {title: "other user's doc"},
+        collection: "todos",
+        entityId: "shared-id",
+        mutationId: "m2",
+        operation: "create",
+        userId: OTHER_USER,
+      });
+      harness.transport.respondWithAck({seq: 7});
+      await harness.coordinator.replay({userId: OTHER_USER});
+      expect(harness.outbox.getMutation({mutationId: "m2"})?.status).toBe("acked");
+      expect(harness.coordinator.getBlockedEntities({userId: OTHER_USER})).toHaveLength(0);
+      // USER's own block is untouched by the other user's activity.
+      expect(harness.coordinator.getBlockedEntities({userId: USER})).toContain("todos:shared-id");
+    });
+
+    it("FIX 4: a validation block with no queued successor is GC'd once its failed row is pruned, letting a later NEW mutation for that entity drain", async () => {
+      const harness = makeHarness();
+      enqueue(harness, {entityId: "e1", mutationId: "m1"});
+      harness.transport.respondWithNack({code: "validation", message: "bad"});
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "m1"})?.status).toBe("failed");
+      // The failed row still exists (not yet pruned) with no successor
+      // queued — the block surfaces the failure until the user acts or the
+      // row ages out, exactly like the pre-FIX-4 behavior.
+      expect(harness.coordinator.getBlockedEntities({userId: USER})).toContain("todos:e1");
+
+      // Prune (removes the failed row — keepFailed: 0 forces it out here;
+      // the default keepFailed of 50 would keep a single row around, which
+      // is exactly the realistic "not pruned yet" case already covered
+      // above): with NO queued successor left to protect the ordering of,
+      // the block is now stale — GC'd, so a brand new mutation for the same
+      // entity is free to drain rather than being quarantined forever
+      // pending an explicit retryFailed the user may never call.
+      harness.outbox.prune({keepFailed: 0, userId: USER});
+      expect(harness.coordinator.getBlockedEntities({userId: USER})).not.toContain("todos:e1");
+      harness.outbox.enqueue({
+        args: {title: "fresh attempt"},
+        collection: "todos",
+        entityId: "e1",
+        mutationId: "m2",
+        operation: "create",
+        userId: USER,
+      });
+      harness.transport.respondWithAck({seq: 1});
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "m2"})?.status).toBe("acked");
+    });
+
+    it("FIX 4: a validation block WITH a queued successor stays blocked until retryFailed, surviving prune of the failed row", async () => {
+      const harness = makeHarness();
+      enqueue(harness, {entityId: "e1", mutationId: "m1"});
+      harness.transport.respondWithNack({code: "validation", message: "bad"});
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "m1"})?.status).toBe("failed");
+
+      // A successor is queued before anything prunes the failed row.
+      harness.outbox.enqueue({
+        args: {title: "v2"},
+        collection: "todos",
+        entityId: "e1",
+        mutationId: "m2",
+        operation: "update",
+        userId: USER,
+      });
+      expect(harness.coordinator.getBlockedEntities({userId: USER})).toContain("todos:e1");
+
+      // Pruning the failed row (keepFailed: 0 forces it out) must not drop
+      // the block while m2 is queued.
+      harness.outbox.prune({keepFailed: 0, userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "m1"})).toBeUndefined();
+      expect(harness.coordinator.getBlockedEntities({userId: USER})).toContain("todos:e1");
+      harness.transport.setDefaultResponder();
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "m2"})?.status).toBe("queued");
+
+      harness.coordinator.retryFailed({entityId: "e1"});
+      await harness.coordinator.replay({userId: USER});
+      expect(harness.outbox.getMutation({mutationId: "m2"})?.status).toBe("acked");
     });
 
     it("error nack halts the whole drain (transient — retry without user action)", async () => {

--- a/syncdb/src/sync/replayCoordinator.ts
+++ b/syncdb/src/sync/replayCoordinator.ts
@@ -3,6 +3,7 @@ import {writeConflict} from "../mutations/conflicts";
 import type {Outbox} from "../mutations/outbox";
 import type {SyncStore} from "../storage/store";
 import type {OutboxMutation, SyncAck, SyncMutateRequest, SyncNack} from "../types";
+import {AuthRequiredError} from "./httpChannel";
 import type {SendMutationResult} from "./transport";
 
 /** Error-nack retries beyond this attempt count become terminal failures. */
@@ -11,6 +12,12 @@ export const MAX_ERROR_NACK_ATTEMPTS = 5;
 /** Base delay for the error-nack exponential backoff (doubles per attempt). */
 export const ERROR_NACK_BASE_BACKOFF_MS = 1_000;
 
+/** Base delay for transport-failure backoff (unlimited retries, same cap/jitter shape). */
+export const TRANSPORT_FAILURE_BASE_BACKOFF_MS = 1_000;
+
+/** Cap applied to every jittered backoff (error-nack and transport-failure alike). */
+export const MAX_BACKOFF_MS = 30_000;
+
 export interface ReplayResult {
   /** Set when replay stopped early because the server rejected our auth. */
   paused?: "auth";
@@ -18,11 +25,55 @@ export interface ReplayResult {
 
 export interface ReplayCoordinator {
   /**
-   * Drain the user's queued mutations FIFO per collection (collections drain
-   * in parallel, mutations within a collection serially). A second call for
-   * the same user while one is running returns the in-flight promise.
+   * Drain the user's queued mutations in one global FIFO pass ordered by
+   * `enqueueOrder` (INV-1) — never per-collection parallel. Resolves once the
+   * queue is fully empty or parked (auth pause, or every remaining mutation is
+   * backing off). A second call for the same user while one is running
+   * returns the in-flight promise.
    */
   replay: (args: {userId: string}) => Promise<ReplayResult>;
+  /**
+   * Clear the single armed wake-up timer (if any) for a user. Called from
+   * `client.stop()` so no post-stop send can fire.
+   */
+  dispose: (args?: {userId?: string}) => void;
+}
+
+export interface CreateReplayCoordinatorArgs {
+  store: SyncStore;
+  outbox: Outbox;
+  sendMutation: (request: SyncMutateRequest) => Promise<SendMutationResult>;
+  /** Millisecond clock, injectable for deterministic backoff tests. */
+  now?: () => number;
+  /** Random source in [0, 1), injectable for deterministic jitter tests. */
+  random?: () => number;
+  /** Optional debug log; when present, each mutation outcome is recorded. */
+  debug?: SyncDebugLog;
+  /**
+   * Called whenever a drain parks on an armed wake-up timer, so the host can
+   * schedule the callback (defaults to the global `setTimeout`/`clearTimeout`).
+   */
+  setTimeoutFn?: (handler: () => void, ms: number) => unknown;
+  clearTimeoutFn?: (handle: unknown) => void;
+  /**
+   * Called after a drain pass that made forward progress (at least one ack)
+   * so the caller can prune acked rows (A5). Optional — tests that don't care
+   * about pruning may omit it.
+   */
+  onDrainPass?: (args: {userId: string}) => void;
+  /**
+   * Called the first time a drain pass for a user enters the auth-paused
+   * state (A4). Not called again until the pause clears and re-triggers.
+   */
+  onAuthPause?: (args: {userId: string}) => void;
+  /**
+   * Consulted before every drain attempt — including internally-scheduled
+   * ones (the armed wake-up timer and the mid-drain-enqueue recheck) that
+   * bypass the caller's own call site. Lets the host gate sending on state the
+   * coordinator does not itself track (simulated offline, auth pause at the
+   * client level). Defaults to always-allow.
+   */
+  shouldDrain?: () => boolean;
 }
 
 /**
@@ -33,34 +84,78 @@ export interface ReplayCoordinator {
  *   belongs to this mutation) and stamp the acked seq;
  * - **nack conflict** → markConflicted + record a `_conflicts` row; the
  *   entity's optimistic state stays in place until the user resolves;
- * - **nack unauthorized** → back to queued and pause replay for the user
- *   (`{paused: "auth"}`); the next replay call retries;
+ * - **nack unauthorized** / thrown `AuthRequiredError` → back to queued and
+ *   pause replay for the user (`{paused: "auth"}`), consuming NO retry budget
+ *   (INV-2); the next replay call (after re-auth) retries;
  * - **nack validation** → markFailed (terminal) and release the entity's
  *   `pendingMutationId` so future deltas are not blocked forever;
- * - **nack error** → back to queued with attemptCount-based exponential
- *   backoff (in-memory), terminal markFailed after
+ * - **nack error** → back to queued with jittered exponential backoff against
+ *   the dedicated `errorNackCount` budget, terminal markFailed after
  *   {@link MAX_ERROR_NACK_ATTEMPTS} attempts;
- * - **send rejection** (timeout / network / disconnect) → back to queued and
- *   stop draining that collection until the next replay call.
+ * - **send rejection** (timeout / network / disconnect) → back to queued with
+ *   unlimited jittered exponential backoff (never terminal, never burns the
+ *   error-nack budget) and the drain parks until the backoff elapses.
+ *
+ * The drain is a SINGLE global FIFO over `enqueueOrder` (INV-1) — no more
+ * per-collection parallelism. `replay()` keeps re-running drain passes until
+ * the queue is empty or parked; when it parks on a backoff, a single
+ * `setTimeout` wakes the next drain automatically so callers never need to
+ * poll.
  */
 export const createReplayCoordinator = ({
   store,
   outbox,
   sendMutation,
   now = () => Date.now(),
+  random = () => Math.random(),
   debug,
-}: {
-  store: SyncStore;
-  outbox: Outbox;
-  sendMutation: (request: SyncMutateRequest) => Promise<SendMutationResult>;
-  /** Millisecond clock, injectable for deterministic backoff tests. */
-  now?: () => number;
-  /** Optional debug log; when present, each mutation outcome is recorded. */
-  debug?: SyncDebugLog;
-}): ReplayCoordinator => {
+  setTimeoutFn = (handler, ms) => setTimeout(handler, ms),
+  clearTimeoutFn = (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+  onDrainPass,
+  onAuthPause,
+  shouldDrain = () => true,
+}: CreateReplayCoordinatorArgs): ReplayCoordinator => {
   const inFlightReplays = new Map<string, Promise<ReplayResult>>();
+  /**
+   * Set when a `replay()` call coalesces into an already-running drain whose
+   * final pass may have already observed the queue as empty (a narrow race:
+   * the in-flight promise's cleanup runs on a later microtask than the
+   * enqueue that prompted this call). Consumed once the in-flight promise
+   * settles to schedule exactly one immediate follow-up drain, so a mutation
+   * enqueued mid-drain is never stranded until an unrelated external trigger.
+   */
+  const recheckRequested = new Set<string>();
   /** mutationId → earliest epoch-ms the next attempt may run (error-nack backoff). */
   const retryAt = new Map<string, number>();
+  /** mutationId → count of transport-failure attempts (in-memory only; unlimited budget). */
+  const transportFailures = new Map<string, number>();
+  /** userId → armed wake-up timer handle (never more than one per user). */
+  const wakeTimers = new Map<string, unknown>();
+  /** userId → whether onAuthPause has already fired for the current pause episode. */
+  const authPauseNotified = new Set<string>();
+
+  const clearWakeTimer = (userId: string): void => {
+    const handle = wakeTimers.get(userId);
+    if (handle !== undefined) {
+      clearTimeoutFn(handle);
+      wakeTimers.delete(userId);
+    }
+  };
+
+  const armWakeTimer = (userId: string, delayMs: number): void => {
+    clearWakeTimer(userId);
+    const handle = setTimeoutFn(() => {
+      wakeTimers.delete(userId);
+      void replay({userId});
+    }, delayMs);
+    wakeTimers.set(userId, handle);
+  };
+
+  /** Full jitter: random(0, base * 2^(attempt-1)), capped at MAX_BACKOFF_MS. */
+  const jitteredBackoff = (attempt: number, baseMs: number): number => {
+    const cap = Math.min(MAX_BACKOFF_MS, baseMs * 2 ** (attempt - 1));
+    return Math.floor(random() * cap);
+  };
 
   const buildRequest = (mutation: OutboxMutation): SyncMutateRequest => {
     const request: SyncMutateRequest = {
@@ -69,7 +164,23 @@ export const createReplayCoordinator = ({
       mutationId: mutation.mutationId,
       operation: mutation.operation,
     };
-    if (mutation.baseVersion !== undefined) {
+    // A2: send-time baseVersion refresh. The entity's CURRENT seq is used as
+    // the base when it is NEWER than the value captured at enqueue time — the
+    // stored value is the floor, never sent lower. A prior mutation in the
+    // same queue may have already acked (stamping the entity's seq via
+    // releaseEntity) since this mutation was enqueued; reading the live seq
+    // here chains bases correctly through a queue of edits to one entity
+    // without any coalescing.
+    if (mutation.operation !== "create") {
+      const entity = store.getEntity({collection: mutation.collection, id: mutation.entityId});
+      const liveSeq = entity?.seq;
+      const floor = mutation.baseVersion;
+      const base =
+        liveSeq !== undefined && (floor === undefined || liveSeq > floor) ? liveSeq : floor;
+      if (base !== undefined) {
+        request.baseVersion = base;
+      }
+    } else if (mutation.baseVersion !== undefined) {
       request.baseVersion = mutation.baseVersion;
     }
     if (mutation.operation !== "delete") {
@@ -104,6 +215,7 @@ export const createReplayCoordinator = ({
   const handleAck = (mutation: OutboxMutation, ack: SyncAck): void => {
     outbox.markAcked({mutationId: mutation.mutationId});
     retryAt.delete(mutation.mutationId);
+    transportFailures.delete(mutation.mutationId);
     releaseEntity(mutation, ack.seq);
     debug?.record({
       collection: mutation.collection,
@@ -121,6 +233,7 @@ export const createReplayCoordinator = ({
   const handleConflict = (mutation: OutboxMutation, nack: SyncNack): void => {
     outbox.markConflicted({mutationId: mutation.mutationId});
     retryAt.delete(mutation.mutationId);
+    transportFailures.delete(mutation.mutationId);
     const entity = store.getEntity({collection: mutation.collection, id: mutation.entityId});
     writeConflict({
       conflict: {
@@ -150,6 +263,7 @@ export const createReplayCoordinator = ({
   const handleTerminalFailure = (mutation: OutboxMutation, reason: string): void => {
     outbox.markFailed({mutationId: mutation.mutationId});
     retryAt.delete(mutation.mutationId);
+    transportFailures.delete(mutation.mutationId);
     // A failed mutation never replays; leaving pendingMutationId set would
     // block server deltas for this entity forever.
     releaseEntity(mutation);
@@ -166,19 +280,27 @@ export const createReplayCoordinator = ({
     });
   };
 
-  const drainCollection = async (
-    mutations: OutboxMutation[],
-    state: {authPaused: boolean}
-  ): Promise<void> => {
+  /** Outcome of one drain pass over the full FIFO queue. */
+  interface DrainPassResult {
+    authPaused: boolean;
+    /** Earliest backoff wake-up across every parked mutation this pass, if any. */
+    nextWakeAt?: number;
+    /** True when at least one mutation acked this pass (progress signal for pruning). */
+    progressed: boolean;
+  }
+
+  const drainOnce = async (userId: string): Promise<DrainPassResult> => {
+    const mutations = outbox.listQueued({userId});
+    let progressed = false;
+    let nextWakeAt: number | undefined;
+
     for (const mutation of mutations) {
-      if (state.authPaused) {
-        return;
-      }
       const nextAttemptAt = retryAt.get(mutation.mutationId);
       if (nextAttemptAt !== undefined && now() < nextAttemptAt) {
-        // FIFO within a collection: a backing-off head blocks the drain rather
-        // than letting later mutations overtake it.
-        return;
+        // INV-1: a backing-off head blocks the ENTIRE global drain rather than
+        // letting later mutations (in this or another collection) overtake it.
+        nextWakeAt = nextWakeAt === undefined ? nextAttemptAt : Math.min(nextWakeAt, nextAttemptAt);
+        return {authPaused: false, nextWakeAt, progressed};
       }
       outbox.markInFlight({mutationId: mutation.mutationId});
       debug?.record({
@@ -194,24 +316,49 @@ export const createReplayCoordinator = ({
       let result: SendMutationResult;
       try {
         result = await sendMutation(buildRequest(mutation));
-      } catch {
-        // Transport failure (timeout, network, disconnect): keep the mutation
-        // queued and stop draining this collection until the next replay.
+      } catch (error) {
+        if (error instanceof AuthRequiredError) {
+          // INV-2: never burn a retry budget on an auth failure. Requeue and
+          // pause the whole drain; the caller retries after re-auth.
+          outbox.markQueued({mutationId: mutation.mutationId});
+          debug?.record({
+            collection: mutation.collection,
+            detail: {code: "unauthorized", paused: true, source: "http"},
+            direction: "inbound",
+            entityId: mutation.entityId,
+            label: `nack ${mutation.collection}/${mutation.entityId} (unauthorized)`,
+            mutationId: mutation.mutationId,
+            ok: false,
+            operation: mutation.operation,
+            type: "nack",
+          });
+          return {authPaused: true, progressed};
+        }
+        // Transport failure (timeout, network, disconnect): unlimited retries
+        // with jittered capped backoff, tracked separately from the
+        // error-nack budget.
         outbox.markQueued({mutationId: mutation.mutationId});
+        const attempt = (transportFailures.get(mutation.mutationId) ?? 0) + 1;
+        transportFailures.set(mutation.mutationId, attempt);
+        const backoffMs = jitteredBackoff(attempt, TRANSPORT_FAILURE_BASE_BACKOFF_MS);
+        const wakeAt = now() + backoffMs;
+        retryAt.set(mutation.mutationId, wakeAt);
+        nextWakeAt = nextWakeAt === undefined ? wakeAt : Math.min(nextWakeAt, wakeAt);
         debug?.record({
           collection: mutation.collection,
-          detail: {reason: "transport"},
+          detail: {attempt, backoffMs, reason: "transport"},
           direction: "system",
           entityId: mutation.entityId,
-          label: `retry ${mutation.collection}/${mutation.entityId} (transport)`,
+          label: `retry ${mutation.collection}/${mutation.entityId} (transport, ${backoffMs}ms)`,
           mutationId: mutation.mutationId,
           operation: mutation.operation,
           type: "retry",
         });
-        return;
+        return {authPaused: false, nextWakeAt, progressed};
       }
       if (result.type === "ack") {
         handleAck(mutation, result.ack);
+        progressed = true;
         continue;
       }
       const {nack} = result;
@@ -221,7 +368,6 @@ export const createReplayCoordinator = ({
       }
       if (nack.code === "unauthorized") {
         outbox.markQueued({mutationId: mutation.mutationId});
-        state.authPaused = true;
         debug?.record({
           collection: mutation.collection,
           detail: {code: "unauthorized", paused: true},
@@ -233,23 +379,26 @@ export const createReplayCoordinator = ({
           operation: mutation.operation,
           type: "nack",
         });
-        return;
+        return {authPaused: true, progressed};
       }
       if (nack.code === "validation") {
         handleTerminalFailure(mutation, "validation");
         continue;
       }
-      // "error": transient server failure — exponential backoff, then terminal.
-      const attempts =
-        outbox.getMutation({mutationId: mutation.mutationId})?.attemptCount ??
-        mutation.attemptCount + 1;
+      // "error": transient server failure — jittered exponential backoff
+      // against the dedicated errorNackCount budget, then terminal.
+      const beforeCount =
+        outbox.getMutation({mutationId: mutation.mutationId})?.errorNackCount ?? 0;
+      const attempts = beforeCount + 1;
       if (attempts >= MAX_ERROR_NACK_ATTEMPTS) {
         handleTerminalFailure(mutation, "error");
         continue;
       }
-      outbox.markQueued({mutationId: mutation.mutationId});
-      const backoffMs = ERROR_NACK_BASE_BACKOFF_MS * 2 ** (attempts - 1);
-      retryAt.set(mutation.mutationId, now() + backoffMs);
+      outbox.markQueuedAfterErrorNack({mutationId: mutation.mutationId});
+      const backoffMs = jitteredBackoff(attempts, ERROR_NACK_BASE_BACKOFF_MS);
+      const wakeAt = now() + backoffMs;
+      retryAt.set(mutation.mutationId, wakeAt);
+      nextWakeAt = nextWakeAt === undefined ? wakeAt : Math.min(nextWakeAt, wakeAt);
       debug?.record({
         collection: mutation.collection,
         detail: {attempt: attempts, backoffMs, reason: "error"},
@@ -260,36 +409,97 @@ export const createReplayCoordinator = ({
         operation: mutation.operation,
         type: "retry",
       });
-      // The backing-off mutation stays at the head of its collection's FIFO;
+      // INV-1: the backing-off mutation stays at the head of the global FIFO;
       // stop draining until its delay elapses.
-      return;
+      return {authPaused: false, nextWakeAt, progressed};
     }
+    return {authPaused: false, progressed};
   };
 
   const replay = ({userId}: {userId: string}): Promise<ReplayResult> => {
     const existing = inFlightReplays.get(userId);
     if (existing) {
+      // The running drain may have already taken its final "queue empty"
+      // snapshot before this call's mutation was enqueued; request a
+      // follow-up check once it settles rather than silently stranding the
+      // new mutation until an unrelated external trigger runs.
+      recheckRequested.add(userId);
       return existing;
     }
+    if (!shouldDrain()) {
+      // The host has gated sending off (simulated offline, client-level auth
+      // pause, post-stop, etc). Internally-scheduled callers (the wake timer,
+      // the recheck above) must respect this exactly like an external caller
+      // would — never send, never arm a new timer, never touch retry state.
+      return Promise.resolve({});
+    }
+    // A fresh replay call supersedes any pending timed wake-up — it is about
+    // to drain right now.
+    clearWakeTimer(userId);
     const run = (async (): Promise<ReplayResult> => {
-      const byCollection = new Map<string, OutboxMutation[]>();
-      for (const mutation of outbox.listQueued({userId})) {
-        const list = byCollection.get(mutation.collection) ?? [];
-        list.push(mutation);
-        byCollection.set(mutation.collection, list);
+      let authPaused = false;
+      let parkedAt: number | undefined;
+      // Drain-until-empty: keep re-running passes while there is still work
+      // and nothing has parked the queue. shouldDrain() is re-checked before
+      // EVERY pass (not just once at entry): a pass can be deferred onto a
+      // later microtask/timer tick by the time it actually runs, during which
+      // the host may have gone offline or paused — an internally-scheduled
+      // continuation must never race past that.
+      for (;;) {
+        if (!shouldDrain()) {
+          break;
+        }
+        const pass = await drainOnce(userId);
+        if (pass.progressed) {
+          onDrainPass?.({userId});
+        }
+        if (pass.authPaused) {
+          authPaused = true;
+          break;
+        }
+        if (pass.nextWakeAt !== undefined) {
+          parkedAt = pass.nextWakeAt;
+          break;
+        }
+        // Only stop looping once nothing is queued (drain-until-empty).
+        if (outbox.listQueued({userId}).length === 0) {
+          break;
+        }
       }
-      const state = {authPaused: false};
-      await Promise.all(
-        [...byCollection.values()].map((mutations) => drainCollection(mutations, state))
-      );
-      return state.authPaused ? {paused: "auth"} : {};
+      if (authPaused) {
+        if (!authPauseNotified.has(userId)) {
+          authPauseNotified.add(userId);
+          onAuthPause?.({userId});
+        }
+        return {paused: "auth"};
+      }
+      authPauseNotified.delete(userId);
+      if (parkedAt !== undefined) {
+        // Timed wake-up: arm a single setTimeout for the earliest backoff
+        // across the parked queue so callers never need to poll.
+        armWakeTimer(userId, Math.max(0, parkedAt - now()));
+      }
+      return {};
     })();
     const tracked = run.finally(() => {
       inFlightReplays.delete(userId);
+      if (recheckRequested.delete(userId)) {
+        void replay({userId});
+      }
     });
     inFlightReplays.set(userId, tracked);
     return tracked;
   };
 
-  return {replay};
+  const dispose = (args?: {userId?: string}): void => {
+    if (args?.userId !== undefined) {
+      clearWakeTimer(args.userId);
+      return;
+    }
+    for (const userId of [...wakeTimers.keys()]) {
+      clearWakeTimer(userId);
+    }
+  };
+
+  return {dispose, replay};
 };

--- a/syncdb/src/sync/replayCoordinator.ts
+++ b/syncdb/src/sync/replayCoordinator.ts
@@ -1,10 +1,20 @@
 import type {SyncDebugLog} from "../debug/debugLog";
-import {writeConflict} from "../mutations/conflicts";
+import {listConflicts, writeConflict} from "../mutations/conflicts";
 import type {Outbox} from "../mutations/outbox";
 import type {SyncStore} from "../storage/store";
-import type {OutboxMutation, SyncAck, SyncMutateRequest, SyncNack} from "../types";
+import type {
+  OutboxMutation,
+  SyncAck,
+  SyncMutateBatchRequest,
+  SyncMutateRequest,
+  SyncNack,
+} from "../types";
 import {AuthRequiredError} from "./httpChannel";
-import type {SendMutationResult} from "./transport";
+import {
+  DEFAULT_BATCH_SIZE,
+  type SendMutationBatchResult,
+  type SendMutationResult,
+} from "./transport";
 
 /** Error-nack retries beyond this attempt count become terminal failures. */
 export const MAX_ERROR_NACK_ATTEMPTS = 5;
@@ -37,12 +47,52 @@ export interface ReplayCoordinator {
    * `client.stop()` so no post-stop send can fire.
    */
   dispose: (args?: {userId?: string}) => void;
+  /**
+   * Re-probe batch support on the next drain (B3): called on transport
+   * reconnect, since a previous `batchUnsupported` determination may have been
+   * against an old server that has since been upgraded (or the reconnect landed
+   * on a different, batch-capable instance behind a load balancer).
+   */
+  notifyReconnect: () => void;
+  /**
+   * Re-enable an entity's blocked queued successors (B4) after a terminal
+   * validation failure: subsequent drains stop skipping mutations for this
+   * entity. Does not touch unresolved conflicts — those clear via
+   * `resolveConflict`.
+   */
+  retryFailed: (args: {entityId: string}) => void;
+  /** Entity ids currently blocked by an unresolved conflict or a skipped validation failure (B4). */
+  getBlockedEntities: (args: {userId: string}) => string[];
+  /**
+   * Current drain progress snapshot for a user (B5): `draining` is true only
+   * while a `replay()` call for this user is in flight. `sentThisDrain` /
+   * `totalThisDrain` reflect the most recent (or in-progress) drain.
+   */
+  getDrainProgress: (args: {userId: string}) => {
+    draining: boolean;
+    sentThisDrain: number;
+    totalThisDrain: number;
+  };
 }
 
 export interface CreateReplayCoordinatorArgs {
   store: SyncStore;
   outbox: Outbox;
   sendMutation: (request: SyncMutateRequest) => Promise<SendMutationResult>;
+  /**
+   * Batch send function (B3). When present, the coordinator builds contiguous
+   * chunks of the global FIFO queue (≤ `batchSize`) and sends them here instead
+   * of one `sendMutation` per mutation, falling back to single sends when the
+   * batch transport reports `unsupported` or is absent.
+   */
+  sendMutationBatch?: (request: SyncMutateBatchRequest) => Promise<SendMutationBatchResult>;
+  /** Max mutations per batch chunk (default {@link DEFAULT_BATCH_SIZE}). */
+  batchSize?: number;
+  /**
+   * When true (B4), a conflict halts the ENTIRE drain instead of just blocking
+   * its entity. Default false (per-entity blocking).
+   */
+  haltQueueOnConflict?: boolean;
   /** Millisecond clock, injectable for deterministic backoff tests. */
   now?: () => number;
   /** Random source in [0, 1), injectable for deterministic jitter tests. */
@@ -67,6 +117,14 @@ export interface CreateReplayCoordinatorArgs {
    */
   onAuthPause?: (args: {userId: string}) => void;
   /**
+   * B5: called after each mutation/chunk send attempt with drain progress —
+   * `sentThisDrain` (attempts made so far in this `replay()` call) and
+   * `totalThisDrain` (queue length observed when this `replay()` call began,
+   * a lower bound since more may enqueue mid-drain). Lets the host surface a
+   * progress indicator (e.g. "12 / 40 synced").
+   */
+  onProgress?: (args: {userId: string; sentThisDrain: number; totalThisDrain: number}) => void;
+  /**
    * Consulted before every drain attempt — including internally-scheduled
    * ones (the armed wake-up timer and the mid-drain-enqueue recheck) that
    * bypass the caller's own call site. Lets the host gate sending on state the
@@ -76,6 +134,8 @@ export interface CreateReplayCoordinatorArgs {
   shouldDrain?: () => boolean;
 }
 
+const entityKey = (collection: string, entityId: string): string => `${collection}:${entityId}`;
+
 /**
  * Bridges the durable outbox and the send channel, resolving each mutation's
  * server outcome:
@@ -83,29 +143,45 @@ export interface CreateReplayCoordinatorArgs {
  * - **ack** → markAcked, clear the entity's `pendingMutationId` (when it still
  *   belongs to this mutation) and stamp the acked seq;
  * - **nack conflict** → markConflicted + record a `_conflicts` row; the
- *   entity's optimistic state stays in place until the user resolves;
+ *   entity's optimistic state stays in place until the user resolves. The
+ *   ENTITY is blocked (B4): later drains skip its other queued mutations
+ *   until the conflict resolves, unless `haltQueueOnConflict` is set, in
+ *   which case the whole drain halts instead;
  * - **nack unauthorized** / thrown `AuthRequiredError` → back to queued and
  *   pause replay for the user (`{paused: "auth"}`), consuming NO retry budget
  *   (INV-2); the next replay call (after re-auth) retries;
  * - **nack validation** → markFailed (terminal) and release the entity's
- *   `pendingMutationId` so future deltas are not blocked forever;
+ *   `pendingMutationId` so future deltas are not blocked forever. The ENTITY
+ *   is blocked (B4) — its queued successors are skipped until `retryFailed`;
  * - **nack error** → back to queued with jittered exponential backoff against
  *   the dedicated `errorNackCount` budget, terminal markFailed after
- *   {@link MAX_ERROR_NACK_ATTEMPTS} attempts;
+ *   {@link MAX_ERROR_NACK_ATTEMPTS} attempts. HALTS THE WHOLE DRAIN (B4);
  * - **send rejection** (timeout / network / disconnect) → back to queued with
  *   unlimited jittered exponential backoff (never terminal, never burns the
- *   error-nack budget) and the drain parks until the backoff elapses.
+ *   error-nack budget) and the drain parks until the backoff elapses. HALTS
+ *   THE WHOLE DRAIN (B4).
  *
  * The drain is a SINGLE global FIFO over `enqueueOrder` (INV-1) — no more
  * per-collection parallelism. `replay()` keeps re-running drain passes until
  * the queue is empty or parked; when it parks on a backoff, a single
  * `setTimeout` wakes the next drain automatically so callers never need to
  * poll.
+ *
+ * B3 layers a batched send on top: each pass sends the next contiguous chunk
+ * of the FIFO queue (≤ `batchSize`, at most one mutation per entity per
+ * chunk) through `sendMutationBatch` when available, walking the results in
+ * order with the same per-outcome handlers above, then applying the B4
+ * stop-the-line policy to whatever the batch response implies. Chunks with no
+ * eligible mutations (everything blocked/backing off) fall through exactly
+ * like the single-send path.
  */
 export const createReplayCoordinator = ({
   store,
   outbox,
   sendMutation,
+  sendMutationBatch,
+  batchSize = DEFAULT_BATCH_SIZE,
+  haltQueueOnConflict = false,
   now = () => Date.now(),
   random = () => Math.random(),
   debug,
@@ -113,6 +189,7 @@ export const createReplayCoordinator = ({
   clearTimeoutFn = (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
   onDrainPass,
   onAuthPause,
+  onProgress,
   shouldDrain = () => true,
 }: CreateReplayCoordinatorArgs): ReplayCoordinator => {
   const inFlightReplays = new Map<string, Promise<ReplayResult>>();
@@ -133,6 +210,34 @@ export const createReplayCoordinator = ({
   const wakeTimers = new Map<string, unknown>();
   /** userId → whether onAuthPause has already fired for the current pause episode. */
   const authPauseNotified = new Set<string>();
+  /**
+   * B4: entities blocked by a terminal validation failure whose queued
+   * successors must be skipped until `retryFailed({entityId})`. Keyed by
+   * `${collection}:${entityId}`. Unresolved-conflict blocking is derived live
+   * from the `_conflicts` table instead (it already tracks resolution).
+   */
+  const validationBlockedEntities = new Set<string>();
+  /** userId → {sent, total} progress counters for the CURRENT replay() call (B5). */
+  const drainProgress = new Map<string, {sent: number; total: number}>();
+
+  const reportProgress = (userId: string, sentDelta: number): void => {
+    if (!onProgress) {
+      return;
+    }
+    const progress = drainProgress.get(userId);
+    if (!progress) {
+      return;
+    }
+    progress.sent += sentDelta;
+    onProgress({sentThisDrain: progress.sent, totalThisDrain: progress.total, userId});
+  };
+  /**
+   * B3: per-connection flag set when the batch transport reports
+   * `unsupported` (HTTP 404 / socket silence past the grace timeout).
+   * Cleared by `notifyReconnect()` so a later reconnect re-probes — the new
+   * connection may land on an upgraded server or a different instance.
+   */
+  let batchUnsupported = false;
 
   const clearWakeTimer = (userId: string): void => {
     const handle = wakeTimers.get(userId);
@@ -280,6 +385,18 @@ export const createReplayCoordinator = ({
     });
   };
 
+  /** True when `mutation`'s entity has an unresolved conflict recorded (B4). */
+  const hasUnresolvedConflict = (mutation: OutboxMutation): boolean =>
+    listConflicts({store}).some(
+      (conflict) =>
+        conflict.collection === mutation.collection && conflict.entityId === mutation.entityId
+    );
+
+  /** True when `mutation`'s entity is blocked (unresolved conflict or skipped validation failure). */
+  const isEntityBlocked = (mutation: OutboxMutation): boolean =>
+    validationBlockedEntities.has(entityKey(mutation.collection, mutation.entityId)) ||
+    hasUnresolvedConflict(mutation);
+
   /** Outcome of one drain pass over the full FIFO queue. */
   interface DrainPassResult {
     authPaused: boolean;
@@ -287,25 +404,248 @@ export const createReplayCoordinator = ({
     nextWakeAt?: number;
     /** True when at least one mutation acked this pass (progress signal for pruning). */
     progressed: boolean;
+    /**
+     * True when this pass ended for a reason that must stop the CURRENT
+     * `replay()` call's drain-until-empty loop even though the queue is
+     * neither empty nor backing off with a known wake time: either every
+     * remaining queued mutation is B4-blocked (unresolved conflict / skipped
+     * validation failure — nothing more can happen until `resolveConflict`
+     * or `retryFailed`), or a halting decision fired with no backoff of its
+     * own (a plain conflict nack under `haltQueueOnConflict`). Without this,
+     * the outer loop would immediately re-call `drainOnce` and either spin
+     * forever (blocked case) or silently defeat the halt by draining
+     * unrelated entities anyway (haltQueueOnConflict case).
+     */
+    stopReplayCall?: boolean;
   }
 
-  const drainOnce = async (userId: string): Promise<DrainPassResult> => {
-    const mutations = outbox.listQueued({userId});
-    let progressed = false;
-    let nextWakeAt: number | undefined;
+  /**
+   * Process one already-resolved outcome for `mutation` (ack/nack), applying
+   * the B4 stop-the-line policy. Returns instructions for the caller (single
+   * or batched send loop) on whether to keep going.
+   */
+  interface OutcomeDecision {
+    /** True when the drain must stop this pass immediately (no more sends). */
+    haltDrain: boolean;
+    authPaused: boolean;
+    nextWakeAt?: number;
+    progressed: boolean;
+  }
 
-    for (const mutation of mutations) {
+  const applyAck = (mutation: OutboxMutation, ack: SyncAck): OutcomeDecision => {
+    handleAck(mutation, ack);
+    return {authPaused: false, haltDrain: false, progressed: true};
+  };
+
+  const applyUnauthorized = (mutation: OutboxMutation): OutcomeDecision => {
+    outbox.markQueued({mutationId: mutation.mutationId});
+    debug?.record({
+      collection: mutation.collection,
+      detail: {code: "unauthorized", paused: true},
+      direction: "inbound",
+      entityId: mutation.entityId,
+      label: `nack ${mutation.collection}/${mutation.entityId} (unauthorized)`,
+      mutationId: mutation.mutationId,
+      ok: false,
+      operation: mutation.operation,
+      type: "nack",
+    });
+    return {authPaused: true, haltDrain: true, progressed: false};
+  };
+
+  const applyConflict = (mutation: OutboxMutation, nack: SyncNack): OutcomeDecision => {
+    handleConflict(mutation, nack);
+    validationBlockedEntities.delete(entityKey(mutation.collection, mutation.entityId));
+    // B4: per-entity blocking is the default; haltQueueOnConflict escalates to
+    // a whole-drain halt for apps with cross-entity ordering dependencies.
+    return {authPaused: false, haltDrain: haltQueueOnConflict, progressed: false};
+  };
+
+  const applyValidation = (mutation: OutboxMutation): OutcomeDecision => {
+    handleTerminalFailure(mutation, "validation");
+    // B4: the entity's queued successors are skipped-and-surfaced until the
+    // user calls retryFailed({entityId}) or resolves the underlying issue —
+    // other entities keep draining.
+    validationBlockedEntities.add(entityKey(mutation.collection, mutation.entityId));
+    return {authPaused: false, haltDrain: false, progressed: false};
+  };
+
+  const applyErrorNack = (mutation: OutboxMutation): OutcomeDecision => {
+    const beforeCount = outbox.getMutation({mutationId: mutation.mutationId})?.errorNackCount ?? 0;
+    const attempts = beforeCount + 1;
+    if (attempts >= MAX_ERROR_NACK_ATTEMPTS) {
+      handleTerminalFailure(mutation, "error");
+      return {authPaused: false, haltDrain: false, progressed: false};
+    }
+    outbox.markQueuedAfterErrorNack({mutationId: mutation.mutationId});
+    const backoffMs = jitteredBackoff(attempts, ERROR_NACK_BASE_BACKOFF_MS);
+    const wakeAt = now() + backoffMs;
+    retryAt.set(mutation.mutationId, wakeAt);
+    debug?.record({
+      collection: mutation.collection,
+      detail: {attempt: attempts, backoffMs, reason: "error"},
+      direction: "system",
+      entityId: mutation.entityId,
+      label: `retry ${mutation.collection}/${mutation.entityId} (error, ${backoffMs}ms)`,
+      mutationId: mutation.mutationId,
+      operation: mutation.operation,
+      type: "retry",
+    });
+    // B4: error nacks halt the WHOLE drain (transient — retrying without user
+    // action will fix it), unlike the per-entity conflict/validation policy.
+    return {authPaused: false, haltDrain: true, nextWakeAt: wakeAt, progressed: false};
+  };
+
+  /** Apply a resolved single-mutation SendMutationResult via the B4 outcome table. */
+  const applyResult = (mutation: OutboxMutation, result: SendMutationResult): OutcomeDecision => {
+    if (result.type === "ack") {
+      return applyAck(mutation, result.ack);
+    }
+    const {nack} = result;
+    if (nack.code === "conflict") {
+      return applyConflict(mutation, nack);
+    }
+    if (nack.code === "unauthorized") {
+      return applyUnauthorized(mutation);
+    }
+    if (nack.code === "validation") {
+      return applyValidation(mutation);
+    }
+    return applyErrorNack(mutation);
+  };
+
+  /** Apply a transport failure (thrown send / AuthRequiredError) via the B4 outcome table. */
+  const applyTransportError = (mutation: OutboxMutation, error: unknown): OutcomeDecision => {
+    if (error instanceof AuthRequiredError) {
+      // INV-2: never burn a retry budget on an auth failure. Requeue and
+      // pause the whole drain; the caller retries after re-auth.
+      outbox.markQueued({mutationId: mutation.mutationId});
+      debug?.record({
+        collection: mutation.collection,
+        detail: {code: "unauthorized", paused: true, source: "http"},
+        direction: "inbound",
+        entityId: mutation.entityId,
+        label: `nack ${mutation.collection}/${mutation.entityId} (unauthorized)`,
+        mutationId: mutation.mutationId,
+        ok: false,
+        operation: mutation.operation,
+        type: "nack",
+      });
+      return {authPaused: true, haltDrain: true, progressed: false};
+    }
+    // Transport failure (timeout, network, disconnect): unlimited retries
+    // with jittered capped backoff, tracked separately from the error-nack
+    // budget. HALTS THE WHOLE DRAIN (B4) — the whole batch is safe to resend
+    // (INV-3).
+    outbox.markQueued({mutationId: mutation.mutationId});
+    const attempt = (transportFailures.get(mutation.mutationId) ?? 0) + 1;
+    transportFailures.set(mutation.mutationId, attempt);
+    const backoffMs = jitteredBackoff(attempt, TRANSPORT_FAILURE_BASE_BACKOFF_MS);
+    const wakeAt = now() + backoffMs;
+    retryAt.set(mutation.mutationId, wakeAt);
+    debug?.record({
+      collection: mutation.collection,
+      detail: {attempt, backoffMs, reason: "transport"},
+      direction: "system",
+      entityId: mutation.entityId,
+      label: `retry ${mutation.collection}/${mutation.entityId} (transport, ${backoffMs}ms)`,
+      mutationId: mutation.mutationId,
+      operation: mutation.operation,
+      type: "retry",
+    });
+    return {authPaused: false, haltDrain: true, nextWakeAt: wakeAt, progressed: false};
+  };
+
+  /**
+   * Single-mutation send path (used when no batch transport is configured, or
+   * batching is marked unsupported for this connection, or a chunk's only
+   * eligible mutation count is 1).
+   */
+  const sendSingle = async (userId: string, mutation: OutboxMutation): Promise<OutcomeDecision> => {
+    outbox.markInFlight({mutationId: mutation.mutationId});
+    debug?.record({
+      collection: mutation.collection,
+      detail: {attempt: mutation.attemptCount + 1},
+      direction: "outbound",
+      entityId: mutation.entityId,
+      label: `send ${mutation.operation} ${mutation.collection}/${mutation.entityId}`,
+      mutationId: mutation.mutationId,
+      operation: mutation.operation,
+      type: "send",
+    });
+    let result: SendMutationResult;
+    try {
+      result = await sendMutation(buildRequest(mutation));
+    } catch (error) {
+      const decision = applyTransportError(mutation, error);
+      reportProgress(userId, 1);
+      return decision;
+    }
+    const decision = applyResult(mutation, result);
+    reportProgress(userId, 1);
+    return decision;
+  };
+
+  /**
+   * Build the next contiguous chunk of the FIFO queue eligible for a batch
+   * send: skips mutations whose entity is currently blocked (B4) or backing
+   * off (retryAt in the future), stops BEFORE a backing-off mutation (INV-1 —
+   * it must remain the effective head once nothing ahead of it can send), and
+   * cuts the chunk short before a second mutation for an entity already
+   * included (B3.2) so per-entity chaining stays correct without guessing
+   * server-assigned seqs.
+   */
+  const buildChunk = (
+    queued: OutboxMutation[]
+  ): {chunk: OutboxMutation[]; blockedWakeAt?: number} => {
+    const chunk: OutboxMutation[] = [];
+    const seenEntities = new Set<string>();
+    let blockedWakeAt: number | undefined;
+    for (const mutation of queued) {
+      if (chunk.length >= batchSize) {
+        break;
+      }
       const nextAttemptAt = retryAt.get(mutation.mutationId);
       if (nextAttemptAt !== undefined && now() < nextAttemptAt) {
-        // INV-1: a backing-off head blocks the ENTIRE global drain rather than
-        // letting later mutations (in this or another collection) overtake it.
-        nextWakeAt = nextWakeAt === undefined ? nextAttemptAt : Math.min(nextWakeAt, nextAttemptAt);
-        return {authPaused: false, nextWakeAt, progressed};
+        // INV-1: a backing-off mutation blocks the entire drain from this
+        // point on — stop building the chunk here.
+        blockedWakeAt =
+          blockedWakeAt === undefined ? nextAttemptAt : Math.min(blockedWakeAt, nextAttemptAt);
+        break;
       }
+      if (isEntityBlocked(mutation)) {
+        // B4: this entity is blocked; skip it (stays queued) but keep
+        // scanning — other entities may still be eligible for this chunk.
+        continue;
+      }
+      const key = entityKey(mutation.collection, mutation.entityId);
+      if (seenEntities.has(key)) {
+        // B3.2: at most one mutation per entity per chunk — cut here.
+        break;
+      }
+      seenEntities.add(key);
+      chunk.push(mutation);
+    }
+    return {blockedWakeAt, chunk};
+  };
+
+  /** Send one chunk as a batch; returns the per-mutation outcome decisions and any halt reached. */
+  const sendChunk = async (
+    userId: string,
+    chunk: OutboxMutation[]
+  ): Promise<{
+    decisions: Map<string, OutcomeDecision>;
+    unsupported: boolean;
+    haltedAt?: number;
+    /** True when the server returned fewer results than mutations sent. */
+    shortResponse: boolean;
+  }> => {
+    const decisions = new Map<string, OutcomeDecision>();
+    for (const mutation of chunk) {
       outbox.markInFlight({mutationId: mutation.mutationId});
       debug?.record({
         collection: mutation.collection,
-        detail: {attempt: mutation.attemptCount + 1},
+        detail: {attempt: mutation.attemptCount + 1, batch: true},
         direction: "outbound",
         entityId: mutation.entityId,
         label: `send ${mutation.operation} ${mutation.collection}/${mutation.entityId}`,
@@ -313,107 +653,221 @@ export const createReplayCoordinator = ({
         operation: mutation.operation,
         type: "send",
       });
-      let result: SendMutationResult;
-      try {
-        result = await sendMutation(buildRequest(mutation));
-      } catch (error) {
-        if (error instanceof AuthRequiredError) {
-          // INV-2: never burn a retry budget on an auth failure. Requeue and
-          // pause the whole drain; the caller retries after re-auth.
-          outbox.markQueued({mutationId: mutation.mutationId});
-          debug?.record({
-            collection: mutation.collection,
-            detail: {code: "unauthorized", paused: true, source: "http"},
-            direction: "inbound",
-            entityId: mutation.entityId,
-            label: `nack ${mutation.collection}/${mutation.entityId} (unauthorized)`,
-            mutationId: mutation.mutationId,
-            ok: false,
-            operation: mutation.operation,
-            type: "nack",
-          });
-          return {authPaused: true, progressed};
+    }
+    const request: SyncMutateBatchRequest = {mutations: chunk.map(buildRequest)};
+    let response: SendMutationBatchResult;
+    try {
+      // biome-ignore lint/style/noNonNullAssertion: caller only invokes sendChunk when sendMutationBatch is defined and batching is not marked unsupported.
+      response = await sendMutationBatch!(request);
+    } catch (error) {
+      // Transport failure for the WHOLE chunk: every mutation in it goes back
+      // to queued via the same transport-error handling as a single send, and
+      // the drain halts (INV-3 — resending the whole chunk is safe).
+      let haltedAt: number | undefined;
+      for (const mutation of chunk) {
+        const decision = applyTransportError(mutation, error);
+        decisions.set(mutation.mutationId, decision);
+        if (decision.nextWakeAt !== undefined) {
+          haltedAt =
+            haltedAt === undefined ? decision.nextWakeAt : Math.min(haltedAt, decision.nextWakeAt);
         }
-        // Transport failure (timeout, network, disconnect): unlimited retries
-        // with jittered capped backoff, tracked separately from the
-        // error-nack budget.
+      }
+      reportProgress(userId, chunk.length);
+      return {decisions, haltedAt, shortResponse: false, unsupported: false};
+    }
+    if (response.type === "unsupported") {
+      // The chunk was marked inFlight before sending (for diagnostics/debug
+      // symmetry with the single-send path) but never actually attempted —
+      // revert every mutation to queued, untouched budgets, so the fallback
+      // single-send pass picks them straight back up.
+      for (const mutation of chunk) {
         outbox.markQueued({mutationId: mutation.mutationId});
-        const attempt = (transportFailures.get(mutation.mutationId) ?? 0) + 1;
-        transportFailures.set(mutation.mutationId, attempt);
-        const backoffMs = jitteredBackoff(attempt, TRANSPORT_FAILURE_BASE_BACKOFF_MS);
-        const wakeAt = now() + backoffMs;
-        retryAt.set(mutation.mutationId, wakeAt);
-        nextWakeAt = nextWakeAt === undefined ? wakeAt : Math.min(nextWakeAt, wakeAt);
-        debug?.record({
-          collection: mutation.collection,
-          detail: {attempt, backoffMs, reason: "transport"},
-          direction: "system",
-          entityId: mutation.entityId,
-          label: `retry ${mutation.collection}/${mutation.entityId} (transport, ${backoffMs}ms)`,
-          mutationId: mutation.mutationId,
-          operation: mutation.operation,
-          type: "retry",
-        });
+      }
+      return {decisions, shortResponse: false, unsupported: true};
+    }
+    // Walk results in order (INV-1), applying the same per-outcome handlers as
+    // the single-send path, then the B4 stop-the-line policy. Per B2, the
+    // server itself stops at the first non-ack and truncates `results`
+    // accordingly — but defensively, once THIS pass decides to halt (auth
+    // pause in particular — nothing after it may be treated as final), every
+    // remaining mutation in the chunk is requeued untouched rather than left
+    // stranded `inFlight`, regardless of what a non-conforming server sent.
+    let halted = false;
+    let haltedAt: number | undefined;
+    let processed = 0;
+    const shortResponse = response.results.length < chunk.length;
+    for (let i = 0; i < chunk.length; i++) {
+      const mutation = chunk[i];
+      if (halted) {
+        outbox.markQueued({mutationId: mutation.mutationId});
+        continue;
+      }
+      const result = response.results[i];
+      if (!result) {
+        // Server halted mid-batch (results shorter than the request): every
+        // mutation with no result goes back to queued, untouched budgets.
+        outbox.markQueued({mutationId: mutation.mutationId});
+        continue;
+      }
+      processed += 1;
+      const decision = applyResult(mutation, result);
+      decisions.set(mutation.mutationId, decision);
+      if (decision.haltDrain) {
+        halted = true;
+        if (decision.nextWakeAt !== undefined) {
+          haltedAt = decision.nextWakeAt;
+        }
+      }
+    }
+    reportProgress(userId, processed);
+    return {decisions, haltedAt, shortResponse, unsupported: false};
+  };
+
+  const drainOnce = async (userId: string): Promise<DrainPassResult> => {
+    let progressed = false;
+    let nextWakeAt: number | undefined;
+
+    for (;;) {
+      const queued = outbox.listQueued({userId});
+      if (queued.length === 0) {
         return {authPaused: false, nextWakeAt, progressed};
       }
-      if (result.type === "ack") {
-        handleAck(mutation, result.ack);
-        progressed = true;
+
+      const useBatch = Boolean(sendMutationBatch) && !batchUnsupported;
+      if (!useBatch) {
+        // Single-mutation fallback (no batch transport, or marked unsupported):
+        // send exactly the FIFO head, honoring blocked/backing-off skips.
+        let sentAny = false;
+        for (const mutation of queued) {
+          const nextAttemptAt = retryAt.get(mutation.mutationId);
+          if (nextAttemptAt !== undefined && now() < nextAttemptAt) {
+            nextWakeAt =
+              nextWakeAt === undefined ? nextAttemptAt : Math.min(nextWakeAt, nextAttemptAt);
+            return {authPaused: false, nextWakeAt, progressed};
+          }
+          if (isEntityBlocked(mutation)) {
+            continue;
+          }
+          const decision = await sendSingle(userId, mutation);
+          sentAny = true;
+          progressed = progressed || decision.progressed;
+          if (decision.authPaused) {
+            return {authPaused: true, progressed};
+          }
+          if (decision.haltDrain) {
+            if (decision.nextWakeAt !== undefined) {
+              nextWakeAt =
+                nextWakeAt === undefined
+                  ? decision.nextWakeAt
+                  : Math.min(nextWakeAt, decision.nextWakeAt);
+            }
+            // A halt with no backoff of its own (e.g. a plain conflict nack
+            // under haltQueueOnConflict) must still stop the CURRENT
+            // replay() call — otherwise the outer loop would immediately
+            // drain unrelated entities anyway, defeating the halt.
+            return {
+              authPaused: false,
+              nextWakeAt,
+              progressed,
+              stopReplayCall: decision.nextWakeAt === undefined,
+            };
+          }
+          break; // re-list after each send so newly-acked bases (A2) apply.
+        }
+        if (!sentAny) {
+          // Nothing eligible this pass (everything blocked/backing off). When
+          // nothing is backing off either (nextWakeAt still undefined), every
+          // remaining mutation is purely B4-blocked — signal that so the
+          // outer drain-until-empty loop stops instead of spinning forever on
+          // a queue that can never shrink without an external event.
+          return {
+            authPaused: false,
+            nextWakeAt,
+            progressed,
+            stopReplayCall: nextWakeAt === undefined,
+          };
+        }
         continue;
       }
-      const {nack} = result;
-      if (nack.code === "conflict") {
-        handleConflict(mutation, nack);
+
+      const {chunk, blockedWakeAt} = buildChunk(queued);
+      if (chunk.length === 0) {
+        if (blockedWakeAt !== undefined) {
+          nextWakeAt =
+            nextWakeAt === undefined ? blockedWakeAt : Math.min(nextWakeAt, blockedWakeAt);
+        }
+        return {
+          authPaused: false,
+          nextWakeAt,
+          progressed,
+          stopReplayCall: blockedWakeAt === undefined,
+        };
+      }
+      if (chunk.length === 1) {
+        // A lone eligible mutation: sending it as a "batch of one" adds no
+        // value and costs an extra round-trip on unsupported servers — reuse
+        // the single-send path directly (still counts as this pass's send).
+        const decision = await sendSingle(userId, chunk[0]);
+        progressed = progressed || decision.progressed;
+        if (decision.authPaused) {
+          return {authPaused: true, progressed};
+        }
+        if (decision.haltDrain) {
+          if (decision.nextWakeAt !== undefined) {
+            nextWakeAt =
+              nextWakeAt === undefined
+                ? decision.nextWakeAt
+                : Math.min(nextWakeAt, decision.nextWakeAt);
+          }
+          return {
+            authPaused: false,
+            nextWakeAt,
+            progressed,
+            stopReplayCall: decision.nextWakeAt === undefined,
+          };
+        }
         continue;
       }
-      if (nack.code === "unauthorized") {
-        outbox.markQueued({mutationId: mutation.mutationId});
-        debug?.record({
-          collection: mutation.collection,
-          detail: {code: "unauthorized", paused: true},
-          direction: "inbound",
-          entityId: mutation.entityId,
-          label: `nack ${mutation.collection}/${mutation.entityId} (unauthorized)`,
-          mutationId: mutation.mutationId,
-          ok: false,
-          operation: mutation.operation,
-          type: "nack",
-        });
+
+      const {decisions, unsupported, haltedAt, shortResponse} = await sendChunk(userId, chunk);
+      if (unsupported) {
+        // B3 capability detection: fall back to single-mutation sends for the
+        // rest of this connection's lifetime, re-probed on reconnect.
+        batchUnsupported = true;
+        continue;
+      }
+      let authPaused = false;
+      for (const decision of decisions.values()) {
+        progressed = progressed || decision.progressed;
+        if (decision.authPaused) {
+          authPaused = true;
+        }
+      }
+      if (authPaused) {
         return {authPaused: true, progressed};
       }
-      if (nack.code === "validation") {
-        handleTerminalFailure(mutation, "validation");
-        continue;
+      if (haltedAt !== undefined) {
+        nextWakeAt = nextWakeAt === undefined ? haltedAt : Math.min(nextWakeAt, haltedAt);
       }
-      // "error": transient server failure — jittered exponential backoff
-      // against the dedicated errorNackCount budget, then terminal.
-      const beforeCount =
-        outbox.getMutation({mutationId: mutation.mutationId})?.errorNackCount ?? 0;
-      const attempts = beforeCount + 1;
-      if (attempts >= MAX_ERROR_NACK_ATTEMPTS) {
-        handleTerminalFailure(mutation, "error");
-        continue;
+      // A halt (conflict-with-haltQueueOnConflict, error-nack backoff,
+      // transport failure) stops the WHOLE drain this pass, mirroring the
+      // single-send path — detect it by re-checking whether any decision
+      // requested a halt. A short response (server halted mid-batch with no
+      // failing nack for the boundary mutation — e.g. it hasn't finished
+      // ledgering yet) halts this pass too (INV-1): the tail already went
+      // back to queued untouched, and the next drain resumes from there.
+      const anyHalt =
+        shortResponse || [...decisions.values()].some((decision) => decision.haltDrain);
+      if (anyHalt) {
+        // As above: a halt with no backoff of its own (plain conflict under
+        // haltQueueOnConflict, or a short response) must stop the CURRENT
+        // replay() call, not just this pass.
+        return {authPaused: false, nextWakeAt, progressed, stopReplayCall: haltedAt === undefined};
       }
-      outbox.markQueuedAfterErrorNack({mutationId: mutation.mutationId});
-      const backoffMs = jitteredBackoff(attempts, ERROR_NACK_BASE_BACKOFF_MS);
-      const wakeAt = now() + backoffMs;
-      retryAt.set(mutation.mutationId, wakeAt);
-      nextWakeAt = nextWakeAt === undefined ? wakeAt : Math.min(nextWakeAt, wakeAt);
-      debug?.record({
-        collection: mutation.collection,
-        detail: {attempt: attempts, backoffMs, reason: "error"},
-        direction: "system",
-        entityId: mutation.entityId,
-        label: `retry ${mutation.collection}/${mutation.entityId} (error, ${backoffMs}ms)`,
-        mutationId: mutation.mutationId,
-        operation: mutation.operation,
-        type: "retry",
-      });
-      // INV-1: the backing-off mutation stays at the head of the global FIFO;
-      // stop draining until its delay elapses.
-      return {authPaused: false, nextWakeAt, progressed};
+      // Progress made and no halt: loop to build the next chunk immediately
+      // (drain-until-empty within this pass too, so a 120-mutation queue
+      // drains in ceil(120/batchSize) round-trips within ONE replay() call).
     }
-    return {authPaused: false, progressed};
   };
 
   const replay = ({userId}: {userId: string}): Promise<ReplayResult> => {
@@ -436,6 +890,10 @@ export const createReplayCoordinator = ({
     // A fresh replay call supersedes any pending timed wake-up — it is about
     // to drain right now.
     clearWakeTimer(userId);
+    // B5: (re)start this call's progress counters. `total` is a lower bound —
+    // snapshotted once at entry — since more may enqueue mid-drain; onProgress
+    // still reports every attempt made.
+    drainProgress.set(userId, {sent: 0, total: outbox.listQueued({userId}).length});
     const run = (async (): Promise<ReplayResult> => {
       let authPaused = false;
       let parkedAt: number | undefined;
@@ -459,6 +917,15 @@ export const createReplayCoordinator = ({
         }
         if (pass.nextWakeAt !== undefined) {
           parkedAt = pass.nextWakeAt;
+          break;
+        }
+        if (pass.stopReplayCall) {
+          // Either every remaining queued mutation is B4-blocked (nothing
+          // more can happen until resolveConflict/retryFailed — looping
+          // again would spin forever on a queue that never shrinks), or a
+          // halting decision with no backoff of its own fired (a plain
+          // conflict nack under haltQueueOnConflict) — looping again would
+          // silently defeat that halt by draining unrelated entities anyway.
           break;
         }
         // Only stop looping once nothing is queued (drain-until-empty).
@@ -501,5 +968,50 @@ export const createReplayCoordinator = ({
     }
   };
 
-  return {dispose, replay};
+  const notifyReconnect = (): void => {
+    batchUnsupported = false;
+  };
+
+  const retryFailed = ({entityId}: {entityId: string}): void => {
+    for (const key of [...validationBlockedEntities]) {
+      if (key.endsWith(`:${entityId}`)) {
+        validationBlockedEntities.delete(key);
+      }
+    }
+  };
+
+  const getBlockedEntities = ({userId}: {userId: string}): string[] => {
+    const blocked = new Set<string>();
+    for (const key of validationBlockedEntities) {
+      blocked.add(key);
+    }
+    for (const mutation of outbox.listQueued({userId})) {
+      if (hasUnresolvedConflict(mutation)) {
+        blocked.add(entityKey(mutation.collection, mutation.entityId));
+      }
+    }
+    return [...blocked];
+  };
+
+  const getDrainProgress = ({
+    userId,
+  }: {
+    userId: string;
+  }): {draining: boolean; sentThisDrain: number; totalThisDrain: number} => {
+    const progress = drainProgress.get(userId);
+    return {
+      draining: inFlightReplays.has(userId),
+      sentThisDrain: progress?.sent ?? 0,
+      totalThisDrain: progress?.total ?? 0,
+    };
+  };
+
+  return {
+    dispose,
+    getBlockedEntities,
+    getDrainProgress,
+    notifyReconnect,
+    replay,
+    retryFailed,
+  };
 };

--- a/syncdb/src/sync/replayCoordinator.ts
+++ b/syncdb/src/sync/replayCoordinator.ts
@@ -28,6 +28,24 @@ export const TRANSPORT_FAILURE_BASE_BACKOFF_MS = 1_000;
 /** Cap applied to every jittered backoff (error-nack and transport-failure alike). */
 export const MAX_BACKOFF_MS = 30_000;
 
+/**
+ * FIX 5: consecutive `unsupported` batch results required before the
+ * per-connection `batchUnsupported` latch engages — a single slow-but-
+ * supported batch (grace elapsed with no receipt is impossible once a
+ * receipt lands, but a genuinely borderline network hiccup could still
+ * produce one stray `unsupported`) must never permanently downgrade the
+ * session to single-sends.
+ */
+export const BATCH_UNSUPPORTED_LATCH_THRESHOLD = 2;
+
+/**
+ * FIX 5: while latched `batchUnsupported`, re-probe batch support on this
+ * interval even without a reconnect — a load balancer could route later
+ * sends to an upgraded instance, or the original instance could itself be
+ * upgraded, without the connection ever dropping.
+ */
+export const BATCH_UNSUPPORTED_REPROBE_INTERVAL_MS = 60_000;
+
 export interface ReplayResult {
   /** Set when replay stopped early because the server rejected our auth. */
   paused?: "auth";
@@ -47,6 +65,17 @@ export interface ReplayCoordinator {
    * `client.stop()` so no post-stop send can fire.
    */
   dispose: (args?: {userId?: string}) => void;
+  /**
+   * FIX 3: clear ALL in-memory coordinator state — every armed wake-up timer
+   * (all users), retry/backoff bookkeeping (`retryAt`, `transportFailures`),
+   * `authPauseNotified`, the batch-capability latch (`batchUnsupported`), drain
+   * progress counters, and `validationBlockedEntities` — so a lifecycle
+   * boundary (client `dispose()`, or a different-user login's wipe path)
+   * never leaks state across users or across a stop/start cycle. Unlike
+   * `dispose()` (which only clears one user's timer), this is a full reset:
+   * call it from `dispose()` itself AND from the different-user wipe path.
+   */
+  reset: () => void;
   /**
    * Re-probe batch support on the next drain (B3): called on transport
    * reconnect, since a previous `batchUnsupported` determination may have been
@@ -136,6 +165,10 @@ export interface CreateReplayCoordinatorArgs {
 
 const entityKey = (collection: string, entityId: string): string => `${collection}:${entityId}`;
 
+/** FIX 3: userId-scoped key for `validationBlockedEntities` — see its declaration comment. */
+const userEntityKey = (userId: string, collection: string, entityId: string): string =>
+  `${userId}|${entityKey(collection, entityId)}`;
+
 /**
  * Bridges the durable outbox and the send channel, resolving each mutation's
  * server outcome:
@@ -159,7 +192,12 @@ const entityKey = (collection: string, entityId: string): string => `${collectio
  * - **send rejection** (timeout / network / disconnect) → back to queued with
  *   unlimited jittered exponential backoff (never terminal, never burns the
  *   error-nack budget) and the drain parks until the backoff elapses. HALTS
- *   THE WHOLE DRAIN (B4).
+ *   THE WHOLE DRAIN (B4);
+ * - **nack rate_limited** → treated EXACTLY like a transport failure (FIX 1):
+ *   back to queued with the same unlimited jittered backoff (respecting the
+ *   server's `retryAfterMs` as a floor when present), NEVER touching
+ *   `errorNackCount` or `attemptCount`'s terminality — a rate limit is never
+ *   allowed to burn the durable-data retry budget. HALTS THE WHOLE DRAIN (B4).
  *
  * The drain is a SINGLE global FIFO over `enqueueOrder` (INV-1) — no more
  * per-collection parallelism. `replay()` keeps re-running drain passes until
@@ -213,8 +251,11 @@ export const createReplayCoordinator = ({
   /**
    * B4: entities blocked by a terminal validation failure whose queued
    * successors must be skipped until `retryFailed({entityId})`. Keyed by
-   * `${collection}:${entityId}`. Unresolved-conflict blocking is derived live
-   * from the `_conflicts` table instead (it already tracks resolution).
+   * `${userId}|${collection}:${entityId}` (FIX 3 — userId-scoped so a stale
+   * entry from one user can never falsely block a different user reusing the
+   * same deterministic entity id, e.g. a singleton settings doc). Unresolved-
+   * conflict blocking is derived live from the `_conflicts` table instead (it
+   * already tracks resolution).
    */
   const validationBlockedEntities = new Set<string>();
   /** userId → {sent, total} progress counters for the CURRENT replay() call (B5). */
@@ -232,12 +273,39 @@ export const createReplayCoordinator = ({
     onProgress({sentThisDrain: progress.sent, totalThisDrain: progress.total, userId});
   };
   /**
-   * B3: per-connection flag set when the batch transport reports
-   * `unsupported` (HTTP 404 / socket silence past the grace timeout).
-   * Cleared by `notifyReconnect()` so a later reconnect re-probes — the new
-   * connection may land on an upgraded server or a different instance.
+   * B3/FIX 5: per-connection flag set once {@link BATCH_UNSUPPORTED_LATCH_THRESHOLD}
+   * CONSECUTIVE batch sends report `unsupported` (HTTP 404, or socket grace
+   * elapsing with no `sync:batchReceived` receipt) — a single slow-but-
+   * supported batch must never trip this. Cleared by `notifyReconnect()` so
+   * a reconnect re-probes, and additionally re-probed every
+   * {@link BATCH_UNSUPPORTED_REPROBE_INTERVAL_MS} while latched, even
+   * without a reconnect (a load balancer or in-place upgrade can flip
+   * support without the connection ever dropping).
    */
   let batchUnsupported = false;
+  /** FIX 5: consecutive `unsupported` results observed since the last successful/real batch response. */
+  let consecutiveUnsupported = 0;
+  /** FIX 5: armed only while `batchUnsupported` is latched; re-probes on a timer. */
+  let reprobeTimer: unknown;
+
+  const clearReprobeTimer = (): void => {
+    if (reprobeTimer !== undefined) {
+      clearTimeoutFn(reprobeTimer);
+      reprobeTimer = undefined;
+    }
+  };
+
+  const armReprobeTimer = (): void => {
+    clearReprobeTimer();
+    reprobeTimer = setTimeoutFn(() => {
+      reprobeTimer = undefined;
+      // Re-probe: clear the latch and let the next drain attempt a real
+      // batch send again. A fresh two-strikes count applies if it fails
+      // again, exactly like the original latch logic.
+      batchUnsupported = false;
+      consecutiveUnsupported = 0;
+    }, BATCH_UNSUPPORTED_REPROBE_INTERVAL_MS);
+  };
 
   const clearWakeTimer = (userId: string): void => {
     const handle = wakeTimers.get(userId);
@@ -385,17 +453,140 @@ export const createReplayCoordinator = ({
     });
   };
 
-  /** True when `mutation`'s entity has an unresolved conflict recorded (B4). */
+  /** True when `mutation`'s entity has an unresolved conflict recorded (B4), scoped to its user. */
   const hasUnresolvedConflict = (mutation: OutboxMutation): boolean =>
     listConflicts({store}).some(
       (conflict) =>
         conflict.collection === mutation.collection && conflict.entityId === mutation.entityId
     );
 
-  /** True when `mutation`'s entity is blocked (unresolved conflict or skipped validation failure). */
-  const isEntityBlocked = (mutation: OutboxMutation): boolean =>
-    validationBlockedEntities.has(entityKey(mutation.collection, mutation.entityId)) ||
-    hasUnresolvedConflict(mutation);
+  /**
+   * FIX 4: an entity's validation block is garbage-collected once NO outbox
+   * row (queued OR still-unpruned failed) remains for it — the block exists
+   * only to protect the ordering of an already-queued successor (or to keep
+   * surfacing the failure until the user acts), not to quarantine the entity
+   * eternally. Checking "any row" rather than "queued only" matters: right
+   * after the validation failure itself, the failed row still exists (not
+   * yet pruned) with no successor queued yet — the block must survive that
+   * window so a successor enqueued moments later is still correctly blocked.
+   * Only once prune() removes the failed row AND nothing is queued for the
+   * entity does the block become stale and get dropped here. An entity WITH
+   * a queued successor, or an unpruned failed row, stays blocked until
+   * retryFailed/resolution — that remains intentional.
+   */
+  const gcStaleValidationBlocks = (userId: string): void => {
+    for (const key of [...validationBlockedEntities]) {
+      if (!key.startsWith(`${userId}|`)) {
+        continue;
+      }
+      const bare = key.slice(userId.length + 1);
+      const separatorIndex = bare.indexOf(":");
+      const collection = bare.slice(0, separatorIndex);
+      const entityId = bare.slice(separatorIndex + 1);
+      if (!outbox.hasAnyRowForEntity({collection, entityId, userId})) {
+        validationBlockedEntities.delete(key);
+      }
+    }
+  };
+
+  /** True when `mutation`'s entity itself is directly blocked (unresolved conflict or skipped validation failure). */
+  const isDirectlyBlocked = (mutation: OutboxMutation): boolean =>
+    validationBlockedEntities.has(
+      userEntityKey(mutation.userId, mutation.collection, mutation.entityId)
+    ) || hasUnresolvedConflict(mutation);
+
+  /**
+   * FIX 2: recursively scan a parsed JSON value for any string that exactly
+   * equals one of `blockedEntityIds` — used to detect a mutation in ANOTHER
+   * collection that references a currently-blocked entity's id (e.g. create
+   * project P conflicts → create todo T {projectId: P} must not drain while
+   * P is blocked). Conservative false positives are acceptable (INV-1: too
+   * much blocking is safe, too little is not).
+   */
+  const referencesBlockedId = (value: unknown, blockedEntityIds: ReadonlySet<string>): boolean => {
+    if (typeof value === "string") {
+      return blockedEntityIds.has(value);
+    }
+    if (Array.isArray(value)) {
+      return value.some((item) => referencesBlockedId(item, blockedEntityIds));
+    }
+    if (value && typeof value === "object") {
+      return Object.values(value as Record<string, unknown>).some((item) =>
+        referencesBlockedId(item, blockedEntityIds)
+      );
+    }
+    return false;
+  };
+
+  /**
+   * FIX 2: compute the full transitive block set for one drain pass, from
+   * current block state (never persisted — recomputed live each call so
+   * resolving a root via `resolveConflict`/`retryFailed` naturally unblocks
+   * its dependents on the NEXT drain). Starts from directly-blocked entities
+   * (unresolved conflict or skipped validation failure) and expands to any
+   * OTHER queued mutation belonging to the same user whose parsed `args`
+   * reference a blocked entity's id anywhere (recursively through nested
+   * objects/arrays) — repeated to a fixpoint so chains of references (P ← T
+   * ← further-mutation-referencing-T) are also blocked.
+   */
+  const computeBlockedEntityKeys = (userId: string): Set<string> => {
+    const queued = outbox.listQueued({userId});
+    const blockedKeys = new Set<string>();
+    const blockedIds = new Set<string>();
+    // Seed directly from recorded block state FIRST — a root entity (e.g. a
+    // validation failure with no queued successor of its own yet, or an
+    // entity whose only mutation already left `queued` — conflicted or
+    // failed) still needs to be in the reference set so OTHER queued
+    // mutations that reference its id are caught, even though the root
+    // itself has nothing queued to represent it in `queued` below.
+    for (const key of validationBlockedEntities) {
+      if (!key.startsWith(`${userId}|`)) {
+        continue;
+      }
+      const bare = key.slice(userId.length + 1);
+      blockedKeys.add(bare);
+      const separatorIndex = bare.indexOf(":");
+      blockedIds.add(bare.slice(separatorIndex + 1));
+    }
+    // Same seeding for unresolved conflicts (the store is scoped one-user-
+    // at-a-time — wiped on user switch — so `listConflicts` needs no
+    // additional userId filter here, matching `hasUnresolvedConflict`).
+    for (const conflict of listConflicts({store})) {
+      blockedKeys.add(entityKey(conflict.collection, conflict.entityId));
+      blockedIds.add(conflict.entityId);
+    }
+    for (const mutation of queued) {
+      if (isDirectlyBlocked(mutation)) {
+        blockedKeys.add(entityKey(mutation.collection, mutation.entityId));
+        blockedIds.add(mutation.entityId);
+      }
+    }
+    // Fixpoint expansion: a mutation whose args reference a currently-blocked
+    // id becomes blocked itself (its own entityId joins the reference set),
+    // which can in turn block a mutation referencing IT.
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const mutation of queued) {
+        const key = entityKey(mutation.collection, mutation.entityId);
+        if (blockedKeys.has(key)) {
+          continue;
+        }
+        let parsedArgs: unknown;
+        try {
+          parsedArgs = JSON.parse(mutation.args);
+        } catch {
+          continue;
+        }
+        if (referencesBlockedId(parsedArgs, blockedIds)) {
+          blockedKeys.add(key);
+          blockedIds.add(mutation.entityId);
+          changed = true;
+        }
+      }
+    }
+    return blockedKeys;
+  };
 
   /** Outcome of one drain pass over the full FIFO queue. */
   interface DrainPassResult {
@@ -455,7 +646,9 @@ export const createReplayCoordinator = ({
 
   const applyConflict = (mutation: OutboxMutation, nack: SyncNack): OutcomeDecision => {
     handleConflict(mutation, nack);
-    validationBlockedEntities.delete(entityKey(mutation.collection, mutation.entityId));
+    validationBlockedEntities.delete(
+      userEntityKey(mutation.userId, mutation.collection, mutation.entityId)
+    );
     // B4: per-entity blocking is the default; haltQueueOnConflict escalates to
     // a whole-drain halt for apps with cross-entity ordering dependencies.
     return {authPaused: false, haltDrain: haltQueueOnConflict, progressed: false};
@@ -466,7 +659,9 @@ export const createReplayCoordinator = ({
     // B4: the entity's queued successors are skipped-and-surfaced until the
     // user calls retryFailed({entityId}) or resolves the underlying issue —
     // other entities keep draining.
-    validationBlockedEntities.add(entityKey(mutation.collection, mutation.entityId));
+    validationBlockedEntities.add(
+      userEntityKey(mutation.userId, mutation.collection, mutation.entityId)
+    );
     return {authPaused: false, haltDrain: false, progressed: false};
   };
 
@@ -496,6 +691,66 @@ export const createReplayCoordinator = ({
     return {authPaused: false, haltDrain: true, nextWakeAt: wakeAt, progressed: false};
   };
 
+  /**
+   * Shared backoff-and-requeue path for outcomes that must NEVER burn a
+   * retry budget: transport failures and rate-limit nacks alike. Both track
+   * attempts in the same in-memory `transportFailures` map (unlimited
+   * retries, jittered capped backoff) and HALT THE WHOLE DRAIN (B4) — the
+   * remaining chunk/mutation is safe to resend (INV-3). `floorMs` (when
+   * present — a server-supplied `retryAfterMs`) raises the computed backoff
+   * so the client never retries before the server's own window clears.
+   */
+  const requeueWithUnlimitedBackoff = (
+    mutation: OutboxMutation,
+    {reason, floorMs}: {reason: string; floorMs?: number}
+  ): OutcomeDecision => {
+    outbox.markQueued({mutationId: mutation.mutationId});
+    const attempt = (transportFailures.get(mutation.mutationId) ?? 0) + 1;
+    transportFailures.set(mutation.mutationId, attempt);
+    const backoffMs = Math.max(
+      jitteredBackoff(attempt, TRANSPORT_FAILURE_BASE_BACKOFF_MS),
+      floorMs ?? 0
+    );
+    const wakeAt = now() + backoffMs;
+    retryAt.set(mutation.mutationId, wakeAt);
+    debug?.record({
+      collection: mutation.collection,
+      detail: {attempt, backoffMs, reason},
+      direction: "system",
+      entityId: mutation.entityId,
+      label: `retry ${mutation.collection}/${mutation.entityId} (${reason}, ${backoffMs}ms)`,
+      mutationId: mutation.mutationId,
+      operation: mutation.operation,
+      type: "retry",
+    });
+    return {authPaused: false, haltDrain: true, nextWakeAt: wakeAt, progressed: false};
+  };
+
+  /**
+   * `rate_limited` nacks (FIX 1): the server is asking the client to slow
+   * down, not reporting a durable-data problem — treat it EXACTLY like a
+   * transport failure. Requeue (never markFailed/terminal), never touch
+   * `errorNackCount`, unlimited retries with the same capped jittered
+   * backoff, respecting the server's `retryAfterMs` as a floor.
+   */
+  const applyRateLimited = (mutation: OutboxMutation, nack: SyncNack): OutcomeDecision => {
+    debug?.record({
+      collection: mutation.collection,
+      detail: {code: "rate_limited", message: nack.message, retryAfterMs: nack.retryAfterMs},
+      direction: "inbound",
+      entityId: mutation.entityId,
+      label: `nack ${mutation.collection}/${mutation.entityId} (rate_limited)`,
+      mutationId: mutation.mutationId,
+      ok: false,
+      operation: mutation.operation,
+      type: "nack",
+    });
+    return requeueWithUnlimitedBackoff(mutation, {
+      floorMs: nack.retryAfterMs,
+      reason: "rate_limited",
+    });
+  };
+
   /** Apply a resolved single-mutation SendMutationResult via the B4 outcome table. */
   const applyResult = (mutation: OutboxMutation, result: SendMutationResult): OutcomeDecision => {
     if (result.type === "ack") {
@@ -510,6 +765,9 @@ export const createReplayCoordinator = ({
     }
     if (nack.code === "validation") {
       return applyValidation(mutation);
+    }
+    if (nack.code === "rate_limited") {
+      return applyRateLimited(mutation, nack);
     }
     return applyErrorNack(mutation);
   };
@@ -537,23 +795,7 @@ export const createReplayCoordinator = ({
     // with jittered capped backoff, tracked separately from the error-nack
     // budget. HALTS THE WHOLE DRAIN (B4) — the whole batch is safe to resend
     // (INV-3).
-    outbox.markQueued({mutationId: mutation.mutationId});
-    const attempt = (transportFailures.get(mutation.mutationId) ?? 0) + 1;
-    transportFailures.set(mutation.mutationId, attempt);
-    const backoffMs = jitteredBackoff(attempt, TRANSPORT_FAILURE_BASE_BACKOFF_MS);
-    const wakeAt = now() + backoffMs;
-    retryAt.set(mutation.mutationId, wakeAt);
-    debug?.record({
-      collection: mutation.collection,
-      detail: {attempt, backoffMs, reason: "transport"},
-      direction: "system",
-      entityId: mutation.entityId,
-      label: `retry ${mutation.collection}/${mutation.entityId} (transport, ${backoffMs}ms)`,
-      mutationId: mutation.mutationId,
-      operation: mutation.operation,
-      type: "retry",
-    });
-    return {authPaused: false, haltDrain: true, nextWakeAt: wakeAt, progressed: false};
+    return requeueWithUnlimitedBackoff(mutation, {reason: "transport"});
   };
 
   /**
@@ -588,18 +830,30 @@ export const createReplayCoordinator = ({
 
   /**
    * Build the next contiguous chunk of the FIFO queue eligible for a batch
-   * send: skips mutations whose entity is currently blocked (B4) or backing
-   * off (retryAt in the future), stops BEFORE a backing-off mutation (INV-1 —
-   * it must remain the effective head once nothing ahead of it can send), and
-   * cuts the chunk short before a second mutation for an entity already
-   * included (B3.2) so per-entity chaining stays correct without guessing
-   * server-assigned seqs.
+   * send: skips mutations whose entity is currently blocked (B4, including
+   * FIX 2's transitive cross-collection reference blocks against entities
+   * blocked BEFORE this pass — `blockedKeys` is computed once per drain pass
+   * by the caller) or backing off (retryAt in the future), stops BEFORE a
+   * backing-off mutation (INV-1 — it must remain the effective head once
+   * nothing ahead of it can send), and cuts the chunk short before a second
+   * mutation for an entity already included (B3.2) so per-entity chaining
+   * stays correct without guessing server-assigned seqs.
+   *
+   * FIX 2 also guards the SAME-BATCH race: a mutation whose args reference
+   * the entity id of another mutation already placed EARLIER in this same
+   * chunk is excluded too, even though that referenced entity isn't blocked
+   * yet (its own outcome — ack or conflict/validation nack — isn't known
+   * until this very batch resolves). Without this, P (create) and T (create,
+   * referencing P) enqueued together would land in the same chunk and could
+   * both be sent before P's conflict is even discovered.
    */
   const buildChunk = (
-    queued: OutboxMutation[]
+    queued: OutboxMutation[],
+    blockedKeys: ReadonlySet<string>
   ): {chunk: OutboxMutation[]; blockedWakeAt?: number} => {
     const chunk: OutboxMutation[] = [];
     const seenEntities = new Set<string>();
+    const chunkEntityIds = new Set<string>();
     let blockedWakeAt: number | undefined;
     for (const mutation of queued) {
       if (chunk.length >= batchSize) {
@@ -613,17 +867,33 @@ export const createReplayCoordinator = ({
           blockedWakeAt === undefined ? nextAttemptAt : Math.min(blockedWakeAt, nextAttemptAt);
         break;
       }
-      if (isEntityBlocked(mutation)) {
-        // B4: this entity is blocked; skip it (stays queued) but keep
-        // scanning — other entities may still be eligible for this chunk.
+      const key = entityKey(mutation.collection, mutation.entityId);
+      if (blockedKeys.has(key)) {
+        // B4/FIX 2: this entity (directly or transitively, via a reference
+        // to another blocked entity) is blocked; skip it (stays queued) but
+        // keep scanning — other entities may still be eligible for this chunk.
         continue;
       }
-      const key = entityKey(mutation.collection, mutation.entityId);
+      if (chunkEntityIds.size > 0) {
+        let parsedArgs: unknown;
+        try {
+          parsedArgs = JSON.parse(mutation.args);
+        } catch {
+          parsedArgs = undefined;
+        }
+        if (parsedArgs !== undefined && referencesBlockedId(parsedArgs, chunkEntityIds)) {
+          // FIX 2 same-batch guard: this mutation references an entity whose
+          // outcome in THIS chunk is not yet known — skip it (stays queued)
+          // rather than risk sending it alongside a root that may conflict.
+          continue;
+        }
+      }
       if (seenEntities.has(key)) {
         // B3.2: at most one mutation per entity per chunk — cut here.
         break;
       }
       seenEntities.add(key);
+      chunkEntityIds.add(mutation.entityId);
       chunk.push(mutation);
     }
     return {blockedWakeAt, chunk};
@@ -728,10 +998,19 @@ export const createReplayCoordinator = ({
     let nextWakeAt: number | undefined;
 
     for (;;) {
+      // FIX 4: drop any validation block whose entity has no queued
+      // successor left (pruned/resolved-away) before computing this pass's
+      // eligibility — an entity must not stay quarantined once nothing
+      // queued depends on the ordering the block was protecting.
+      gcStaleValidationBlocks(userId);
       const queued = outbox.listQueued({userId});
       if (queued.length === 0) {
         return {authPaused: false, nextWakeAt, progressed};
       }
+      // FIX 2: transitive block set (direct blocks + cross-collection
+      // references to a blocked entity's id), recomputed fresh every pass so
+      // resolving a root naturally unblocks its dependents on the next drain.
+      const blockedKeys = computeBlockedEntityKeys(userId);
 
       const useBatch = Boolean(sendMutationBatch) && !batchUnsupported;
       if (!useBatch) {
@@ -745,7 +1024,7 @@ export const createReplayCoordinator = ({
               nextWakeAt === undefined ? nextAttemptAt : Math.min(nextWakeAt, nextAttemptAt);
             return {authPaused: false, nextWakeAt, progressed};
           }
-          if (isEntityBlocked(mutation)) {
+          if (blockedKeys.has(entityKey(mutation.collection, mutation.entityId))) {
             continue;
           }
           const decision = await sendSingle(userId, mutation);
@@ -790,7 +1069,7 @@ export const createReplayCoordinator = ({
         continue;
       }
 
-      const {chunk, blockedWakeAt} = buildChunk(queued);
+      const {chunk, blockedWakeAt} = buildChunk(queued, blockedKeys);
       if (chunk.length === 0) {
         if (blockedWakeAt !== undefined) {
           nextWakeAt =
@@ -831,11 +1110,22 @@ export const createReplayCoordinator = ({
 
       const {decisions, unsupported, haltedAt, shortResponse} = await sendChunk(userId, chunk);
       if (unsupported) {
-        // B3 capability detection: fall back to single-mutation sends for the
-        // rest of this connection's lifetime, re-probed on reconnect.
-        batchUnsupported = true;
+        // FIX 5: only latch after BATCH_UNSUPPORTED_LATCH_THRESHOLD
+        // consecutive unsupported results — a single slow-but-supported
+        // batch (grace elapsed without a receipt landing in time, but the
+        // server really does have a handler) must not permanently downgrade
+        // the connection to single-sends.
+        consecutiveUnsupported += 1;
+        if (consecutiveUnsupported >= BATCH_UNSUPPORTED_LATCH_THRESHOLD) {
+          batchUnsupported = true;
+          armReprobeTimer();
+        }
         continue;
       }
+      // A real (non-unsupported) batch response proves the server supports
+      // batching — reset the consecutive-failure counter so a later stray
+      // unsupported result starts counting from zero again.
+      consecutiveUnsupported = 0;
       let authPaused = false;
       for (const decision of decisions.values()) {
         progressed = progressed || decision.progressed;
@@ -958,18 +1248,36 @@ export const createReplayCoordinator = ({
     return tracked;
   };
 
-  const dispose = (args?: {userId?: string}): void => {
-    if (args?.userId !== undefined) {
-      clearWakeTimer(args.userId);
-      return;
-    }
+  /** FIX 3: full lifecycle reset — see the `ReplayCoordinator.reset` doc comment. */
+  const reset = (): void => {
     for (const userId of [...wakeTimers.keys()]) {
       clearWakeTimer(userId);
     }
+    clearReprobeTimer();
+    retryAt.clear();
+    transportFailures.clear();
+    authPauseNotified.clear();
+    validationBlockedEntities.clear();
+    drainProgress.clear();
+    recheckRequested.clear();
+    batchUnsupported = false;
+    consecutiveUnsupported = 0;
+  };
+
+  /**
+   * FIX 3: `dispose()` is the client-stop/sign-out teardown hook, so a full
+   * `reset()` is always safe here regardless of the (legacy) `userId` arg —
+   * nothing else uses this coordinator instance once dispose has run for the
+   * current lifecycle.
+   */
+  const dispose = (_args?: {userId?: string}): void => {
+    reset();
   };
 
   const notifyReconnect = (): void => {
+    clearReprobeTimer();
     batchUnsupported = false;
+    consecutiveUnsupported = 0;
   };
 
   const retryFailed = ({entityId}: {entityId: string}): void => {
@@ -981,16 +1289,13 @@ export const createReplayCoordinator = ({
   };
 
   const getBlockedEntities = ({userId}: {userId: string}): string[] => {
-    const blocked = new Set<string>();
-    for (const key of validationBlockedEntities) {
-      blocked.add(key);
-    }
-    for (const mutation of outbox.listQueued({userId})) {
-      if (hasUnresolvedConflict(mutation)) {
-        blocked.add(entityKey(mutation.collection, mutation.entityId));
-      }
-    }
-    return [...blocked];
+    // FIX 4: drop stale blocks (no queued successor left) before reporting.
+    gcStaleValidationBlocks(userId);
+    // FIX 2/3: report the full transitive block set (direct + cross-collection
+    // references), scoped to THIS user only — a different user's stale
+    // in-memory entry (or a same-id different-user block) must never surface
+    // here (FIX 3: getBlockedEntities({userId}) filters accordingly).
+    return [...computeBlockedEntityKeys(userId)];
   };
 
   const getDrainProgress = ({
@@ -1012,6 +1317,7 @@ export const createReplayCoordinator = ({
     getDrainProgress,
     notifyReconnect,
     replay,
+    reset,
     retryFailed,
   };
 };

--- a/syncdb/src/sync/socketTransport.test.ts
+++ b/syncdb/src/sync/socketTransport.test.ts
@@ -279,4 +279,51 @@ describe("createSocketTransport", () => {
     await expect(dead.connect()).rejects.toBeDefined();
     dead.disconnect();
   });
+
+  // D1: the server's session re-validation sweep emits sync:auth-expired
+  // immediately before disconnect(true) — the transport must tag the resulting
+  // status notification so the client maps it into the auth-pause path (not a
+  // generic transport blip eligible for unlimited-retry backoff).
+  it("tags the disconnect status as authExpired after a sync:auth-expired event", async () => {
+    const statuses: TransportStatus[] = [];
+    const connecting = makeTransport();
+    connecting.onStatusChange((status) => statuses.push(status));
+    await connecting.connect();
+
+    server.sockets[0]?.emit("sync:auth-expired", {reason: "expired"});
+    server.sockets[0]?.disconnect(true);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(statuses).toEqual([{connected: true}, {authExpired: true, connected: false}]);
+  });
+
+  it("does not tag an ordinary disconnect as authExpired", async () => {
+    const statuses: TransportStatus[] = [];
+    const connecting = makeTransport();
+    connecting.onStatusChange((status) => statuses.push(status));
+    await connecting.connect();
+
+    server.sockets[0]?.disconnect(true);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(statuses).toEqual([{connected: true}, {connected: false}]);
+  });
+
+  it("does not carry authExpired into a later, unrelated disconnect", async () => {
+    const statuses: TransportStatus[] = [];
+    const connecting = makeTransport();
+    connecting.onStatusChange((status) => statuses.push(status));
+    await connecting.connect();
+
+    server.sockets[0]?.emit("sync:auth-expired", {reason: "expired"});
+    server.sockets[0]?.disconnect(true);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    // Reconnect and disconnect again, ordinarily this time.
+    await connecting.connect();
+    server.sockets[server.sockets.length - 1]?.disconnect(true);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(statuses[statuses.length - 1]).toEqual({connected: false});
+  });
 });

--- a/syncdb/src/sync/socketTransport.test.ts
+++ b/syncdb/src/sync/socketTransport.test.ts
@@ -3,7 +3,13 @@ import {createServer, type Server as HttpServer} from "node:http";
 import type {AddressInfo} from "node:net";
 import {Server, type Socket as ServerSocket} from "socket.io";
 
-import type {SyncAck, SyncDelta, SyncMutateRequest, SyncNack} from "../types";
+import type {
+  SyncAck,
+  SyncDelta,
+  SyncMutateBatchRequest,
+  SyncMutateRequest,
+  SyncNack,
+} from "../types";
 import {createSocketTransport} from "./socketTransport";
 import type {SyncTransport, TransportStatus} from "./transport";
 
@@ -17,6 +23,12 @@ interface TestServer {
   subscribes: {collections: string[]}[];
   /** Handler answering sync:mutate; replace per test. */
   mutateHandler: (request: SyncMutateRequest, socket: ServerSocket) => void;
+  /** Handler answering sync:mutateBatch; replace per test (no-op = unsupported). */
+  mutateBatchHandler?: (
+    request: SyncMutateBatchRequest,
+    socket: ServerSocket,
+    ack: (response: unknown) => void
+  ) => void;
   close: () => Promise<void>;
 }
 
@@ -47,6 +59,12 @@ const startServer = async (): Promise<TestServer> => {
     socket.on("sync:mutate", (request: SyncMutateRequest) => {
       server.mutateHandler(request, socket);
     });
+    socket.on(
+      "sync:mutateBatch",
+      (request: SyncMutateBatchRequest, ack: (response: unknown) => void) => {
+        server.mutateBatchHandler?.(request, socket, ack);
+      }
+    );
   });
   await new Promise<void>((resolve) => {
     httpServer.listen(0, () => resolve());
@@ -61,7 +79,7 @@ describe("createSocketTransport", () => {
   let transport: SyncTransport | undefined;
   const tokenCalls: number[] = [];
 
-  const makeTransport = (timeoutMs?: number): SyncTransport => {
+  const makeTransport = (timeoutMs?: number, batchUnsupportedGraceMs?: number): SyncTransport => {
     transport = createSocketTransport({
       authProvider: {
         getToken: async () => {
@@ -70,6 +88,7 @@ describe("createSocketTransport", () => {
         },
       },
       baseUrl: server.baseUrl,
+      batchUnsupportedGraceMs,
       timeoutMs,
     });
     return transport;
@@ -269,6 +288,71 @@ describe("createSocketTransport", () => {
     server.sockets[0]?.emit("sync:delta", {...delta, id: "t2"});
     await new Promise((resolve) => setTimeout(resolve, 30));
     expect(seen).toHaveLength(1);
+  });
+
+  it("sendMutationBatch resolves results from the Socket.io ack callback (FIX 5)", async () => {
+    server.mutateBatchHandler = (request, socket, ack) => {
+      socket.emit("sync:batchReceived", {batchId: request.batchId});
+      ack({
+        results: request.mutations.map((mutation) => ({
+          ack: {id: mutation.id ?? "x", mutationId: mutation.mutationId, seq: 1},
+          type: "ack" as const,
+        })),
+      });
+    };
+    const sender = makeTransport();
+    await sender.connect();
+    // biome-ignore lint/style/noNonNullAssertion: sendMutationBatch is always defined on the socket transport.
+    const result = await sender.sendMutationBatch!({
+      mutations: [{collection: "todos", id: "t1", mutationId: "m1", operation: "create"}],
+    });
+    expect(result).toEqual({
+      results: [{ack: {id: "t1", mutationId: "m1", seq: 1}, type: "ack"}],
+      type: "results",
+    });
+  });
+
+  it("sendMutationBatch resolves unsupported when the grace period elapses with NO receipt and NO ack (FIX 5)", async () => {
+    // No mutateBatchHandler registered at all — mirrors a server with no
+    // sync:mutateBatch listener (Socket.io silently drops the emit).
+    const sender = makeTransport(undefined, 30);
+    await sender.connect();
+    const start = Date.now();
+    // biome-ignore lint/style/noNonNullAssertion: sendMutationBatch is always defined on the socket transport.
+    const result = await sender.sendMutationBatch!({
+      mutations: [{collection: "todos", id: "t1", mutationId: "m1", operation: "create"}],
+    });
+    expect(result).toEqual({type: "unsupported"});
+    // Resolved close to the grace period, not the full mutation timeout.
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+
+  it("a receipt within the grace period prevents 'unsupported' even though the final response is slower than the grace window (FIX 5)", async () => {
+    server.mutateBatchHandler = (request, socket, ack) => {
+      // Emit the receipt immediately (well within the short grace window),
+      // then finish the actual batch AFTER the grace period would have
+      // elapsed — this must NOT be treated as unsupported, and must NOT
+      // fall back to single sends.
+      socket.emit("sync:batchReceived", {batchId: request.batchId});
+      setTimeout(() => {
+        ack({
+          results: request.mutations.map((mutation) => ({
+            ack: {id: mutation.id ?? "x", mutationId: mutation.mutationId, seq: 1},
+            type: "ack" as const,
+          })),
+        });
+      }, 60);
+    };
+    const sender = makeTransport(undefined, 30);
+    await sender.connect();
+    // biome-ignore lint/style/noNonNullAssertion: sendMutationBatch is always defined on the socket transport.
+    const result = await sender.sendMutationBatch!({
+      mutations: [{collection: "todos", id: "t1", mutationId: "m1", operation: "create"}],
+    });
+    expect(result).toEqual({
+      results: [{ack: {id: "t1", mutationId: "m1", seq: 1}, type: "ack"}],
+      type: "results",
+    });
   });
 
   it("connect() rejects when the server is unreachable", async () => {

--- a/syncdb/src/sync/socketTransport.ts
+++ b/syncdb/src/sync/socketTransport.ts
@@ -17,13 +17,27 @@ import {
 } from "./transport";
 
 /**
- * Grace period to wait for a `sync:mutateBatch` ack callback before treating the
- * server as not supporting the batch event. Socket.io silently drops emits to
- * event names with no registered handler — there is no error to catch, only
- * silence — so this must be much shorter than the full mutation timeout or every
- * batch send against an old server would stall for the full 15s.
+ * Grace period to wait for EITHER a `sync:mutateBatch` ack callback OR the
+ * `sync:batchReceived` receipt before treating the server as not supporting
+ * the batch event at all. Socket.io silently drops emits to event names with
+ * no registered handler — there is no error to catch, only silence — so this
+ * must be much shorter than the full batch timeout or every batch send
+ * against an old server would stall for that long. Once the receipt DOES
+ * arrive within this window, the server is known to support batching (it's
+ * just slow) and the client waits the full {@link batchTimeoutMs} instead of
+ * falling back (FIX 5).
  */
 export const BATCH_UNSUPPORTED_GRACE_MS = 2_000;
+
+/**
+ * Compute the batch send timeout once a `sync:batchReceived` receipt has
+ * confirmed the server is processing (as opposed to silent/unsupported): the
+ * existing per-mutation timeout scaled by chunk size, so a large batch isn't
+ * timed out prematurely just because it's slower than a single mutation
+ * (FIX 5).
+ */
+export const batchTimeoutMs = (mutationCount: number, perMutationTimeoutMs: number): number =>
+  Math.max(perMutationTimeoutMs, mutationCount * 1_000);
 
 export interface SocketTransportConfig {
   /** Server origin, e.g. "http://localhost:4000". */
@@ -74,11 +88,16 @@ export const createSocketTransport = ({
   const statusListeners = new Set<(status: TransportStatus) => void>();
   const pending = new Map<string, PendingMutation>();
   const pendingBatches = new Map<
-    number,
+    string,
     {
       resolve: (result: SendMutationBatchResult) => void;
       reject: (error: Error) => void;
-      graceTimer: ReturnType<typeof setTimeout>;
+      /** Cleared once a `sync:batchReceived` receipt arrives (FIX 5). */
+      graceTimer?: ReturnType<typeof setTimeout>;
+      /** Armed once the receipt lands, replacing the grace timer (FIX 5). */
+      fullTimer?: ReturnType<typeof setTimeout>;
+      /** Removes this batch's `sync:batchReceived` listener (FIX 5). */
+      offReceived: () => void;
     }
   >();
   let nextBatchId = 1;
@@ -120,7 +139,13 @@ export const createSocketTransport = ({
     }
     for (const [batchId, entry] of pendingBatches) {
       pendingBatches.delete(batchId);
-      clearTimeout(entry.graceTimer);
+      if (entry.graceTimer !== undefined) {
+        clearTimeout(entry.graceTimer);
+      }
+      if (entry.fullTimer !== undefined) {
+        clearTimeout(entry.fullTimer);
+      }
+      entry.offReceived();
       entry.reject(new Error(reason));
     }
   };
@@ -222,20 +247,73 @@ export const createSocketTransport = ({
     request: {mutations: SyncMutateRequest[]} & SyncMutateBatchRequest
   ): Promise<SendMutationBatchResult> =>
     new Promise<SendMutationBatchResult>((resolve, reject) => {
-      const batchId = nextBatchId++;
-      // A server without a sync:mutateBatch handler never invokes this ack
-      // callback (Socket.io silently drops emits to unregistered events) — a
-      // short grace timeout distinguishes "unsupported" from a genuine
-      // transport failure, so callers don't wait out the full mutation timeout
-      // on every batch send against an old server.
-      const graceTimer = setTimeout(() => {
+      const batchId = String(nextBatchId++);
+
+      // FIX 5: a server without a sync:mutateBatch handler never invokes the
+      // ack callback NOR emits sync:batchReceived (Socket.io silently drops
+      // emits to unregistered events) — a short grace timeout with NO
+      // receipt landing is the ONLY signal for "unsupported". Once a
+      // receipt (or the final ack callback, whichever arrives first) lands
+      // within that window, the server is known to support batching and is
+      // just slow — the full batch timeout (proportional to chunk size)
+      // takes over instead of resolving `unsupported` prematurely.
+      const cleanup = (): void => {
         pendingBatches.delete(batchId);
-        resolve({type: "unsupported"});
+        socket.off("sync:batchReceived", onReceived);
+      };
+      const finish = (result: SendMutationBatchResult): void => {
+        cleanup();
+        resolve(result);
+      };
+      const armFullTimer = (): void => {
+        const entry = pendingBatches.get(batchId);
+        if (!entry || entry.fullTimer !== undefined) {
+          return;
+        }
+        if (entry.graceTimer !== undefined) {
+          clearTimeout(entry.graceTimer);
+          entry.graceTimer = undefined;
+        }
+        entry.fullTimer = setTimeout(
+          () => {
+            // The server confirmed support (a receipt or ack landed) but never
+            // finished within the scaled batch timeout — this is a genuine
+            // transport failure (not "unsupported"), so reject: the
+            // coordinator applies its unlimited-backoff transport-failure
+            // path and resends the whole chunk (INV-3), rather than wrongly
+            // downgrading a merely-slow-but-supported server to single-sends.
+            cleanup();
+            reject(
+              new Error(`Timed out after the batch timeout waiting for batch ${batchId} to finish`)
+            );
+          },
+          batchTimeoutMs(request.mutations.length, timeoutMs)
+        );
+      };
+      const onReceived = ({batchId: receivedId}: {batchId?: string}): void => {
+        if (receivedId === batchId) {
+          armFullTimer();
+        }
+      };
+      socket.on("sync:batchReceived", onReceived);
+
+      const graceTimer = setTimeout(() => {
+        finish({type: "unsupported"});
       }, batchUnsupportedGraceMs);
-      pendingBatches.set(batchId, {graceTimer, reject, resolve});
+      // The pendingBatches entry MUST exist before the emit: on localhost the
+      // server's immediate sync:batchReceived echo can round-trip fast enough
+      // to race this same synchronous block, and armFullTimer/the ack
+      // callback both look up this entry by batchId.
+      pendingBatches.set(batchId, {
+        graceTimer,
+        offReceived: () => socket.off("sync:batchReceived", onReceived),
+        reject,
+        resolve,
+      });
+
       socket.emit(
         "sync:mutateBatch",
-        request,
+        {...request, batchId},
         (response: {
           results?: ({type: "ack"; ack: SyncAck} | {type: "nack"; nack: SyncNack})[];
         }) => {
@@ -243,12 +321,13 @@ export const createSocketTransport = ({
           if (!entry) {
             return;
           }
-          pendingBatches.delete(batchId);
-          clearTimeout(entry.graceTimer);
+          if (entry.fullTimer !== undefined) {
+            clearTimeout(entry.fullTimer);
+          }
           if (Array.isArray(response?.results)) {
-            entry.resolve({results: response.results, type: "results"});
+            finish({results: response.results, type: "results"});
           } else {
-            entry.resolve({type: "unsupported"});
+            finish({type: "unsupported"});
           }
         }
       );

--- a/syncdb/src/sync/socketTransport.ts
+++ b/syncdb/src/sync/socketTransport.ts
@@ -125,11 +125,17 @@ export const createSocketTransport = ({
     }
   };
 
-  const notifyStatus = (connected: boolean): void => {
+  const notifyStatus = (connected: boolean, authExpired?: boolean): void => {
     for (const listener of statusListeners) {
-      listener({connected});
+      listener(authExpired ? {authExpired: true, connected} : {connected});
     }
   };
+
+  // D1: the server's session re-validation sweep emits `sync:auth-expired`
+  // immediately before calling `socket.disconnect(true)` — this flag survives just
+  // long enough for the subsequent `disconnect` handler to tag its status
+  // notification, then resets so a later, unrelated disconnect isn't misattributed.
+  let pendingAuthExpired = false;
 
   socket.on("sync:delta", (delta: SyncDelta) => {
     for (const listener of deltaListeners) {
@@ -141,6 +147,22 @@ export const createSocketTransport = ({
   });
   socket.on("sync:nack", (nack: SyncNack) => {
     settle(nack.mutationId, {nack, type: "nack"});
+  });
+  socket.on("sync:auth-expired", () => {
+    pendingAuthExpired = true;
+  });
+  // D1: Socket.io's own automatic background reconnection (reconnection: true,
+  // configured below) re-runs the handshake without going through this module's
+  // connect() promise — so an auth rejection on a RECONNECT attempt (token expired
+  // or session revoked while offline, discovered only when the client comes back)
+  // must be observed here, not just on the initial connect(). Any auth-shaped
+  // rejection (the server's auth middleware `next(error)`, matching the
+  // `UnauthorizedError` data shape from @thream/socketio-jwt / socketAuth.ts) maps
+  // into the same auth-pause path as an explicit sync:auth-expired disconnect.
+  socket.on("connect_error", (error: Error & {data?: {type?: string}}) => {
+    if (error?.data?.type === "UnauthorizedError") {
+      notifyStatus(false, true);
+    }
   });
   socket.on("connect", () => {
     // Server-side subscriptions are per-connection: re-subscribe on reconnect.
@@ -154,7 +176,9 @@ export const createSocketTransport = ({
     // reject now so the replay coordinator can requeue instead of waiting out
     // the full timeout.
     rejectAllPending("Socket disconnected before the mutation was acknowledged");
-    notifyStatus(false);
+    const authExpired = pendingAuthExpired;
+    pendingAuthExpired = false;
+    notifyStatus(false, authExpired);
   });
 
   const connect = (): Promise<void> =>

--- a/syncdb/src/sync/socketTransport.ts
+++ b/syncdb/src/sync/socketTransport.ts
@@ -17,13 +17,27 @@ import {
 } from "./transport";
 
 /**
- * Grace period to wait for a `sync:mutateBatch` ack callback before treating the
- * server as not supporting the batch event. Socket.io silently drops emits to
- * event names with no registered handler — there is no error to catch, only
- * silence — so this must be much shorter than the full mutation timeout or every
- * batch send against an old server would stall for the full 15s.
+ * Grace period to wait for EITHER a `sync:mutateBatch` ack callback OR the
+ * `sync:batchReceived` receipt before treating the server as not supporting
+ * the batch event at all. Socket.io silently drops emits to event names with
+ * no registered handler — there is no error to catch, only silence — so this
+ * must be much shorter than the full batch timeout or every batch send
+ * against an old server would stall for that long. Once the receipt DOES
+ * arrive within this window, the server is known to support batching (it's
+ * just slow) and the client waits the full {@link batchTimeoutMs} instead of
+ * falling back (FIX 5).
  */
 export const BATCH_UNSUPPORTED_GRACE_MS = 2_000;
+
+/**
+ * Compute the batch send timeout once a `sync:batchReceived` receipt has
+ * confirmed the server is processing (as opposed to silent/unsupported): the
+ * existing per-mutation timeout scaled by chunk size, so a large batch isn't
+ * timed out prematurely just because it's slower than a single mutation
+ * (FIX 5).
+ */
+export const batchTimeoutMs = (mutationCount: number, perMutationTimeoutMs: number): number =>
+  Math.max(perMutationTimeoutMs, mutationCount * 1_000);
 
 export interface SocketTransportConfig {
   /** Server origin, e.g. "http://localhost:4000". */
@@ -74,11 +88,16 @@ export const createSocketTransport = ({
   const statusListeners = new Set<(status: TransportStatus) => void>();
   const pending = new Map<string, PendingMutation>();
   const pendingBatches = new Map<
-    number,
+    string,
     {
       resolve: (result: SendMutationBatchResult) => void;
       reject: (error: Error) => void;
-      graceTimer: ReturnType<typeof setTimeout>;
+      /** Cleared once a `sync:batchReceived` receipt arrives (FIX 5). */
+      graceTimer?: ReturnType<typeof setTimeout>;
+      /** Armed once the receipt lands, replacing the grace timer (FIX 5). */
+      fullTimer?: ReturnType<typeof setTimeout>;
+      /** Removes this batch's `sync:batchReceived` listener (FIX 5). */
+      offReceived: () => void;
     }
   >();
   let nextBatchId = 1;
@@ -120,7 +139,13 @@ export const createSocketTransport = ({
     }
     for (const [batchId, entry] of pendingBatches) {
       pendingBatches.delete(batchId);
-      clearTimeout(entry.graceTimer);
+      if (entry.graceTimer !== undefined) {
+        clearTimeout(entry.graceTimer);
+      }
+      if (entry.fullTimer !== undefined) {
+        clearTimeout(entry.fullTimer);
+      }
+      entry.offReceived();
       entry.reject(new Error(reason));
     }
   };
@@ -246,20 +271,73 @@ export const createSocketTransport = ({
     request: {mutations: SyncMutateRequest[]} & SyncMutateBatchRequest
   ): Promise<SendMutationBatchResult> =>
     new Promise<SendMutationBatchResult>((resolve, reject) => {
-      const batchId = nextBatchId++;
-      // A server without a sync:mutateBatch handler never invokes this ack
-      // callback (Socket.io silently drops emits to unregistered events) — a
-      // short grace timeout distinguishes "unsupported" from a genuine
-      // transport failure, so callers don't wait out the full mutation timeout
-      // on every batch send against an old server.
-      const graceTimer = setTimeout(() => {
+      const batchId = String(nextBatchId++);
+
+      // FIX 5: a server without a sync:mutateBatch handler never invokes the
+      // ack callback NOR emits sync:batchReceived (Socket.io silently drops
+      // emits to unregistered events) — a short grace timeout with NO
+      // receipt landing is the ONLY signal for "unsupported". Once a
+      // receipt (or the final ack callback, whichever arrives first) lands
+      // within that window, the server is known to support batching and is
+      // just slow — the full batch timeout (proportional to chunk size)
+      // takes over instead of resolving `unsupported` prematurely.
+      const cleanup = (): void => {
         pendingBatches.delete(batchId);
-        resolve({type: "unsupported"});
+        socket.off("sync:batchReceived", onReceived);
+      };
+      const finish = (result: SendMutationBatchResult): void => {
+        cleanup();
+        resolve(result);
+      };
+      const armFullTimer = (): void => {
+        const entry = pendingBatches.get(batchId);
+        if (!entry || entry.fullTimer !== undefined) {
+          return;
+        }
+        if (entry.graceTimer !== undefined) {
+          clearTimeout(entry.graceTimer);
+          entry.graceTimer = undefined;
+        }
+        entry.fullTimer = setTimeout(
+          () => {
+            // The server confirmed support (a receipt or ack landed) but never
+            // finished within the scaled batch timeout — this is a genuine
+            // transport failure (not "unsupported"), so reject: the
+            // coordinator applies its unlimited-backoff transport-failure
+            // path and resends the whole chunk (INV-3), rather than wrongly
+            // downgrading a merely-slow-but-supported server to single-sends.
+            cleanup();
+            reject(
+              new Error(`Timed out after the batch timeout waiting for batch ${batchId} to finish`)
+            );
+          },
+          batchTimeoutMs(request.mutations.length, timeoutMs)
+        );
+      };
+      const onReceived = ({batchId: receivedId}: {batchId?: string}): void => {
+        if (receivedId === batchId) {
+          armFullTimer();
+        }
+      };
+      socket.on("sync:batchReceived", onReceived);
+
+      const graceTimer = setTimeout(() => {
+        finish({type: "unsupported"});
       }, batchUnsupportedGraceMs);
-      pendingBatches.set(batchId, {graceTimer, reject, resolve});
+      // The pendingBatches entry MUST exist before the emit: on localhost the
+      // server's immediate sync:batchReceived echo can round-trip fast enough
+      // to race this same synchronous block, and armFullTimer/the ack
+      // callback both look up this entry by batchId.
+      pendingBatches.set(batchId, {
+        graceTimer,
+        offReceived: () => socket.off("sync:batchReceived", onReceived),
+        reject,
+        resolve,
+      });
+
       socket.emit(
         "sync:mutateBatch",
-        request,
+        {...request, batchId},
         (response: {
           results?: ({type: "ack"; ack: SyncAck} | {type: "nack"; nack: SyncNack})[];
         }) => {
@@ -267,12 +345,13 @@ export const createSocketTransport = ({
           if (!entry) {
             return;
           }
-          pendingBatches.delete(batchId);
-          clearTimeout(entry.graceTimer);
+          if (entry.fullTimer !== undefined) {
+            clearTimeout(entry.fullTimer);
+          }
           if (Array.isArray(response?.results)) {
-            entry.resolve({results: response.results, type: "results"});
+            finish({results: response.results, type: "results"});
           } else {
-            entry.resolve({type: "unsupported"});
+            finish({type: "unsupported"});
           }
         }
       );

--- a/syncdb/src/sync/socketTransport.ts
+++ b/syncdb/src/sync/socketTransport.ts
@@ -1,12 +1,29 @@
 import {io, type Socket} from "socket.io-client";
 
-import type {AuthProvider, SyncAck, SyncDelta, SyncMutateRequest, SyncNack} from "../types";
+import type {
+  AuthProvider,
+  SyncAck,
+  SyncDelta,
+  SyncMutateBatchRequest,
+  SyncMutateRequest,
+  SyncNack,
+} from "../types";
 import {
   DEFAULT_MUTATION_TIMEOUT_MS,
+  type SendMutationBatchResult,
   type SendMutationResult,
   type SyncTransport,
   type TransportStatus,
 } from "./transport";
+
+/**
+ * Grace period to wait for a `sync:mutateBatch` ack callback before treating the
+ * server as not supporting the batch event. Socket.io silently drops emits to
+ * event names with no registered handler — there is no error to catch, only
+ * silence — so this must be much shorter than the full mutation timeout or every
+ * batch send against an old server would stall for the full 15s.
+ */
+export const BATCH_UNSUPPORTED_GRACE_MS = 2_000;
 
 export interface SocketTransportConfig {
   /** Server origin, e.g. "http://localhost:4000". */
@@ -15,6 +32,8 @@ export interface SocketTransportConfig {
   authProvider: Pick<AuthProvider, "getToken">;
   /** How long to wait for a mutation ack/nack before rejecting (default 15s). */
   timeoutMs?: number;
+  /** Grace period before a batch send is treated as unsupported (default 2s). */
+  batchUnsupportedGraceMs?: number;
 }
 
 interface PendingMutation {
@@ -49,10 +68,20 @@ export const createSocketTransport = ({
   baseUrl,
   authProvider,
   timeoutMs = DEFAULT_MUTATION_TIMEOUT_MS,
+  batchUnsupportedGraceMs = BATCH_UNSUPPORTED_GRACE_MS,
 }: SocketTransportConfig): SyncTransport => {
   const deltaListeners = new Set<(delta: SyncDelta) => void>();
   const statusListeners = new Set<(status: TransportStatus) => void>();
   const pending = new Map<string, PendingMutation>();
+  const pendingBatches = new Map<
+    number,
+    {
+      resolve: (result: SendMutationBatchResult) => void;
+      reject: (error: Error) => void;
+      graceTimer: ReturnType<typeof setTimeout>;
+    }
+  >();
+  let nextBatchId = 1;
   const subscribed = new Set<string>();
 
   const socket: Socket = io(baseUrl, {
@@ -87,6 +116,11 @@ export const createSocketTransport = ({
     for (const [mutationId, entry] of pending) {
       pending.delete(mutationId);
       clearTimeout(entry.timer);
+      entry.reject(new Error(reason));
+    }
+    for (const [batchId, entry] of pendingBatches) {
+      pendingBatches.delete(batchId);
+      clearTimeout(entry.graceTimer);
       entry.reject(new Error(reason));
     }
   };
@@ -184,6 +218,42 @@ export const createSocketTransport = ({
       });
     });
 
+  const sendMutationBatch = (
+    request: {mutations: SyncMutateRequest[]} & SyncMutateBatchRequest
+  ): Promise<SendMutationBatchResult> =>
+    new Promise<SendMutationBatchResult>((resolve, reject) => {
+      const batchId = nextBatchId++;
+      // A server without a sync:mutateBatch handler never invokes this ack
+      // callback (Socket.io silently drops emits to unregistered events) — a
+      // short grace timeout distinguishes "unsupported" from a genuine
+      // transport failure, so callers don't wait out the full mutation timeout
+      // on every batch send against an old server.
+      const graceTimer = setTimeout(() => {
+        pendingBatches.delete(batchId);
+        resolve({type: "unsupported"});
+      }, batchUnsupportedGraceMs);
+      pendingBatches.set(batchId, {graceTimer, reject, resolve});
+      socket.emit(
+        "sync:mutateBatch",
+        request,
+        (response: {
+          results?: ({type: "ack"; ack: SyncAck} | {type: "nack"; nack: SyncNack})[];
+        }) => {
+          const entry = pendingBatches.get(batchId);
+          if (!entry) {
+            return;
+          }
+          pendingBatches.delete(batchId);
+          clearTimeout(entry.graceTimer);
+          if (Array.isArray(response?.results)) {
+            entry.resolve({results: response.results, type: "results"});
+          } else {
+            entry.resolve({type: "unsupported"});
+          }
+        }
+      );
+    });
+
   return {
     connect,
     disconnect,
@@ -200,6 +270,7 @@ export const createSocketTransport = ({
       };
     },
     sendMutation,
+    sendMutationBatch,
     subscribe,
   };
 };

--- a/syncdb/src/sync/transport.ts
+++ b/syncdb/src/sync/transport.ts
@@ -1,10 +1,31 @@
-import type {SyncAck, SyncDelta, SyncMutateRequest, SyncNack} from "../types";
+import type {
+  SyncAck,
+  SyncDelta,
+  SyncMutateBatchRequest,
+  SyncMutateRequest,
+  SyncNack,
+} from "../types";
 
 /** Default time to wait for a mutation ack/nack before rejecting. */
 export const DEFAULT_MUTATION_TIMEOUT_MS = 15_000;
 
+/** Default max mutations per batch send (server also enforces this cap). */
+export const DEFAULT_BATCH_SIZE = 50;
+
 /** The server's reply to a sent mutation: accepted (ack) or rejected (nack). */
 export type SendMutationResult = {type: "ack"; ack: SyncAck} | {type: "nack"; nack: SyncNack};
+
+/**
+ * The server's reply to a batch send: a `results` array (see
+ * `SyncMutateBatchResponse`), or `unsupported` when the transport/server has no
+ * batch endpoint (HTTP 404, or a socket that never acks `sync:mutateBatch` within
+ * the timeout — Socket.io silently drops emits to unregistered events). Callers
+ * treat `unsupported` as a signal to set the per-connection `batchUnsupported`
+ * flag and fall back to single-mutation sends, never as a transport failure.
+ */
+export type SendMutationBatchResult =
+  | {type: "results"; results: ({type: "ack"; ack: SyncAck} | {type: "nack"; nack: SyncNack})[]}
+  | {type: "unsupported"};
 
 /** Transport connection status snapshot delivered to status listeners. */
 export interface TransportStatus {
@@ -31,6 +52,15 @@ export interface SyncTransport {
    * the connection drops before the reply.
    */
   sendMutation: (request: SyncMutateRequest) => Promise<SendMutationResult>;
+  /**
+   * Send a batch of mutations (`sync:mutateBatch`) and resolve with either the
+   * server's per-mutation results or `unsupported` (server has no batch handler —
+   * Socket.io drops emits to unregistered events, so this resolves after a short
+   * grace timeout rather than the full mutation timeout). Rejects on transport
+   * failure exactly like `sendMutation` (timeout waiting for a KNOWN-supported
+   * server, network error, disconnect).
+   */
+  sendMutationBatch?: (request: SyncMutateBatchRequest) => Promise<SendMutationBatchResult>;
   /** Subscribe to inbound `sync:delta` events. Returns an unsubscribe function. */
   onDelta: (callback: (delta: SyncDelta) => void) => () => void;
   /** Subscribe to connection status changes. Returns an unsubscribe function. */

--- a/syncdb/src/sync/transport.ts
+++ b/syncdb/src/sync/transport.ts
@@ -30,6 +30,14 @@ export type SendMutationBatchResult =
 /** Transport connection status snapshot delivered to status listeners. */
 export interface TransportStatus {
   connected: boolean;
+  /**
+   * D1: set when this disconnect was caused by the server's session re-validation
+   * sweep (`sync:auth-expired`, emitted before `socket.disconnect(true)`) rather than
+   * a generic network drop. The client maps this into the existing A4 auth-pause path
+   * (INV-2 — no wipe, outbox intact) instead of treating it as a transient transport
+   * blip eligible for unlimited-retry backoff.
+   */
+  authExpired?: boolean;
 }
 
 /**

--- a/syncdb/src/types.ts
+++ b/syncdb/src/types.ts
@@ -89,7 +89,10 @@ export interface OutboxMutation {
   args: string;
   baseVersion?: number;
   status: OutboxStatus;
+  /** Diagnostic total attempt count across every send (transport + error-nack). */
   attemptCount: number;
+  /** Retry-budget counter incremented only on server error-nacks (see MAX_ERROR_NACK_ATTEMPTS). */
+  errorNackCount: number;
   /** The user this mutation belongs to; replay skips mutations from other users. */
   userId: string;
   createdAt: string;
@@ -116,6 +119,14 @@ export interface SyncStatus {
   isSyncing: boolean;
   queuedCount: number;
   conflictCount: number;
+  /** Count of mutations in the terminal `failed` state. */
+  failedCount: number;
+  /**
+   * Set when replay is paused because the server rejected our auth (401 /
+   * AuthRequiredError / unauthorized nack / socket auth rejection). Clears
+   * automatically when the same user re-authenticates and replay resumes.
+   */
+  paused?: "auth";
   /** Per-stream cursors (stream key → highest applied seq). */
   streams: Record<string, number>;
 }
@@ -131,4 +142,12 @@ export interface AuthProvider {
   getUserId: () => Promise<string | null>;
   /** Subscribe to auth changes (login, logout, user switch). Returns unsubscribe. */
   onAuthChange: (callback: () => void) => () => void;
+  /**
+   * Optional silent token refresh. When present, the client calls it exactly
+   * once per auth-pause episode before surfacing the pause to the app;
+   * resolving `true` means the refresh likely succeeded and replay should be
+   * retried immediately. Adapters without a meaningful refresh path (or that
+   * refresh transparently inside `getToken`) may omit this.
+   */
+  refresh?: () => Promise<boolean>;
 }

--- a/syncdb/src/types.ts
+++ b/syncdb/src/types.ts
@@ -46,9 +46,15 @@ export interface SyncAck {
   id: string;
   /** The document's new seq. */
   seq: number;
+  /**
+   * Set when the document write succeeded but the server's post-hook threw
+   * (informational only — never a reason to retry, roll back, or treat this
+   * as anything other than a full success).
+   */
+  warning?: string;
 }
 
-export type SyncNackCode = "conflict" | "unauthorized" | "validation" | "error";
+export type SyncNackCode = "conflict" | "unauthorized" | "validation" | "error" | "rate_limited";
 
 /** Rejected mutation. Conflict nacks carry the canonical server document. */
 export interface SyncNack {
@@ -59,6 +65,11 @@ export interface SyncNack {
   /** The server document's current seq (conflict nacks). */
   serverSeq?: number;
   message?: string;
+  /**
+   * Minimum time (ms) the client should wait before retrying, filled by the
+   * server with the remaining rate-limit window (`rate_limited` nacks only).
+   */
+  retryAfterMs?: number;
 }
 
 /**
@@ -69,6 +80,13 @@ export interface SyncNack {
 export interface SyncMutateBatchRequest {
   /** Ordered mutations; each still carries its own mutationId. */
   mutations: SyncMutateRequest[];
+  /**
+   * Client-generated correlation id, socket transport only (ignored over
+   * HTTP). Echoed back immediately via `sync:batchReceived {batchId}` before
+   * processing begins, distinguishing "unsupported" (silence past the grace
+   * period) from "slow" (a receipt arrived; keep waiting).
+   */
+  batchId?: string;
 }
 
 /** One result per PROCESSED mutation in a batch, in request order. */

--- a/syncdb/src/types.ts
+++ b/syncdb/src/types.ts
@@ -61,6 +61,30 @@ export interface SyncNack {
   message?: string;
 }
 
+/**
+ * A batch of client mutations sent via `sync:mutateBatch` or
+ * `POST /sync/mutate/batch`. The server applies strictly in array order and
+ * stops at the first non-ack outcome.
+ */
+export interface SyncMutateBatchRequest {
+  /** Ordered mutations; each still carries its own mutationId. */
+  mutations: SyncMutateRequest[];
+}
+
+/** One result per PROCESSED mutation in a batch, in request order. */
+export type SyncMutateBatchResult = {type: "ack"; ack: SyncAck} | {type: "nack"; nack: SyncNack};
+
+/**
+ * Response to a batch mutation request.
+ *
+ * `results.length < request.mutations.length` means the server halted at the
+ * first non-ack: `results[results.length - 1]` is that failing outcome, and
+ * every mutation after it was NOT attempted — still safe to resend later.
+ */
+export interface SyncMutateBatchResponse {
+  results: SyncMutateBatchResult[];
+}
+
 /** One entity in a `GET /sync/snapshot` page. */
 export interface SyncSnapshotEntity {
   id: string;
@@ -127,6 +151,18 @@ export interface SyncStatus {
    * automatically when the same user re-authenticates and replay resumes.
    */
   paused?: "auth";
+  /**
+   * Number of distinct entities currently blocked from draining (B4): an
+   * unresolved conflict, or a terminal validation failure whose successors
+   * are skipped-and-surfaced pending `client.retryFailed({entityId})`.
+   */
+  blockedEntities: number;
+  /** True while a replay/drain is actively in flight for the current user. */
+  draining: boolean;
+  /** Mutations attempted so far in the current (or most recent) drain call. */
+  sentThisDrain: number;
+  /** Queue length observed when the current (or most recent) drain call began. */
+  totalThisDrain: number;
   /** Per-stream cursors (stream key → highest applied seq). */
   streams: Record<string, number>;
 }

--- a/syncdb/src/types.ts
+++ b/syncdb/src/types.ts
@@ -183,6 +183,16 @@ export interface SyncStatus {
   totalThisDrain: number;
   /** Per-stream cursors (stream key → highest applied seq). */
   streams: Record<string, number>;
+  /**
+   * E3(c)/(a): local persistence health. `"durable"` (default) means the
+   * platform persister is backed by real storage (IndexedDB/SQLite);
+   * `"memory"` means the web factory fell back to in-memory persistence
+   * (no `globalThis.indexedDB` in this environment — data will not survive a
+   * reload); `"error"` means the last load attempt hit a storage READ error
+   * (distinct from "no data") and the client deliberately skipped autosave to
+   * avoid clobbering a still-possibly-intact persisted blob.
+   */
+  persistence: "durable" | "memory" | "error";
 }
 
 /**

--- a/syncdb/src/types.ts
+++ b/syncdb/src/types.ts
@@ -21,6 +21,12 @@ export interface SyncDelta {
   seq: number;
   /** Stream key this delta belongs to (e.g. "todos|owner:123"). */
   stream: string;
+  /**
+   * C1: the stream's stable frontier at emit time. The client advances its cursor to
+   * `min(seq, frontierSeq)` so a delta observed out of commit order never advances a
+   * cursor past an uncommitted hole. Absent from older servers (treated as `seq`).
+   */
+  frontierSeq?: number;
   /** True when the entity is soft-deleted. */
   deleted?: boolean;
 }
@@ -111,11 +117,34 @@ export interface SyncSnapshotEntity {
   deleted: boolean;
 }
 
-/** Response shape of `GET /sync/snapshot`. */
+/** Response shape of `GET /sync/snapshot` (C2: one stream per request). */
 export interface SyncSnapshotResponse {
+  /** The stream this page belongs to (echoed from the request). */
+  stream: string;
   entities: SyncSnapshotEntity[];
+  /** Highest seq in this page (never above `frontierSeq`); pass back as `cursor`. */
   cursor: number;
   hasMore: boolean;
+  /** C1: the stream's stable frontier — the client must not advance its cursor beyond this. */
+  frontierSeq: number;
+  /**
+   * C7: the lowest seq still retained for the stream. A stored cursor below this means
+   * compacted tombstones may have been missed → re-bootstrap the stream from 0.
+   */
+  oldestRetainedSeq: number;
+  /**
+   * C3: opaque forward token for paging the legacy (seq-0) stratum by `_id`. Echoed back
+   * verbatim until absent (stratum exhausted), then paging proceeds by seq.
+   */
+  legacyCursor?: string;
+}
+
+/** One stream a user currently belongs to, from `GET /sync/streams`. */
+export interface SyncStreamInfo {
+  /** Stream key (e.g. "todos|owner:123"). */
+  stream: string;
+  /** Collection tag the stream belongs to. */
+  collection: string;
 }
 
 /** Durable outbox mutation lifecycle. */

--- a/ui/src/Box.tsx
+++ b/ui/src/Box.tsx
@@ -273,7 +273,11 @@ export const Box = React.forwardRef((props: BoxProps, ref) => {
       const value = props[prop];
       if (BOX_STYLE_MAP[prop]) {
         Object.assign(style, BOX_STYLE_MAP[prop](value, props));
-      } else if (prop !== "children" && prop !== "onClick") {
+      } else if (
+        prop !== "children" &&
+        prop !== "onClick" &&
+        (prop as string) !== "accessibilityRole"
+      ) {
         style[prop] = value;
         // console.warn(`Box: unknown property ${prop}`);
       }
@@ -302,11 +306,17 @@ export const Box = React.forwardRef((props: BoxProps, ref) => {
   let box: React.ReactElement;
 
   // Adding the accessibilityRole of button throws a warning in React Native since we nest buttons
-  // within Box and RN does not support nested buttons
+  // within Box and RN does not support nested buttons — so this stays on `aria-role` (which RN
+  // itself translates to accessibilityRole under the hood) by default; an explicit
+  // `accessibilityRole` prop is only forwarded literally when the caller opts in.
   if (props.onClick) {
+    const explicitAccessibilityRole = (props as AccessibilityProps).accessibilityRole;
     box = (
       <Pressable
         accessibilityHint={(props as AccessibilityProps).accessibilityHint}
+        {...(explicitAccessibilityRole
+          ? {accessibilityRole: explicitAccessibilityRole as never}
+          : {})}
         aria-label={(props as AccessibilityProps).accessibilityLabel}
         aria-role="button"
         onLayout={props.onLayout}

--- a/ui/src/Common.ts
+++ b/ui/src/Common.ts
@@ -516,6 +516,13 @@ export interface LayerProps {
 export interface AccessibilityProps {
   accessibilityLabel: string;
   accessibilityHint: string;
+  /**
+   * RN/RNW accessibility role (e.g. "button") for a clickable Box. Optional —
+   * most onClick Boxes get an implicit button role already (see Box.tsx); set
+   * this explicitly when a screen-reader-facing role needs to be guaranteed
+   * (e.g. a badge that opens a sheet).
+   */
+  accessibilityRole?: string;
 }
 
 export interface BoxPropsBase extends WithTestID {

--- a/ui/src/ConflictSheet.test.tsx
+++ b/ui/src/ConflictSheet.test.tsx
@@ -48,7 +48,7 @@ describe("ConflictSheet", () => {
         visible={true}
       />
     );
-    fireEvent.press(getByTestId("conflict-keep-mine-button"));
+    fireEvent.press(getByTestId("conflict-keep-mine-button-m-1"));
     await flush();
     expect(onResolve).toHaveBeenCalledTimes(1);
     expect(onResolve.mock.calls[0][0]).toEqual({mutationId: "m-1", strategy: "keepMine"});
@@ -58,7 +58,7 @@ describe("ConflictSheet", () => {
   it("calls onResolve with useServer without dismissing when other conflicts remain", async () => {
     const onResolve = mock(() => {});
     const onDismiss = mock(() => {});
-    const {getAllByTestId} = renderWithTheme(
+    const {getByTestId} = renderWithTheme(
       <ConflictSheet
         conflicts={[buildConflict(), buildConflict({entityId: "todo-2", mutationId: "m-2"})]}
         onDismiss={onDismiss}
@@ -66,11 +66,29 @@ describe("ConflictSheet", () => {
         visible={true}
       />
     );
-    fireEvent.press(getAllByTestId("conflict-use-server-button")[0]);
+    fireEvent.press(getByTestId("conflict-use-server-button-m-1"));
     await flush();
     expect(onResolve).toHaveBeenCalledTimes(1);
     expect(onResolve.mock.calls[0][0]).toEqual({mutationId: "m-1", strategy: "useServer"});
     expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("suffixes testIDs with mutationId so multiple conflicts never collide (E6, RN Testing Library strict-mode fix)", () => {
+    const {getByTestId} = renderWithTheme(
+      <ConflictSheet
+        conflicts={[buildConflict(), buildConflict({entityId: "todo-2", mutationId: "m-2"})]}
+        onDismiss={() => {}}
+        onResolve={() => {}}
+        visible={true}
+      />
+    );
+    // getByTestId throws if more than one match is found — this is exactly
+    // what would happen with the old shared "conflict-keep-mine-button" /
+    // "conflict-use-server-button" testIDs across two rendered conflicts.
+    expect(getByTestId("conflict-keep-mine-button-m-1")).toBeTruthy();
+    expect(getByTestId("conflict-keep-mine-button-m-2")).toBeTruthy();
+    expect(getByTestId("conflict-use-server-button-m-1")).toBeTruthy();
+    expect(getByTestId("conflict-use-server-button-m-2")).toBeTruthy();
   });
 
   it("falls back to a JSON summary when the payload has no title", () => {

--- a/ui/src/ConflictSheet.tsx
+++ b/ui/src/ConflictSheet.tsx
@@ -97,13 +97,13 @@ const ConflictItem: React.FC<{
       <Box direction="row" gap={2}>
         <Button
           onClick={handleKeepMine}
-          testID="conflict-keep-mine-button"
+          testID={`conflict-keep-mine-button-${conflict.mutationId}`}
           text="Keep mine"
           variant="outline"
         />
         <Button
           onClick={handleUseServer}
-          testID="conflict-use-server-button"
+          testID={`conflict-use-server-button-${conflict.mutationId}`}
           text="Use server"
           variant="primary"
         />

--- a/ui/src/SyncStatusBanner.test.tsx
+++ b/ui/src/SyncStatusBanner.test.tsx
@@ -60,6 +60,14 @@ describe("SyncStatusBanner", () => {
     expect(onOpenConflicts).toHaveBeenCalledTimes(1);
   });
 
+  it("gives the conflict badge an explicit accessibilityRole of button (E6)", () => {
+    const {getByTestId} = renderWithTheme(
+      <SyncStatusBanner conflictCount={1} isOnline={true} isSyncing={false} queuedCount={0} />
+    );
+    const badge = getByTestId("sync-conflict-badge-clickable");
+    expect(badge.props.accessibilityRole).toBe("button");
+  });
+
   it("hides the conflict badge when there are no conflicts", () => {
     const {queryByTestId} = renderWithTheme(
       <SyncStatusBanner conflictCount={0} isOnline={true} isSyncing={false} queuedCount={0} />

--- a/ui/src/SyncStatusBanner.test.tsx
+++ b/ui/src/SyncStatusBanner.test.tsx
@@ -66,4 +66,106 @@ describe("SyncStatusBanner", () => {
     );
     expect(queryByTestId("sync-conflict-badge")).toBeNull();
   });
+
+  it("renders a pressable paused-for-auth indicator and calls onAuthRequired when pressed", async () => {
+    const onAuthRequired = mock(() => {});
+    const {getByTestId} = renderWithTheme(
+      <SyncStatusBanner
+        conflictCount={0}
+        isOnline={true}
+        isSyncing={false}
+        onAuthRequired={onAuthRequired}
+        paused="auth"
+        queuedCount={0}
+      />
+    );
+    const badge = getByTestId("sync-paused-auth-indicator-clickable");
+    expect(badge).toBeTruthy();
+    fireEvent.press(badge);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onAuthRequired).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the paused-for-auth indicator when not paused", () => {
+    const {queryByTestId} = renderWithTheme(
+      <SyncStatusBanner conflictCount={0} isOnline={true} isSyncing={false} queuedCount={0} />
+    );
+    expect(queryByTestId("sync-paused-auth-indicator")).toBeNull();
+    expect(queryByTestId("sync-paused-auth-indicator-clickable")).toBeNull();
+  });
+
+  it("renders a pressable failed badge and calls onOpenFailed when pressed", async () => {
+    const onOpenFailed = mock(() => {});
+    const {getByTestId} = renderWithTheme(
+      <SyncStatusBanner
+        conflictCount={0}
+        failedCount={2}
+        isOnline={true}
+        isSyncing={false}
+        onOpenFailed={onOpenFailed}
+        queuedCount={0}
+      />
+    );
+    const badge = getByTestId("sync-failed-badge-clickable");
+    expect(badge).toBeTruthy();
+    fireEvent.press(badge);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onOpenFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the failed badge when there are no failed mutations", () => {
+    const {queryByTestId} = renderWithTheme(
+      <SyncStatusBanner conflictCount={0} isOnline={true} isSyncing={false} queuedCount={0} />
+    );
+    expect(queryByTestId("sync-failed-badge")).toBeNull();
+  });
+
+  it("shows queued count when queued is at or below the progress threshold, even while draining", () => {
+    const {getByTestId, queryByTestId} = renderWithTheme(
+      <SyncStatusBanner
+        conflictCount={0}
+        draining={true}
+        isOnline={true}
+        isSyncing={true}
+        queuedCount={5}
+        sentThisDrain={1}
+        totalThisDrain={5}
+      />
+    );
+    expect(getByTestId("sync-queued-count")).toBeTruthy();
+    expect(queryByTestId("sync-drain-progress")).toBeNull();
+  });
+
+  it("switches to numeric drain progress once queued exceeds the progress threshold while draining", () => {
+    const {getByTestId, queryByTestId} = renderWithTheme(
+      <SyncStatusBanner
+        conflictCount={0}
+        draining={true}
+        isOnline={true}
+        isSyncing={true}
+        queuedCount={40}
+        sentThisDrain={12}
+        totalThisDrain={40}
+      />
+    );
+    const progress = getByTestId("sync-drain-progress");
+    expect(progress).toBeTruthy();
+    expect(queryByTestId("sync-queued-count")).toBeNull();
+  });
+
+  it("does not show drain progress when queued is large but not currently draining", () => {
+    const {getByTestId, queryByTestId} = renderWithTheme(
+      <SyncStatusBanner
+        conflictCount={0}
+        draining={false}
+        isOnline={true}
+        isSyncing={false}
+        queuedCount={40}
+        sentThisDrain={0}
+        totalThisDrain={0}
+      />
+    );
+    expect(getByTestId("sync-queued-count")).toBeTruthy();
+    expect(queryByTestId("sync-drain-progress")).toBeNull();
+  });
 });

--- a/ui/src/SyncStatusBanner.tsx
+++ b/ui/src/SyncStatusBanner.tsx
@@ -128,6 +128,7 @@ export const SyncStatusBanner: React.FC<SyncStatusBannerProps> = ({
         <Box
           accessibilityHint="Opens the sync conflict resolution sheet"
           accessibilityLabel="View sync conflicts"
+          accessibilityRole="button"
           alignItems="center"
           direction="row"
           gap={1}

--- a/ui/src/SyncStatusBanner.tsx
+++ b/ui/src/SyncStatusBanner.tsx
@@ -5,6 +5,9 @@ import {Badge} from "./Badge";
 import {Box} from "./Box";
 import {Text} from "./Text";
 
+/** Queued count above which the banner switches to a numeric drain-progress display. */
+const PROGRESS_THRESHOLD = 20;
+
 export interface SyncStatusBannerProps {
   /** Whether the client currently has connectivity. */
   isOnline: boolean;
@@ -14,28 +17,64 @@ export interface SyncStatusBannerProps {
   isSyncing: boolean;
   /** Number of unresolved conflicts. */
   conflictCount: number;
+  /**
+   * Set when replay is paused pending re-authentication (B4/INV-2). Tapping
+   * the paused indicator invokes `onAuthRequired`.
+   */
+  paused?: "auth";
+  /** Count of mutations in the terminal `failed` state (B5). */
+  failedCount?: number;
+  /** True while a batched drain is actively in flight (B5). */
+  draining?: boolean;
+  /** Mutations attempted so far in the current (or most recent) drain (B5). */
+  sentThisDrain?: number;
+  /** Queue length observed when the current (or most recent) drain began (B5). */
+  totalThisDrain?: number;
   /** Opens the conflict resolution UI; wired to the pressable conflict badge. */
   onOpenConflicts?: () => void;
+  /** Invoked when the paused-for-auth indicator is tapped, to prompt re-login. */
+  onAuthRequired?: () => void;
+  /** Opens a failed-mutations detail view; wired to the pressable failed badge. */
+  onOpenFailed?: () => void;
   testID?: string;
 }
 
 /**
  * Compact, presentational sync-state banner for local-first (e.g. @terreno/syncdb) screens:
- * offline indicator, queued mutation count, syncing state, and a pressable conflict badge. It is
- * intentionally data-driven (no data-layer imports) so it can be reused with any sync store — wire
- * a status hook (such as `useSyncStatus`) to its props in the consuming app.
+ * offline indicator, queued mutation count (with drain progress once the queue grows past
+ * {@link PROGRESS_THRESHOLD}), syncing state, a paused-for-auth indicator, a pressable failed
+ * count, and a pressable conflict badge. It is intentionally data-driven (no data-layer imports)
+ * so it can be reused with any sync store — wire a status hook (such as `useSyncStatus`) to its
+ * props in the consuming app.
  */
 export const SyncStatusBanner: React.FC<SyncStatusBannerProps> = ({
   isOnline,
   queuedCount,
   isSyncing,
   conflictCount,
+  paused,
+  failedCount = 0,
+  draining = false,
+  sentThisDrain = 0,
+  totalThisDrain = 0,
   onOpenConflicts,
+  onAuthRequired,
+  onOpenFailed,
   testID = "sync-status-banner",
 }) => {
   const handleOpenConflicts = useCallback((): void => {
     onOpenConflicts?.();
   }, [onOpenConflicts]);
+
+  const handleAuthRequired = useCallback((): void => {
+    onAuthRequired?.();
+  }, [onAuthRequired]);
+
+  const handleOpenFailed = useCallback((): void => {
+    onOpenFailed?.();
+  }, [onOpenFailed]);
+
+  const showProgress = draining && queuedCount > PROGRESS_THRESHOLD && totalThisDrain > 0;
 
   return (
     <Box direction="row" gap={2} marginBottom={4} testID={testID} wrap>
@@ -44,15 +83,46 @@ export const SyncStatusBanner: React.FC<SyncStatusBannerProps> = ({
           <Badge status="error" value="Offline" />
         </Box>
       )}
-      {queuedCount > 0 && (
+      {paused === "auth" && (
+        <Box
+          accessibilityHint="Sign in again to resume syncing"
+          accessibilityLabel="Sync paused, sign in required"
+          alignItems="center"
+          direction="row"
+          gap={1}
+          onClick={handleAuthRequired}
+          testID="sync-paused-auth-indicator"
+        >
+          <Badge status="warning" value="Sign in to sync" />
+        </Box>
+      )}
+      {queuedCount > 0 && !showProgress && (
         <Box alignItems="center" direction="row" gap={1} testID="sync-queued-count">
           <Badge status="warning" value={`${queuedCount} queued`} />
+        </Box>
+      )}
+      {showProgress && (
+        <Box alignItems="center" direction="row" gap={1} testID="sync-drain-progress">
+          <Badge status="warning" value={`Syncing ${sentThisDrain} / ${totalThisDrain}`} />
         </Box>
       )}
       {isSyncing && (
         <Text color="secondaryLight" size="sm" testID="sync-syncing-indicator">
           Syncing…
         </Text>
+      )}
+      {failedCount > 0 && (
+        <Box
+          accessibilityHint="Opens the failed sync mutations detail view"
+          accessibilityLabel="View failed sync mutations"
+          alignItems="center"
+          direction="row"
+          gap={1}
+          onClick={handleOpenFailed}
+          testID="sync-failed-badge"
+        >
+          <Badge status="error" value={`${failedCount} failed`} />
+        </Box>
       )}
       {conflictCount > 0 && (
         <Box


### PR DESCRIPTION
## Summary
Hardening pass on top of #869 (`@terreno/syncdb` local-first data layer), covering findings from a multi-angle code review: replay correctness and scheduling, an ordered batch protocol with strict stop-on-error semantics, socket auth revalidation, sync protocol correctness (sequence ordering, per-stream cursors, legacy pagination), storage/React lifecycle fixes, and new load + chaos e2e infrastructure. Full rationale and design decisions are in `docs/implementationPlans/terreno-syncdb-2.md` and `docs/implementationPlans/syncdb-phase-c-design.md`.

Two hard invariants held throughout: mutation order is never violated (a retryable failure halts the drain rather than skipping ahead), and a 401/auth failure never wipes local data — it pauses sync and resumes cleanly on re-auth.

## Human Testing Steps
- [ ] Review `docs/implementationPlans/terreno-syncdb-2.md` for the full defect list and fix rationale
- [ ] Exercise the example app's offline → many-edits → reconnect flow and confirm sync drains without getting stuck
- [ ] Force a 401 (expire/revoke a session) mid-sync and confirm the app pauses and recovers without data loss on re-login
- [ ] Run `bun run api:load` against a local replica-set backend to see the load harness output
- [ ] Run the new `syncdb-chaos.spec.ts` and `syncdb-loadlab.spec.ts` (`@load` tag) e2e specs against a live stack

## Changes
- Replay engine: startup recovery for crashed/stranded mutations, send-time baseVersion refresh, a real drain-until-empty scheduler with jittered backoff and split retry budgets, and a full 401 auth-pause contract
- Ordered batch protocol (`POST /sync/mutate/batch`, `sync:mutateBatch`) with server-side strict-serial stop-on-first-nack, client-side per-entity chunking, and a stop-the-line policy for conflicts/validation/transport/auth failures
- Batch protocol review fixes: dedicated `rate_limited` nack code (never burns the terminal retry budget), transitive cross-entity reference blocking, coordinator lifecycle reset on user switch, capability-receipt-based batch detection, mutation ledger crash/lease recovery
- Socket auth hardening: periodic session revalidation, full-user socket authorization (fixes silent tenant-scoping failure over websockets), tenant create-escape fix, admin action audit logging
- Sync protocol correctness: stable-frontier sequence fencing (closes a class of permanently-missed documents under concurrent writes), per-stream snapshot cursors + stream discovery, `_id`-paged legacy document pagination, durable scope-move markers, write-scope enforcement, tombstone retention
- Storage/React: serialized client lifecycle (start/stop/auth-change), schema versioning, persistence failure surfacing, transaction-batched bootstrap/delta application, client-side tombstone compaction
- New test/load infra: server-side load harness (`bun run api:load`), chaos e2e (flaky-connection simulation), load-lab e2e, and root-cause fixes for previously-flaky integration tests

## Automated Tests
- `bun run syncdb:test`: 409 pass, 0 fail
- `bun run ui:test`: 1775 pass, 0 fail
- `bun run api:test`: 1585 pass, 0 fail
- `bun run compile`: clean across the workspace
- `bun run lint`: clean for all touched packages
- New: `api/src/sync/loadHarness.ts` load script, `example-frontend/e2e/syncdb-chaos.spec.ts`, `example-frontend/e2e/syncdb-loadlab.spec.ts` (compiled/linted/resolve via `playwright test --list`; not executed against a live stack in this environment — see PR description notes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, WebSocket authorization, sync sequencing/frontiers, and mutation idempotency—incorrect behavior could leak data across tenants or lose/corrupt synced state.
> 
> **Overview**
> Follow-up hardening on the `@terreno/syncdb` stack: replay stays ordered (stop-the-line on retryable failures) and **401/auth never wipes local data**—sync pauses and resumes after re-auth.
> 
> **API / realtime / sync server:** Bearer JWT handling now uses structural `jwt.decode` instead of dot-counting so opaque session tokens fall through correctly. Socket JWT auth gains **issuer parity** with HTTP, loads/refreshes **full user** docs for permission/`getUserScopes`, and runs a **periodic session revalidation** sweep (`sync:auth-expired`, disabled users, Better Auth re-check, **sync room re-resolution**). Password changes enforce **max length** and optional **admin audit** logs (no password in logs). Change-stream sync emits **`frontierSeq`**, **durable scope-move tombstones** via `SyncScopeMove`, **per-entity ordered** delta dispatch, ignores internal sync collections, and tombstones skip payload serialization. Seq claiming adds a **stable frontier** with pending claims/confirm; mutation ledger **lease takeover** and **post-hooks after ledger finalize** (`skipPostHooks` + warnings on hook failure). **Batch mutate** validation/application, idempotent soft-delete, and `ensureSyncIndexes` startup failure behavior are covered by expanded tests.
> 
> **Client / ops (from PR scope):** Ordered **batch replay**, auth-pause contract, per-stream cursors, and integration fixes for flaky “settled” waits; manual **`bun run api:load`** harness.
> 
> **CI:** PR matrix adds **`syncdb-chaos`**; heavy **`syncdb-loadlab`** moves to **nightly** / `load-test` label workflow. New e2e users/specs for chaos and load lab; login helper waits for tabs to avoid redirect races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d89d45932656aa103e5f093215253da4c8adca34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->