### PR TITLE
Return 401s from compiled binaries by routing auth failures around passport's AuthenticationError

### DIFF
--- a/api/src/auth.compile.test.ts
+++ b/api/src/auth.compile.test.ts
@@ -1,0 +1,106 @@
+import {afterAll, beforeAll, describe, expect, it} from "bun:test";
+import {mkdtemp, rm} from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Regression test: auth failures must stay 401s inside `bun build --compile`
+ * binaries.
+ *
+ * passport's internal AuthenticationError calls `Error.captureStackTrace(this,
+ * arguments.callee)`. Bundling into a single-file executable puts that CJS
+ * code in strict-mode context, where touching `arguments.callee` throws a
+ * TypeError — so with `failWithError: true`, every unauthenticated request
+ * used to 500 instead of 401 (while behaving fine under plain `bun run`).
+ * authenticateMiddleware therefore must never route failures through
+ * passport's error class.
+ *
+ * This compiles a real fixture server (src/tests/fixtures/compileAuthEntry.ts)
+ * and asserts the 401 contract against the running binary.
+ */
+
+/** Grab an OS-assigned free port, then release it for the fixture binary. */
+const findFreePort = async (): Promise<number> => {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("Failed to allocate a port"));
+        return;
+      }
+      const {port} = address;
+      server.close(() => resolve(port));
+    });
+    server.on("error", reject);
+  });
+};
+
+describe("authenticateMiddleware inside a bun-compiled binary", () => {
+  let tmpDir: string;
+  let child: ReturnType<typeof Bun.spawn> | null = null;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "terreno-compile-auth-"));
+    const binaryPath = path.join(tmpDir, "compile-auth-server");
+    const entryPath = path.join(__dirname, "tests/fixtures/compileAuthEntry.ts");
+
+    const build = Bun.spawn(["bun", "build", "--compile", entryPath, "--outfile", binaryPath], {
+      cwd: __dirname,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const buildExit = await build.exited;
+    if (buildExit !== 0) {
+      throw new Error(`bun build --compile failed: ${await new Response(build.stderr).text()}`);
+    }
+
+    const port = await findFreePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+    child = Bun.spawn([binaryPath], {
+      env: {...process.env, PORT: String(port)},
+      stderr: "inherit",
+      stdout: "inherit",
+    });
+
+    // Poll until the fixture server answers (or its process dies).
+    const deadline = Date.now() + 15000;
+    for (;;) {
+      try {
+        await fetch(`${baseUrl}/secure`);
+        break;
+      } catch {
+        if (child.exitCode !== null) {
+          throw new Error(`fixture server exited with code ${child.exitCode}`);
+        }
+        if (Date.now() > deadline) {
+          throw new Error("fixture server never became reachable");
+        }
+        await Bun.sleep(100);
+      }
+    }
+  }, 120000);
+
+  afterAll(async () => {
+    child?.kill();
+    await child?.exited;
+    await rm(tmpDir, {force: true, recursive: true});
+  });
+
+  it("returns 401 (not 500) for a request with no token", async () => {
+    const res = await fetch(`${baseUrl}/secure`);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({status: 401, title: "Unauthorized"});
+  });
+
+  it("returns 401 (not 500) for a request with an invalid token", async () => {
+    const res = await fetch(`${baseUrl}/secure`, {
+      headers: {Authorization: "Bearer not-a-real-jwt"},
+    });
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({status: 401, title: "Unauthorized"});
+  });
+});

--- a/api/src/auth.test.ts
+++ b/api/src/auth.test.ts
@@ -499,6 +499,11 @@ describe("auth tests", () => {
     expect(failRes.body).toEqual({status: 401, title: "User is disabled"});
   });
 
+  it("signup without credentials is a 400, not a fallthrough 500", async () => {
+    const res = await agent.post("/auth/signup").send({email: "new@example.com"}).expect(400);
+    expect(res.body).toEqual({meta: {}, status: 400, title: "Missing credentials"});
+  });
+
   it("signup user with email that is already registered", async () => {
     await agent
       .post("/auth/signup")

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -60,16 +60,39 @@ export const authenticateMiddleware = (anonymous = false) => {
   if (anonymous) {
     strategies.push("anonymous");
   }
-  const passportAuth = passport.authenticate(strategies, {
-    failureMessage: false, // this is just avoiding storing the message in the session
-    failWithError: true,
-    session: false,
-  });
   return (req: express.Request, res: express.Response, next: express.NextFunction) => {
     if (req.user) {
       return next();
     }
-    return passportAuth(req, res, next);
+    // Failures use a custom callback rather than passport's `failWithError`:
+    // passport's internal AuthenticationError touches `arguments.callee`,
+    // which throws a TypeError in strict-mode contexts — inside
+    // `bun build --compile` binaries that turned every 401 into a 500. The
+    // plain Error("Unauthorized") below is what apiUnauthorizedMiddleware
+    // matches on, so the response contract is unchanged.
+    // (The anonymous strategy calls pass(), which skips this callback and
+    // continues the chain with no user — same as before.)
+    return passport.authenticate(
+      strategies,
+      {session: false},
+      (
+        err: Error | null,
+        user: NonNullable<express.Request["user"]> | false | null,
+        info: unknown
+      ) => {
+        if (err) {
+          return next(err);
+        }
+        if (!user) {
+          return next(new Error("Unauthorized"));
+        }
+        req.user = user;
+        // req.logIn used to populate authInfo; keep that passport-public API
+        // intact for downstream consumers.
+        req.authInfo = (info ?? {}) as Express.AuthInfo;
+        return next();
+      }
+    )(req, res, next);
   };
 };
 
@@ -412,7 +435,26 @@ export const addAuthRoutes = (
   if (!signupDisabled) {
     router.post(
       "/signup",
-      passport.authenticate("signup", {failWithError: true, session: false}),
+      // Custom callback instead of `failWithError` — passport's internal
+      // AuthenticationError is unusable in strict-mode bundles (see
+      // authenticateMiddleware). Strategy errors (e.g. duplicate email) pass
+      // through unchanged; a bare failure (missing credentials) is a 400.
+      (req: express.Request, res: express.Response, next: express.NextFunction) => {
+        passport.authenticate(
+          "signup",
+          {session: false},
+          (err: Error | null, user: NonNullable<express.Request["user"]> | false | null) => {
+            if (err) {
+              return next(err);
+            }
+            if (!user) {
+              return next(new APIError({status: 400, title: "Missing credentials"}));
+            }
+            req.user = user;
+            return next();
+          }
+        )(req, res, next);
+      },
       async (req: express.Request, res: express.Response) => {
         const tokens = await generateTokens(req.user, authOptions);
         if (tokens.sessionId) {

--- a/api/src/tests/fixtures/compileAuthEntry.ts
+++ b/api/src/tests/fixtures/compileAuthEntry.ts
@@ -1,0 +1,43 @@
+// Minimal server for the bun-compile auth regression test
+// (src/auth.compile.test.ts). Registers a real passport JWT strategy and
+// guards one route with authenticateMiddleware, using the same error
+// middleware chain as expressServer. Compiled with `bun build --compile`, an
+// unauthenticated request must produce a 401 — not a 500 from passport's
+// strict-mode-illegal AuthenticationError (`arguments.callee`).
+
+import express from "express";
+import passport from "passport";
+import {ExtractJwt, Strategy as JwtStrategy} from "passport-jwt";
+import {authenticateMiddleware} from "../../auth";
+import {apiErrorMiddleware, apiUnauthorizedMiddleware} from "../../errors";
+
+passport.use(
+  "jwt",
+  new JwtStrategy(
+    {
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: "compile-test-secret",
+    },
+    (payload, done) => done(null, payload)
+  )
+);
+
+const app = express();
+app.use(passport.initialize());
+
+app.get("/secure", authenticateMiddleware(), (_req, res) => {
+  res.json({data: "ok"});
+});
+
+app.use(apiUnauthorizedMiddleware);
+app.use(apiErrorMiddleware);
+// Terreno's fallthrough: anything reaching here surfaces as a 500. The
+// regression turns auth failures into exactly this kind of error.
+app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  res.status(500).json({status: 500, title: `Fallthrough error: ${err.message}`});
+});
+
+const port = Number(process.env.PORT ?? 0);
+app.listen(port, () => {
+  console.info(`LISTENING ${port}`);
+});


### PR DESCRIPTION
## Problem

In `bun build --compile` binaries, every request that failed authentication returned a **500** (`Fallthrough error: 'arguments', 'callee', and 'caller' cannot be accessed in this context`) instead of a 401 — while behaving normally under plain `bun run`. Found in production on a shade deployment where all unauthenticated probes 500'd.

**Root cause:** passport's internal `AuthenticationError` calls `Error.captureStackTrace(this, arguments.callee)`. Single-file executable bundling puts that CJS in strict-mode context, where touching `arguments.callee` throws a TypeError. With `failWithError: true`, that constructor runs on every auth failure.

## Fix

- `authenticateMiddleware` and `/auth/signup` use passport's custom-callback form instead of `failWithError`, so passport's error class is never constructed.
- Failures raise a plain `Error("Unauthorized")` — exactly what `apiUnauthorizedMiddleware` matches — so the 401 response body is unchanged: `{status: 401, title: "Unauthorized"}`.
- Success still sets `req.user` and `req.authInfo` (previously populated via `req.logIn`).
- The anonymous strategy's `pass()` bypasses the callback and continues the chain without a user, same as before.

**One deliberate behavior change:** `/auth/signup` with missing credentials now returns `400 {title: "Missing credentials"}`. Previously passport produced `AuthenticationError("Bad Request", 400)`, which matched no error middleware and fell through to a 500.

## Tests

- New `api/src/auth.compile.test.ts`: compiles a fixture server with `bun build --compile`, runs the binary, and asserts the 401 contract for missing and invalid tokens. Reproduced the 500 before the fix; fails if the fix is reverted.
- New signup test pinning the missing-credentials 400.
- All 57 existing auth tests and the full api suite pass unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core authentication middleware and signup routing; incorrect error handling could change status codes or break compiled production binaries, though behavior is heavily regression-tested.
> 
> **Overview**
> Fixes **`bun build --compile`** deployments where failed auth returned **500** instead of **401**, because passport’s `failWithError` path constructs `AuthenticationError`, which uses `arguments.callee` and throws under strict-mode bundling.
> 
> **`authenticateMiddleware`** and **`/auth/signup`** now use passport’s **custom callback** instead of `failWithError`. Auth failures call `next(new Error("Unauthorized"))`, which **`apiUnauthorizedMiddleware`** still maps to `{status: 401, title: "Unauthorized"}`. Successful auth still sets `req.user` and `req.authInfo`.
> 
> **`/auth/signup`** without credentials now returns **400** `{title: "Missing credentials"}` instead of falling through to a 500.
> 
> Adds **`auth.compile.test.ts`** (compiles a fixture server and asserts 401 for missing/invalid tokens) plus a unit test for the signup 400 behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03791b2af9f9541e063fd823076d2de54f10168b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->